### PR TITLE
[fixes] stackalloc warnings, consolidate duplicated methods, minor adjustments in project settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ packages/
 Thumbs.db
 Desktop.ini
 ehthumbs.db
+
+.vs/

--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -7,9 +7,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
   <Folder Name="/src/">
     <Project Path="src/SharpEmu.CLI/SharpEmu.CLI.csproj" />
     <Project Path="src/SharpEmu.Core/SharpEmu.Core.csproj" />
-    <Project Path="src/SharpEmu.GUI/SharpEmu.GUI.csproj">
-      <Build Solution="Debug|*" Project="false" />
-    </Project>
+    <Project Path="src/SharpEmu.GUI/SharpEmu.GUI.csproj" />
     <Project Path="src/SharpEmu.HLE/SharpEmu.HLE.csproj" />
     <Project Path="src/SharpEmu.Libs/SharpEmu.Libs.csproj" />
     <Project Path="src/SharpEmu.Logging/SharpEmu.Logging.csproj" />

--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -7,7 +7,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
   <Folder Name="/src/">
     <Project Path="src/SharpEmu.CLI/SharpEmu.CLI.csproj" />
     <Project Path="src/SharpEmu.Core/SharpEmu.Core.csproj" />
-    <Project Path="src/SharpEmu.GUI/SharpEmu.GUI.csproj" />
+    <Project Path="src/SharpEmu.GUI/SharpEmu.GUI.csproj">
+      <Build Solution="Debug|*" Project="false" />
+    </Project>
     <Project Path="src/SharpEmu.HLE/SharpEmu.HLE.csproj" />
     <Project Path="src/SharpEmu.Libs/SharpEmu.Libs.csproj" />
     <Project Path="src/SharpEmu.Logging/SharpEmu.Logging.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
         "version": "10.0.103",
-        "rollForward": "disable"
+        "rollForward": "latestFeature"
     }
 }

--- a/src/SharpEmu.CLI/SharpEmu.CLI.csproj
+++ b/src/SharpEmu.CLI/SharpEmu.CLI.csproj
@@ -38,6 +38,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <Win32Icon>..\..\assets\images\SharpEmu.ico</Win32Icon>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+  
   <ItemGroup>
     <Content Include="..\..\LICENSE.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/SharpEmu.CLI/packages.lock.json
+++ b/src/SharpEmu.CLI/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "0B6nZyCHWXnvmlB559oduOspVdNOnpNXPjhpWVMovLPAsDVG7A4jJR9rzECf67JUzxP8/ee/wA8clwIzJcWNFA=="
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "4Iw41e2h7I4t70SJcX2GCmbyKJIlA273Cfm9RJMM050/3VBejGAG1KcthP5Z2L6SQcbfbf6BhNWO26+ZG+GzMg=="
       },
       "Avalonia.Angle.Windows.Natives": {
         "type": "Transitive",

--- a/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
+++ b/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
@@ -415,8 +415,8 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
 
         const ulong entryParamsSize = 0x20;
         var entryParamsAddress = AlignDown(argv0Address - entryParamsSize, 16);
-        if (!TryWriteUInt32(context, entryParamsAddress + 0x00, 1) ||
-            !TryWriteUInt32(context, entryParamsAddress + 0x04, 0) ||
+        if (!context.TryWriteUInt32(entryParamsAddress + 0x00, 1) ||
+            !context.TryWriteUInt32(entryParamsAddress + 0x04, 0) ||
             !context.TryWriteUInt64(entryParamsAddress + 0x08, argv0Address) ||
             !context.TryWriteUInt64(entryParamsAddress + 0x10, 0) ||
             !context.TryWriteUInt64(entryParamsAddress + 0x18, 0))
@@ -454,13 +454,6 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
     private static ulong AlignDown(ulong value, ulong alignment)
     {
         return value & ~(alignment - 1);
-    }
-
-    private static bool TryWriteUInt32(CpuContext context, ulong address, uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
-        return context.Memory.TryWrite(address, buffer);
     }
 
     private static string BuildEntryFrameDiagnostic(

--- a/src/SharpEmu.Core/SharpEmu.Core.csproj
+++ b/src/SharpEmu.Core/SharpEmu.Core.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright (C) 2026 SharpEmu Emulator Project
 SPDX-License-Identifier: GPL-2.0-or-later
 -->
@@ -13,6 +13,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
   <ItemGroup>
     <PackageReference Include="Iced" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/SharpEmu.HLE/CpuContext.cs
+++ b/src/SharpEmu.HLE/CpuContext.cs
@@ -2,25 +2,20 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Buffers.Binary;
+using System.Text;
 
 namespace SharpEmu.HLE;
 
-public sealed class CpuContext
+public sealed class CpuContext(ICpuMemory memory, Generation generation)
 {
     private readonly ulong[] _registers = new ulong[16];
     private readonly ulong[] _xmmRegisters = new ulong[32];
     private readonly ulong[] _ymmUpperRegisters = new ulong[32];
     private bool _raxWritten;
 
-    public CpuContext(ICpuMemory memory, Generation generation)
-    {
-        Memory = memory ?? throw new ArgumentNullException(nameof(memory));
-        TargetGeneration = generation;
-    }
+    public ICpuMemory Memory { get; } = memory ?? throw new ArgumentNullException(nameof(memory));
 
-    public ICpuMemory Memory { get; }
-
-    public Generation TargetGeneration { get; }
+    public Generation TargetGeneration { get; } = generation;
 
     public ulong Rip { get; set; }
 
@@ -130,6 +125,39 @@ public sealed class CpuContext
         SetYmmUpper(registerIndex, highLow, highHigh);
     }
 
+    public bool TryReadByte(ulong address, out byte value)
+    {
+        Span<byte> buffer = stackalloc byte[1];
+        if (!Memory.TryRead(address, buffer))
+        {
+            value = 0;
+            return false;
+        }
+
+        value = buffer[0];
+        return true;
+    }
+
+    public bool TryReadUInt32(ulong address, out uint value)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        if (!Memory.TryRead(address, buffer))
+        {
+            value = 0;
+            return false;
+        }
+
+        value = BinaryPrimitives.ReadUInt32LittleEndian(buffer);
+        return true;
+    }
+
+    public bool TryWriteUInt32(ulong address, uint value)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
+        return Memory.TryWrite(address, buffer);
+    }
+
     public bool TryReadUInt64(ulong address, out ulong value)
     {
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
@@ -148,6 +176,33 @@ public sealed class CpuContext
         Span<byte> buffer = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
         return Memory.TryWrite(address, buffer);
+    }
+
+    public bool TryReadNullTerminatedUtf8(ulong address, int capacity, out string value)
+    {
+        value = string.Empty;
+        if (address == 0 || capacity <= 0)
+        {
+            return false;
+        }
+
+        var bytes = new byte[capacity];
+        for (var index = 0; index < bytes.Length; index++)
+        {
+            if (!Memory.TryRead(address + (ulong)index, bytes.AsSpan(index, 1)))
+            {
+                return false;
+            }
+
+            if (bytes[index] == 0)
+            {
+                value = Encoding.UTF8.GetString(bytes, 0, index);
+                return true;
+            }
+        }
+
+        value = Encoding.UTF8.GetString(bytes);
+        return true;
     }
 
     public bool PushUInt64(ulong value)

--- a/src/SharpEmu.HLE/SharpEmu.HLE.csproj
+++ b/src/SharpEmu.HLE/SharpEmu.HLE.csproj
@@ -8,6 +8,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Aerolib\aerolib.bin" />
   </ItemGroup>

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -442,8 +442,8 @@ public static class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryReadUInt32(ctx, headerAddress, out var fileHeader) ||
-            !TryReadUInt32(ctx, headerAddress + sizeof(uint), out var version))
+        if (!ctx.TryReadUInt32(headerAddress, out var fileHeader) ||
+            !ctx.TryReadUInt32(headerAddress + sizeof(uint), out var version))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -465,7 +465,7 @@ public static class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
-        if (!TryReadUInt64(ctx, headerAddress + ShaderUserDataOffset, out var userDataAddress))
+        if (!ctx.TryReadUInt64(headerAddress + ShaderUserDataOffset, out var userDataAddress))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -567,8 +567,8 @@ public static class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryReadByte(ctx, geometryShaderAddress + ShaderTypeOffset, out var shaderType) || !IsEsGeometryShaderType(shaderType) ||
-            !TryReadUInt64(ctx, geometryShaderAddress + ShaderSpecialsOffset, out var specialsAddress) ||
+        if (!ctx.TryReadByte(geometryShaderAddress + ShaderTypeOffset, out var shaderType) || !IsEsGeometryShaderType(shaderType) ||
+            !ctx.TryReadUInt64(geometryShaderAddress + ShaderSpecialsOffset, out var specialsAddress) ||
             specialsAddress == 0)
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
@@ -578,8 +578,8 @@ public static class AgcExports
             !CopyShaderRegister(ctx, specialsAddress + ShaderSpecialVgtGsOutPrimTypeOffset, cxRegistersAddress + 8) ||
             !CopyShaderRegister(ctx, specialsAddress + ShaderSpecialGeCntlOffset, ucRegistersAddress) ||
             !CopyShaderRegister(ctx, specialsAddress + ShaderSpecialGeUserVgprEnOffset, ucRegistersAddress + 8) ||
-            !TryWriteUInt32(ctx, ucRegistersAddress + 16, VgtPrimitiveType) ||
-            !TryWriteUInt32(ctx, ucRegistersAddress + 20, primitiveType))
+            !ctx.TryWriteUInt32(ucRegistersAddress + 16, VgtPrimitiveType) ||
+            !ctx.TryWriteUInt32(ucRegistersAddress + 20, primitiveType))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -605,16 +605,16 @@ public static class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryReadUInt64(ctx, geometryShaderAddress + ShaderOutputSemanticsOffset, out var outputSemanticsAddress) ||
-            !TryReadUInt32(ctx, geometryShaderAddress + ShaderNumOutputSemanticsOffset, out var outputSemanticsCount))
+        if (!ctx.TryReadUInt64(geometryShaderAddress + ShaderOutputSemanticsOffset, out var outputSemanticsAddress) ||
+            !ctx.TryReadUInt32(geometryShaderAddress + ShaderNumOutputSemanticsOffset, out var outputSemanticsCount))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
         ulong inputSemanticsAddress = 0;
         if (pixelShaderAddress != 0 &&
-            (!TryReadUInt64(ctx, pixelShaderAddress + ShaderInputSemanticsOffset, out inputSemanticsAddress) ||
-             !TryReadUInt32(ctx, pixelShaderAddress + ShaderNumInputSemanticsOffset, out _)))
+            (!ctx.TryReadUInt64(pixelShaderAddress + ShaderInputSemanticsOffset, out inputSemanticsAddress) ||
+             !ctx.TryReadUInt32(pixelShaderAddress + ShaderNumInputSemanticsOffset, out _)))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -626,7 +626,7 @@ public static class AgcExports
             {
                 var flat = false;
                 if (pixelShaderAddress != 0 && inputSemanticsAddress != 0 &&
-                    TryReadUInt32(ctx, inputSemanticsAddress + (i * sizeof(uint)), out var inputSemantic))
+                    ctx.TryReadUInt32(inputSemanticsAddress + (i * sizeof(uint)), out var inputSemantic))
                 {
                     flat = ((inputSemantic >> 22) & 0x1) != 0;
                 }
@@ -635,8 +635,8 @@ public static class AgcExports
             }
 
             var destination = registersAddress + (i * 8);
-            if (!TryWriteUInt32(ctx, destination, SpiPsInputCntl0 + i) ||
-                !TryWriteUInt32(ctx, destination + sizeof(uint), value))
+            if (!ctx.TryWriteUInt32(destination, SpiPsInputCntl0 + i) ||
+                !ctx.TryWriteUInt32(destination + sizeof(uint), value))
             {
                 return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             }
@@ -665,7 +665,7 @@ public static class AgcExports
         var payloadAddress = commandAddress + 8;
         if (type == 0)
         {
-            if (!TryReadUInt32(ctx, commandAddress, out var header))
+            if (!ctx.TryReadUInt32(commandAddress, out var header))
             {
                 return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             }
@@ -706,14 +706,14 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, dwordCount, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(dwordCount, ItNop, RZero)))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(dwordCount, ItNop, RZero)))
         {
             return ReturnPointer(ctx, 0);
         }
 
         for (uint index = 1; index < dwordCount; index++)
         {
-            if (!TryWriteUInt32(ctx, commandAddress + ((ulong)index * sizeof(uint)), 0))
+            if (!ctx.TryWriteUInt32(commandAddress + ((ulong)index * sizeof(uint)), 0))
             {
                 return ReturnPointer(ctx, 0);
             }
@@ -736,11 +736,11 @@ public static class AgcExports
         var modifier = (uint)ctx[CpuRegister.R8];
         if (commandBufferAddress == 0 ||
             !TryAllocateCommandDwords(ctx, commandBufferAddress, 5, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(5, ItDispatchDirect, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, groupCountX) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, groupCountY) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, groupCountZ) ||
-            !TryWriteUInt32(ctx, commandAddress + 16, (modifier & 0xA038u) | 0x41u))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(5, ItDispatchDirect, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, groupCountX) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, groupCountY) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, groupCountZ) ||
+            !ctx.TryWriteUInt32(commandAddress + 16, (modifier & 0xA038u) | 0x41u))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -772,8 +772,8 @@ public static class AgcExports
         for (uint index = 0; index < registerCount; index++)
         {
             var entryAddress = registersAddress + ((ulong)index * 8);
-            if (!TryReadUInt32(ctx, entryAddress, out var offset) ||
-                !TryReadUInt32(ctx, entryAddress + sizeof(uint), out var value))
+            if (!ctx.TryReadUInt32(entryAddress, out var offset) ||
+                !ctx.TryReadUInt32(entryAddress + sizeof(uint), out var value))
             {
                 return ReturnPointer(ctx, 0);
             }
@@ -796,8 +796,8 @@ public static class AgcExports
             var valueCount = (uint)(endIndex - startIndex);
             var packetDwords = valueCount + 2;
             if (!TryAllocateCommandDwords(ctx, commandBufferAddress, packetDwords, out var commandAddress) ||
-                !TryWriteUInt32(ctx, commandAddress, Pm4(packetDwords, ItSetShReg, 0)) ||
-                !TryWriteUInt32(ctx, commandAddress + 4, registers[startIndex].Offset & 0xFFFFu))
+                !ctx.TryWriteUInt32(commandAddress, Pm4(packetDwords, ItSetShReg, 0)) ||
+                !ctx.TryWriteUInt32(commandAddress + 4, registers[startIndex].Offset & 0xFFFFu))
             {
                 return ReturnPointer(ctx, 0);
             }
@@ -805,8 +805,7 @@ public static class AgcExports
             firstCommandAddress = firstCommandAddress == 0 ? commandAddress : firstCommandAddress;
             for (var index = startIndex; index < endIndex; index++)
             {
-                if (!TryWriteUInt32(
-                        ctx,
+                if (!ctx.TryWriteUInt32(
                         commandAddress + 8 + ((ulong)(index - startIndex) * sizeof(uint)),
                         registers[index].Value))
                 {
@@ -830,8 +829,8 @@ public static class AgcExports
         var commandBufferAddress = ctx[CpuRegister.Rdi];
         if (commandBufferAddress == 0 ||
             !TryAllocateCommandDwords(ctx, commandBufferAddress, 2, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(2, ItNop, RAcbReset)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, 0))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(2, ItNop, RAcbReset)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, 0))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -857,15 +856,15 @@ public static class AgcExports
         var hasAddress = (eventType & ~1u) == 0x38;
         var packetDwords = hasAddress ? 4u : 2u;
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, packetDwords, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(packetDwords, ItEventWrite, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, hasAddress ? eventType | 0x100u : eventType & 0x3Fu))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(packetDwords, ItEventWrite, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, hasAddress ? eventType | 0x100u : eventType & 0x3Fu))
         {
             return ReturnPointer(ctx, 0);
         }
 
         if (hasAddress &&
-            (!TryWriteUInt32(ctx, commandAddress + 8, (uint)eventAddress & ~7u) ||
-             !TryWriteUInt32(ctx, commandAddress + 12, (uint)(eventAddress >> 32))))
+            (!ctx.TryWriteUInt32(commandAddress + 8, (uint)eventAddress & ~7u) ||
+             !ctx.TryWriteUInt32(commandAddress + 12, (uint)(eventAddress >> 32))))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -896,14 +895,14 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 8, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(8, ItNop, RAcquireMem)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, 0x8000_0000u) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, noSize ? 0 : (uint)(sizeBytes >> 8)) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 16, (uint)(baseAddress >> 8)) ||
-            !TryWriteUInt32(ctx, commandAddress + 20, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 24, pollCycles / 40) ||
-            !TryWriteUInt32(ctx, commandAddress + 28, gcrControl))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(8, ItNop, RAcquireMem)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, 0x8000_0000u) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, noSize ? 0 : (uint)(sizeBytes >> 8)) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, 0) ||
+            !ctx.TryWriteUInt32(commandAddress + 16, (uint)(baseAddress >> 8)) ||
+            !ctx.TryWriteUInt32(commandAddress + 20, 0) ||
+            !ctx.TryWriteUInt32(commandAddress + 24, pollCycles / 40) ||
+            !ctx.TryWriteUInt32(commandAddress + 28, gcrControl))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -925,8 +924,8 @@ public static class AgcExports
         var address = ctx[CpuRegister.R8];
         var reference = ctx[CpuRegister.R9];
         var stackAddress = ctx[CpuRegister.Rsp];
-        if (!TryReadUInt64(ctx, stackAddress + sizeof(ulong), out var mask) ||
-            !TryReadUInt32(ctx, stackAddress + (2 * sizeof(ulong)), out var pollCycles) ||
+        if (!ctx.TryReadUInt64(stackAddress + sizeof(ulong), out var mask) ||
+            !ctx.TryReadUInt32(stackAddress + (2 * sizeof(ulong)), out var pollCycles) ||
             commandBufferAddress == 0 ||
             size > 1 ||
             compareFunction > 7 ||
@@ -938,27 +937,27 @@ public static class AgcExports
         var packetDwords = size == 0 ? 6u : 9u;
         var packetRegister = size == 0 ? RWaitMem32 : RWaitMem64;
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, packetDwords, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(packetDwords, ItNop, packetRegister)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, (uint)address) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, (uint)(address >> 32)) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, (uint)mask))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(packetDwords, ItNop, packetRegister)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, (uint)address) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, (uint)(address >> 32)) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, (uint)mask))
         {
             return ReturnPointer(ctx, 0);
         }
 
         if (size == 0)
         {
-            if (!TryWriteUInt32(ctx, commandAddress + 16, compareFunction) ||
-                !TryWriteUInt32(ctx, commandAddress + 20, (uint)reference))
+            if (!ctx.TryWriteUInt32(commandAddress + 16, compareFunction) ||
+                !ctx.TryWriteUInt32(commandAddress + 20, (uint)reference))
             {
                 return ReturnPointer(ctx, 0);
             }
         }
-        else if (!TryWriteUInt32(ctx, commandAddress + 16, (uint)(mask >> 32)) ||
-                 !TryWriteUInt32(ctx, commandAddress + 20, (uint)reference) ||
-                 !TryWriteUInt32(ctx, commandAddress + 24, (uint)(reference >> 32)) ||
-                 !TryWriteUInt32(ctx, commandAddress + 28, compareFunction) ||
-                 !TryWriteUInt32(ctx, commandAddress + 32, pollCycles / 40))
+        else if (!ctx.TryWriteUInt32(commandAddress + 16, (uint)(mask >> 32)) ||
+                 !ctx.TryWriteUInt32(commandAddress + 20, (uint)reference) ||
+                 !ctx.TryWriteUInt32(commandAddress + 24, (uint)(reference >> 32)) ||
+                 !ctx.TryWriteUInt32(commandAddress + 28, compareFunction) ||
+                 !ctx.TryWriteUInt32(commandAddress + 32, pollCycles / 40))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -986,10 +985,10 @@ public static class AgcExports
         var modifier = (uint)ctx[CpuRegister.Rdx];
         if (commandBufferAddress == 0 ||
             !TryAllocateCommandDwords(ctx, commandBufferAddress, 4, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(4, ItDispatchIndirect, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, (uint)argumentsAddress) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, (uint)(argumentsAddress >> 32)) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, (modifier & 0xA038u) | 0x41u))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(4, ItDispatchIndirect, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, (uint)argumentsAddress) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, (uint)(argumentsAddress >> 32)) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, (modifier & 0xA038u) | 0x41u))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1014,11 +1013,11 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 2, out var markerAddress) ||
-            !TryWriteUInt32(ctx, markerAddress, Pm4(2, ItNop, RZero)) ||
-            !TryWriteUInt32(ctx, markerAddress + 4, CbSetShRegisterRangeMarker) ||
+            !ctx.TryWriteUInt32(markerAddress, Pm4(2, ItNop, RZero)) ||
+            !ctx.TryWriteUInt32(markerAddress + 4, CbSetShRegisterRangeMarker) ||
             !TryAllocateCommandDwords(ctx, commandBufferAddress, valueCount + 2, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(valueCount + 2, ItSetShReg, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, offset))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(valueCount + 2, ItSetShReg, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, offset))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1027,12 +1026,12 @@ public static class AgcExports
         {
             var value = 0u;
             if (valuesAddress != 0 &&
-                !TryReadUInt32(ctx, valuesAddress + (i * sizeof(uint)), out value))
+                !ctx.TryReadUInt32(valuesAddress + (i * sizeof(uint)), out value))
             {
                 return ReturnPointer(ctx, 0);
             }
 
-            if (!TryWriteUInt32(ctx, commandAddress + 8 + (i * sizeof(uint)), value))
+            if (!ctx.TryWriteUInt32(commandAddress + 8 + (i * sizeof(uint)), value))
             {
                 return ReturnPointer(ctx, 0);
             }
@@ -1056,12 +1055,12 @@ public static class AgcExports
         var cachePolicy = (uint)(ctx[CpuRegister.R8] & 0xFF);
         var destinationAddress = ctx[CpuRegister.R9];
         var stackAddress = ctx[CpuRegister.Rsp];
-        if (!TryReadUInt64(ctx, stackAddress + 8, out var dataSelectionRaw) ||
-            !TryReadUInt64(ctx, stackAddress + 16, out var data) ||
-            !TryReadUInt64(ctx, stackAddress + 24, out var gdsOffsetRaw) ||
-            !TryReadUInt64(ctx, stackAddress + 32, out var gdsSizeRaw) ||
-            !TryReadUInt64(ctx, stackAddress + 40, out var interruptRaw) ||
-            !TryReadUInt64(ctx, stackAddress + 48, out var interruptContextIdRaw))
+        if (!ctx.TryReadUInt64(stackAddress + 8, out var dataSelectionRaw) ||
+            !ctx.TryReadUInt64(stackAddress + 16, out var data) ||
+            !ctx.TryReadUInt64(stackAddress + 24, out var gdsOffsetRaw) ||
+            !ctx.TryReadUInt64(stackAddress + 32, out var gdsSizeRaw) ||
+            !ctx.TryReadUInt64(stackAddress + 40, out var interruptRaw) ||
+            !ctx.TryReadUInt64(stackAddress + 48, out var interruptContextIdRaw))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1082,17 +1081,16 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 8, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(8, ItNop, RReleaseMem)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, action | (cachePolicy << 8)) ||
-            !TryWriteUInt32(
-                ctx,
+            !ctx.TryWriteUInt32(commandAddress, Pm4(8, ItNop, RReleaseMem)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, action | (cachePolicy << 8)) ||
+            !ctx.TryWriteUInt32(
                 commandAddress + 8,
                 gcrControl | (dataSelection << 16) | (interrupt << 24)) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, (uint)destinationAddress) ||
-            !TryWriteUInt32(ctx, commandAddress + 16, (uint)(destinationAddress >> 32)) ||
-            !TryWriteUInt32(ctx, commandAddress + 20, (uint)data) ||
-            !TryWriteUInt32(ctx, commandAddress + 24, (uint)(data >> 32)) ||
-            !TryWriteUInt32(ctx, commandAddress + 28, interruptContextId))
+            !ctx.TryWriteUInt32(commandAddress + 12, (uint)destinationAddress) ||
+            !ctx.TryWriteUInt32(commandAddress + 16, (uint)(destinationAddress >> 32)) ||
+            !ctx.TryWriteUInt32(commandAddress + 20, (uint)data) ||
+            !ctx.TryWriteUInt32(commandAddress + 24, (uint)(data >> 32)) ||
+            !ctx.TryWriteUInt32(commandAddress + 28, interruptContextId))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1119,8 +1117,8 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 2, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(2, ItNop, RDrawReset)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, 0))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(2, ItNop, RDrawReset)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, 0))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1169,8 +1167,8 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 2, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(2, ItIndexType, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, indexSize))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(2, ItIndexType, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, indexSize))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1194,8 +1192,8 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 2, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(2, ItNumInstances, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, instanceCount))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(2, ItNumInstances, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, instanceCount))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1222,21 +1220,21 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 5, out var baseCommand) ||
-            !TryWriteUInt32(ctx, baseCommand, Pm4(3, ItIndexBase, 0)) ||
-            !TryWriteUInt32(ctx, baseCommand + 4, (uint)indexAddress) ||
-            !TryWriteUInt32(ctx, baseCommand + 8, (uint)(indexAddress >> 32)) ||
-            !TryWriteUInt32(ctx, baseCommand + 12, Pm4(2, ItIndexBufferSize, 0)) ||
-            !TryWriteUInt32(ctx, baseCommand + 16, indexCount))
+            !ctx.TryWriteUInt32(baseCommand, Pm4(3, ItIndexBase, 0)) ||
+            !ctx.TryWriteUInt32(baseCommand + 4, (uint)indexAddress) ||
+            !ctx.TryWriteUInt32(baseCommand + 8, (uint)(indexAddress >> 32)) ||
+            !ctx.TryWriteUInt32(baseCommand + 12, Pm4(2, ItIndexBufferSize, 0)) ||
+            !ctx.TryWriteUInt32(baseCommand + 16, indexCount))
         {
             return ReturnPointer(ctx, 0);
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 5, out var drawCommand) ||
-            !TryWriteUInt32(ctx, drawCommand, Pm4(5, ItDrawIndex2, 0)) ||
-            !TryWriteUInt32(ctx, drawCommand + 4, indexCount) ||
-            !TryWriteUInt32(ctx, drawCommand + 8, 0) ||
-            !TryWriteUInt32(ctx, drawCommand + 12, 0) ||
-            !TryWriteUInt32(ctx, drawCommand + 16, 0))
+            !ctx.TryWriteUInt32(drawCommand, Pm4(5, ItDrawIndex2, 0)) ||
+            !ctx.TryWriteUInt32(drawCommand + 4, indexCount) ||
+            !ctx.TryWriteUInt32(drawCommand + 8, 0) ||
+            !ctx.TryWriteUInt32(drawCommand + 12, 0) ||
+            !ctx.TryWriteUInt32(drawCommand + 16, 0))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1265,13 +1263,13 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 7, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(7, ItNop, RDrawIndexAuto)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, indexCount) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 16, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 20, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 24, 0))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(7, ItNop, RDrawIndexAuto)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, indexCount) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, 0) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, 0) ||
+            !ctx.TryWriteUInt32(commandAddress + 16, 0) ||
+            !ctx.TryWriteUInt32(commandAddress + 20, 0) ||
+            !ctx.TryWriteUInt32(commandAddress + 24, 0))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1305,8 +1303,8 @@ public static class AgcExports
         var control = (uint)ctx[CpuRegister.Rcx];
         var counterMask = (uint)ctx[CpuRegister.R8] & 0xFFu;
         var resetCounters = (uint)ctx[CpuRegister.R9] & 0x1u;
-        if (!TryReadUInt64(ctx, ctx[CpuRegister.Rsp] + sizeof(ulong), out var enableRaw) ||
-            !TryReadUInt64(ctx, ctx[CpuRegister.Rsp] + (2 * sizeof(ulong)), out var counterSelectRaw) ||
+        if (!ctx.TryReadUInt64(ctx[CpuRegister.Rsp] + sizeof(ulong), out var enableRaw) ||
+            !ctx.TryReadUInt64(ctx[CpuRegister.Rsp] + (2 * sizeof(ulong)), out var counterSelectRaw) ||
             commandBufferAddress == 0)
         {
             return ReturnPointer(ctx, 0);
@@ -1321,11 +1319,11 @@ public static class AgcExports
             (counterMask << 10) |
             (counterSelect << 2);
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 5, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(5, ItGetLodStats, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, control) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, (uint)destinationAddress & ~0x3Fu) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, (uint)(destinationAddress >> 32)) ||
-            !TryWriteUInt32(ctx, commandAddress + 16, packetControl))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(5, ItGetLodStats, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, control) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, (uint)destinationAddress & ~0x3Fu) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, (uint)(destinationAddress >> 32)) ||
+            !ctx.TryWriteUInt32(commandAddress + 16, packetControl))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1352,8 +1350,8 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 2, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(2, ItEventWrite, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, eventType))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(2, ItEventWrite, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, eventType))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1375,7 +1373,7 @@ public static class AgcExports
         var gcrControl = (uint)ctx[CpuRegister.Rcx];
         var baseAddress = ctx[CpuRegister.R8];
         var sizeBytes = ctx[CpuRegister.R9];
-        if (!TryReadUInt32(ctx, ctx[CpuRegister.Rsp] + sizeof(ulong), out var pollCycles))
+        if (!ctx.TryReadUInt32(ctx[CpuRegister.Rsp] + sizeof(ulong), out var pollCycles))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1392,14 +1390,14 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 8, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(8, ItNop, RAcquireMem)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, (engine << 31) | cbDbOp) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, noSize ? 0 : (uint)(sizeBytes >> 8)) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 16, (uint)(baseAddress >> 8)) ||
-            !TryWriteUInt32(ctx, commandAddress + 20, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 24, pollCycles / 40) ||
-            !TryWriteUInt32(ctx, commandAddress + 28, gcrControl))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(8, ItNop, RAcquireMem)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, (engine << 31) | cbDbOp) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, noSize ? 0 : (uint)(sizeBytes >> 8)) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, 0) ||
+            !ctx.TryWriteUInt32(commandAddress + 16, (uint)(baseAddress >> 8)) ||
+            !ctx.TryWriteUInt32(commandAddress + 20, 0) ||
+            !ctx.TryWriteUInt32(commandAddress + 24, pollCycles / 40) ||
+            !ctx.TryWriteUInt32(commandAddress + 28, gcrControl))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1424,8 +1422,8 @@ public static class AgcExports
         var dataAddress = ctx[CpuRegister.R8];
         var dwordCount = (uint)ctx[CpuRegister.R9];
         var stackAddress = ctx[CpuRegister.Rsp];
-        if (!TryReadUInt64(ctx, stackAddress + sizeof(ulong), out var incrementRaw) ||
-            !TryReadUInt64(ctx, stackAddress + (2 * sizeof(ulong)), out var writeConfirmRaw))
+        if (!ctx.TryReadUInt64(stackAddress + sizeof(ulong), out var incrementRaw) ||
+            !ctx.TryReadUInt64(stackAddress + (2 * sizeof(ulong)), out var writeConfirmRaw))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1442,21 +1440,20 @@ public static class AgcExports
 
         var packetDwords = dwordCount + 4;
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, packetDwords, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(packetDwords, ItNop, RWriteData)) ||
-            !TryWriteUInt32(
-                ctx,
+            !ctx.TryWriteUInt32(commandAddress, Pm4(packetDwords, ItNop, RWriteData)) ||
+            !ctx.TryWriteUInt32(
                 commandAddress + 4,
                 destination | (cachePolicy << 8) | (increment << 16) | (writeConfirm << 24)) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, (uint)destinationAddress) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, (uint)(destinationAddress >> 32)))
+            !ctx.TryWriteUInt32(commandAddress + 8, (uint)destinationAddress) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, (uint)(destinationAddress >> 32)))
         {
             return ReturnPointer(ctx, 0);
         }
 
         for (uint index = 0; index < dwordCount; index++)
         {
-            if (!TryReadUInt32(ctx, dataAddress + ((ulong)index * sizeof(uint)), out var value) ||
-                !TryWriteUInt32(ctx, commandAddress + 16 + ((ulong)index * sizeof(uint)), value))
+            if (!ctx.TryReadUInt32(dataAddress + ((ulong)index * sizeof(uint)), out var value) ||
+                !ctx.TryWriteUInt32(commandAddress + 16 + ((ulong)index * sizeof(uint)), value))
             {
                 return ReturnPointer(ctx, 0);
             }
@@ -1487,9 +1484,9 @@ public static class AgcExports
         var cachePolicy = (uint)(ctx[CpuRegister.R8] & 0xFF);
         var address = ctx[CpuRegister.R9];
         var stackAddress = ctx[CpuRegister.Rsp];
-        if (!TryReadUInt64(ctx, stackAddress + sizeof(ulong), out var reference) ||
-            !TryReadUInt64(ctx, stackAddress + (2 * sizeof(ulong)), out var mask) ||
-            !TryReadUInt32(ctx, stackAddress + (3 * sizeof(ulong)), out var pollCycles))
+        if (!ctx.TryReadUInt64(stackAddress + sizeof(ulong), out var reference) ||
+            !ctx.TryReadUInt64(stackAddress + (2 * sizeof(ulong)), out var mask) ||
+            !ctx.TryReadUInt32(stackAddress + (3 * sizeof(ulong)), out var pollCycles))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1513,37 +1510,37 @@ public static class AgcExports
 
         if (standardWait)
         {
-            if (!TryWriteUInt32(ctx, commandAddress, Pm4(packetDwords, ItWaitRegMem, 0)) ||
-                !TryWriteUInt32(ctx, commandAddress + 4, compareFunction | ((operation & 1) << 8)) ||
-                !TryWriteUInt32(ctx, commandAddress + 8, (uint)address) ||
-                !TryWriteUInt32(ctx, commandAddress + 12, (uint)(address >> 32)) ||
-                !TryWriteUInt32(ctx, commandAddress + 16, (uint)reference) ||
-                !TryWriteUInt32(ctx, commandAddress + 20, (uint)mask) ||
-                !TryWriteUInt32(ctx, commandAddress + 24, pollCycles / 40))
+            if (!ctx.TryWriteUInt32(commandAddress, Pm4(packetDwords, ItWaitRegMem, 0)) ||
+                !ctx.TryWriteUInt32(commandAddress + 4, compareFunction | ((operation & 1) << 8)) ||
+                !ctx.TryWriteUInt32(commandAddress + 8, (uint)address) ||
+                !ctx.TryWriteUInt32(commandAddress + 12, (uint)(address >> 32)) ||
+                !ctx.TryWriteUInt32(commandAddress + 16, (uint)reference) ||
+                !ctx.TryWriteUInt32(commandAddress + 20, (uint)mask) ||
+                !ctx.TryWriteUInt32(commandAddress + 24, pollCycles / 40))
             {
                 return ReturnPointer(ctx, 0);
             }
         }
-        else if (!TryWriteUInt32(ctx, commandAddress, Pm4(packetDwords, ItNop, packetRegister)) ||
-                 !TryWriteUInt32(ctx, commandAddress + 4, (uint)address) ||
-                 !TryWriteUInt32(ctx, commandAddress + 8, (uint)(address >> 32)) ||
-                 !TryWriteUInt32(ctx, commandAddress + 12, (uint)mask))
+        else if (!ctx.TryWriteUInt32(commandAddress, Pm4(packetDwords, ItNop, packetRegister)) ||
+                 !ctx.TryWriteUInt32(commandAddress + 4, (uint)address) ||
+                 !ctx.TryWriteUInt32(commandAddress + 8, (uint)(address >> 32)) ||
+                 !ctx.TryWriteUInt32(commandAddress + 12, (uint)mask))
         {
             return ReturnPointer(ctx, 0);
         }
         else if (size == 0)
         {
-            if (!TryWriteUInt32(ctx, commandAddress + 16, compareFunction | (operation << 8)) ||
-                !TryWriteUInt32(ctx, commandAddress + 20, (uint)reference))
+            if (!ctx.TryWriteUInt32(commandAddress + 16, compareFunction | (operation << 8)) ||
+                !ctx.TryWriteUInt32(commandAddress + 20, (uint)reference))
             {
                 return ReturnPointer(ctx, 0);
             }
         }
-        else if (!TryWriteUInt32(ctx, commandAddress + 16, (uint)(mask >> 32)) ||
-                 !TryWriteUInt32(ctx, commandAddress + 20, (uint)reference) ||
-                 !TryWriteUInt32(ctx, commandAddress + 24, (uint)(reference >> 32)) ||
-                 !TryWriteUInt32(ctx, commandAddress + 28, compareFunction | (operation << 8)) ||
-                 !TryWriteUInt32(ctx, commandAddress + 32, pollCycles / 40))
+        else if (!ctx.TryWriteUInt32(commandAddress + 16, (uint)(mask >> 32)) ||
+                 !ctx.TryWriteUInt32(commandAddress + 20, (uint)reference) ||
+                 !ctx.TryWriteUInt32(commandAddress + 24, (uint)(reference >> 32)) ||
+                 !ctx.TryWriteUInt32(commandAddress + 28, compareFunction | (operation << 8)) ||
+                 !ctx.TryWriteUInt32(commandAddress + 32, pollCycles / 40))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1573,12 +1570,12 @@ public static class AgcExports
         var destinationAddress = ctx[CpuRegister.R8];
         var sourceCachePolicy = (uint)(ctx[CpuRegister.R9] & 0xFF);
         var stackAddress = ctx[CpuRegister.Rsp];
-        if (!TryReadUInt64(ctx, stackAddress + sizeof(ulong), out var control4Raw) ||
-            !TryReadUInt64(ctx, stackAddress + (2 * sizeof(ulong)), out var sourceAddress) ||
-            !TryReadUInt32(ctx, stackAddress + (3 * sizeof(ulong)), out var byteCount) ||
-            !TryReadUInt64(ctx, stackAddress + (4 * sizeof(ulong)), out var control7Raw) ||
-            !TryReadUInt64(ctx, stackAddress + (5 * sizeof(ulong)), out var control8Raw) ||
-            !TryReadUInt64(ctx, stackAddress + (6 * sizeof(ulong)), out var control9Raw))
+        if (!ctx.TryReadUInt64(stackAddress + sizeof(ulong), out var control4Raw) ||
+            !ctx.TryReadUInt64(stackAddress + (2 * sizeof(ulong)), out var sourceAddress) ||
+            !ctx.TryReadUInt32(stackAddress + (3 * sizeof(ulong)), out var byteCount) ||
+            !ctx.TryReadUInt64(stackAddress + (4 * sizeof(ulong)), out var control7Raw) ||
+            !ctx.TryReadUInt64(stackAddress + (5 * sizeof(ulong)), out var control8Raw) ||
+            !ctx.TryReadUInt64(stackAddress + (6 * sizeof(ulong)), out var control9Raw))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1593,19 +1590,17 @@ public static class AgcExports
         var control8 = (uint)(control8Raw & 0xFF);
         var control9 = (uint)(control9Raw & 0xFF);
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 8, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(8, ItNop, RDmaData)) ||
-            !TryWriteUInt32(
-                ctx,
+            !ctx.TryWriteUInt32(commandAddress, Pm4(8, ItNop, RDmaData)) ||
+            !ctx.TryWriteUInt32(
                 commandAddress + 4,
                 destination |
                 (destinationCachePolicy << 8) |
                 (source << 16) |
                 (sourceCachePolicy << 24)) ||
-            !TryWriteUInt32(
-                ctx,
+            !ctx.TryWriteUInt32(
                 commandAddress + 8,
                 control4 | (control7 << 8) | (control8 << 16) | (control9 << 24)) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, byteCount) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, byteCount) ||
             !ctx.TryWriteUInt64(commandAddress + 16, destinationAddress) ||
             !ctx.TryWriteUInt64(commandAddress + 24, sourceAddress))
         {
@@ -1631,10 +1626,10 @@ public static class AgcExports
         var address = ctx[CpuRegister.Rdx];
         if (commandBufferAddress == 0 ||
             !TryAllocateCommandDwords(ctx, commandBufferAddress, 4, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(4, ItSetBase, 0) | (baseIndex << 1)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, 1) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, (uint)address & ~7u) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, (uint)(address >> 32)))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(4, ItSetBase, 0) | (baseIndex << 1)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, 1) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, (uint)address & ~7u) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, (uint)(address >> 32)))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1654,9 +1649,9 @@ public static class AgcExports
         var modifier = (uint)ctx[CpuRegister.Rdx];
         if (commandBufferAddress == 0 ||
             !TryAllocateCommandDwords(ctx, commandBufferAddress, 3, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(3, ItDispatchIndirect, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, dataOffset) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, (modifier & 0xA038u) | 0x41u))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(3, ItDispatchIndirect, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, dataOffset) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, (modifier & 0xA038u) | 0x41u))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1682,7 +1677,7 @@ public static class AgcExports
         var payloadDwords = Math.Max(((uint)marker.Length + 4) / 4, 1);
         var packetDwords = payloadDwords + 1;
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, packetDwords, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(packetDwords, ItNop, RPushMarker)))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(packetDwords, ItNop, RPushMarker)))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1699,7 +1694,7 @@ public static class AgcExports
                 }
             }
 
-            if (!TryWriteUInt32(ctx, commandAddress + 4 + ((ulong)index * sizeof(uint)), value))
+            if (!ctx.TryWriteUInt32(commandAddress + 4 + ((ulong)index * sizeof(uint)), value))
             {
                 return ReturnPointer(ctx, 0);
             }
@@ -1718,8 +1713,8 @@ public static class AgcExports
         var commandBufferAddress = ctx[CpuRegister.Rdi];
         if (commandBufferAddress == 0 ||
             !TryAllocateCommandDwords(ctx, commandBufferAddress, 2, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(2, ItNop, RPopMarker)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, 0))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(2, ItNop, RPopMarker)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, 0))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1814,11 +1809,11 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 5, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(3, ItIndexBase, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, (uint)(indexBufferAddress & 0xFFFF_FFFFUL)) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, (uint)(indexBufferAddress >> 32)) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, Pm4(2, ItIndexBufferSize, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 16, indexCount))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(3, ItIndexBase, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, (uint)(indexBufferAddress & 0xFFFF_FFFFUL)) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, (uint)(indexBufferAddress >> 32)) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, Pm4(2, ItIndexBufferSize, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 16, indexCount))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1844,11 +1839,11 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 5, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(5, ItDrawIndexOffset2, 0)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, indexCount) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, indexOffset) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, indexCount) ||
-            !TryWriteUInt32(ctx, commandAddress + 16, flags & 0xE000_0001u))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(5, ItDrawIndexOffset2, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, indexCount) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, indexOffset) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, indexCount) ||
+            !ctx.TryWriteUInt32(commandAddress + 16, flags & 0xE000_0001u))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1873,13 +1868,13 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 7, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(7, ItNop, RWaitFlipDone)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, videoOutHandle) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, displayBufferIndex) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 16, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 20, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 24, 0))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(7, ItNop, RWaitFlipDone)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, videoOutHandle) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, displayBufferIndex) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, 0) ||
+            !ctx.TryWriteUInt32(commandAddress + 16, 0) ||
+            !ctx.TryWriteUInt32(commandAddress + 20, 0) ||
+            !ctx.TryWriteUInt32(commandAddress + 24, 0))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1906,12 +1901,12 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 6, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(6, ItNop, RFlip)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, videoOutHandle) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, unchecked((uint)displayBufferIndex)) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, flipMode) ||
-            !TryWriteUInt32(ctx, commandAddress + 16, (uint)(flipArg & 0xFFFF_FFFFUL)) ||
-            !TryWriteUInt32(ctx, commandAddress + 20, (uint)(flipArg >> 32)))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(6, ItNop, RFlip)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, videoOutHandle) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, unchecked((uint)displayBufferIndex)) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, flipMode) ||
+            !ctx.TryWriteUInt32(commandAddress + 16, (uint)(flipArg & 0xFFFF_FFFFUL)) ||
+            !ctx.TryWriteUInt32(commandAddress + 20, (uint)(flipArg >> 32)))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -1973,8 +1968,8 @@ public static class AgcExports
     {
         var packetAddress = ctx[CpuRegister.Rdi];
         if (packetAddress == 0 ||
-            !TryReadUInt64(ctx, packetAddress, out var commandAddress) ||
-            !TryReadUInt32(ctx, packetAddress + 8, out var dwordCount))
+            !ctx.TryReadUInt64(packetAddress, out var commandAddress) ||
+            !ctx.TryReadUInt32(packetAddress + 8, out var dwordCount))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
@@ -2013,8 +2008,8 @@ public static class AgcExports
         var ownerHandle = (uint)ctx[CpuRegister.Rdi];
         var packetAddress = ctx[CpuRegister.Rsi];
         if (packetAddress == 0 ||
-            !TryReadUInt64(ctx, packetAddress, out var commandAddress) ||
-            !TryReadUInt32(ctx, packetAddress + 8, out var dwordCount))
+            !ctx.TryReadUInt64(packetAddress, out var commandAddress) ||
+            !ctx.TryReadUInt32(packetAddress + 8, out var dwordCount))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
@@ -2065,7 +2060,7 @@ public static class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryWriteUInt32(ctx, outAddress, 256))
+        if (!ctx.TryWriteUInt32(outAddress, 256))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -2089,7 +2084,7 @@ public static class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryWriteUInt32(ctx, ownerAddress, DefaultAgcOwner))
+        if (!ctx.TryWriteUInt32(ownerAddress, DefaultAgcOwner))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -2155,7 +2150,7 @@ public static class AgcExports
         var commandBufferAddress = ctx[CpuRegister.Rdi];
         if (commandBufferAddress == 0 ||
             !TryAllocateCommandDwords(ctx, commandBufferAddress, 1, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, 0x8000_0000))
+            !ctx.TryWriteUInt32(commandAddress, 0x8000_0000))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -2183,7 +2178,7 @@ public static class AgcExports
         while (offset < dwordCount)
         {
             var currentAddress = commandAddress + ((ulong)offset * sizeof(uint));
-            if (!TryReadUInt32(ctx, currentAddress, out var header))
+            if (!ctx.TryReadUInt32(currentAddress, out var header))
             {
                 return;
             }
@@ -2230,16 +2225,16 @@ public static class AgcExports
 
             if (op == ItSetBase &&
                 length >= 4 &&
-                TryReadUInt32(ctx, currentAddress + 4, out var baseSelector) &&
+                ctx.TryReadUInt32(currentAddress + 4, out var baseSelector) &&
                 baseSelector == 1 &&
-                TryReadUInt64(ctx, currentAddress + 8, out var indirectArgsAddress))
+                ctx.TryReadUInt64(currentAddress + 8, out var indirectArgsAddress))
             {
                 state.IndirectArgsAddress = indirectArgsAddress;
             }
 
             if (op == ItEventWrite &&
                 length >= 2 &&
-                TryReadUInt32(ctx, currentAddress + sizeof(uint), out var eventTypeRaw))
+                ctx.TryReadUInt32(currentAddress + sizeof(uint), out var eventTypeRaw))
             {
                 var eventType = eventTypeRaw & 0x3Fu;
                 var triggered = KernelEventQueueCompatExports.TriggerRegisteredEvents(
@@ -2279,8 +2274,8 @@ public static class AgcExports
 
             if (op == ItIndexBase &&
                 length >= 3 &&
-                TryReadUInt32(ctx, currentAddress + 4, out var indexBaseLo) &&
-                TryReadUInt32(ctx, currentAddress + 8, out var indexBaseHi))
+                ctx.TryReadUInt32(currentAddress + 4, out var indexBaseLo) &&
+                ctx.TryReadUInt32(currentAddress + 8, out var indexBaseHi))
             {
                 state.IndexBufferAddress =
                     indexBaseLo | ((ulong)indexBaseHi << 32);
@@ -2288,21 +2283,21 @@ public static class AgcExports
 
             if (op == ItIndexBufferSize &&
                 length >= 2 &&
-                TryReadUInt32(ctx, currentAddress + 4, out var indexBufferCount))
+                ctx.TryReadUInt32(currentAddress + 4, out var indexBufferCount))
             {
                 state.IndexBufferCount = indexBufferCount;
             }
 
             if (op == ItIndexType &&
                 length >= 2 &&
-                TryReadUInt32(ctx, currentAddress + 4, out var indexSize))
+                ctx.TryReadUInt32(currentAddress + 4, out var indexSize))
             {
                 state.IndexSize = indexSize & 0x3;
             }
 
             if (op == ItNumInstances &&
                 length >= 2 &&
-                TryReadUInt32(ctx, currentAddress + 4, out var instanceCount))
+                ctx.TryReadUInt32(currentAddress + 4, out var instanceCount))
             {
                 state.InstanceCount = Math.Max(instanceCount, 1);
             }
@@ -2348,7 +2343,7 @@ public static class AgcExports
             if (op == ItNop &&
                 register == RDrawIndexAuto &&
                 length >= 2 &&
-                TryReadUInt32(ctx, currentAddress + 4, out var autoIndexCount) &&
+                ctx.TryReadUInt32(currentAddress + 4, out var autoIndexCount) &&
                 autoIndexCount != 0)
             {
                 TryTranslateGuestDraw(
@@ -2373,11 +2368,11 @@ public static class AgcExports
 
             if (op == ItNop && register == RFlip && length >= 6)
             {
-                if (!TryReadUInt32(ctx, currentAddress + 4, out var videoOutHandle) ||
-                    !TryReadUInt32(ctx, currentAddress + 8, out var displayBufferIndexRaw) ||
-                    !TryReadUInt32(ctx, currentAddress + 12, out var flipMode) ||
-                    !TryReadUInt32(ctx, currentAddress + 16, out var flipArgLo) ||
-                    !TryReadUInt32(ctx, currentAddress + 20, out var flipArgHi))
+                if (!ctx.TryReadUInt32(currentAddress + 4, out var videoOutHandle) ||
+                    !ctx.TryReadUInt32(currentAddress + 8, out var displayBufferIndexRaw) ||
+                    !ctx.TryReadUInt32(currentAddress + 12, out var flipMode) ||
+                    !ctx.TryReadUInt32(currentAddress + 16, out var flipArgLo) ||
+                    !ctx.TryReadUInt32(currentAddress + 20, out var flipArgHi))
                 {
                     return;
                 }
@@ -2502,9 +2497,9 @@ public static class AgcExports
         ulong packetAddress,
         bool tracePacket)
     {
-        if (!TryReadUInt32(ctx, packetAddress + 12, out var byteCount) ||
-            !TryReadUInt64(ctx, packetAddress + 16, out var destinationAddress) ||
-            !TryReadUInt64(ctx, packetAddress + 24, out var sourceAddress))
+        if (!ctx.TryReadUInt32(packetAddress + 12, out var byteCount) ||
+            !ctx.TryReadUInt64(packetAddress + 16, out var destinationAddress) ||
+            !ctx.TryReadUInt64(packetAddress + 24, out var sourceAddress))
         {
             return;
         }
@@ -2527,12 +2522,12 @@ public static class AgcExports
         CpuContext ctx,
         ulong packetAddress)
     {
-        if (!TryReadUInt32(ctx, packetAddress + 4, out var control) ||
-            !TryReadUInt32(ctx, packetAddress + 8, out var sourceLow) ||
-            !TryReadUInt32(ctx, packetAddress + 12, out var sourceHigh) ||
-            !TryReadUInt32(ctx, packetAddress + 16, out var destinationLow) ||
-            !TryReadUInt32(ctx, packetAddress + 20, out var destinationHigh) ||
-            !TryReadUInt32(ctx, packetAddress + 24, out var command))
+        if (!ctx.TryReadUInt32(packetAddress + 4, out var control) ||
+            !ctx.TryReadUInt32(packetAddress + 8, out var sourceLow) ||
+            !ctx.TryReadUInt32(packetAddress + 12, out var sourceHigh) ||
+            !ctx.TryReadUInt32(packetAddress + 16, out var destinationLow) ||
+            !ctx.TryReadUInt32(packetAddress + 20, out var destinationHigh) ||
+            !ctx.TryReadUInt32(packetAddress + 24, out var command))
         {
             return;
         }
@@ -2563,7 +2558,7 @@ public static class AgcExports
             if (sourceAddressIncrement != 0)
             {
                 copied =
-                    TryReadUInt32(ctx, sourceAddress, out var fillValue) &&
+                    ctx.TryReadUInt32(sourceAddress, out var fillValue) &&
                     TryFillGuestMemory(
                         ctx,
                         fillValue,
@@ -2609,8 +2604,8 @@ public static class AgcExports
         uint packetLength,
         bool tracePacket)
     {
-        if (!TryReadUInt32(ctx, packetAddress + 4, out var control) ||
-            !TryReadUInt64(ctx, packetAddress + 8, out var destinationAddress))
+        if (!ctx.TryReadUInt32(packetAddress + 4, out var control) ||
+            !ctx.TryReadUInt64(packetAddress + 8, out var destinationAddress))
         {
             return;
         }
@@ -2625,8 +2620,8 @@ public static class AgcExports
             var targetAddress = destinationAddress +
                 (increment == 0 ? (ulong)index * sizeof(uint) : 0);
             wroteData =
-                TryReadUInt32(ctx, sourceAddress, out var value) &&
-                TryWriteUInt32(ctx, targetAddress, value);
+                ctx.TryReadUInt32(sourceAddress, out var value) &&
+                ctx.TryWriteUInt32(targetAddress, value);
         }
 
         if (tracePacket)
@@ -2643,8 +2638,8 @@ public static class AgcExports
         bool is64Bit,
         bool tracePacket)
     {
-        if (!TryReadUInt64(ctx, packetAddress + 4, out var address) ||
-            !TryReadUInt32(ctx, packetAddress + (is64Bit ? 28u : 16u), out var control))
+        if (!ctx.TryReadUInt64(packetAddress + 4, out var address) ||
+            !ctx.TryReadUInt32(packetAddress + (is64Bit ? 28u : 16u), out var control))
         {
             return;
         }
@@ -2654,18 +2649,18 @@ public static class AgcExports
         ulong value;
         if (is64Bit)
         {
-            if (!TryReadUInt64(ctx, packetAddress + 12, out mask) ||
-                !TryReadUInt64(ctx, packetAddress + 20, out reference) ||
-                !TryReadUInt64(ctx, address, out value))
+            if (!ctx.TryReadUInt64(packetAddress + 12, out mask) ||
+                !ctx.TryReadUInt64(packetAddress + 20, out reference) ||
+                !ctx.TryReadUInt64(address, out value))
             {
                 return;
             }
         }
         else
         {
-            if (!TryReadUInt32(ctx, packetAddress + 12, out var mask32) ||
-                !TryReadUInt32(ctx, packetAddress + 20, out var reference32) ||
-                !TryReadUInt32(ctx, address, out var value32))
+            if (!ctx.TryReadUInt32(packetAddress + 12, out var mask32) ||
+                !ctx.TryReadUInt32(packetAddress + 20, out var reference32) ||
+                !ctx.TryReadUInt32(address, out var value32))
             {
                 return;
             }
@@ -2691,11 +2686,11 @@ public static class AgcExports
         ulong packetAddress,
         bool tracePacket)
     {
-        if (!TryReadUInt32(ctx, packetAddress + 4, out var control) ||
-            !TryReadUInt64(ctx, packetAddress + 8, out var address) ||
-            !TryReadUInt32(ctx, packetAddress + 16, out var reference) ||
-            !TryReadUInt32(ctx, packetAddress + 20, out var mask) ||
-            !TryReadUInt32(ctx, address, out var value))
+        if (!ctx.TryReadUInt32(packetAddress + 4, out var control) ||
+            !ctx.TryReadUInt64(packetAddress + 8, out var address) ||
+            !ctx.TryReadUInt32(packetAddress + 16, out var reference) ||
+            !ctx.TryReadUInt32(packetAddress + 20, out var mask) ||
+            !ctx.TryReadUInt32(address, out var value))
         {
             return;
         }
@@ -2740,11 +2735,11 @@ public static class AgcExports
         ulong packetAddress,
         bool tracePacket)
     {
-        if (!TryReadUInt32(ctx, packetAddress + 8, out var control) ||
-            !TryReadUInt32(ctx, packetAddress + 12, out var destinationLo) ||
-            !TryReadUInt32(ctx, packetAddress + 16, out var destinationHi) ||
-            !TryReadUInt32(ctx, packetAddress + 20, out var dataLo) ||
-            !TryReadUInt32(ctx, packetAddress + 24, out var dataHi))
+        if (!ctx.TryReadUInt32(packetAddress + 8, out var control) ||
+            !ctx.TryReadUInt32(packetAddress + 12, out var destinationLo) ||
+            !ctx.TryReadUInt32(packetAddress + 16, out var destinationHi) ||
+            !ctx.TryReadUInt32(packetAddress + 20, out var dataLo) ||
+            !ctx.TryReadUInt32(packetAddress + 24, out var dataHi))
         {
             return;
         }
@@ -2754,7 +2749,7 @@ public static class AgcExports
         var data = ((ulong)dataHi << 32) | dataLo;
         var wroteData = dataSelection switch
         {
-            1 or 2 => TryWriteUInt32(ctx, destinationAddress, dataLo),
+            1 or 2 => ctx.TryWriteUInt32(destinationAddress, dataLo),
             3 => ctx.TryWriteUInt64(destinationAddress, data),
             _ => false,
         };
@@ -2778,7 +2773,7 @@ public static class AgcExports
         if (op is ItSetShReg or ItSetContextReg or ItSetUconfigReg)
         {
             if (packetLength < 3 ||
-                !TryReadUInt32(ctx, packetAddress + sizeof(uint), out var startRegister))
+                !ctx.TryReadUInt32(packetAddress + sizeof(uint), out var startRegister))
             {
                 return;
             }
@@ -2791,8 +2786,7 @@ public static class AgcExports
             };
             for (uint index = 0; index < packetLength - 2; index++)
             {
-                if (!TryReadUInt32(
-                        ctx,
+                if (!ctx.TryReadUInt32(
                         packetAddress + 8 + ((ulong)index * sizeof(uint)),
                         out var value))
                 {
@@ -2808,8 +2802,8 @@ public static class AgcExports
         if (op != ItNop ||
             register is not (RCxRegsIndirect or RShRegsIndirect or RUcRegsIndirect) ||
             packetLength < 4 ||
-            !TryReadUInt32(ctx, packetAddress + sizeof(uint), out var registerCount) ||
-            !TryReadUInt64(ctx, packetAddress + 8, out var registersAddress))
+            !ctx.TryReadUInt32(packetAddress + sizeof(uint), out var registerCount) ||
+            !ctx.TryReadUInt64(packetAddress + 8, out var registersAddress))
         {
             return;
         }
@@ -2823,8 +2817,8 @@ public static class AgcExports
         for (uint index = 0; index < registerCount; index++)
         {
             var entryAddress = registersAddress + ((ulong)index * 8);
-            if (!TryReadUInt32(ctx, entryAddress, out var registerOffset) ||
-                !TryReadUInt32(ctx, entryAddress + sizeof(uint), out var value))
+            if (!ctx.TryReadUInt32(entryAddress, out var registerOffset) ||
+                !ctx.TryReadUInt32(entryAddress + sizeof(uint), out var value))
             {
                 return;
             }
@@ -2848,20 +2842,20 @@ public static class AgcExports
         switch (op)
         {
             case ItDrawIndexAuto when packetLength >= 3:
-                return TryReadUInt32(ctx, packetAddress + 4, out drawCount);
+                return ctx.TryReadUInt32(packetAddress + 4, out drawCount);
             case ItDrawIndex2 when packetLength >= 6:
                 state.DrawIndexOffset = 0;
-                return TryReadUInt32(ctx, packetAddress + 16, out drawCount);
+                return ctx.TryReadUInt32(packetAddress + 16, out drawCount);
             case ItDrawIndexOffset2 when packetLength >= 5:
-                if (!TryReadUInt32(ctx, packetAddress + 8, out var indexOffset))
+                if (!ctx.TryReadUInt32(packetAddress + 8, out var indexOffset))
                 {
                     return false;
                 }
 
                 state.DrawIndexOffset = indexOffset;
-                return TryReadUInt32(ctx, packetAddress + 12, out drawCount);
+                return ctx.TryReadUInt32(packetAddress + 12, out drawCount);
             case ItDrawIndexMultiAuto when packetLength >= 4:
-                if (!TryReadUInt32(ctx, packetAddress + 12, out var control))
+                if (!ctx.TryReadUInt32(packetAddress + 12, out var control))
                 {
                     return false;
                 }
@@ -2870,13 +2864,12 @@ public static class AgcExports
                 return true;
             case ItDrawIndirect or ItDrawIndexIndirect
                 when packetLength >= 5 && state.IndirectArgsAddress != 0:
-                if (!TryReadUInt32(ctx, packetAddress + 4, out var dataOffset))
+                if (!ctx.TryReadUInt32(packetAddress + 4, out var dataOffset))
                 {
                     return false;
                 }
 
-                return TryReadUInt32(
-                    ctx,
+                return ctx.TryReadUInt32(
                     state.IndirectArgsAddress + dataOffset,
                     out drawCount);
             default:
@@ -3939,7 +3932,7 @@ public static class AgcExports
         if (opcode == ItDispatchDirect)
         {
             if (packetLength < 5 ||
-                !TryReadUInt32(ctx, packetAddress + 16, out initiator))
+                !ctx.TryReadUInt32(packetAddress + 16, out initiator))
             {
                 return false;
             }
@@ -3948,8 +3941,8 @@ public static class AgcExports
         }
         else if (packetLength >= 4)
         {
-            if (!TryReadUInt64(ctx, packetAddress + 4, out dimensionsAddress) ||
-                !TryReadUInt32(ctx, packetAddress + 12, out initiator))
+            if (!ctx.TryReadUInt64(packetAddress + 4, out dimensionsAddress) ||
+                !ctx.TryReadUInt32(packetAddress + 12, out initiator))
             {
                 return false;
             }
@@ -3958,8 +3951,8 @@ public static class AgcExports
         {
             if (packetLength < 3 ||
                 state.IndirectArgsAddress == 0 ||
-                !TryReadUInt32(ctx, packetAddress + 4, out var dataOffset) ||
-                !TryReadUInt32(ctx, packetAddress + 8, out initiator))
+                !ctx.TryReadUInt32(packetAddress + 4, out var dataOffset) ||
+                !ctx.TryReadUInt32(packetAddress + 8, out initiator))
             {
                 return false;
             }
@@ -3968,9 +3961,9 @@ public static class AgcExports
         }
 
         if ((initiator & 1) == 0 ||
-            !TryReadUInt32(ctx, dimensionsAddress, out var groupCountX) ||
-            !TryReadUInt32(ctx, dimensionsAddress + 4, out var groupCountY) ||
-            !TryReadUInt32(ctx, dimensionsAddress + 8, out var groupCountZ) ||
+            !ctx.TryReadUInt32(dimensionsAddress, out var groupCountX) ||
+            !ctx.TryReadUInt32(dimensionsAddress + 4, out var groupCountY) ||
+            !ctx.TryReadUInt32(dimensionsAddress + 8, out var groupCountZ) ||
             groupCountX == 0 ||
             groupCountY == 0 ||
             groupCountZ == 0)
@@ -4746,8 +4739,7 @@ public static class AgcExports
                 .Take(16)
                 .Select(candidate =>
                 {
-                    var type = TryReadByte(
-                        ctx,
+                    var type = ctx.TryReadByte(
                         candidate.Header + ShaderTypeOffset,
                         out var shaderType)
                         ? shaderType.ToString()
@@ -4783,7 +4775,7 @@ public static class AgcExports
     {
         descriptor = default;
         if (packetLength < 10 ||
-            !TryReadUInt32(ctx, packetAddress + 4, out var startRegister))
+            !ctx.TryReadUInt32(packetAddress + 4, out var startRegister))
         {
             return false;
         }
@@ -4802,7 +4794,7 @@ public static class AgcExports
         Span<uint> fields = stackalloc uint[4];
         for (var i = 0; i < fields.Length; i++)
         {
-            if (!TryReadUInt32(ctx, descriptorAddress + ((ulong)i * sizeof(uint)), out fields[i]))
+            if (!ctx.TryReadUInt32(descriptorAddress + ((ulong)i * sizeof(uint)), out fields[i]))
             {
                 return false;
             }
@@ -5025,7 +5017,7 @@ public static class AgcExports
         var payloadCount = Math.Min(length - 1, 32u);
         for (uint i = 0; i < payloadCount; i++)
         {
-            if (!TryReadUInt32(ctx, packetAddress + ((ulong)(i + 1) * sizeof(uint)), out var value))
+            if (!ctx.TryReadUInt32(packetAddress + ((ulong)(i + 1) * sizeof(uint)), out var value))
             {
                 return;
             }
@@ -5036,8 +5028,8 @@ public static class AgcExports
         if (op != ItNop ||
             register is not (RCxRegsIndirect or RShRegsIndirect or RUcRegsIndirect) ||
             length < 4 ||
-            !TryReadUInt32(ctx, packetAddress + 4, out var registerCount) ||
-            !TryReadUInt64(ctx, packetAddress + 8, out var registersAddress))
+            !ctx.TryReadUInt32(packetAddress + 4, out var registerCount) ||
+            !ctx.TryReadUInt64(packetAddress + 8, out var registersAddress))
         {
             return;
         }
@@ -5048,8 +5040,8 @@ public static class AgcExports
         for (uint i = 0; i < tracedCount; i++)
         {
             var entryAddress = registersAddress + ((ulong)i * 8);
-            if (!TryReadUInt32(ctx, entryAddress, out var registerOffset) ||
-                !TryReadUInt32(ctx, entryAddress + 4, out var value))
+            if (!ctx.TryReadUInt32(entryAddress, out var registerOffset) ||
+                !ctx.TryReadUInt32(entryAddress + 4, out var value))
             {
                 TraceAgc($"agc.dcb.indirect_read_failed space={registerSpace} index={i} addr=0x{entryAddress:X16}");
                 return;
@@ -5066,9 +5058,9 @@ public static class AgcExports
 
     private static bool PatchShaderProgramRegisters(CpuContext ctx, ulong headerAddress, ulong codeAddress)
     {
-        if (!TryReadUInt64(ctx, headerAddress + ShaderShRegistersOffset, out var shRegistersAddress) ||
-            !TryReadByte(ctx, headerAddress + ShaderTypeOffset, out var shaderType) ||
-            !TryReadByte(ctx, headerAddress + ShaderNumShRegistersOffset, out var registerCount))
+        if (!ctx.TryReadUInt64(headerAddress + ShaderShRegistersOffset, out var shRegistersAddress) ||
+            !ctx.TryReadByte(headerAddress + ShaderTypeOffset, out var shaderType) ||
+            !ctx.TryReadByte(headerAddress + ShaderNumShRegistersOffset, out var registerCount))
         {
             return false;
         }
@@ -5078,8 +5070,8 @@ public static class AgcExports
             return false;
         }
 
-        if (!TryReadUInt32(ctx, shRegistersAddress, out var loRegister) ||
-            !TryReadUInt32(ctx, shRegistersAddress + 8, out var hiRegister))
+        if (!ctx.TryReadUInt32(shRegistersAddress, out var loRegister) ||
+            !ctx.TryReadUInt32(shRegistersAddress + 8, out var hiRegister))
         {
             return false;
         }
@@ -5108,8 +5100,8 @@ public static class AgcExports
 
         var loValue = (uint)((codeAddress >> 8) & 0xFFFF_FFFFUL);
         var hiValue = (uint)((codeAddress >> 40) & 0xFFUL);
-        return TryWriteUInt32(ctx, shRegistersAddress + sizeof(uint), loValue) &&
-               TryWriteUInt32(ctx, shRegistersAddress + 8 + sizeof(uint), hiValue);
+        return ctx.TryWriteUInt32(shRegistersAddress + sizeof(uint), loValue) &&
+               ctx.TryWriteUInt32(shRegistersAddress + 8 + sizeof(uint), hiValue);
     }
 
     private static bool IsEsGeometryShaderType(byte shaderType) =>
@@ -5124,8 +5116,8 @@ public static class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryWriteUInt32(ctx, commandAddress + 8, (uint)(registersAddress & 0xFFFF_FFFFUL)) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, (uint)(registersAddress >> 32)))
+        if (!ctx.TryWriteUInt32(commandAddress + 8, (uint)(registersAddress & 0xFFFF_FFFFUL)) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, (uint)(registersAddress >> 32)))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -5144,8 +5136,8 @@ public static class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryReadUInt32(ctx, commandAddress + 4, out var currentCount) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, currentCount + registerCount))
+        if (!ctx.TryReadUInt32(commandAddress + 4, out var currentCount) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, currentCount + registerCount))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -5166,10 +5158,10 @@ public static class AgcExports
         }
 
         if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 4, out var commandAddress) ||
-            !TryWriteUInt32(ctx, commandAddress, Pm4(4, ItNop, packetRegister)) ||
-            !TryWriteUInt32(ctx, commandAddress + 4, registerCount) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, (uint)(registersAddress & 0xFFFF_FFFFUL)) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, (uint)(registersAddress >> 32)))
+            !ctx.TryWriteUInt32(commandAddress, Pm4(4, ItNop, packetRegister)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, registerCount) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, (uint)(registersAddress & 0xFFFF_FFFFUL)) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, (uint)(registersAddress >> 32)))
         {
             return ReturnPointer(ctx, 0);
         }
@@ -5182,10 +5174,10 @@ public static class AgcExports
     {
         commandAddress = 0;
         if (sizeDwords == 0 ||
-            !TryReadUInt64(ctx, commandBufferAddress + CommandBufferCursorUpOffset, out var cursorUp) ||
-            !TryReadUInt64(ctx, commandBufferAddress + CommandBufferCursorDownOffset, out var cursorDown) ||
-            !TryReadUInt64(ctx, commandBufferAddress + CommandBufferCallbackOffset, out var callback) ||
-            !TryReadUInt32(ctx, commandBufferAddress + CommandBufferReservedDwOffset, out var reservedDwords))
+            !ctx.TryReadUInt64(commandBufferAddress + CommandBufferCursorUpOffset, out var cursorUp) ||
+            !ctx.TryReadUInt64(commandBufferAddress + CommandBufferCursorDownOffset, out var cursorDown) ||
+            !ctx.TryReadUInt64(commandBufferAddress + CommandBufferCallbackOffset, out var callback) ||
+            !ctx.TryReadUInt32(commandBufferAddress + CommandBufferReservedDwOffset, out var reservedDwords))
         {
             return false;
         }
@@ -5212,19 +5204,19 @@ public static class AgcExports
 
     private static bool CopyShaderRegister(CpuContext ctx, ulong sourceAddress, ulong destinationAddress)
     {
-        if (!TryReadUInt32(ctx, sourceAddress, out var offset) ||
-            !TryReadUInt32(ctx, sourceAddress + sizeof(uint), out var value))
+        if (!ctx.TryReadUInt32(sourceAddress, out var offset) ||
+            !ctx.TryReadUInt32(sourceAddress + sizeof(uint), out var value))
         {
             return false;
         }
 
-        return TryWriteUInt32(ctx, destinationAddress, offset) &&
-               TryWriteUInt32(ctx, destinationAddress + sizeof(uint), value);
+        return ctx.TryWriteUInt32(destinationAddress, offset) &&
+               ctx.TryWriteUInt32(destinationAddress + sizeof(uint), value);
     }
 
     private static bool RelocatePointerField(CpuContext ctx, ulong fieldAddress)
     {
-        if (!TryReadUInt64(ctx, fieldAddress, out var relativeAddress))
+        if (!ctx.TryReadUInt64(fieldAddress, out var relativeAddress))
         {
             return false;
         }
@@ -5405,52 +5397,6 @@ public static class AgcExports
     private static uint Pm4Length(uint header) =>
         ((header >> 16) & 0x3FFFu) + 2u;
 
-    private static bool TryReadByte(CpuContext ctx, ulong address, out byte value)
-    {
-        Span<byte> buffer = stackalloc byte[1];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = buffer[0];
-        return true;
-    }
-
-    private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt32LittleEndian(buffer);
-        return true;
-    }
-
-    private static bool TryWriteUInt32(CpuContext ctx, ulong address, uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
-        return ctx.Memory.TryWrite(address, buffer);
-    }
-
-    private static bool TryReadUInt64(CpuContext ctx, ulong address, out ulong value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt64LittleEndian(buffer);
-        return true;
-    }
-
     private static bool TryReadGuestCString(
         CpuContext ctx,
         ulong address,
@@ -5466,7 +5412,7 @@ public static class AgcExports
         var values = new List<byte>(Math.Min(maximumLength, 128));
         for (var index = 0; index < maximumLength; index++)
         {
-            if (!TryReadByte(ctx, address + (ulong)index, out var value))
+            if (!ctx.TryReadByte(address + (ulong)index, out var value))
             {
                 bytes = [];
                 return false;
@@ -5493,7 +5439,7 @@ public static class AgcExports
     {
         op = 0;
         register = 0;
-        if (commandAddress == 0 || !TryReadUInt32(ctx, commandAddress, out var header))
+        if (commandAddress == 0 || !ctx.TryReadUInt32(commandAddress, out var header))
         {
             return false;
         }

--- a/src/SharpEmu.Libs/Agc/Gen5ShaderMetadataReader.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5ShaderMetadataReader.cs
@@ -18,9 +18,9 @@ internal static class Gen5ShaderMetadataReader
         out Gen5ShaderMetadata metadata)
     {
         metadata = default!;
-        if (!TryReadUInt64(ctx, shaderHeaderAddress + ShaderUserDataOffset, out var userDataAddress) ||
+        if (!ctx.TryReadUInt64(shaderHeaderAddress + ShaderUserDataOffset, out var userDataAddress) ||
             userDataAddress == 0 ||
-            !TryReadUInt64(ctx, userDataAddress, out var directResourceOffsetsAddress))
+            !ctx.TryReadUInt64(userDataAddress, out var directResourceOffsetsAddress))
         {
             return false;
         }
@@ -28,8 +28,7 @@ internal static class Gen5ShaderMetadataReader
         var resourceOffsets = new ulong[ResourceClassCount];
         for (var resourceClass = 0; resourceClass < ResourceClassCount; resourceClass++)
         {
-            if (!TryReadUInt64(
-                    ctx,
+            if (!ctx.TryReadUInt64(
                     userDataAddress + 0x08 + (ulong)(resourceClass * sizeof(ulong)),
                     out resourceOffsets[resourceClass]))
             {
@@ -136,19 +135,6 @@ internal static class Gen5ShaderMetadataReader
         }
 
         value = BinaryPrimitives.ReadUInt16LittleEndian(bytes);
-        return true;
-    }
-
-    private static bool TryReadUInt64(CpuContext ctx, ulong address, out ulong value)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
-        if (!ctx.Memory.TryRead(address, bytes))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt64LittleEndian(bytes);
         return true;
     }
 }

--- a/src/SharpEmu.Libs/Agc/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5ShaderScalarEvaluator.cs
@@ -3,7 +3,6 @@
 
 using SharpEmu.HLE;
 using SharpEmu.Libs.Kernel;
-using System.Buffers.Binary;
 using System.Numerics;
 
 namespace SharpEmu.Libs.Agc;
@@ -1405,8 +1404,7 @@ internal static class Gen5ShaderScalarEvaluator
                 continue;
             }
 
-            if (!TryReadUInt32(
-                    ctx,
+            if (!ctx.TryReadUInt32(
                     address + (ulong)(index * sizeof(uint)),
                     out var value) &&
                 !TryReadUserDataScalarLoad(
@@ -1727,16 +1725,4 @@ internal static class Gen5ShaderScalarEvaluator
         opcode.StartsWith("ImageSample", StringComparison.Ordinal) ||
         opcode.StartsWith("ImageGather", StringComparison.Ordinal);
 
-    private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(uint)];
-        if (!ctx.Memory.TryRead(address, bytes))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt32LittleEndian(bytes);
-        return true;
-    }
 }

--- a/src/SharpEmu.Libs/Agc/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5ShaderTranslator.cs
@@ -294,7 +294,7 @@ internal static class Gen5ShaderTranslator
         var instructionCount = 0;
         for (uint pc = 0; instructionCount < MaxInstructions;)
         {
-            if (!TryReadUInt32(ctx, address + pc, out var word))
+            if (!ctx.TryReadUInt32(address + pc, out var word))
             {
                 error = $"read-failed pc=0x{pc:X}";
                 return false;
@@ -317,7 +317,7 @@ internal static class Gen5ShaderTranslator
             words[0] = word;
             for (uint wordIndex = 1; wordIndex < sizeDwords; wordIndex++)
             {
-                if (!TryReadUInt32(ctx, address + pc + wordIndex * sizeof(uint), out words[wordIndex]))
+                if (!ctx.TryReadUInt32(address + pc + wordIndex * sizeof(uint), out words[wordIndex]))
                 {
                     error = $"read-failed pc=0x{pc + wordIndex * sizeof(uint):X}";
                     return false;
@@ -397,7 +397,7 @@ internal static class Gen5ShaderTranslator
             case 0x34:
             case 0x35:
                 encoding = Gen5ShaderEncoding.Vop3;
-                if (!TryReadUInt32(ctx, baseAddress + pc + sizeof(uint), out var vop3Extra))
+                if (!ctx.TryReadUInt32(baseAddress + pc + sizeof(uint), out var vop3Extra))
                 {
                     error = $"vop3-extra-read-failed pc=0x{pc:X}";
                     return false;
@@ -418,7 +418,7 @@ internal static class Gen5ShaderTranslator
                 return DecodeFlat(word, out name, out sizeDwords, out error);
             case 0x38:
                 encoding = Gen5ShaderEncoding.Mubuf;
-                if (!TryReadUInt32(ctx, baseAddress + pc + sizeof(uint), out var mubufExtra))
+                if (!ctx.TryReadUInt32(baseAddress + pc + sizeof(uint), out var mubufExtra))
                 {
                     error = $"mubuf-extra-read-failed pc=0x{pc:X}";
                     return false;
@@ -427,7 +427,7 @@ internal static class Gen5ShaderTranslator
                 return DecodeMubuf(word, mubufExtra, out name, out sizeDwords, out error);
             case 0x3A:
                 encoding = Gen5ShaderEncoding.Mtbuf;
-                if (!TryReadUInt32(ctx, baseAddress + pc + sizeof(uint), out var mtbufExtra))
+                if (!ctx.TryReadUInt32(baseAddress + pc + sizeof(uint), out var mtbufExtra))
                 {
                     error = $"mtbuf-extra-read-failed pc=0x{pc:X}";
                     return false;
@@ -1739,19 +1739,6 @@ internal static class Gen5ShaderTranslator
     {
         counts.TryGetValue(key, out var count);
         counts[key] = count + 1;
-    }
-
-    private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(uint)];
-        if (!ctx.Memory.TryRead(address, bytes))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt32LittleEndian(bytes);
-        return true;
     }
 
     private readonly record struct ShaderDecodeInfo(

--- a/src/SharpEmu.Libs/Ampr/AmprExports.cs
+++ b/src/SharpEmu.Libs/Ampr/AmprExports.cs
@@ -453,7 +453,7 @@ public static class AmprExports
         var offset = 0UL;
         while (offset < writeOffset)
         {
-            if (!TryReadUInt32(ctx, buffer + offset, out var recordType))
+            if (!ctx.TryReadUInt32(buffer + offset, out var recordType))
             {
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
             }
@@ -880,19 +880,6 @@ public static class AmprExports
         }
 
         TraceAmpr(ctx, "complete_write_address", address, value, 0);
-        return true;
-    }
-
-    private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt32LittleEndian(buffer);
         return true;
     }
 

--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -95,7 +95,7 @@ public static class AudioOut2Exports
         }
 
         var handle = (ulong)Interlocked.Increment(ref _nextContextHandle);
-        return TryWriteUInt64(ctx, outContextAddress, handle)
+        return ctx.TryWriteUInt64(outContextAddress, handle)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
     }
@@ -125,7 +125,7 @@ public static class AudioOut2Exports
 
         var portId = unchecked((uint)Interlocked.Increment(ref _nextPortId)) & 0xFF;
         var handle = 0x2000_0000UL | ((ulong)(uint)type << 16) | portId;
-        return TryWriteUInt64(ctx, outPortAddress, handle)
+        return ctx.TryWriteUInt64(outPortAddress, handle)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
     }
@@ -211,16 +211,9 @@ public static class AudioOut2Exports
         }
 
         var handle = (ulong)Interlocked.Increment(ref _nextUserHandle);
-        return TryWriteUInt64(ctx, outUserAddress, handle)
+        return ctx.TryWriteUInt64(outUserAddress, handle)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
-    }
-
-    private static bool TryWriteUInt64(CpuContext ctx, ulong address, ulong value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
-        return ctx.Memory.TryWrite(address, buffer);
     }
 
     private static int SetReturn(CpuContext ctx, int result)

--- a/src/SharpEmu.Libs/Fiber/FiberExports.cs
+++ b/src/SharpEmu.Libs/Fiber/FiberExports.cs
@@ -112,7 +112,7 @@ public static class FiberExports
             return SetReturn(ctx, FiberErrorAlignment);
         }
 
-        return TryWriteUInt32(ctx, optParam, FiberOptSignature)
+        return ctx.TryWriteUInt32(optParam, FiberOptSignature)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, FiberErrorInvalid);
     }
@@ -130,7 +130,7 @@ public static class FiberExports
             return SetReturn(ctx, error);
         }
 
-        if (!TryReadUInt32(ctx, fiber + FiberStateOffset, out var state))
+        if (!ctx.TryReadUInt32(fiber + FiberStateOffset, out var state))
         {
             return SetReturn(ctx, FiberErrorInvalid);
         }
@@ -143,7 +143,7 @@ public static class FiberExports
         _continuations.TryRemove(fiber, out _);
         _returnTargets.TryRemove(fiber, out _);
         _stackRanges.TryRemove(fiber, out _);
-        _ = TryWriteUInt32(ctx, fiber + FiberStateOffset, FiberStateTerminated);
+        _ = ctx.TryWriteUInt32(fiber + FiberStateOffset, FiberStateTerminated);
         return SetReturn(ctx, 0);
     }
 
@@ -240,7 +240,7 @@ public static class FiberExports
 
         var returnArgument = ctx[CpuRegister.Rdi];
         var argOnRunAddress = ctx[CpuRegister.Rsi];
-        if (argOnRunAddress != 0 && !TryWriteUInt64(ctx, argOnRunAddress, 0))
+        if (argOnRunAddress != 0 && !ctx.TryWriteUInt64(argOnRunAddress, 0))
         {
             return SetReturn(ctx, FiberErrorInvalid);
         }
@@ -264,7 +264,7 @@ public static class FiberExports
             {
                 if (!_continuations.TryRemove(previousFiber, out var previousContinuation) ||
                     !TryWriteResumeArgument(ctx, previousContinuation, returnArgument) ||
-                    !TryWriteUInt32(ctx, previousFiber + FiberStateOffset, FiberStateRun))
+                    !ctx.TryWriteUInt32(previousFiber + FiberStateOffset, FiberStateRun))
                 {
                     _continuations.TryRemove(fiberAddress, out _);
                     return SetReturn(ctx, FiberErrorState);
@@ -284,7 +284,7 @@ public static class FiberExports
                 transferTarget = returnTarget.ThreadContinuation.Value.Context with { Rax = 0 };
             }
 
-            if (!TryWriteUInt32(ctx, fiberAddress + FiberStateOffset, FiberStateIdle))
+            if (!ctx.TryWriteUInt32(fiberAddress + FiberStateOffset, FiberStateIdle))
             {
                 return SetReturn(ctx, FiberErrorInvalid);
             }
@@ -318,7 +318,7 @@ public static class FiberExports
             return SetReturn(ctx, FiberErrorPermission);
         }
 
-        return TryWriteUInt64(ctx, outAddress, fiberAddress)
+        return ctx.TryWriteUInt64(outAddress, fiberAddress)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, FiberErrorInvalid);
     }
@@ -342,7 +342,7 @@ public static class FiberExports
             return SetReturn(ctx, error);
         }
 
-        if (!TryReadUInt64(ctx, info, out var size) || size != FiberInfoSize)
+        if (!ctx.TryReadUInt64(info, out var size) || size != FiberInfoSize)
         {
             return SetReturn(ctx, FiberErrorInvalid);
         }
@@ -352,12 +352,12 @@ public static class FiberExports
             return SetReturn(ctx, FiberErrorInvalid);
         }
 
-        if (!TryWriteUInt64(ctx, info + 8, fields.Entry) ||
-            !TryWriteUInt64(ctx, info + 16, fields.ArgOnInitialize) ||
-            !TryWriteUInt64(ctx, info + 24, fields.ContextAddress) ||
-            !TryWriteUInt64(ctx, info + 32, fields.ContextSize) ||
+        if (!ctx.TryWriteUInt64(info + 8, fields.Entry) ||
+            !ctx.TryWriteUInt64(info + 16, fields.ArgOnInitialize) ||
+            !ctx.TryWriteUInt64(info + 24, fields.ContextAddress) ||
+            !ctx.TryWriteUInt64(info + 32, fields.ContextSize) ||
             !TryWriteName(ctx, info + 40, fields.Name) ||
-            !TryWriteUInt64(ctx, info + 72, ulong.MaxValue))
+            !ctx.TryWriteUInt64(info + 72, ulong.MaxValue))
         {
             return SetReturn(ctx, FiberErrorInvalid);
         }
@@ -384,7 +384,7 @@ public static class FiberExports
             return SetReturn(ctx, FiberErrorNull);
         }
 
-        if (!TryReadNullTerminatedUtf8(ctx, nameAddress, MaxNameLength + 1, out var name))
+        if (!ctx.TryReadNullTerminatedUtf8(nameAddress, MaxNameLength + 1, out var name))
         {
             return SetReturn(ctx, FiberErrorInvalid);
         }
@@ -441,7 +441,7 @@ public static class FiberExports
             return SetReturn(ctx, FiberErrorPermission);
         }
 
-        return TryWriteUInt64(ctx, outAddress, ctx[CpuRegister.Rbp])
+        return ctx.TryWriteUInt64(outAddress, ctx[CpuRegister.Rbp])
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, FiberErrorInvalid);
     }
@@ -482,12 +482,12 @@ public static class FiberExports
         }
 
         if (optParam != 0 &&
-            (!TryReadUInt32(ctx, optParam, out var optMagic) || optMagic != FiberOptSignature))
+            (!ctx.TryReadUInt32(optParam, out var optMagic) || optMagic != FiberOptSignature))
         {
             return SetReturn(ctx, FiberErrorInvalid);
         }
 
-        if (!TryReadNullTerminatedUtf8(ctx, nameAddress, MaxNameLength + 1, out var name))
+        if (!ctx.TryReadNullTerminatedUtf8(nameAddress, MaxNameLength + 1, out var name))
         {
             return SetReturn(ctx, FiberErrorInvalid);
         }
@@ -497,25 +497,25 @@ public static class FiberExports
             flags |= FiberFlagContextSizeCheck;
         }
 
-        if (!TryWriteUInt32(ctx, fiber + FiberMagicStartOffset, FiberSignature0) ||
-            !TryWriteUInt32(ctx, fiber + FiberStateOffset, FiberStateIdle) ||
-            !TryWriteUInt64(ctx, fiber + FiberEntryOffset, entry) ||
-            !TryWriteUInt64(ctx, fiber + FiberArgOnInitializeOffset, argOnInitialize) ||
-            !TryWriteUInt64(ctx, fiber + FiberContextAddressOffset, contextAddress) ||
-            !TryWriteUInt64(ctx, fiber + FiberContextSizeOffset, contextSize) ||
+        if (!ctx.TryWriteUInt32(fiber + FiberMagicStartOffset, FiberSignature0) ||
+            !ctx.TryWriteUInt32(fiber + FiberStateOffset, FiberStateIdle) ||
+            !ctx.TryWriteUInt64(fiber + FiberEntryOffset, entry) ||
+            !ctx.TryWriteUInt64(fiber + FiberArgOnInitializeOffset, argOnInitialize) ||
+            !ctx.TryWriteUInt64(fiber + FiberContextAddressOffset, contextAddress) ||
+            !ctx.TryWriteUInt64(fiber + FiberContextSizeOffset, contextSize) ||
             !TryWriteName(ctx, fiber + FiberNameOffset, name) ||
-            !TryWriteUInt64(ctx, fiber + FiberContextPointerOffset, 0) ||
-            !TryWriteUInt32(ctx, fiber + FiberFlagsOffset, flags) ||
-            !TryWriteUInt64(ctx, fiber + FiberContextStartOffset, contextAddress) ||
-            !TryWriteUInt64(ctx, fiber + FiberContextEndOffset, contextAddress == 0 ? 0 : contextAddress + contextSize) ||
-            !TryWriteUInt32(ctx, fiber + FiberMagicEndOffset, FiberSignature1))
+            !ctx.TryWriteUInt64(fiber + FiberContextPointerOffset, 0) ||
+            !ctx.TryWriteUInt32(fiber + FiberFlagsOffset, flags) ||
+            !ctx.TryWriteUInt64(fiber + FiberContextStartOffset, contextAddress) ||
+            !ctx.TryWriteUInt64(fiber + FiberContextEndOffset, contextAddress == 0 ? 0 : contextAddress + contextSize) ||
+            !ctx.TryWriteUInt32(fiber + FiberMagicEndOffset, FiberSignature1))
         {
             return SetReturn(ctx, FiberErrorInvalid);
         }
 
         if (contextAddress != 0)
         {
-            if (!TryWriteUInt64(ctx, contextAddress, FiberStackSignature))
+            if (!ctx.TryWriteUInt64(contextAddress, FiberStackSignature))
             {
                 return SetReturn(ctx, FiberErrorInvalid);
             }
@@ -616,9 +616,9 @@ public static class FiberExports
 
             if (previousFiber != 0)
             {
-                if (!TryReadUInt32(ctx, previousFiber + FiberStateOffset, out var previousState) ||
+                if (!ctx.TryReadUInt32(previousFiber + FiberStateOffset, out var previousState) ||
                     previousState != FiberStateRun ||
-                    !TryWriteUInt32(ctx, previousFiber + FiberStateOffset, FiberStateIdle))
+                    !ctx.TryWriteUInt32(previousFiber + FiberStateOffset, FiberStateIdle))
                 {
                     return SetReturn(ctx, FiberErrorState);
                 }
@@ -631,12 +631,12 @@ public static class FiberExports
                 _returnTargets[fiber] = new FiberReturnTarget(0, callerContinuation);
             }
 
-            if (!TryWriteUInt32(ctx, fiber + FiberStateOffset, FiberStateRun))
+            if (!ctx.TryWriteUInt32(fiber + FiberStateOffset, FiberStateRun))
             {
                 if (previousFiber != 0)
                 {
                     _continuations.TryRemove(previousFiber, out _);
-                    _ = TryWriteUInt32(ctx, previousFiber + FiberStateOffset, FiberStateRun);
+                    _ = ctx.TryWriteUInt32(previousFiber + FiberStateOffset, FiberStateRun);
                 }
                 _returnTargets.TryRemove(fiber, out _);
                 return SetReturn(ctx, FiberErrorInvalid);
@@ -673,7 +673,7 @@ public static class FiberExports
 
         var stackEnd = fields.ContextAddress + fields.ContextSize;
         var entryRsp = (stackEnd & ~15UL) - sizeof(ulong);
-        if (!TryWriteUInt64(ctx, entryRsp, 0))
+        if (!ctx.TryWriteUInt64(entryRsp, 0))
         {
             return false;
         }
@@ -708,7 +708,7 @@ public static class FiberExports
         FiberContinuation continuation,
         ulong argument) =>
         continuation.ArgOnRunAddress == 0 ||
-        TryWriteUInt64(ctx, continuation.ArgOnRunAddress, argument);
+        ctx.TryWriteUInt64(continuation.ArgOnRunAddress, argument);
 
     private static GuestCpuContinuation CaptureContinuation(
         CpuContext ctx,
@@ -779,11 +779,11 @@ public static class FiberExports
             return FiberErrorInvalid;
         }
 
-        if (!TryWriteUInt64(ctx, fiber + FiberContextAddressOffset, contextAddress) ||
-            !TryWriteUInt64(ctx, fiber + FiberContextSizeOffset, contextSize) ||
-            !TryWriteUInt64(ctx, fiber + FiberContextStartOffset, contextAddress) ||
-            !TryWriteUInt64(ctx, fiber + FiberContextEndOffset, contextAddress + contextSize) ||
-            !TryWriteUInt64(ctx, contextAddress, FiberStackSignature))
+        if (!ctx.TryWriteUInt64(fiber + FiberContextAddressOffset, contextAddress) ||
+            !ctx.TryWriteUInt64(fiber + FiberContextSizeOffset, contextSize) ||
+            !ctx.TryWriteUInt64(fiber + FiberContextStartOffset, contextAddress) ||
+            !ctx.TryWriteUInt64(fiber + FiberContextEndOffset, contextAddress + contextSize) ||
+            !ctx.TryWriteUInt64(contextAddress, FiberStackSignature))
         {
             return FiberErrorInvalid;
         }
@@ -839,8 +839,8 @@ public static class FiberExports
             return false;
         }
 
-        if (!TryReadUInt32(ctx, fiber + FiberMagicStartOffset, out var magicStart) ||
-            !TryReadUInt32(ctx, fiber + FiberMagicEndOffset, out var magicEnd) ||
+        if (!ctx.TryReadUInt32(fiber + FiberMagicStartOffset, out var magicStart) ||
+            !ctx.TryReadUInt32(fiber + FiberMagicEndOffset, out var magicEnd) ||
             magicStart != FiberSignature0 ||
             magicEnd != FiberSignature1)
         {
@@ -855,12 +855,12 @@ public static class FiberExports
     private static bool TryReadFiberFields(CpuContext ctx, ulong fiber, out FiberFields fields)
     {
         fields = default;
-        if (!TryReadUInt32(ctx, fiber + FiberStateOffset, out var state) ||
-            !TryReadUInt64(ctx, fiber + FiberEntryOffset, out var entry) ||
-            !TryReadUInt64(ctx, fiber + FiberArgOnInitializeOffset, out var argOnInitialize) ||
-            !TryReadUInt64(ctx, fiber + FiberContextAddressOffset, out var contextAddress) ||
-            !TryReadUInt64(ctx, fiber + FiberContextSizeOffset, out var contextSize) ||
-            !TryReadUInt32(ctx, fiber + FiberFlagsOffset, out var flags) ||
+        if (!ctx.TryReadUInt32(fiber + FiberStateOffset, out var state) ||
+            !ctx.TryReadUInt64(fiber + FiberEntryOffset, out var entry) ||
+            !ctx.TryReadUInt64(fiber + FiberArgOnInitializeOffset, out var argOnInitialize) ||
+            !ctx.TryReadUInt64(fiber + FiberContextAddressOffset, out var contextAddress) ||
+            !ctx.TryReadUInt64(fiber + FiberContextSizeOffset, out var contextSize) ||
+            !ctx.TryReadUInt32(fiber + FiberFlagsOffset, out var flags) ||
             !TryReadInlineName(ctx, fiber + FiberNameOffset, out var name))
         {
             return false;
@@ -898,46 +898,6 @@ public static class FiberExports
         return 0;
     }
 
-    private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt32LittleEndian(buffer);
-        return true;
-    }
-
-    private static bool TryWriteUInt32(CpuContext ctx, ulong address, uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
-        return ctx.Memory.TryWrite(address, buffer);
-    }
-
-    private static bool TryReadUInt64(CpuContext ctx, ulong address, out ulong value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt64LittleEndian(buffer);
-        return true;
-    }
-
-    private static bool TryWriteUInt64(CpuContext ctx, ulong address, ulong value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
-        return ctx.Memory.TryWrite(address, buffer);
-    }
-
     private static bool TryWriteName(CpuContext ctx, ulong address, string name)
     {
         Span<byte> buffer = stackalloc byte[MaxNameLength + 1];
@@ -962,31 +922,6 @@ public static class FiberExports
         }
 
         value = Encoding.UTF8.GetString(buffer[..length]);
-        return true;
-    }
-
-    private static bool TryReadNullTerminatedUtf8(CpuContext ctx, ulong address, int capacity, out string value)
-    {
-        var bytes = new byte[capacity];
-        for (var index = 0; index < bytes.Length; index++)
-        {
-            Span<byte> current = stackalloc byte[1];
-            if (!ctx.Memory.TryRead(address + (ulong)index, current))
-            {
-                value = string.Empty;
-                return false;
-            }
-
-            if (current[0] == 0)
-            {
-                value = Encoding.UTF8.GetString(bytes, 0, index);
-                return true;
-            }
-
-            bytes[index] = current[0];
-        }
-
-        value = Encoding.UTF8.GetString(bytes);
         return true;
     }
 

--- a/src/SharpEmu.Libs/Kernel/KernelAprCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelAprCompatExports.cs
@@ -3,7 +3,6 @@
 
 using SharpEmu.HLE;
 using SharpEmu.Libs.Ampr;
-using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Threading;
 
@@ -50,7 +49,7 @@ public static class KernelAprCompatExports
             return completionResult;
         }
 
-        if (outSubmissionId != 0 && !TryWriteUInt32(ctx, outSubmissionId, submissionId))
+        if (outSubmissionId != 0 && !ctx.TryWriteUInt32(outSubmissionId, submissionId))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
@@ -141,7 +140,7 @@ public static class KernelAprCompatExports
             return completionResult;
         }
 
-        if (!TryWriteUInt32(ctx, outSubmissionId, submissionId))
+        if (!ctx.TryWriteUInt32(outSubmissionId, submissionId))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
@@ -176,13 +175,6 @@ public static class KernelAprCompatExports
     {
         var tag = value >> 56;
         return tag is 0x0C or 0x10;
-    }
-
-    private static bool TryWriteUInt32(CpuContext ctx, ulong address, uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
-        return ctx.Memory.TryWrite(address, buffer);
     }
 
     private static void TraceApr(

--- a/src/SharpEmu.Libs/Kernel/KernelEventFlagCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventFlagCompatExports.cs
@@ -1,7 +1,6 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Text;
 using SharpEmu.HLE;
@@ -55,7 +54,7 @@ public static class KernelEventFlagCompatExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryReadNullTerminatedUtf8(ctx, nameAddress, MaxEventFlagNameLength + 1, out var name))
+        if (!ctx.TryReadNullTerminatedUtf8(nameAddress, MaxEventFlagNameLength + 1, out var name))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -219,7 +218,7 @@ public static class KernelEventFlagCompatExports
         }
 
         uint timeoutUsec = 0;
-        if (timeoutAddress != 0 && !TryReadUInt32(ctx, timeoutAddress, out timeoutUsec))
+        if (timeoutAddress != 0 && !ctx.TryReadUInt32(timeoutAddress, out timeoutUsec))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -234,7 +233,7 @@ public static class KernelEventFlagCompatExports
 
             if (timeoutAddress != 0)
             {
-                _ = TryWriteUInt32(ctx, timeoutAddress, 0);
+                _ = ctx.TryWriteUInt32(timeoutAddress, 0);
                 _ = TryWriteResultPattern(ctx, resultAddress, state.Bits);
                 TraceEventFlag($"wait-timeout handle=0x{handle:X16} pattern=0x{pattern:X16} timeout={timeoutUsec} ret=0x{returnRip:X16}");
                 return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT);
@@ -340,7 +339,7 @@ public static class KernelEventFlagCompatExports
         lock (state.Gate)
         {
             if (waiterCountAddress != 0 &&
-                !TryWriteUInt32(ctx, waiterCountAddress, unchecked((uint)state.WaitingThreads)))
+                !ctx.TryWriteUInt32(waiterCountAddress, unchecked((uint)state.WaitingThreads)))
             {
                 return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             }
@@ -453,77 +452,6 @@ public static class KernelEventFlagCompatExports
     private static bool TryWriteResultPattern(CpuContext ctx, ulong address, ulong bits) =>
         address == 0 || ctx.TryWriteUInt64(address, bits);
 
-    private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt32LittleEndian(buffer);
-        return true;
-    }
-
-    private static bool TryReadUInt64(CpuContext ctx, ulong address, out ulong value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt64LittleEndian(buffer);
-        return true;
-    }
-
-    private static bool TryReadByte(CpuContext ctx, ulong address, out byte value)
-    {
-        Span<byte> buffer = stackalloc byte[1];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = buffer[0];
-        return true;
-    }
-
-    private static bool TryWriteUInt32(CpuContext ctx, ulong address, uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
-        return ctx.Memory.TryWrite(address, buffer);
-    }
-
-    private static bool TryReadNullTerminatedUtf8(CpuContext ctx, ulong address, int capacity, out string value)
-    {
-        var bytes = new byte[capacity];
-        for (var index = 0; index < bytes.Length; index++)
-        {
-            Span<byte> current = stackalloc byte[1];
-            if (!ctx.Memory.TryRead(address + (ulong)index, current))
-            {
-                value = string.Empty;
-                return false;
-            }
-
-            if (current[0] == 0)
-            {
-                value = Encoding.UTF8.GetString(bytes, 0, index);
-                return true;
-            }
-
-            bytes[index] = current[0];
-        }
-
-        value = Encoding.UTF8.GetString(bytes);
-        return true;
-    }
-
     private static int SetReturn(CpuContext ctx, OrbisGen2Result result)
     {
         var value = (int)result;
@@ -614,7 +542,7 @@ public static class KernelEventFlagCompatExports
 
     private static void AppendByte(StringBuilder builder, CpuContext ctx, ulong address, string name)
     {
-        if (TryReadByte(ctx, address, out var value))
+        if (ctx.TryReadByte(address, out var value))
         {
             builder.Append($" {name}=0x{value:X2}");
         }
@@ -622,7 +550,7 @@ public static class KernelEventFlagCompatExports
 
     private static void AppendUInt32(StringBuilder builder, CpuContext ctx, ulong address, string name)
     {
-        if (TryReadUInt32(ctx, address, out var value))
+        if (ctx.TryReadUInt32(address, out var value))
         {
             builder.Append($" {name}=0x{value:X8}");
         }
@@ -630,7 +558,7 @@ public static class KernelEventFlagCompatExports
 
     private static void AppendUInt64(StringBuilder builder, CpuContext ctx, ulong address, string name)
     {
-        if (TryReadUInt64(ctx, address, out var value))
+        if (ctx.TryReadUInt64(address, out var value))
         {
             builder.Append($" {name}=0x{value:X16}");
         }

--- a/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
@@ -287,13 +287,13 @@ public static class KernelEventQueueCompatExports
         }
 
         uint timeoutUsec = 0;
-        if (timeoutAddress != 0 && !TryReadUInt32(ctx, timeoutAddress, out timeoutUsec))
+        if (timeoutAddress != 0 && !ctx.TryReadUInt32(timeoutAddress, out timeoutUsec))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
         var deliveredCount = DequeueEvents(ctx, handle, eventsAddress, eventCapacity);
-        if (outCountAddress != 0 && !TryWriteUInt32(ctx, outCountAddress, (uint)deliveredCount))
+        if (outCountAddress != 0 && !ctx.TryWriteUInt32(outCountAddress, (uint)deliveredCount))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
@@ -336,7 +336,7 @@ public static class KernelEventQueueCompatExports
             }
 
             deliveredCount = DequeueEvents(ctx, handle, eventsAddress, eventCapacity);
-            if (outCountAddress != 0 && !TryWriteUInt32(ctx, outCountAddress, (uint)deliveredCount))
+            if (outCountAddress != 0 && !ctx.TryWriteUInt32(outCountAddress, (uint)deliveredCount))
             {
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
             }
@@ -541,7 +541,7 @@ public static class KernelEventQueueCompatExports
         ulong outCountAddress)
     {
         var deliveredCount = DequeueEvents(ctx, handle, eventsAddress, eventCapacity);
-        if (outCountAddress != 0 && !TryWriteUInt32(ctx, outCountAddress, (uint)deliveredCount))
+        if (outCountAddress != 0 && !ctx.TryWriteUInt32(outCountAddress, (uint)deliveredCount))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
@@ -654,29 +654,8 @@ public static class KernelEventQueueCompatExports
             return;
         }
 
-        var returnRip = 0UL;
-        _ = ctx.TryReadUInt64(ctx[CpuRegister.Rsp], out returnRip);
+        _ = ctx.TryReadUInt64(ctx[CpuRegister.Rsp], out ulong returnRip);
         Console.Error.WriteLine(
             $"[LOADER][TRACE] equeue.{operation}: handle=0x{handle:X16} rsi=0x{ctx[CpuRegister.Rsi]:X16} rdx=0x{ctx[CpuRegister.Rdx]:X16} ret=0x{returnRip:X16}");
-    }
-
-    private static bool TryWriteUInt32(CpuContext ctx, ulong address, uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
-        return ctx.Memory.TryWrite(address, buffer);
-    }
-
-    private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt32LittleEndian(buffer);
-        return true;
     }
 }

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -7,9 +7,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Text;
-using System.Threading;
 using System.Runtime.InteropServices;
-using System.Linq;
 using System.Globalization;
 
 namespace SharpEmu.Libs.Kernel;
@@ -4527,7 +4525,7 @@ public static class KernelMemoryCompatExports
                 continue;
             }
 
-            Span<byte> one = stackalloc byte[1];
+            var one = chunk.AsSpan(0, 1);
             if (!TryReadCompat(ctx, current, one))
             {
                 return false;

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -1018,19 +1018,12 @@ public static class KernelPthreadCompatExports
     }
 
     private static bool InitializeMutexObject(CpuContext ctx, ulong address, PthreadMutexState state) =>
-        TryWriteUInt32(ctx, address + 0x20, unchecked((uint)state.Type)) &&
-        TryWriteUInt32(ctx, address + 0x3C, unchecked((uint)state.Protocol));
+        ctx.TryWriteUInt32(address + 0x20, unchecked((uint)state.Type)) &&
+        ctx.TryWriteUInt32(address + 0x3C, unchecked((uint)state.Protocol));
 
     private static bool WriteMutexAttrObject(CpuContext ctx, ulong address, PthreadMutexAttrState state) =>
-        TryWriteUInt32(ctx, address, unchecked((uint)state.Type)) &&
-        TryWriteUInt32(ctx, address + 4, unchecked((uint)state.Protocol));
-
-    private static bool TryWriteUInt32(CpuContext ctx, ulong address, uint value)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(uint)];
-        BitConverter.TryWriteBytes(bytes, value);
-        return ctx.Memory.TryWrite(address, bytes);
-    }
+        ctx.TryWriteUInt32(address, unchecked((uint)state.Type)) &&
+        ctx.TryWriteUInt32(address + 4, unchecked((uint)state.Protocol));
 
     private static int PthreadCondInitCore(CpuContext ctx, ulong condAddress)
     {

--- a/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
@@ -1,9 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-using System.Buffers.Binary;
 using System.Collections.Concurrent;
-using System.Text;
 using SharpEmu.HLE;
 
 namespace SharpEmu.Libs.Kernel;
@@ -49,7 +47,7 @@ public static class KernelSemaphoreCompatExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryReadNullTerminatedUtf8(ctx, nameAddress, MaxSemaphoreNameLength, out var name))
+        if (!ctx.TryReadNullTerminatedUtf8(nameAddress, MaxSemaphoreNameLength, out var name))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -68,7 +66,7 @@ public static class KernelSemaphoreCompatExports
             Count = initialCount,
         };
 
-        if (!TryWriteUInt32(ctx, semaphoreAddress, handle))
+        if (!ctx.TryWriteUInt32(semaphoreAddress, handle))
         {
             _semaphores.TryRemove(handle, out _);
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
@@ -110,12 +108,12 @@ public static class KernelSemaphoreCompatExports
 
             if (timeoutAddress != 0)
             {
-                if (!TryReadUInt32(ctx, timeoutAddress, out _))
+                if (!ctx.TryReadUInt32(timeoutAddress, out _))
                 {
                     return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
                 }
 
-                _ = TryWriteUInt32(ctx, timeoutAddress, 0);
+                _ = ctx.TryWriteUInt32(timeoutAddress, 0);
                 TraceSemaphore($"wait-timeout handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
                 return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT);
             }
@@ -222,7 +220,7 @@ public static class KernelSemaphoreCompatExports
 
         lock (semaphore.Gate)
         {
-            if (waitingThreadsAddress != 0 && !TryWriteUInt32(ctx, waitingThreadsAddress, unchecked((uint)semaphore.WaitingThreads)))
+            if (waitingThreadsAddress != 0 && !ctx.TryWriteUInt32(waitingThreadsAddress, unchecked((uint)semaphore.WaitingThreads)))
             {
                 return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             }
@@ -256,56 +254,6 @@ public static class KernelSemaphoreCompatExports
         var value = (int)result;
         ctx[CpuRegister.Rax] = unchecked((ulong)value);
         return value;
-    }
-
-    private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt32LittleEndian(buffer);
-        return true;
-    }
-
-    private static bool TryWriteUInt32(CpuContext ctx, ulong address, uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
-        return ctx.Memory.TryWrite(address, buffer);
-    }
-
-    private static bool TryReadNullTerminatedUtf8(CpuContext ctx, ulong address, int maxLength, out string value)
-    {
-        value = string.Empty;
-        if (address == 0 || maxLength <= 0)
-        {
-            return false;
-        }
-
-        var bytes = new byte[Math.Min(maxLength, 4096)];
-        for (var i = 0; i < bytes.Length; i++)
-        {
-            Span<byte> current = stackalloc byte[1];
-            if (!ctx.Memory.TryRead(address + (ulong)i, current))
-            {
-                return false;
-            }
-
-            if (current[0] == 0)
-            {
-                value = Encoding.UTF8.GetString(bytes, 0, i);
-                return true;
-            }
-
-            bytes[i] = current[0];
-        }
-
-        value = Encoding.UTF8.GetString(bytes);
-        return true;
     }
 
     private static void TraceSemaphore(string message)

--- a/src/SharpEmu.Libs/PlayGo/PlayGoExports.cs
+++ b/src/SharpEmu.Libs/PlayGo/PlayGoExports.cs
@@ -234,7 +234,7 @@ public static class PlayGoExports
         if (outChunkIdList == 0)
         {
             TracePlayGo($"get_chunk_id count_only entries={availableEntries} out_entries=0x{outEntries:X16}");
-            return TryWriteUInt32(ctx, outEntries, availableEntries)
+            return ctx.TryWriteUInt32(outEntries, availableEntries)
                 ? (int)OrbisGen2Result.ORBIS_GEN2_OK
                 : (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
@@ -256,7 +256,7 @@ public static class PlayGoExports
         }
 
         TracePlayGo($"get_chunk_id write requested={numberOfEntries} wrote={entriesToWrite} available={availableEntries}");
-        return TryWriteUInt32(ctx, outEntries, entriesToWrite)
+        return ctx.TryWriteUInt32(outEntries, entriesToWrite)
             ? (int)OrbisGen2Result.ORBIS_GEN2_OK
             : (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
     }
@@ -503,7 +503,7 @@ public static class PlayGoExports
         }
 
         TracePlayGo($"get_todo requested={numberOfEntries} wrote=0");
-        return TryWriteUInt32(ctx, outEntries, 0)
+        return ctx.TryWriteUInt32(outEntries, 0)
             ? (int)OrbisGen2Result.ORBIS_GEN2_OK
             : (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
     }
@@ -745,13 +745,6 @@ public static class PlayGoExports
     {
         Span<byte> buffer = stackalloc byte[sizeof(ushort)];
         BinaryPrimitives.WriteUInt16LittleEndian(buffer, value);
-        return ctx.Memory.TryWrite(address, buffer);
-    }
-
-    private static bool TryWriteUInt32(CpuContext ctx, ulong address, uint value)
-    {
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
         return ctx.Memory.TryWrite(address, buffer);
     }
 

--- a/src/SharpEmu.Libs/SaveData/SaveDataDialogExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataDialogExports.cs
@@ -60,7 +60,7 @@ public static class SaveDataDialogExports
         }
 
         _lastMode = TryReadInt32(ctx, paramAddress, out var mode) ? mode : 0;
-        _lastUserData = TryReadUInt64(ctx, paramAddress + 0xC8, out var userData) ? userData : 0;
+        _lastUserData = ctx.TryReadUInt64(paramAddress + 0xC8, out var userData) ? userData : 0;
 
         // There is no host save dialog yet. Complete immediately with OK so
         // guest polling sees a finished dialog instead of spinning forever.
@@ -179,19 +179,6 @@ public static class SaveDataDialogExports
         }
 
         value = BinaryPrimitives.ReadInt32LittleEndian(bytes);
-        return true;
-    }
-
-    private static bool TryReadUInt64(CpuContext ctx, ulong address, out ulong value)
-    {
-        value = 0;
-        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
-        if (!ctx.Memory.TryRead(address, bytes))
-        {
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt64LittleEndian(bytes);
         return true;
     }
 

--- a/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
@@ -108,8 +108,8 @@ public static class SaveDataExports
             var setNum = result.DirNamesNum == 0
                 ? 0
                 : Math.Min(result.DirNamesNum, entries.Count);
-            if (!TryWriteUInt32(ctx, resultAddress + ResultHitNumOffset, checked((uint)entries.Count)) ||
-                !TryWriteUInt32(ctx, resultAddress + ResultSetNumOffset, checked((uint)setNum)))
+            if (!ctx.TryWriteUInt32(resultAddress + ResultHitNumOffset, checked((uint)entries.Count)) ||
+                !ctx.TryWriteUInt32(resultAddress + ResultSetNumOffset, checked((uint)setNum)))
             {
                 return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             }
@@ -173,9 +173,9 @@ public static class SaveDataExports
             !ctx.TryReadUInt64(mountAddress + 0x08, out var dirNameAddress) ||
             !ctx.TryReadUInt64(mountAddress + 0x10, out var blocks) ||
             !ctx.TryReadUInt64(mountAddress + 0x18, out var systemBlocks) ||
-            !TryReadUInt32(ctx, mountAddress + 0x20, out var mountMode) ||
-            !TryReadUInt32(ctx, mountAddress + 0x24, out var resource) ||
-            !TryReadUInt32(ctx, mountAddress + 0x28, out var mode) ||
+            !ctx.TryReadUInt32(mountAddress + 0x20, out var mountMode) ||
+            !ctx.TryReadUInt32(mountAddress + 0x24, out var resource) ||
+            !ctx.TryReadUInt32(mountAddress + 0x28, out var mode) ||
             dirNameAddress == 0 ||
             !TryReadFixedAscii(ctx, dirNameAddress, SaveDataDirNameSize, out var dirName))
         {
@@ -263,7 +263,7 @@ public static class SaveDataExports
 
         var id = (uint)Interlocked.Increment(ref _nextTransactionResource);
 
-        if (!TryWriteUInt32(ctx, resourceAddress, id))
+        if (!ctx.TryWriteUInt32(resourceAddress, id))
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -280,8 +280,8 @@ public static class SaveDataExports
         if (!TryReadInt32(ctx, address, out var userId) ||
             !ctx.TryReadUInt64(address + 0x08, out var titleIdAddress) ||
             !ctx.TryReadUInt64(address + 0x10, out var dirNameAddress) ||
-            !TryReadUInt32(ctx, address + 0x18, out var sortKey) ||
-            !TryReadUInt32(ctx, address + 0x1C, out var sortOrder))
+            !ctx.TryReadUInt32(address + 0x18, out var sortKey) ||
+            !ctx.TryReadUInt32(address + 0x1C, out var sortOrder))
         {
             return false;
         }
@@ -304,7 +304,7 @@ public static class SaveDataExports
     {
         result = default;
         if (!ctx.TryReadUInt64(address + ResultDirNamesOffset, out var dirNamesAddress) ||
-            !TryReadUInt32(ctx, address + ResultDirNamesNumOffset, out var dirNamesNum) ||
+            !ctx.TryReadUInt32(address + ResultDirNamesNumOffset, out var dirNamesNum) ||
             !ctx.TryReadUInt64(address + ResultParamsOffset, out var paramsAddress) ||
             !ctx.TryReadUInt64(address + ResultInfosOffset, out var infosAddress))
         {
@@ -516,26 +516,6 @@ public static class SaveDataExports
 
         value = BinaryPrimitives.ReadInt32LittleEndian(bytes);
         return true;
-    }
-
-    private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(uint)];
-        if (!ctx.Memory.TryRead(address, bytes))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt32LittleEndian(bytes);
-        return true;
-    }
-
-    private static bool TryWriteUInt32(CpuContext ctx, ulong address, uint value)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(uint)];
-        BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
-        return ctx.Memory.TryWrite(address, bytes);
     }
 
     private static int SetReturn(CpuContext ctx, int result)

--- a/src/SharpEmu.Libs/SharpEmu.Libs.csproj
+++ b/src/SharpEmu.Libs/SharpEmu.Libs.csproj
@@ -16,6 +16,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
   </ItemGroup>
 
   <PropertyGroup>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 </Project>

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -922,9 +922,9 @@ public static class VideoOutExports
     private static bool TryReadBufferAttribute(CpuContext ctx, ulong attributeAddress, bool attribute2, out BufferAttribute attribute)
     {
         attribute = default;
-        if (!TryReadUInt32(ctx, attributeAddress + 0x04, out var tilingMode) ||
-            !TryReadUInt32(ctx, attributeAddress + 0x0C, out var width) ||
-            !TryReadUInt32(ctx, attributeAddress + 0x10, out var height))
+        if (!ctx.TryReadUInt32(attributeAddress + 0x04, out var tilingMode) ||
+            !ctx.TryReadUInt32(attributeAddress + 0x0C, out var width) ||
+            !ctx.TryReadUInt32(attributeAddress + 0x10, out var height))
         {
             return false;
         }
@@ -941,10 +941,10 @@ public static class VideoOutExports
             return true;
         }
 
-        if (!TryReadUInt32(ctx, attributeAddress + 0x00, out var pixelFormat32) ||
-            !TryReadUInt32(ctx, attributeAddress + 0x08, out var aspectRatio) ||
-            !TryReadUInt32(ctx, attributeAddress + 0x14, out var pitchInPixel) ||
-            !TryReadUInt32(ctx, attributeAddress + 0x18, out var option32))
+        if (!ctx.TryReadUInt32(attributeAddress + 0x00, out var pixelFormat32) ||
+            !ctx.TryReadUInt32(attributeAddress + 0x08, out var aspectRatio) ||
+            !ctx.TryReadUInt32(attributeAddress + 0x14, out var pitchInPixel) ||
+            !ctx.TryReadUInt32(attributeAddress + 0x18, out var option32))
         {
             return false;
         }
@@ -1280,19 +1280,6 @@ public static class VideoOutExports
     private static bool TryReadStackUInt32(CpuContext ctx, int stackIndex, out uint value)
     {
         var address = ctx[CpuRegister.Rsp] + 0x08 + ((ulong)stackIndex * 0x08);
-        Span<byte> buffer = stackalloc byte[sizeof(uint)];
-        if (!ctx.Memory.TryRead(address, buffer))
-        {
-            value = 0;
-            return false;
-        }
-
-        value = BinaryPrimitives.ReadUInt32LittleEndian(buffer);
-        return true;
-    }
-
-    private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)
-    {
         Span<byte> buffer = stackalloc byte[sizeof(uint)];
         if (!ctx.Memory.TryRead(address, buffer))
         {

--- a/src/SharpEmu.Logging/SharpEmu.Logging.csproj
+++ b/src/SharpEmu.Logging/SharpEmu.Logging.csproj
@@ -4,4 +4,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 -->
 
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

This PR fixes all `CA2014` ("potential stack overflow - move stackalloc out of loop") warnings and follows up with a refactor that removes copies of guest-memory helper methods duplicated across the codebase, consolidating them as instance methods on `CpuContext`.

## CA2014 fixes

`stackalloc` memory is not released at the end of the loop - it's only reclaimed when method returns. This can lead to a growing stack frame with each iteration.

The offending pattern flagged by Roslyn compiler was:

```cs
Span<byte> current = stackalloc byte[1]
```

Rather than hoisting the allocation out of the loop, the temporary variable was removed - each guest byte is now read directly into the destination array via `bytes.AsSpan(index, 1)`, which points into pre-existing `bytes` array and also drops a per-byte copy. This is because compiler adds variable above the loop automatically while using `.AsSpan()`.

Behavior is still the same, the byte-at-a-time read pattern is preserved on purpose, since it correctly handles strings than terminate just before an unmapped page. This change can be treated as QoL modification.

## Helper consolidation

Same private helpers (`TryReadByte`, `TryReadUInt32`, `TryWriteUInt32`, `TryReadUInt64`, `TryWriteUInt64`, `TryReadNullTerminatedUtf8`) were duplicated across the codebase, each taking `CpuContext` as a parameter. `CpuContext` already exposed `TryReadUInt64`/`TryWriteUInt64`, so the remaining helpers were added there as instance methods and all duplicates removed.

### Deliberately not migrated

- `ShareExports.TryReadNullTerminatedUtf8` - different contract: returns `false` when no NUL terminator is found within `maxLength` (the canonical version returns the truncated string)
- `KernelMemoryCompatExports.TryReadNullTerminatedUtf8` - reads through that file's `TryReadCompat` translation path rather than `ctx.Memory`
- `IVirtualMemory`-based helpers in `SelfLoader`, `SharpEmuRuntime`, `PhysicalVirtualMemory`, and `CpuDispatcher`'s private `TryWriteUInt32/64(ulong, …)` - these don't take `CpuContext` and are out of scope

## Adjustments in `.csproj` and `global.json`

`global.json` previously pinned the .NET SDK with `"rollForward": "disable"`, which required exactly SDK `10.0.103` to be installed - in my case I had a newer version of the SDK, which failed to resolve. This is now relaxed.

`latestFeature` keeps 10.0.103 as the minimum but allows the SDK resolver to roll forward to the latest installed feature band and patch within .NET 10.0.

All five projects now add `CS1591` warning ignore, because it fired for every public type and member without an XML doc comment, generating unnecessary warnings during the build. Suppresing it project-wide keeps build output focused on warnings that indicate real problems.