### PR TITLE
[runtime] Run sceLibcParam malloc-replace init before initializers

### DIFF
--- a/src/SharpEmu.Core/Runtime/LibcParamBootstrap.cs
+++ b/src/SharpEmu.Core/Runtime/LibcParamBootstrap.cs
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+
+namespace SharpEmu.Core.Runtime;
+
+/// <summary>
+/// Resolves the allocator-replacement initializer a title advertises through the
+/// SceProcParam -> sceLibcParam -> _sceLibcMallocReplace chain. On hardware,
+/// libSceLibcInternal reads this chain while libc itself initializes — before the
+/// application image's own initializers run — and calls the game's user_malloc_init
+/// so the replacement allocator exists before any guest static initializer allocates.
+/// Titles that ship a replace table (e.g. UE4 titles) never construct their global
+/// allocator without this call, and their static-init cascade dereferences a null
+/// allocator singleton.
+/// All fields are read from guest memory and are untrusted: every read is
+/// bounds-checked through <see cref="ICpuMemory"/> and every size/magic validated
+/// before the resolved entry point is considered callable.
+/// </summary>
+public static class LibcParamBootstrap
+{
+    private const uint ProcParamMagic = 0x4942524F; // "ORBI"
+    private const int ProcParamLibcParamOffset = 0x38;
+    private const ulong ProcParamMinimumSize = ProcParamLibcParamOffset + sizeof(ulong);
+    private const int LibcParamMallocReplaceOffset = 0x30;
+    private const ulong LibcParamMinimumSize = LibcParamMallocReplaceOffset + sizeof(ulong);
+    private const int MallocReplaceInitOffset = 0x10;
+    private const ulong MallocReplaceMinimumSize = MallocReplaceInitOffset + sizeof(ulong);
+    private const ulong MallocReplaceMagicGen4 = 1; // PS4-era table (size 0x70)
+    private const ulong MallocReplaceMagicGen5 = 2; // PS5 table (size 0x78)
+    private const ulong MaxPlausibleStructSize = 0x1000;
+
+    public static bool TryResolveUserMallocInit(
+        ICpuMemory memory,
+        ulong procParamAddress,
+        out ulong userMallocInit,
+        out string detail)
+    {
+        userMallocInit = 0;
+
+        if (procParamAddress == 0)
+        {
+            detail = "no SceProcParam segment";
+            return false;
+        }
+
+        if (!TryReadUInt64(memory, procParamAddress, out var procParamSize) ||
+            !TryReadUInt32(memory, procParamAddress + 8, out var procParamMagic))
+        {
+            detail = $"SceProcParam header unreadable at 0x{procParamAddress:X16}";
+            return false;
+        }
+
+        if (procParamMagic != ProcParamMagic)
+        {
+            detail = $"SceProcParam magic mismatch (0x{procParamMagic:X8})";
+            return false;
+        }
+
+        if (procParamSize < ProcParamMinimumSize || procParamSize > MaxPlausibleStructSize)
+        {
+            detail = $"SceProcParam size 0x{procParamSize:X} out of range";
+            return false;
+        }
+
+        if (!TryReadUInt64(memory, procParamAddress + ProcParamLibcParamOffset, out var libcParamAddress))
+        {
+            detail = "sceLibcParam slot unreadable";
+            return false;
+        }
+
+        if (libcParamAddress == 0)
+        {
+            detail = "no sceLibcParam block";
+            return false;
+        }
+
+        if (!TryReadUInt64(memory, libcParamAddress, out var libcParamSize))
+        {
+            detail = $"sceLibcParam header unreadable at 0x{libcParamAddress:X16}";
+            return false;
+        }
+
+        if (libcParamSize < LibcParamMinimumSize || libcParamSize > MaxPlausibleStructSize)
+        {
+            detail = $"sceLibcParam size 0x{libcParamSize:X} out of range";
+            return false;
+        }
+
+        if (!TryReadUInt64(memory, libcParamAddress + LibcParamMallocReplaceOffset, out var mallocReplaceAddress))
+        {
+            detail = "_sceLibcMallocReplace slot unreadable";
+            return false;
+        }
+
+        if (mallocReplaceAddress == 0)
+        {
+            detail = "no _sceLibcMallocReplace table";
+            return false;
+        }
+
+        if (!TryReadUInt64(memory, mallocReplaceAddress, out var mallocReplaceSize) ||
+            !TryReadUInt64(memory, mallocReplaceAddress + 8, out var mallocReplaceMagic))
+        {
+            detail = $"_sceLibcMallocReplace header unreadable at 0x{mallocReplaceAddress:X16}";
+            return false;
+        }
+
+        if (mallocReplaceMagic != MallocReplaceMagicGen4 && mallocReplaceMagic != MallocReplaceMagicGen5)
+        {
+            detail = $"_sceLibcMallocReplace magic {mallocReplaceMagic} unsupported";
+            return false;
+        }
+
+        if (mallocReplaceSize < MallocReplaceMinimumSize || mallocReplaceSize > MaxPlausibleStructSize)
+        {
+            detail = $"_sceLibcMallocReplace size 0x{mallocReplaceSize:X} out of range";
+            return false;
+        }
+
+        if (!TryReadUInt64(memory, mallocReplaceAddress + MallocReplaceInitOffset, out var initAddress))
+        {
+            detail = "user_malloc_init slot unreadable";
+            return false;
+        }
+
+        if (initAddress == 0)
+        {
+            detail = "user_malloc_init entry absent";
+            return false;
+        }
+
+        // The entry must point at mapped guest memory; anything else is a corrupt
+        // table and must not be dispatched as guest code.
+        Span<byte> probe = stackalloc byte[1];
+        if (!memory.TryRead(initAddress, probe))
+        {
+            detail = $"user_malloc_init 0x{initAddress:X16} is not mapped";
+            return false;
+        }
+
+        userMallocInit = initAddress;
+        detail =
+            $"proc_param=0x{procParamAddress:X16} libc_param=0x{libcParamAddress:X16} " +
+            $"malloc_replace=0x{mallocReplaceAddress:X16} (size=0x{mallocReplaceSize:X}, magic={mallocReplaceMagic}) " +
+            $"user_malloc_init=0x{initAddress:X16}";
+        return true;
+    }
+
+    private static bool TryReadUInt64(ICpuMemory memory, ulong address, out ulong value)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        if (!memory.TryRead(address, buffer))
+        {
+            value = 0;
+            return false;
+        }
+
+        value = BinaryPrimitives.ReadUInt64LittleEndian(buffer);
+        return true;
+    }
+
+    private static bool TryReadUInt32(ICpuMemory memory, ulong address, out uint value)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        if (!memory.TryRead(address, buffer))
+        {
+            value = 0;
+            return false;
+        }
+
+        value = BinaryPrimitives.ReadUInt32LittleEndian(buffer);
+        return true;
+    }
+}

--- a/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
+++ b/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
@@ -400,6 +400,22 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
         IReadOnlyDictionary<string, ulong> activeRuntimeSymbols,
         string processImageName)
     {
+        // Real libc reads procParam->sceLibcParam during its own initialization — before
+        // any other module or application initializer — and calls the title's replacement
+        // allocator bootstrap (user_malloc_init). Skipping this leaves the title's global
+        // allocator unconstructed and its static-init cascade dereferencing null.
+        // Note: if a real (LLE) libc module is ever preloaded successfully, its own init
+        // performs this call and this HLE bootstrap must be skipped instead.
+        var mallocReplaceResult = RunLibcMallocReplaceInitializer(
+            mainImage,
+            generation,
+            activeImportStubs,
+            activeRuntimeSymbols);
+        if (mallocReplaceResult is not null)
+        {
+            return mallocReplaceResult;
+        }
+
         var moduleStartResult = RunPreloadedModuleInitializers(
             loadedModuleImages,
             generation,
@@ -413,6 +429,42 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
         // On current PS5 dumps DT_INIT commonly resolves to imageBase+0x10, which is inside
         // the mapped ELF header rather than a callable guest routine. Startup must remain
         // guest-driven until the PS5 init/module ABI is identified precisely.
+        return null;
+    }
+
+    private OrbisGen2Result? RunLibcMallocReplaceInitializer(
+        SelfImage mainImage,
+        Generation generation,
+        IReadOnlyDictionary<ulong, string> activeImportStubs,
+        IReadOnlyDictionary<string, ulong> activeRuntimeSymbols)
+    {
+        if (!LibcParamBootstrap.TryResolveUserMallocInit(
+                _virtualMemory,
+                mainImage.ProcParamAddress,
+                out var userMallocInit,
+                out var detail))
+        {
+            Log.Info($"sceLibcParam malloc replace: skipped ({detail})");
+            return null;
+        }
+
+        Log.Info($"sceLibcParam malloc replace: {detail}");
+        Log.Info($"Calling user_malloc_init at 0x{userMallocInit:X16}");
+
+        var result = _cpuDispatcher.DispatchModuleInitializer(
+            userMallocInit,
+            generation,
+            activeImportStubs,
+            activeRuntimeSymbols,
+            "sceLibcParam:user_malloc_init",
+            _cpuExecutionOptions);
+        if (result != OrbisGen2Result.ORBIS_GEN2_OK)
+        {
+            Log.Error($"user_malloc_init failed: {result}");
+            return result;
+        }
+
+        Log.Info("user_malloc_init completed");
         return null;
     }
 


### PR DESCRIPTION
## Problem

Real libc reads `SceProcParam -> sceLibcParam -> _sceLibcMallocReplace` during its own initialization and calls the title's `user_malloc_init` before any application initializer runs, so the replacement allocator exists before the first static initializer allocates. SharpEmu never did this, so titles that ship a replace table (UE4 games in particular) left their global allocator unconstructed and crashed during static init dereferencing a null singleton.

## Change

- **`LibcParamBootstrap` (new):** a validated, bounds-checked parse of the guest proc-param chain that resolves `user_malloc_init`. Every field is treated as hostile input — reads go through `ICpuMemory.TryRead`, sizes and magic are gated, null pointers are rejected, and the resolved entry is probed for mapping before use.
- **`SharpEmuRuntime`:** dispatches `user_malloc_init` before other initializers via the existing `DispatchModuleInitializer` path, mirroring hardware libc init order.

If no valid replace table is present the resolver returns false and boot continues unchanged, so titles that do not ship one are unaffected.

## Testing

- Builds clean (0 warnings / 0 errors).
- Verified on The Oregon Trail (PPSA19244): without this change, boot dies with an access violation during static init; with it, the resolver finds the PS5 replace table (size 0x78, magic 2), `user_malloc_init` completes, and the title boots through all static initialization (~3.3M import calls) until the next unimplemented libc function.
