### PR TITLE
core: implement sceKernelGetCompiledSdkVersion based on target generation

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelExports.cs
@@ -13,6 +13,8 @@ public static class KernelExports
     private static readonly object _coredumpGate = new();
     private static ulong _coredumpHandler;
     private static ulong _coredumpHandlerContext;
+    private const uint Gen4CompiledSdkVersion = 0x05000000;
+    private const uint Gen5CompiledSdkVersion = 0x09000000;
 
     private readonly record struct CxaDestructorEntry(
         ulong Function,
@@ -26,7 +28,24 @@ public static class KernelExports
         LibraryName = "libKernel")]
     public static int KernelGetCompiledSdkVersion(CpuContext ctx)
     {
-        _ = ctx;
+        var versionAddress = ctx[CpuRegister.Rdi];
+        if (versionAddress == 0)
+        {
+            ctx[CpuRegister.Rax] = unchecked((ulong)(int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        var sdkVersion = ctx.TargetGeneration == Generation.Gen5
+            ? Gen5CompiledSdkVersion
+            : Gen4CompiledSdkVersion;
+
+        if (!ctx.TryWriteUInt32(versionAddress, sdkVersion))
+        {
+            ctx[CpuRegister.Rax] = unchecked((ulong)(int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 


### PR DESCRIPTION
Replaced the no-op stub for `sceKernelGetCompiledSdkVersion` with a proper runtime compliance implementation.

* **Runtime Validation:** Added explicit `NULL` pointer verification for the destination buffer address (`versionAddress == 0`). It returns `ORBIS_GEN2_ERROR_INVALID_ARGUMENT` and sign-extends the target `Rax` register to `0xFFFFFFFF80020003`, strictly mirroring the `PthreadJoin` error-handling pattern of this subsystem.
* **Target-Based SDK Fallback:** Implemented deterministic fallback version routing based on `ctx.TargetGeneration` (`0x05000000` for Gen4 and `0x09000000` for Gen5 standard Orbis layout). This ensures guest applications pass early firmware checks until native metadata extraction is implemented.
* **Atomic Memory Write:** Secured the state write sequence via the native `ctx.TryWriteUInt32` layer, correctly catching virtual memory page faults, propagating `ORBIS_GEN2_ERROR_MEMORY_FAULT` to `Rax`, and safely bypassing partial-write state corruption.

**Out of scope (follow-up):** Native parsing of the compiled SDK version flags directly out of the guest ELF note/metadata sections.

**Files:** `KernelExports.cs`