### PR TITLE
[kernel] Wake blocked waiters on semaphore signal, cancel, and delete

### DIFF
--- a/src/SharpEmu.HLE/OrbisGen2Result.cs
+++ b/src/SharpEmu.HLE/OrbisGen2Result.cs
@@ -41,6 +41,13 @@ public enum OrbisGen2Result : int
     ORBIS_GEN2_ERROR_DEADLOCK = unchecked((int)0x8002000B),
 
     /// <summary>
+    /// Indicates that the waited-on object was deleted while the caller was
+    /// blocked on it. Matches the SCE kernel EACCES code that waiters of a
+    /// deleted semaphore observe.
+    /// </summary>
+    ORBIS_GEN2_ERROR_DELETED = unchecked((int)0x8002000D),
+
+    /// <summary>
     /// Indicates that the target resource is busy.
     /// </summary>
     ORBIS_GEN2_ERROR_BUSY = unchecked((int)0x80020010),
@@ -49,6 +56,13 @@ public enum OrbisGen2Result : int
     /// Indicates that the operation should be retried later.
     /// </summary>
     ORBIS_GEN2_ERROR_TRY_AGAIN = unchecked((int)0x80020023),
+
+    /// <summary>
+    /// Indicates that a blocked wait was canceled (e.g. sceKernelCancelSema).
+    /// Matches the SCE kernel ECANCELED code that canceled semaphore waiters
+    /// observe.
+    /// </summary>
+    ORBIS_GEN2_ERROR_CANCELED = unchecked((int)0x80020055),
 
     /// <summary>
     /// Indicates that behavior is recognized but not implemented yet.

--- a/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
@@ -19,8 +19,21 @@ public static class KernelSemaphoreCompatExports
         public required int MaxCount { get; init; }
         public int Count { get; set; }
         public int WaitingThreads { get; set; }
+        public int CancelEpoch { get; set; }
+        public bool Deleted { get; set; }
         public object Gate { get; } = new();
     }
+
+    private sealed class SemaphoreWaiter
+    {
+        public required int NeedCount { get; init; }
+        public required int CancelEpochAtBlock { get; init; }
+
+        // Written and read only under the owning semaphore's Gate.
+        public int? Result { get; set; }
+    }
+
+    private static string GetSemaphoreWakeKey(uint handle) => $"kernel_sema:0x{handle:X8}";
 
     [SysAbiExport(
         Nid = "188x57JYp0g",
@@ -58,17 +71,27 @@ public static class KernelSemaphoreCompatExports
             handle = unchecked((uint)Interlocked.Increment(ref _nextSemaphoreHandle));
         }
 
-        _semaphores[handle] = new KernelSemaphoreState
+        var state = new KernelSemaphoreState
         {
             Name = name,
             InitialCount = initialCount,
             MaxCount = maxCount,
             Count = initialCount,
         };
+        _semaphores[handle] = state;
 
         if (!ctx.TryWriteUInt32(semaphoreAddress, handle))
         {
             _semaphores.TryRemove(handle, out _);
+            // Handles are sequential and guest-predictable, so a hostile guest can
+            // race a WaitSema onto the handle between publication above and this
+            // rollback. Strand-proof that waiter exactly like DeleteSema does.
+            lock (state.Gate)
+            {
+                state.Deleted = true;
+            }
+
+            _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
             return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
@@ -118,7 +141,17 @@ public static class KernelSemaphoreCompatExports
                 return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT);
             }
 
-            if (!GuestThreadExecution.RequestCurrentThreadBlock(ctx, "sceKernelWaitSema"))
+            var waiter = new SemaphoreWaiter
+            {
+                NeedCount = needCount,
+                CancelEpochAtBlock = semaphore.CancelEpoch,
+            };
+            if (!GuestThreadExecution.RequestCurrentThreadBlock(
+                    ctx,
+                    "sceKernelWaitSema",
+                    GetSemaphoreWakeKey(handle),
+                    resumeHandler: () => CompleteBlockedSemaWait(semaphore, waiter),
+                    wakeHandler: () => TryConsumeBlockedSemaWait(semaphore, waiter)))
             {
                 TraceSemaphore($"wait-would-block handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
                 return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN);
@@ -193,8 +226,14 @@ public static class KernelSemaphoreCompatExports
 
             semaphore.Count += signalCount;
             TraceSemaphore($"signal handle=0x{handle:X8} name='{semaphore.Name}' signal={signalCount} count={semaphore.Count} waiters={semaphore.WaitingThreads}");
-            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
         }
+
+        // Wake after releasing the gate (lock order: scheduler gate -> semaphore gate).
+        // Wake everyone; the wake handler consumes the count per waiter, so a waiter
+        // whose needCount exceeds the remaining count stays parked while a smaller
+        // waiter can proceed.
+        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
     [SysAbiExport(
@@ -226,10 +265,16 @@ public static class KernelSemaphoreCompatExports
             }
 
             semaphore.Count = setCount < 0 ? semaphore.InitialCount : setCount;
-            semaphore.WaitingThreads = 0;
+            semaphore.CancelEpoch++;
+            // WaitingThreads is NOT zeroed here: each canceled waiter decrements it
+            // exactly once in its wake handler. Zeroing here as well would double-count
+            // and silently absorb the increment of a waiter that parks between this
+            // gate release and the wake-all below.
             TraceSemaphore($"cancel handle=0x{handle:X8} name='{semaphore.Name}' set={setCount} count={semaphore.Count}");
-            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
         }
+
+        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
     [SysAbiExport(
@@ -245,8 +290,82 @@ public static class KernelSemaphoreCompatExports
             return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND);
         }
 
+        // Delete succeeds even with blocked waiters; they wake with the deleted
+        // result (the SCE kernel wakes waiters with the EACCES-class code).
+        lock (semaphore.Gate)
+        {
+            semaphore.Deleted = true;
+        }
+
+        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
         TraceSemaphore($"delete handle=0x{handle:X8} name='{semaphore.Name}'");
         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    // Wake handler: runs under the scheduler's guest-thread gate (lock order:
+    // scheduler gate -> semaphore gate). Returns true iff the waiter has a final
+    // result and should be re-readied; false leaves it parked.
+    private static bool TryConsumeBlockedSemaWait(KernelSemaphoreState semaphore, SemaphoreWaiter waiter)
+    {
+        lock (semaphore.Gate)
+        {
+            return TryConsumeBlockedSemaWaitLocked(semaphore, waiter);
+        }
+    }
+
+    private static bool TryConsumeBlockedSemaWaitLocked(KernelSemaphoreState semaphore, SemaphoreWaiter waiter)
+    {
+        if (waiter.Result is not null)
+        {
+            return true;
+        }
+
+        if (semaphore.Deleted)
+        {
+            waiter.Result = (int)OrbisGen2Result.ORBIS_GEN2_ERROR_DELETED;
+            semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
+            TraceSemaphore($"wake-deleted name='{semaphore.Name}' need={waiter.NeedCount}");
+            return true;
+        }
+
+        if (semaphore.CancelEpoch != waiter.CancelEpochAtBlock)
+        {
+            waiter.Result = (int)OrbisGen2Result.ORBIS_GEN2_ERROR_CANCELED;
+            semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
+            TraceSemaphore($"wake-canceled name='{semaphore.Name}' need={waiter.NeedCount}");
+            return true;
+        }
+
+        if (semaphore.Count >= waiter.NeedCount)
+        {
+            semaphore.Count -= waiter.NeedCount;
+            waiter.Result = (int)OrbisGen2Result.ORBIS_GEN2_OK;
+            semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
+            TraceSemaphore($"wake-consume name='{semaphore.Name}' need={waiter.NeedCount} count={semaphore.Count} waiters={semaphore.WaitingThreads}");
+            return true;
+        }
+
+        return false;
+    }
+
+    // Resume handler: runs on the woken guest thread outside the scheduler gate;
+    // its return value becomes the guest's RAX for the resumed sceKernelWaitSema.
+    private static int CompleteBlockedSemaWait(KernelSemaphoreState semaphore, SemaphoreWaiter waiter)
+    {
+        lock (semaphore.Gate)
+        {
+            if (waiter.Result is null && !TryConsumeBlockedSemaWaitLocked(semaphore, waiter))
+            {
+                // Nothing readies a parked semaphore waiter without the wake handler
+                // resolving it, so reaching here means the scheduler contract changed.
+                Console.Error.WriteLine(
+                    $"[LOADER][GAP] sema.resume-no-outcome name='{semaphore.Name}' need={waiter.NeedCount} count={semaphore.Count}");
+                waiter.Result = (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN;
+                semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
+            }
+
+            return waiter.Result!.Value;
+        }
     }
 
     private static void TraceSemaphore(string message)


### PR DESCRIPTION
## What's wrong

If a game blocks in `sceKernelWaitSema` waiting for a semaphore, it never wakes up.

`sceKernelWaitSema` does the right thing when the count is short — it parks the guest thread on the scheduler. But `sceKernelSignalSema` just bumps the count and returns. There's no `WakeBlockedThreads` call anywhere in `KernelSemaphoreCompatExports.cs`, so nothing ever readies a thread that's parked in a wait. `sceKernelCancelSema` and `sceKernelDeleteSema` leave parked waiters stranded the same way. So any title that actually contends a semaphore hangs the moment it blocks on one.

## The fix

Wire the wait side and the signal side together the same way the event-flag and event-queue paths in this repo already do:

- Each semaphore gets a per-handle wake key, and each blocked waiter gets a small record holding the count it needs plus a result slot.
- `signal` / `cancel` / `delete` call `WakeBlockedThreads` after releasing the semaphore lock (keeping the existing scheduler-gate → primitive-lock order).
- The wake handler runs under the scheduler gate and consumes the count under the semaphore lock, so a waiter that needs more than is available stays parked while a smaller waiter can still go through. The resume handler hands the recorded result back as the guest's return value.

Cancel and delete return what the kernel returns to those waiters: `ECANCELED` (`0x80020055`) for a canceled wait and the `EACCES`-class `0x8002000D` for a deleted semaphore, and delete still succeeds even when waiters are present. Those two codes and the "delete succeeds and wakes waiters" behavior match what shadPS4 and Kyty both do.

Nothing on the fast paths changes: an available count is still taken inline, and a wait that was given a timeout pointer still returns immediately as before (actually honoring the timeout is a separate change I'm keeping out of this PR).

Two smaller things the wake path made necessary: only the woken waiter's own handler adjusts the waiting-thread count (so a waiter that parks during a cancel isn't double-counted), and if `create` fails to write the handle back to the guest after publishing the semaphore, it now wakes a waiter that raced onto that handle instead of stranding it.

## How it's tested

This is tested with a harness that drives real guest threads through the real import trampolines and scheduler (not a mock) and checks the observable outcome — thread state, the value the guest gets back, and the semaphore's count and waiter count. It covers: signal-after-block, a signal racing the park, two waiters woken by one signal, a big-need waiter staying parked while a smaller one slips past, and cancel and delete with parked waiters (including the reported waiter count). It also re-runs the event-flag and event-queue equivalents so the shared scheduler machinery didn't shift. All of it passes on this branch.

Honest about coverage: the only game dump on hand here is Oregon Trail, and it doesn't itself contend a semaphore on its boot path, so the game-level check only confirms this doesn't regress that boot — the harness is the real evidence for the wake behavior. The change is fail-open by shape, though: it only adds the missing wake to a path that already blocks, so a title that never touches semaphores is untouched, and one that currently hangs on a wait can only get further. If there's one of your test titles that does use semaphores, happy to run it there too.

Builds clean (`dotnet build SharpEmu.slnx -c Release`) on Windows and Linux.
