### PR TITLE
Implement sceKernelNanosleep in libKernel

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
@@ -15,6 +15,7 @@ namespace SharpEmu.Libs.Kernel;
 public static class KernelRuntimeCompatExports
 {
     private const int Efault = 14;
+    private const int Einval = 22;
     private const ulong TlsErrnoOffset = 0x40;
     private const ulong TlsStackChkGuardBaseOffset = 0x800;
     private const ulong StackChkGuardFieldOffset = 0x10;
@@ -64,6 +65,77 @@ public static class KernelRuntimeCompatExports
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate ulong RdtscDelegate();
+
+    [SysAbiExport(
+        Nid = "QvsZxomvUHs",
+        ExportName = "sceKernelNanosleep",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelNanosleep(CpuContext ctx)
+    {
+        var requestAddress = ctx[CpuRegister.Rdi];
+        var remainAddress = ctx[CpuRegister.Rsi];
+
+        if (requestAddress == 0)
+        {
+            ctx[CpuRegister.Rax] = Einval;
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        Span<byte> timespecBuffer = stackalloc byte[16];
+        if (!ctx.Memory.TryRead(requestAddress, timespecBuffer))
+        {
+            ctx[CpuRegister.Rax] = Efault;
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        var tvSec = BinaryPrimitives.ReadInt64LittleEndian(timespecBuffer);
+        var tvNsec = BinaryPrimitives.ReadInt64LittleEndian(timespecBuffer[sizeof(long)..]);
+
+        if (tvSec < 0 || tvNsec < 0 || tvNsec >= 1_000_000_000L)
+        {
+            ctx[CpuRegister.Rax] = Einval;
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (tvSec == 0 && tvNsec == 0)
+        {
+            WriteRemainingTime(ctx, remainAddress, 0, 0);
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        GuestThreadExecution.Scheduler?.Pump(ctx, "sceKernelNanosleep");
+
+        // TimeSpan resolution is 100 ns ticks, so sub-100 ns requests round up to
+        // a single tick rather than collapsing to a zero-length (no-op) sleep.
+        var totalTicks = tvSec * TimeSpan.TicksPerSecond + Math.Max(tvNsec / 100L, 1L);
+        try
+        {
+            Thread.Sleep(TimeSpan.FromTicks(totalTicks));
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            Thread.Sleep(TimeSpan.FromMilliseconds(int.MaxValue));
+        }
+
+        WriteRemainingTime(ctx, remainAddress, 0, 0);
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    private static void WriteRemainingTime(CpuContext ctx, ulong remainAddress, long seconds, long nanoseconds)
+    {
+        if (remainAddress == 0)
+        {
+            return;
+        }
+
+        Span<byte> remainBuffer = stackalloc byte[16];
+        BinaryPrimitives.WriteInt64LittleEndian(remainBuffer, seconds);
+        BinaryPrimitives.WriteInt64LittleEndian(remainBuffer[sizeof(long)..], nanoseconds);
+        ctx.Memory.TryWrite(remainAddress, remainBuffer);
+    }
 
     [SysAbiExport(
         Nid = "1jfXLRVzisc",


### PR DESCRIPTION
## What this does

Adds the missing `sceKernelNanosleep` export to `libKernel`. We already had `sceKernelUsleep` but nothing for nanosecond-resolution sleeps, so any title calling `sceKernelNanosleep` was hitting an unresolved import.

## Details

- Registered under NID `QvsZxomvUHs` for both `Gen4` and `Gen5`.
- Reads `rqtp` as a guest pointer to a `timespec` (`tv_sec` / `tv_nsec`, two little-endian int64s) instead of treating the registers as raw values.
- Validates the pointer (`EFAULT` on unmapped memory) and the argument range (`EINVAL` when `tv_nsec` is out of `[0, 1e9)` or values are negative).
- Handles the zero-duration case as an immediate success.
- Sleeps for the requested duration and zeroes the optional `rmtp` remaining-time struct on completion.
- Left the optimized `sceKernelUsleep` short-sleep fast path untouched.

## Testing

Full solution builds clean (0 warnings, 0 errors) on the pinned .NET 10 SDK. I also ran the export directly against a mock guest memory to check every branch:

- null `rqtp` -> EINVAL
- unmapped `rqtp` -> EFAULT
- out-of-range `tv_nsec` -> EINVAL
- zero timespec -> success
- `rmtp` zeroed on success
- 50ms request -> returns success and actually sleeps ~50ms

All checks pass.
