### PR TITLE
fix(vfs): harden getdirentries and APR filepath resolution

### DIFF
--- a/src/SharpEmu.Libs/Ampr/AmprFileRegistry.cs
+++ b/src/SharpEmu.Libs/Ampr/AmprFileRegistry.cs
@@ -21,7 +21,7 @@ internal static class AmprFileRegistry
         return _hostPathsById.TryGetValue(id, out hostPath!);
     }
 
-    private static uint ComputeFileId(string guestPath)
+    internal static uint ComputeFileId(string guestPath)
     {
         var bytes = System.Text.Encoding.UTF8.GetBytes(guestPath);
 

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -6350,19 +6350,19 @@ public static class KernelMemoryCompatExports
         }
 
         var currentIndex = directory.NextIndex;
-        if (basePointerAddress != 0 && !TryWriteUInt64Compat(ctx, basePointerAddress, (ulong)currentIndex))
-        {
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
-        }
-
         if (currentIndex >= directory.Entries.Length)
         {
+            if (basePointerAddress != 0 &&
+                !TryWriteUInt64Compat(ctx, basePointerAddress, (ulong)currentIndex))
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+            }
+
             ctx[CpuRegister.Rax] = 0;
             return (int)OrbisGen2Result.ORBIS_GEN2_OK;
         }
 
         var entryName = directory.Entries[currentIndex];
-        directory.NextIndex = currentIndex + 1;
 
         var entryBytes = Encoding.UTF8.GetBytes(entryName);
         var nameLength = Math.Min(entryBytes.Length, 255);
@@ -6381,6 +6381,13 @@ public static class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
+        if (basePointerAddress != 0 &&
+            !TryWriteUInt64Compat(ctx, basePointerAddress, (ulong)currentIndex))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        directory.NextIndex = currentIndex + 1;
         ctx[CpuRegister.Rax] = 512;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -1689,15 +1689,15 @@ public static class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
+        var entryCount = (int)count;
+        Span<uint> localIds = count <= 256 ? stackalloc uint[entryCount] : new uint[entryCount];
+        Span<ulong> localSizes = count <= 128 ? stackalloc ulong[entryCount] : new ulong[entryCount];
+        var resolvedGuestPaths = new string[entryCount];
+        var resolvedHostPaths = new string[entryCount];
+
         for (ulong i = 0; i < count; i++)
         {
-            if (idsAddress != 0 &&
-                !TryWriteUInt32Compat(ctx, idsAddress + (i * sizeof(uint)), uint.MaxValue))
-            {
-                KernelRuntimeCompatExports.TrySetErrno(ctx, Efault);
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
-            }
-
+            var index = (int)i;
             if (!TryResolveAprFilepath(ctx, pathListAddress, i, out var guestPath))
             {
                 KernelRuntimeCompatExports.TrySetErrno(ctx, Efault);
@@ -1712,21 +1712,45 @@ public static class KernelMemoryCompatExports
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
             }
 
-            var fileId = AmprFileRegistry.Register(guestPath, hostPath);
+            var fileId = AmprFileRegistry.ComputeFileId(guestPath);
             LogIoTrace("apr_resolve", guestPath, $"host='{hostPath}' index={i} count={count} id=0x{fileId:X8} size={fileSize}");
 
-            if (idsAddress != 0 &&
-                !TryWriteUInt32Compat(ctx, idsAddress + (i * sizeof(uint)), fileId))
+            localIds[index] = fileId;
+            localSizes[index] = fileSize;
+            resolvedGuestPaths[index] = guestPath;
+            resolvedHostPaths[index] = hostPath;
+        }
+
+        Span<byte> sizePayload = count <= 64 ? stackalloc byte[entryCount * sizeof(ulong)] : new byte[entryCount * sizeof(ulong)];
+        for (ulong i = 0; i < count; i++)
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(sizePayload[(int)(i * sizeof(ulong))..], localSizes[(int)i]);
+        }
+
+        if (!TryWriteCompat(ctx, sizesAddress, sizePayload))
+        {
+            KernelRuntimeCompatExports.TrySetErrno(ctx, Efault);
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        if (idsAddress != 0)
+        {
+            Span<byte> idPayload = count <= 128 ? stackalloc byte[entryCount * sizeof(uint)] : new byte[entryCount * sizeof(uint)];
+            for (ulong i = 0; i < count; i++)
             {
-                KernelRuntimeCompatExports.TrySetErrno(ctx, Efault);
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+                BinaryPrimitives.WriteUInt32LittleEndian(idPayload[(int)(i * sizeof(uint))..], localIds[(int)i]);
             }
 
-            if (!TryWriteUInt64Compat(ctx, sizesAddress + (i * sizeof(ulong)), fileSize))
+            if (!TryWriteCompat(ctx, idsAddress, idPayload))
             {
                 KernelRuntimeCompatExports.TrySetErrno(ctx, Efault);
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
             }
+        }
+
+        for (var i = 0; i < entryCount; i++)
+        {
+            AmprFileRegistry.Register(resolvedGuestPaths[i], resolvedHostPaths[i]);
         }
 
         ctx[CpuRegister.Rax] = 0;


### PR DESCRIPTION
Follow-up VFS hardening applying the same guest-writes-first discipline from the time subsystem to directory enumeration and APR filepath resolution.

**Getdirentries (`KernelGetdirentriesCore`):**
* Write the 512-byte dirent buffer first via `TryWriteCompat`, update `basep` second (when non-null) via `TryWriteUInt64Compat`, and advance `directory.NextIndex` only after both guest writes succeed.
* Removed the early `basep` write at method entry that could mutate guest memory before buffer validation and advance the host cursor before a successful dirent delivery, causing permanent entry loss on `MEMORY_FAULT` at `bufferAddress`.
* On EOF (`currentIndex >= Entries.Length`), write `basep` with the final offset and return 0 without mutating `NextIndex`, matching FreeBSD `getdirentries(2)` semantics. For `KernelGetdents`, `basePointerAddress` is 0, so only the buffer write and host cursor advance run.

**APR (`sceKernelAprResolveFilepathsToIdsAndFileSizes`):**
* Stopped writing ids and sizes into guest memory inside the loop; path resolution and file size lookup fill host-side local buffers first (stackalloc for small counts, heap arrays when count exceeds the thresholds). On `EFAULT` or `NOT_FOUND`, guest arrays are untouched and `AmprFileRegistry` is not updated.
* Pack `localSizes` and `localIds` into contiguous byte buffers and write each output array with one `TryWriteCompat` call instead of per-element `TryWriteUInt32Compat` / `TryWriteUInt64Compat` pairs.
* `AmprFileRegistry.Register` runs only after guest writes succeed. `AmprFileRegistry.ComputeFileId` is internal so ids can be computed during the resolve loop without premature registry mutation. Removed the `uint.MaxValue` placeholder pre-write.

Out of scope: NetCtl connected-state stubs; writable range validation pre-probes for split outputs.

Files: `KernelMemoryCompatExports.cs`, `AmprFileRegistry.cs`