### PR TITLE
Libs: add libSceDiscMap HLE exports

### DIFF
--- a/src/SharpEmu.Libs/DiscMap/DiscMapExports.cs
+++ b/src/SharpEmu.Libs/DiscMap/DiscMapExports.cs
@@ -1,0 +1,104 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+
+namespace SharpEmu.Libs.DiscMap;
+
+/// <summary>
+/// HLE implementation of libSceDiscMap, ported from Kyty's LibDiscMap.cpp
+/// (https://github.com/InoriRus/Kyty, MIT). Titles installed to internal
+/// storage query these entry points on nearly every file access to decide
+/// whether a read must be redirected to the Blu-ray drive. Reporting every
+/// request as already resident on HDD lets the regular file system path
+/// service the read.
+/// </summary>
+public static class DiscMapExports
+{
+    private const int DiscMapErrorInvalidArgument = unchecked((int)0x81100001);
+    private const int DiscMapErrorLocationNotMapped = unchecked((int)0x81100002);
+    private const int DiscMapErrorFileNotFound = unchecked((int)0x81100003);
+    private const int DiscMapErrorNoBitmapInfo = unchecked((int)0x81100004);
+
+    [SysAbiExport(
+        Nid = "lbQKqsERhtE",
+        ExportName = "sceDiscMapIsRequestOnHDD",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceDiscMap")]
+    public static int DiscMapIsRequestOnHDD(CpuContext ctx)
+    {
+        var pathAddress = ctx[CpuRegister.Rdi];
+        var offset = ctx[CpuRegister.Rsi];
+        var size = ctx[CpuRegister.Rdx];
+        var resultAddress = ctx[CpuRegister.Rcx];
+
+        if (pathAddress == 0 || resultAddress == 0)
+        {
+            return DiscMapErrorInvalidArgument;
+        }
+
+        if (!ctx.TryWriteInt32(resultAddress, 1))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        TraceDiscMap(ctx, "sceDiscMapIsRequestOnHDD", pathAddress, offset, size);
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "fJgP+wqifno",
+        ExportName = "sceDiscMapUnknownFJgP",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceDiscMap")]
+    public static int DiscMapUnknownFJgP(CpuContext ctx) => WriteMappingTriple(ctx, "sceDiscMapUnknownFJgP");
+
+    [SysAbiExport(
+        Nid = "ioKMruft1ek",
+        ExportName = "sceDiscMapUnknownIoKM",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceDiscMap")]
+    public static int DiscMapUnknownIoKM(CpuContext ctx) => WriteMappingTriple(ctx, "sceDiscMapUnknownIoKM");
+
+    private static int WriteMappingTriple(CpuContext ctx, string exportName)
+    {
+        var pathAddress = ctx[CpuRegister.Rdi];
+        var offset = ctx[CpuRegister.Rsi];
+        var size = ctx[CpuRegister.Rdx];
+        var flagsAddress = ctx[CpuRegister.Rcx];
+        var outAddress1 = ctx[CpuRegister.R8];
+        var outAddress2 = ctx[CpuRegister.R9];
+
+        if (pathAddress == 0 || flagsAddress == 0 || outAddress1 == 0 || outAddress2 == 0)
+        {
+            return DiscMapErrorInvalidArgument;
+        }
+
+        if (!ctx.TryWriteUInt64(flagsAddress, 0) ||
+            !ctx.TryWriteUInt64(outAddress1, 0) ||
+            !ctx.TryWriteUInt64(outAddress2, 0))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        TraceDiscMap(ctx, exportName, pathAddress, offset, size);
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    private static void TraceDiscMap(CpuContext ctx, string exportName, ulong pathAddress, ulong offset, ulong size)
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_DISCMAP"), "1", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var path = ctx.TryReadNullTerminatedUtf8(pathAddress, 1024, out var value)
+            ? value
+            : $"<unreadable 0x{pathAddress:X16}>";
+        Console.Error.WriteLine($"[HLE][DISCMAP] {exportName} path={path} offset=0x{offset:X} size=0x{size:X}");
+    }
+}


### PR DESCRIPTION
## What

Adds an HLE implementation of `libSceDiscMap` as a new `DiscMapExports` class in `SharpEmu.Libs`, following the existing `SysAbiExport` conventions (validated pointers, `OrbisGen2Result` codes, optional env-gated tracing).

Disc-installed titles call into `libSceDiscMap` on most file accesses to decide whether a read has to be redirected to the Blu-ray drive. Without these exports the imports resolve to `ORBIS_GEN2_ERROR_NOT_FOUND`, which titles can treat as an I/O failure. Reporting every request as already resident on internal storage keeps reads on the regular file system path.

## Exports

| NID | Export | Behavior |
| --- | --- | --- |
| `lbQKqsERhtE` | `sceDiscMapIsRequestOnHDD` | writes `1` to the result pointer, returns `0` |
| `fJgP+wqifno` | `sceDiscMapUnknownFJgP` | zero-fills the three output pointers, returns `0` |
| `ioKMruft1ek` | `sceDiscMapUnknownIoKM` | zero-fills the three output pointers, returns `0` |

- Null path/output pointers return `DISC_MAP_ERROR_INVALID_ARGUMENT` (`0x81100001`), consistent with the known `0x811000xx` libSceDiscMap error range.
- Unreadable/unwritable guest memory returns `ORBIS_GEN2_ERROR_MEMORY_FAULT`.
- Set `SHARPEMU_LOG_DISCMAP=1` to trace calls (path, offset, size), matching the `SHARPEMU_LOG_PTHREADS` pattern.
- `sceDiscMapIsRequestOnHDD` is already in `scripts/ps5_names.txt`, so Aerolib resolves the name; the two unidentified NIDs keep descriptive `Unknown` export names like the existing `sceKernelUnknown*` entries.

## Source / attribution

Behavior is ported from the `LibDiscMap.cpp` stubs in [Kyty](https://github.com/InoriRus/Kyty) (MIT), rewritten in C# for SharpEmu's export model. shadPS4's HLE discmap work was used as a cross-reference for the argument layout of the two unidentified NIDs (path, offset, nbytes, three out-pointers). This PR was prepared with the help of an AI assistant; flagging that for the maintainers' awareness.

## Testing

- `dotnet build SharpEmu.slnx` — clean, 0 warnings / 0 errors (SDK 10.0.103)
- Verified via a small harness against `ModuleManager.RegisterFromAssembly`: all three NIDs register and dispatch, `sceDiscMapIsRequestOnHDD` writes `1` and returns `0`, null-pointer calls return `0x81100001`, and the triple-output NIDs zero their out-params.

No existing NIDs are touched; the change is purely additive.