### PR TITLE
[logging] Migrate HLE diagnostics to SharpEmuLog

### DIFF
--- a/src/SharpEmu.CLI/packages.lock.json
+++ b/src/SharpEmu.CLI/packages.lock.json
@@ -216,7 +216,10 @@
         }
       },
       "sharpemu.hle": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.Logging": "[1.0.0, )"
+        }
       },
       "sharpemu.libs": {
         "type": "Project",

--- a/src/SharpEmu.Core/packages.lock.json
+++ b/src/SharpEmu.Core/packages.lock.json
@@ -65,7 +65,10 @@
         "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
       },
       "sharpemu.hle": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.Logging": "[1.0.0, )"
+        }
       },
       "sharpemu.libs": {
         "type": "Project",

--- a/src/SharpEmu.HLE/Aerolib/Aerolib.cs
+++ b/src/SharpEmu.HLE/Aerolib/Aerolib.cs
@@ -3,11 +3,13 @@
 
 using System.Buffers.Binary;
 using System.Linq;
+using SharpEmu.Logging;
 
 namespace SharpEmu.HLE;
 
 public sealed class Aerolib : ISymbolCatalog
 {
+    private static readonly SharpEmuLogger Log = SharpEmuLog.For("Aerolib");
     private static readonly Lazy<Aerolib> _instance = new(() => new Aerolib());
     private static readonly Aerolib EmptyCatalog = new Aerolib(empty: true);
 
@@ -108,14 +110,14 @@ public sealed class Aerolib : ISymbolCatalog
 
             if (resourceName == null)
             {
-                Console.Error.WriteLine("[AEROLIB] Embedded resource 'aerolib.bin' not found");
+                Log.Error("Embedded resource 'aerolib.bin' not found");
                 return;
             }
 
             using var stream = assembly.GetManifestResourceStream(resourceName);
             if (stream == null)
             {
-                Console.Error.WriteLine("[AEROLIB] Failed to open embedded resource stream");
+                Log.Error("Failed to open embedded resource stream");
                 return;
             }
 
@@ -145,11 +147,11 @@ public sealed class Aerolib : ISymbolCatalog
                 _byExportName[name] = symbol;
             }
 
-            Console.Error.WriteLine($"[AEROLIB] Loaded {_byNid.Count} NID entries from binary resource");
+            Log.Info($"Loaded {_byNid.Count} NID entries from binary resource");
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"[AEROLIB] Failed to load embedded aerolib.bin: {ex.Message}");
+            Log.Error($"Failed to load embedded aerolib.bin: {ex.Message}", ex);
         }
     }
 

--- a/src/SharpEmu.HLE/ModuleManager.cs
+++ b/src/SharpEmu.HLE/ModuleManager.cs
@@ -3,11 +3,14 @@
 
 using System.Collections.Concurrent;
 using System.Reflection;
+using SharpEmu.Logging;
 
 namespace SharpEmu.HLE;
 
 public sealed class ModuleManager : IModuleManager
 {
+    private static readonly SharpEmuLogger Log = SharpEmuLog.For("HLE");
+
     private readonly ConcurrentDictionary<string, Delegate> _dispatchTable = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, ExportedFunction> _exportTable = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, ExportedFunction> _exportNameTable = new(StringComparer.Ordinal);
@@ -47,7 +50,7 @@ public sealed class ModuleManager : IModuleManager
                     var handler = CreateHandler(type, method, instances);
                     if (!_dispatchTable.TryAdd(exportInfo.Value.Nid, handler))
                     {
-                        Console.Error.WriteLine($"[HLE] Duplicate NID '{exportInfo.Value.Nid}' ({exportInfo.Value.ExportName}) — already registered, skipping.");
+                        Log.Warning($"Duplicate NID '{exportInfo.Value.Nid}' ({exportInfo.Value.ExportName}) — already registered, skipping.");
                         continue;
                     }
 
@@ -106,7 +109,7 @@ public sealed class ModuleManager : IModuleManager
 
         if (!_dispatchTable.TryGetValue(nid, out var function) || !_exportTable.TryGetValue(nid, out var export))
         {
-            Console.Error.WriteLine($"[HLE] NID '{nid}' not found in dispatch table.");
+            Log.Warning($"NID '{nid}' not found in dispatch table.");
             context[CpuRegister.Rax] = unchecked((ulong)(int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND);
             result = OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
             return false;
@@ -114,7 +117,7 @@ public sealed class ModuleManager : IModuleManager
 
         if ((export.Target & context.TargetGeneration) == 0)
         {
-            Console.Error.WriteLine($"[HLE] NID '{nid}' ({export.Name}) found but not implemented for generation {context.TargetGeneration} (targets: {export.Target}).");
+            Log.Warning($"NID '{nid}' ({export.Name}) found but not implemented for generation {context.TargetGeneration} (targets: {export.Target}).");
             context[CpuRegister.Rax] = unchecked((ulong)(int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_IMPLEMENTED);
             result = OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_IMPLEMENTED;
             return false;

--- a/src/SharpEmu.HLE/SharpEmu.HLE.csproj
+++ b/src/SharpEmu.HLE/SharpEmu.HLE.csproj
@@ -13,6 +13,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SharpEmu.Logging\SharpEmu.Logging.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Aerolib\aerolib.bin" />
   </ItemGroup>
 </Project>

--- a/src/SharpEmu.HLE/packages.lock.json
+++ b/src/SharpEmu.HLE/packages.lock.json
@@ -1,6 +1,10 @@
 {
   "version": 2,
   "dependencies": {
-    "net10.0": {}
+    "net10.0": {
+      "sharpemu.logging": {
+        "type": "Project"
+      }
+    }
   }
 }

--- a/src/SharpEmu.Libs/packages.lock.json
+++ b/src/SharpEmu.Libs/packages.lock.json
@@ -98,6 +98,12 @@
         "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
       },
       "sharpemu.hle": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.Logging": "[1.0.0, )"
+        }
+      },
+      "sharpemu.logging": {
         "type": "Project"
       }
     }


### PR DESCRIPTION
## Summary

- Route `ModuleManager` dispatch diagnostics through the `HLE` logger.
- Route Aerolib resource loading status and failures through the `Aerolib` logger.
- Preserve appropriate warning, info, and error levels.
- Include the original exception when Aerolib loading fails.
- Update project references and lockfiles for the internal logging dependency.

## Why

These diagnostics were written directly to stderr, bypassing the configured
SharpEmu log sinks and file logging. This migration makes HLE and Aerolib
messages consistent with the rest of the structured logging infrastructure.

## Validation

- `dotnet restore SharpEmu.slnx --locked-mode`
- `dotnet build SharpEmu.slnx -c Release --no-restore`
  - 0 warnings
  - 0 errors
- `dotnet publish src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r win-x64 --self-contained true --no-restore`
- `reuse lint`