### PR TITLE
[agc] Reset transparent Chowdren effect-layer fills

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -3296,8 +3296,58 @@ public static class AgcExports
             globalMemoryBindings,
             vertexInputs,
             renderTargets,
-            CreateRenderState(state.CxRegisters, renderTargets.FirstOrDefault()));
+            ApplyTransparentPremultipliedFillClear(
+                CreateRenderState(state.CxRegisters, renderTargets.FirstOrDefault()),
+                textures,
+                vertexInputs,
+                pixelEvaluation.InitialScalarRegisters));
         return true;
+    }
+
+    private static readonly bool _transparentFillClearEnabled = !string.Equals(
+        Environment.GetEnvironmentVariable("SHARPEMU_DISABLE_TRANSPARENT_FILL_CLEAR"),
+        "1",
+        StringComparison.Ordinal);
+
+    /// <summary>
+    /// Chowdren resets its effect layers with an untextured transparent-black
+    /// fill using premultiplied blending. With One/OneMinusSrcAlpha that draw
+    /// is otherwise a no-op, causing fog and vignette layers to accumulate.
+    /// Treat precisely that draw shape as an overwrite.
+    /// </summary>
+    private static VulkanGuestRenderState ApplyTransparentPremultipliedFillClear(
+        VulkanGuestRenderState renderState,
+        IReadOnlyList<TranslatedImageBinding> textures,
+        IReadOnlyList<Gen5VertexInputBinding> vertexInputs,
+        IReadOnlyList<uint> pixelUserData)
+    {
+        if (!_transparentFillClearEnabled ||
+            textures.Count != 0 ||
+            vertexInputs.Count != 0 ||
+            pixelUserData.Count < 4 ||
+            renderState.Blend is not
+            {
+                Enable: true,
+                ColorSrcFactor: 1,
+                ColorDstFactor: 5,
+                ColorFunc: 0,
+            })
+        {
+            return renderState;
+        }
+
+        for (var index = 0; index < 4; index++)
+        {
+            if ((pixelUserData[index] & 0x7FFF_FFFFu) != 0)
+            {
+                return renderState;
+            }
+        }
+
+        return renderState with
+        {
+            Blend = renderState.Blend with { Enable = false },
+        };
     }
 
     private static VulkanGuestIndexBuffer? CreateVulkanIndexBuffer(


### PR DESCRIPTION
## Summary
- recognize Chowdren’s untextured transparent-black premultiplied fill as an effect-layer reset
- prevent Dreaming Sarah fog and vignette render targets from accumulating across frames
- provide `SHARPEMU_DISABLE_TRANSPARENT_FILL_CLEAR=1` to restore the previous behavior

## Scope
This is the minimal rendering portion of the earlier Dreaming Sarah investigation: 51 additions and one call-site change in `AgcExports.cs`. It deliberately excludes the unrelated guest-image synchronization and diagnostics work.

## Validation
- `$HOME/.dotnet/dotnet build SharpEmu.slnx --no-restore`