### PR TITLE
[cpu] Route memmove through guarded HLE

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -1406,12 +1406,15 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	{
 		return exportName switch
 		{
-			"memmove" or
-			// memset/memcpy excluded: the raw LLE routines have no null/bounds guard and crash
-			// with an access violation on bad pointers (observed hit during Quake's CL_Init,
-			// where a still-unidentified upstream bug calls memcpy/memset with a null
-			// destination). Both are instead served by the guarded native intrinsics in
-			// TryCreateNativeImportIntrinsic, which fail safely without leaving the leaf path.
+			// memset/memcpy excluded: the raw LLE routines have no null/bounds guard and
+			// crash with an access violation on bad pointers (observed hit during Quake's
+			// CL_Init, where a still-unidentified upstream bug calls memcpy/memset with a
+			// null destination). Both are served by the guarded native intrinsics in
+			// TryCreateNativeImportIntrinsic, which fail safely without leaving the leaf
+			// path.
+			// memmove excluded preventively for the same reason — raw LLE has no guards;
+			// it falls back to the HLE handler KernelMemoryCompatExports.Memmove, which
+			// delegates to the guarded Memcpy with a 512 MiB count cap.
 			"memcmp" or
 			// _Getpctype must come from the game's own Dinkumware libc when one is bundled:
 			// it returns a pointer to that CRT's ctype bitmask table, whose bit layout


### PR DESCRIPTION
## What

Removes `memmove` from the safe LLE allowlist (`IsSafeLleLibcExport`) in `DirectExecutionBackend.cs`. Raw LLE `memmove` has no pointer/count guards — an oversized or null-pointer `memmove` from guest code can corrupt host memory.

## Why

PR #68 added guarded native intrinsics for `memcpy` and `memset` (null/low-page check, canonical user space check, 512 MiB count cap) and excluded them from raw LLE bridging. `memmove` was left in the allowlist, leaving the same unguarded path open.

The HLE handler `KernelMemoryCompatExports.Memmove` delegates to the guarded `Memcpy` which enforces a 512 MiB count cap and validates source/destination pointers before copying. After this change, `memmove` calls fall back to that HLE path instead of the raw LLE bridge.

## Change

- `IsSafeLleLibcExport`: removed `"memmove"` from the safe LLE list
- Updated comment to separate the observed memcpy/memset crash in Quake from the preventive memmove exclusion

This is preventive hardening, not a proven fix for issue #9.

## Testing

- `dotnet build SharpEmu.slnx -c Release` — 0 warnings, 0 errors (SDK 10.0.103)
- `git diff --check` — whitespace clean
- Single file changed: `src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs` (+9 −6)

Signed-off-by: kostyaff <filipchukks@gmail.com>