### PR TITLE
Linux support: guest-thread scheduling, pthread sync, and GC fail-fast fixes

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.103",
+        "version": "10.0.301",
         "rollForward": "disable"
     }
 }

--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -90,6 +90,10 @@ internal static partial class Program
 
         Console.Error.WriteLine("[DEBUG] Creating runtime...");
 
+        SharpEmu.HLE.Diagnostics.StallDiagnostics.SyncObjectStateDumper = address =>
+            SharpEmu.Libs.Kernel.KernelPthreadExtendedCompatExports.DumpRwlockStateForStall(address)
+            ?? SharpEmu.Libs.Kernel.KernelPthreadCompatExports.DumpMutexStateForStall(address);
+
         using var runtime = SharpEmuRuntime.CreateDefault(runtimeOptions);
 
         OrbisGen2Result result;

--- a/src/SharpEmu.CLI/packages.lock.json
+++ b/src/SharpEmu.CLI/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "0B6nZyCHWXnvmlB559oduOspVdNOnpNXPjhpWVMovLPAsDVG7A4jJR9rzECf67JUzxP8/ee/wA8clwIzJcWNFA=="
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "4Iw41e2h7I4t70SJcX2GCmbyKJIlA273Cfm9RJMM050/3VBejGAG1KcthP5Z2L6SQcbfbf6BhNWO26+ZG+GzMg=="
       },
       "Avalonia.Angle.Windows.Natives": {
         "type": "Transitive",

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Diagnostics.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Diagnostics.cs
@@ -52,8 +52,11 @@ public sealed partial class DirectExecutionBackend
 			var entry = _recentImportTrace[num2];
 			if (!string.IsNullOrEmpty(entry.Nid))
 			{
+				var exportText = _moduleManager.TryGetExport(entry.Nid, out var export)
+					? $"{export.LibraryName}:{export.Name}"
+					: "<unresolved>";
 				Log.Info(
-					$"     #{entry.DispatchIndex} nid={entry.Nid} ret=0x{entry.ReturnRip:X16} " +
+					$"     #{entry.DispatchIndex} {exportText} nid={entry.Nid} ret=0x{entry.ReturnRip:X16} " +
 					$"rdi=0x{entry.Arg0:X16} rsi=0x{entry.Arg1:X16} rdx=0x{entry.Arg2:X16}");
 			}
 		}

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
@@ -195,6 +195,7 @@ public sealed partial class DirectExecutionBackend
 				};
 				Console.Error.WriteLine("[LOADER][INFO]   AV access: " + accessText);
 				Console.Error.WriteLine($"[LOADER][INFO]   AV target: 0x{target:X16}");
+				DumpAccessViolationAddressHints(rip, target, rax, rbx, rcx, rdx, rsi, rdi, rbp, rsp, r8, r9, r10, r11, r12, r13, r14, r15);
 				if (VirtualQuery((void*)target, out var mbi, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) != 0)
 				{
 					Console.Error.WriteLine($"[LOADER][INFO]   AV target region: base=0x{mbi.BaseAddress:X16} size=0x{mbi.RegionSize:X16} state=0x{mbi.State:X08} protect=0x{mbi.Protect:X08}");
@@ -387,6 +388,79 @@ public sealed partial class DirectExecutionBackend
 			Console.Error.WriteLine(
 				$"[LOADER][INFO]     0x{instruction.Rip:X16}: {instruction.Text} bytes={IcedDecoder.FormatBytes(instruction.Bytes)}");
 			rip += (ulong)instruction.Length;
+		}
+	}
+
+	private void DumpAccessViolationAddressHints(
+		ulong rip,
+		ulong target,
+		ulong rax,
+		ulong rbx,
+		ulong rcx,
+		ulong rdx,
+		ulong rsi,
+		ulong rdi,
+		ulong rbp,
+		ulong rsp,
+		ulong r8,
+		ulong r9,
+		ulong r10,
+		ulong r11,
+		ulong r12,
+		ulong r13,
+		ulong r14,
+		ulong r15)
+	{
+		if (_cpuContext == null ||
+			!IcedDecoder.TryReadGuestBytes(_cpuContext.Memory, rip, maxLen: 15, out var bytes) ||
+			!IcedDecoder.TryDecode(rip, bytes, out var instruction))
+		{
+			return;
+		}
+
+		Console.Error.WriteLine($"[LOADER][INFO]   Fault instruction: {instruction.Text} bytes={IcedDecoder.FormatBytes(instruction.Bytes)}");
+		var registers = new (string Name, ulong Value)[]
+		{
+			("rax", rax),
+			("rbx", rbx),
+			("rcx", rcx),
+			("rdx", rdx),
+			("rsi", rsi),
+			("rdi", rdi),
+			("rbp", rbp),
+			("rsp", rsp),
+			("r8", r8),
+			("r9", r9),
+			("r10", r10),
+			("r11", r11),
+			("r12", r12),
+			("r13", r13),
+			("r14", r14),
+			("r15", r15),
+		};
+
+		foreach (var register in registers)
+		{
+			if (register.Value == target)
+			{
+				Console.Error.WriteLine($"[LOADER][INFO]   AV target matches {register.Name}");
+			}
+		}
+
+		DumpAddressCandidate("rcx+r12", rcx, r12, target);
+		DumpAddressCandidate("rcx+r12+2", rcx + 2, r12, target);
+		DumpAddressCandidate("rdi+r12", rdi, r12, target);
+		DumpAddressCandidate("rsi+r12", rsi, r12, target);
+		DumpAddressCandidate("rdx+r12", rdx, r12, target);
+	}
+
+	private static void DumpAddressCandidate(string name, ulong baseValue, ulong indexValue, ulong target)
+	{
+		ulong value = unchecked(baseValue + indexValue);
+		ulong distance = value >= target ? value - target : target - value;
+		if (distance <= 0x100)
+		{
+			Console.Error.WriteLine($"[LOADER][INFO]   AV candidate {name}=0x{value:X16} (base=0x{baseValue:X16} index=0x{indexValue:X16})");
 		}
 	}
 

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
@@ -17,9 +17,42 @@ public sealed partial class DirectExecutionBackend
 {
 	private const ulong LazyCommitWindowBytes = 0x0200_0000UL;
 	private static int _lazyCommitTraceCount;
+	private static int _lazyCommitGate;
+
+	// Guest threads execute managed HLE exports on a hijacked (non-CLR-owned) call stack.
+	// Lazily running a static constructor or the managed-exception/resource-loading machinery
+	// for the FIRST time in that context fail-fasts the whole CLR with the misleading
+	// "Invalid Program: attempted to call a UnmanagedCallersOnly method from managed code".
+	// Force the fragile paths to initialize here, once, on a normal host thread during setup.
+	private static int _guestThreadRuntimeWarmed;
+	private static void WarmGuestThreadSensitiveRuntime()
+	{
+		if (Interlocked.Exchange(ref _guestThreadRuntimeWarmed, 1) != 0)
+		{
+			return;
+		}
+
+		try
+		{
+			// Trigger the IOException + SR.GetResourceString + ResourceReader..cctor path that
+			// KernelOpenUnderscore (and other file HLE) hits when a guest opens a missing file.
+			var probe = System.IO.Path.Combine(
+				System.IO.Path.GetTempPath(),
+				"sharpemu-warm-" + Guid.NewGuid().ToString("N"),
+				"missing");
+			using var _ = new System.IO.FileStream(probe, System.IO.FileMode.Open, System.IO.FileAccess.Read);
+		}
+		catch (Exception)
+		{
+			// Expected: the probe path does not exist. The point is to run the exception and
+			// resource machinery now, on this normal thread, so no guest thread ever runs it lazily.
+		}
+	}
 
 	private unsafe void SetupExceptionHandler()
 	{
+		WarmGuestThreadSensitiveRuntime();
+
 		if (!OperatingSystem.IsWindows())
 		{
 			InstallUnixSignalHandlers();
@@ -158,6 +191,10 @@ public sealed partial class DirectExecutionBackend
 			Console.Error.WriteLine($"[LOADER][INFO]   Code: 0x{exceptionCode:X8}");
 			Console.Error.WriteLine($"[LOADER][INFO]   Exception Address: 0x{exceptionAddress:X16}");
 			Console.Error.WriteLine($"[LOADER][INFO]   RIP: 0x{rip:X16}");
+			if (rip >= GuestModuleBaseForDiag)
+			{
+				Console.Error.WriteLine($"[LOADER][INFO]   RIP module_offset (IDA): 0x{rip - GuestModuleBaseForDiag:X}");
+			}
 			if (TryFormatNearestRuntimeSymbol(rip, out string symbol))
 			{
 				Console.Error.WriteLine("[LOADER][INFO]   RIP symbol: " + symbol);
@@ -987,6 +1024,28 @@ public sealed partial class DirectExecutionBackend
 		{
 			return false;
 		}
+
+		// Serialized: two threads faulting in the same window must not both see a
+		// stale MEM_FREE query and race their reserve/commit against each other.
+		// Spin gate rather than Monitor — this runs inside the SIGSEGV handler,
+		// where managed blocking primitives are unsafe.
+		while (Interlocked.CompareExchange(ref _lazyCommitGate, 1, 0) != 0)
+		{
+			Thread.SpinWait(64);
+		}
+
+		try
+		{
+			return HandleLazyCommittedPageLocked(faultAddress, accessType, owner, rip, rsp);
+		}
+		finally
+		{
+			Volatile.Write(ref _lazyCommitGate, 0);
+		}
+	}
+
+	private unsafe bool HandleLazyCommittedPageLocked(ulong faultAddress, ulong accessType, string owner, ulong rip, ulong rsp)
+	{
 		if (VirtualQuery((void*)faultAddress, out var mbi, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) == 0)
 		{
 			return false;
@@ -1078,8 +1137,11 @@ public sealed partial class DirectExecutionBackend
 					committedBase = pageBase;
 					committedSize = 4096uL;
 				}
-				else if (!OperatingSystem.IsWindows() && TryReserveThenCommitReplace(pageBase, 4096uL, pageBase, 4096uL, commitProtect))
+				else if (!OperatingSystem.IsWindows() && TryCommitRange(pageBase, 4096uL, commitProtect))
 				{
+					// The reserve failed because the page is already mapped (the
+					// MEM_FREE query was stale); commit-in-place keeps its contents
+					// instead of replacing it with a zero page.
 					committed = true;
 					committedBase = pageBase;
 					committedSize = 4096uL;
@@ -1216,16 +1278,6 @@ public sealed partial class DirectExecutionBackend
 				return false;
 			}
 			return TryCommitRange(commitAddress, commitSize, protection);
-		}
-
-		static unsafe bool TryReserveThenCommitReplace(ulong reserveAddress, ulong reserveSize, ulong commitAddress, ulong commitSize, uint protection)
-		{
-			if (reserveAddress != commitAddress || reserveSize != commitSize)
-			{
-				return false;
-			}
-
-			return VirtualAllocFixedReplace((void*)reserveAddress, (nuint)reserveSize, 4096u | 8192u, protection) != null;
 		}
 
 		static bool IsAccessCompatible(ulong accessType, uint protection)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
@@ -20,6 +20,12 @@ public sealed partial class DirectExecutionBackend
 
 	private unsafe void SetupExceptionHandler()
 	{
+		if (!OperatingSystem.IsWindows())
+		{
+			InstallUnixSignalHandlers();
+			return;
+		}
+
 		if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_DISABLE_RAW_HANDLER"), "1", StringComparison.Ordinal))
 		{
 			_rawExceptionHandlerStub = CreateExceptionHandlerTrampoline(RawVectoredHandlerPtrManaged);
@@ -934,6 +940,35 @@ public sealed partial class DirectExecutionBackend
 		ulong committedBase = 0;
 		ulong committedSize = 0;
 
+		if (mbi.State == 4096)
+		{
+			if (TryGetLazyCommitWindow(faultAddress, mbi.BaseAddress, mbi.RegionSize, out var protectWindowBase, out var protectWindowSize) &&
+				TryCommitRange(protectWindowBase, protectWindowSize, commitProtect))
+			{
+				committed = true;
+				committedBase = protectWindowBase;
+				committedSize = protectWindowSize;
+			}
+			else if (TryCommitRange(pageBase, 4096uL, commitProtect))
+			{
+				committed = true;
+				committedBase = pageBase;
+				committedSize = 4096uL;
+			}
+
+			if (!committed)
+			{
+				return false;
+			}
+
+			TryCommitRange(pageBase + 4096, 4096uL, commitProtect);
+			if (traceLazyCommit)
+			{
+				Console.Error.WriteLine($"[LOADER][TRACE] lazy-protect#{traceIndex}: addr=0x{committedBase:X16} size=0x{committedSize:X16} access={accessType} protect=0x{commitProtect:X8}");
+			}
+			return true;
+		}
+
 		if (mbi.State == 65536)
 		{
 			if (TryGetLazyCommitWindow(faultAddress, mbi.BaseAddress, mbi.RegionSize, out var windowBase, out var windowSize) &&
@@ -964,6 +999,12 @@ public sealed partial class DirectExecutionBackend
 					committedSize = 65536uL;
 				}
 				else if (TryReserveThenCommit(pageBase, 4096uL, pageBase, 4096uL, commitProtect))
+				{
+					committed = true;
+					committedBase = pageBase;
+					committedSize = 4096uL;
+				}
+				else if (!OperatingSystem.IsWindows() && TryReserveThenCommitReplace(pageBase, 4096uL, pageBase, 4096uL, commitProtect))
 				{
 					committed = true;
 					committedBase = pageBase;
@@ -1101,6 +1142,16 @@ public sealed partial class DirectExecutionBackend
 				return false;
 			}
 			return TryCommitRange(commitAddress, commitSize, protection);
+		}
+
+		static unsafe bool TryReserveThenCommitReplace(ulong reserveAddress, ulong reserveSize, ulong commitAddress, ulong commitSize, uint protection)
+		{
+			if (reserveAddress != commitAddress || reserveSize != commitSize)
+			{
+				return false;
+			}
+
+			return VirtualAllocFixedReplace((void*)reserveAddress, (nuint)reserveSize, 4096u | 8192u, protection) != null;
 		}
 
 		static bool IsAccessCompatible(ulong accessType, uint protection)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Host.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Host.cs
@@ -166,30 +166,6 @@ public sealed unsafe partial class DirectExecutionBackend
 		return result;
 	}
 
-	private static void* VirtualAllocFixedReplace(void* address, nuint size, uint allocationType, uint protection)
-	{
-		if (OperatingSystem.IsWindows())
-		{
-			return WindowsVirtualAlloc(address, size, allocationType, protection);
-		}
-
-		if (address == null)
-		{
-			return null;
-		}
-
-		var alignedSize = (nuint)AlignUp((ulong)size, 0x1000);
-		var prot = (allocationType & MEM_COMMIT) != 0 ? ToUnixProtection(protection) : PROT_NONE;
-		var result = mmap(address, alignedSize, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
-		if (result == (void*)-1 || result != address)
-		{
-			return null;
-		}
-
-		UnixAllocationSizes[(ulong)result] = alignedSize;
-		return result;
-	}
-
 	private static bool VirtualFree(void* address, nuint size, uint freeType)
 	{
 		if (OperatingSystem.IsWindows())
@@ -384,11 +360,44 @@ public sealed unsafe partial class DirectExecutionBackend
 	private static nuint QueryUnixRegionSize(ulong address) =>
 		TryQueryUnixMemory(address, out var info) ? (nuint)info.RegionSize : 0;
 
+	// Allocated eagerly from native memory: this buffer is used from the SIGSEGV
+	// handler, where the GC must not be involved at all (a GC allocation here crashed
+	// coreclr internals once the maps file outgrew a lazily grown buffer). 8MB fits
+	// ~100k mappings. Guarded by an Interlocked spin gate for the same reason — no
+	// managed blocking in signal context.
+	private const int UnixMapsBufferSize = 8 * 1024 * 1024;
+	private static readonly byte* UnixMapsBuffer = (byte*)NativeMemory.Alloc(UnixMapsBufferSize);
+	private static int _unixMapsGate;
+
 	private static bool TryQueryUnixMemory(ulong address, out MEMORY_BASIC_INFORMATION64 info)
 	{
+		while (Interlocked.CompareExchange(ref _unixMapsGate, 1, 0) != 0)
+		{
+			Thread.SpinWait(64);
+		}
+
+		try
+		{
+			return TryQueryUnixMemoryLocked(address, out info);
+		}
+		finally
+		{
+			Volatile.Write(ref _unixMapsGate, 0);
+		}
+	}
+
+	private static bool TryQueryUnixMemoryLocked(ulong address, out MEMORY_BASIC_INFORMATION64 info)
+	{
 		info = default;
-		var maps = GC.AllocateUninitializedArray<byte>(128 * 1024);
-		var mapsLength = ReadUnixProcSelfMaps(maps);
+		var maps = UnixMapsBuffer;
+		var mapsLength = ReadUnixProcSelfMaps(maps, UnixMapsBufferSize);
+		if (mapsLength == UnixMapsBufferSize)
+		{
+			// Truncated listing: mappings past the cut-off would be misreported as
+			// MEM_FREE and later zero-wiped. Fail the query instead; the fault then
+			// surfaces with full diagnostics rather than corrupting guest memory.
+			return false;
+		}
 		var offset = 0;
 		var pageAddress = AlignDown(address, 0x1000);
 		var nextMappedAddress = ulong.MaxValue;
@@ -457,7 +466,7 @@ public sealed unsafe partial class DirectExecutionBackend
 		return true;
 	}
 
-	private static int ReadUnixProcSelfMaps(byte[] destination)
+	private static int ReadUnixProcSelfMaps(byte* destination, int capacity)
 	{
 		Span<byte> path = stackalloc byte[16];
 		path[0] = (byte)'/';
@@ -488,21 +497,15 @@ public sealed unsafe partial class DirectExecutionBackend
 			var total = 0;
 			try
 			{
-				fixed (byte* destinationPointer = destination)
+				while (total < capacity)
 				{
-					while (total < destination.Length)
+					var read = unix_read(fd, destination + total, (nuint)(capacity - total));
+					if (read <= 0)
 					{
-						var read = unix_read(
-							fd,
-							destinationPointer + total,
-							(nuint)(destination.Length - total));
-						if (read <= 0)
-						{
-							break;
-						}
-
-						total += checked((int)read);
+						break;
 					}
+
+					total += checked((int)read);
 				}
 			}
 			finally
@@ -514,7 +517,7 @@ public sealed unsafe partial class DirectExecutionBackend
 		}
 	}
 
-	private static bool TryParseHexBytes(byte[] bytes, int start, int end, out ulong value)
+	private static bool TryParseHexBytes(byte* bytes, int start, int end, out ulong value)
 	{
 		value = 0;
 		if (start >= end)
@@ -549,7 +552,7 @@ public sealed unsafe partial class DirectExecutionBackend
 		return true;
 	}
 
-	private static uint UnixPermsToProtection(byte[] bytes, int start, int lineEnd)
+	private static uint UnixPermsToProtection(byte* bytes, int start, int lineEnd)
 	{
 		var read = start < lineEnd && bytes[start] == (byte)'r';
 		var write = start + 1 < lineEnd && bytes[start + 1] == (byte)'w';

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Host.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Host.cs
@@ -1,0 +1,582 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace SharpEmu.Core.Cpu.Native;
+
+public sealed unsafe partial class DirectExecutionBackend
+{
+	private const int PROT_NONE = 0x0;
+	private const int PROT_READ = 0x1;
+	private const int PROT_WRITE = 0x2;
+	private const int PROT_EXEC = 0x4;
+	private const int MAP_PRIVATE = 0x02;
+	private const int MAP_ANONYMOUS = 0x20;
+	private const int MAP_FIXED = 0x10;
+	private const int MAP_FIXED_NOREPLACE = 0x100000;
+	private const int O_RDONLY = 0;
+
+	private static long _nextUnixTlsIndex;
+	private static ConcurrentDictionary<ulong, nuint>? _unixAllocationSizes;
+	private static ConcurrentDictionary<ulong, nuint> UnixAllocationSizes =>
+		_unixAllocationSizes ??= new ConcurrentDictionary<ulong, nuint>();
+	private static readonly ThreadLocal<Dictionary<uint, nint>> UnixTlsValues = new(() => new Dictionary<uint, nint>());
+	private static readonly HostTlsGetValueDelegate UnixTlsGetValueDelegate = UnixTlsGetValue;
+	private static readonly HostQueryPerformanceCounterDelegate UnixQueryPerformanceCounterDelegate = UnixQueryPerformanceCounter;
+	private static readonly HostSwitchToThreadDelegate UnixSwitchToThreadDelegate = UnixSwitchToThread;
+	private static readonly HostSleepDelegate UnixSleepDelegate = UnixSleep;
+	private static readonly nint UnixTlsGetValueTarget = Marshal.GetFunctionPointerForDelegate(UnixTlsGetValueDelegate);
+	private static readonly nint UnixQueryPerformanceCounterTarget = Marshal.GetFunctionPointerForDelegate(UnixQueryPerformanceCounterDelegate);
+	private static readonly nint UnixSwitchToThreadTarget = Marshal.GetFunctionPointerForDelegate(UnixSwitchToThreadDelegate);
+	private static readonly nint UnixSleepTarget = Marshal.GetFunctionPointerForDelegate(UnixSleepDelegate);
+	private static readonly nint UnixTlsGetValueThunk = CreateWin64UIntThunk(UnixTlsGetValueTarget);
+	private static readonly nint UnixQueryPerformanceCounterThunk = CreateWin64PointerThunk(UnixQueryPerformanceCounterTarget);
+	private static readonly nint UnixSwitchToThreadThunk = CreateWin64NoArgThunk(UnixSwitchToThreadTarget);
+	private static readonly nint UnixSleepThunk = CreateWin64UIntThunk(UnixSleepTarget);
+
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+	private delegate nint HostTlsGetValueDelegate(uint index);
+
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+	private delegate int HostQueryPerformanceCounterDelegate(nint counter);
+
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+	private delegate int HostSwitchToThreadDelegate();
+
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+	private delegate void HostSleepDelegate(uint milliseconds);
+
+	private static nint ResolveHostProcedure(string name)
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			var kernel32 = WindowsGetModuleHandle("kernel32.dll");
+			return kernel32 != 0 ? WindowsGetProcAddress(kernel32, name) : 0;
+		}
+
+		return name switch
+		{
+			"TlsGetValue" => UnixTlsGetValueThunk,
+			"QueryPerformanceCounter" => UnixQueryPerformanceCounterThunk,
+			"SwitchToThread" => UnixSwitchToThreadThunk,
+			"Sleep" => UnixSleepThunk,
+			_ => 0
+		};
+	}
+
+	private static uint TlsAlloc()
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return WindowsTlsAlloc();
+		}
+
+		var index = Interlocked.Increment(ref _nextUnixTlsIndex);
+		return index > uint.MaxValue ? uint.MaxValue : (uint)index;
+	}
+
+	private static bool TlsFree(uint index)
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return WindowsTlsFree(index);
+		}
+
+		UnixTlsValues.Value?.Remove(index);
+		return true;
+	}
+
+	private static bool TlsSetValue(uint index, nint value)
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return WindowsTlsSetValue(index, value);
+		}
+
+		UnixTlsValues.Value![index] = value;
+		return true;
+	}
+
+	private static nint TlsGetValue(uint index)
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return WindowsTlsGetValue(index);
+		}
+
+		return UnixTlsGetValue(index);
+	}
+
+	private static nint UnixTlsGetValue(uint index) =>
+		UnixTlsValues.Value is { } values && values.TryGetValue(index, out var value) ? value : 0;
+
+	private static int UnixQueryPerformanceCounter(nint counter)
+	{
+		if (counter == 0)
+		{
+			return 0;
+		}
+
+		*(long*)counter = Stopwatch.GetTimestamp();
+		return 1;
+	}
+
+	private static int UnixSwitchToThread()
+	{
+		Thread.Yield();
+		return 1;
+	}
+
+	private static void UnixSleep(uint milliseconds)
+	{
+		Thread.Sleep(milliseconds > int.MaxValue ? int.MaxValue : (int)milliseconds);
+	}
+
+	private static void* VirtualAlloc(void* address, nuint size, uint allocationType, uint protection)
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return WindowsVirtualAlloc(address, size, allocationType, protection);
+		}
+
+		if ((allocationType & MEM_COMMIT) != 0 && (allocationType & MEM_RESERVE) == 0)
+		{
+			return mprotect(address, size, ToUnixProtection(protection)) == 0 ? address : null;
+		}
+
+		var flags = MAP_PRIVATE | MAP_ANONYMOUS;
+		if (address != null)
+		{
+			flags |= MAP_FIXED_NOREPLACE;
+		}
+
+		var alignedSize = (nuint)AlignUp((ulong)size, 0x1000);
+		var prot = (allocationType & MEM_COMMIT) != 0 ? ToUnixProtection(protection) : PROT_NONE;
+		var result = mmap(address, alignedSize, prot, flags, -1, 0);
+		if (result == (void*)-1)
+		{
+			return null;
+		}
+
+		UnixAllocationSizes[(ulong)result] = alignedSize;
+		return result;
+	}
+
+	private static void* VirtualAllocFixedReplace(void* address, nuint size, uint allocationType, uint protection)
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return WindowsVirtualAlloc(address, size, allocationType, protection);
+		}
+
+		if (address == null)
+		{
+			return null;
+		}
+
+		var alignedSize = (nuint)AlignUp((ulong)size, 0x1000);
+		var prot = (allocationType & MEM_COMMIT) != 0 ? ToUnixProtection(protection) : PROT_NONE;
+		var result = mmap(address, alignedSize, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+		if (result == (void*)-1 || result != address)
+		{
+			return null;
+		}
+
+		UnixAllocationSizes[(ulong)result] = alignedSize;
+		return result;
+	}
+
+	private static bool VirtualFree(void* address, nuint size, uint freeType)
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return WindowsVirtualFree(address, size, freeType);
+		}
+
+		if (freeType != MEM_RELEASE || address == null)
+		{
+			return false;
+		}
+
+		var addressKey = (ulong)address;
+		var length = size != 0
+			? (nuint)AlignUp((ulong)size, 0x1000)
+			: (UnixAllocationSizes.TryGetValue(addressKey, out var trackedSize)
+				? trackedSize
+				: QueryUnixRegionSize(addressKey));
+
+		if (length == 0 || munmap(address, length) != 0)
+		{
+			return false;
+		}
+
+		UnixAllocationSizes.TryRemove(addressKey, out _);
+		return true;
+	}
+
+	private static bool VirtualProtect(void* address, nuint size, uint protection, uint* oldProtection)
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return WindowsVirtualProtect(address, size, protection, oldProtection);
+		}
+
+		if (oldProtection != null)
+		{
+			*oldProtection = QueryUnixProtection((ulong)address);
+		}
+
+		var start = AlignDown((ulong)address, 0x1000);
+		var end = AlignUp(checked((ulong)address + size), 0x1000);
+		return mprotect((void*)start, (nuint)(end - start), ToUnixProtection(protection)) == 0;
+	}
+
+	private static void* GetCurrentProcess() =>
+		OperatingSystem.IsWindows() ? WindowsGetCurrentProcess() : null;
+
+	private static bool FlushInstructionCache(void* process, void* address, nuint size) =>
+		OperatingSystem.IsWindows() ? WindowsFlushInstructionCache(process, address, size) : true;
+
+	private static nuint VirtualQuery(void* address, out MEMORY_BASIC_INFORMATION64 buffer, nuint length)
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return WindowsVirtualQuery(address, out buffer, length);
+		}
+
+		return TryQueryUnixMemory((ulong)address, out buffer) ? (nuint)sizeof(MEMORY_BASIC_INFORMATION64) : 0;
+	}
+
+	private static void* AddVectoredExceptionHandler(uint first, nint handler) =>
+		OperatingSystem.IsWindows() ? WindowsAddVectoredExceptionHandler(first, handler) : null;
+
+	private static uint RemoveVectoredExceptionHandler(void* handle) =>
+		OperatingSystem.IsWindows() ? WindowsRemoveVectoredExceptionHandler(handle) : 0;
+
+	private static nint SetUnhandledExceptionFilter(nint filter) =>
+		OperatingSystem.IsWindows() ? WindowsSetUnhandledExceptionFilter(filter) : 0;
+
+	private static uint GetCurrentThreadId() =>
+		OperatingSystem.IsWindows() ? WindowsGetCurrentThreadId() : unchecked((uint)Environment.CurrentManagedThreadId);
+
+	private static nint GetCurrentThread() =>
+		OperatingSystem.IsWindows() ? WindowsGetCurrentThread() : 1;
+
+	private static nuint SetThreadAffinityMask(nint thread, nuint mask) =>
+		OperatingSystem.IsWindows() ? WindowsSetThreadAffinityMask(thread, mask) : 1;
+
+	private static nint OpenThread(uint desiredAccess, bool inheritHandle, uint threadId) =>
+		OperatingSystem.IsWindows() ? WindowsOpenThread(desiredAccess, inheritHandle, threadId) : 0;
+
+	private static uint SuspendThread(nint thread) =>
+		OperatingSystem.IsWindows() ? WindowsSuspendThread(thread) : uint.MaxValue;
+
+	private static uint ResumeThread(nint thread) =>
+		OperatingSystem.IsWindows() ? WindowsResumeThread(thread) : uint.MaxValue;
+
+	private static bool GetThreadContext(nint thread, void* context) =>
+		OperatingSystem.IsWindows() && WindowsGetThreadContext(thread, context);
+
+	private static bool CloseHandle(nint handle) =>
+		OperatingSystem.IsWindows() && WindowsCloseHandle(handle);
+
+	private static nint CreateWin64UIntThunk(nint target)
+	{
+		var code = (byte*)VirtualAlloc(null, 32, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+		if (code == null)
+		{
+			return 0;
+		}
+
+		var offset = 0;
+		code[offset++] = 0x89; code[offset++] = 0xCF; // mov edi, ecx
+		code[offset++] = 0x48; code[offset++] = 0xB8; // mov rax, target
+		*(nint*)(code + offset) = target;
+		offset += sizeof(nint);
+		code[offset++] = 0xFF; code[offset++] = 0xE0; // jmp rax
+		_ = VirtualProtect(code, 32, PAGE_EXECUTE_READ, null);
+		_ = FlushInstructionCache(GetCurrentProcess(), code, 32);
+		return (nint)code;
+	}
+
+	private static nint CreateWin64NoArgThunk(nint target)
+	{
+		var code = (byte*)VirtualAlloc(null, 32, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+		if (code == null)
+		{
+			return 0;
+		}
+
+		var offset = 0;
+		code[offset++] = 0x48; code[offset++] = 0xB8; // mov rax, target
+		*(nint*)(code + offset) = target;
+		offset += sizeof(nint);
+		code[offset++] = 0xFF; code[offset++] = 0xE0; // jmp rax
+		_ = VirtualProtect(code, 32, PAGE_EXECUTE_READ, null);
+		_ = FlushInstructionCache(GetCurrentProcess(), code, 32);
+		return (nint)code;
+	}
+
+	private static nint CreateWin64PointerThunk(nint target)
+	{
+		var code = (byte*)VirtualAlloc(null, 32, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+		if (code == null)
+		{
+			return 0;
+		}
+
+		var offset = 0;
+		code[offset++] = 0x48; code[offset++] = 0x89; code[offset++] = 0xCF; // mov rdi, rcx
+		code[offset++] = 0x48; code[offset++] = 0xB8; // mov rax, target
+		*(nint*)(code + offset) = target;
+		offset += sizeof(nint);
+		code[offset++] = 0xFF; code[offset++] = 0xE0; // jmp rax
+		_ = VirtualProtect(code, 32, PAGE_EXECUTE_READ, null);
+		_ = FlushInstructionCache(GetCurrentProcess(), code, 32);
+		return (nint)code;
+	}
+
+	private static nint CreateWin64ImportGatewayThunk(nint target)
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			return target;
+		}
+
+		var code = (byte*)VirtualAlloc(null, 64, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+		if (code == null)
+		{
+			return 0;
+		}
+
+		var offset = 0;
+		code[offset++] = 0x48; code[offset++] = 0x89; code[offset++] = 0xCF; // mov rdi, rcx
+		code[offset++] = 0x89; code[offset++] = 0xD6;                         // mov esi, edx
+		code[offset++] = 0x4C; code[offset++] = 0x89; code[offset++] = 0xC2;   // mov rdx, r8
+		code[offset++] = 0x48; code[offset++] = 0xB8;                         // mov rax, target
+		*(nint*)(code + offset) = target;
+		offset += sizeof(nint);
+		code[offset++] = 0xFF; code[offset++] = 0xE0;                         // jmp rax
+		_ = VirtualProtect(code, 64, PAGE_EXECUTE_READ, null);
+		_ = FlushInstructionCache(GetCurrentProcess(), code, 64);
+		return (nint)code;
+	}
+
+	private static int ToUnixProtection(uint protection) =>
+		protection switch
+		{
+			1 => PROT_NONE,
+			2 => PROT_READ,
+			PAGE_READWRITE => PROT_READ | PROT_WRITE,
+			16 => PROT_EXEC,
+			PAGE_EXECUTE_READ => PROT_READ | PROT_EXEC,
+			PAGE_EXECUTE_READWRITE or 128 => PROT_READ | PROT_WRITE | PROT_EXEC,
+			_ => PROT_READ | PROT_WRITE
+		};
+
+	private static uint QueryUnixProtection(ulong address) =>
+		TryQueryUnixMemory(address, out var info) ? info.Protect : PAGE_READWRITE;
+
+	private static nuint QueryUnixRegionSize(ulong address) =>
+		TryQueryUnixMemory(address, out var info) ? (nuint)info.RegionSize : 0;
+
+	private static bool TryQueryUnixMemory(ulong address, out MEMORY_BASIC_INFORMATION64 info)
+	{
+		info = default;
+		var maps = GC.AllocateUninitializedArray<byte>(128 * 1024);
+		var mapsLength = ReadUnixProcSelfMaps(maps);
+		var offset = 0;
+		var pageAddress = AlignDown(address, 0x1000);
+		var nextMappedAddress = ulong.MaxValue;
+		while (offset < mapsLength)
+		{
+			var lineStart = offset;
+			while (offset < mapsLength && maps[offset] != (byte)'\n')
+			{
+				offset++;
+			}
+
+			var lineEnd = offset;
+			if (offset < mapsLength && maps[offset] == (byte)'\n')
+			{
+				offset++;
+			}
+
+			var dash = lineStart;
+			while (dash < lineEnd && maps[dash] != (byte)'-')
+			{
+				dash++;
+			}
+
+			var space = dash + 1;
+			while (space < lineEnd && maps[space] != (byte)' ')
+			{
+				space++;
+			}
+
+			if (dash == lineStart ||
+				dash >= lineEnd ||
+				space >= lineEnd ||
+				!TryParseHexBytes(maps, lineStart, dash, out var start) ||
+				!TryParseHexBytes(maps, dash + 1, space, out var end))
+			{
+				continue;
+			}
+
+			if (address >= start && address < end)
+			{
+				var permsStart = space + 1;
+				info.BaseAddress = start;
+				info.AllocationBase = start;
+				info.RegionSize = end - start;
+				info.State = MEM_COMMIT;
+				info.Protect = UnixPermsToProtection(maps, permsStart, lineEnd);
+				info.AllocationProtect = info.Protect;
+				return true;
+			}
+
+			if (start > pageAddress && start < nextMappedAddress)
+			{
+				nextMappedAddress = start;
+			}
+		}
+
+		var freeSize = nextMappedAddress == ulong.MaxValue
+			? 0x1000UL
+			: Math.Max(0x1000UL, nextMappedAddress - pageAddress);
+		info.BaseAddress = pageAddress;
+		info.AllocationBase = pageAddress;
+		info.RegionSize = freeSize;
+		info.State = MEM_FREE;
+		info.Protect = PAGE_NOACCESS;
+		info.AllocationProtect = PAGE_NOACCESS;
+		return true;
+	}
+
+	private static int ReadUnixProcSelfMaps(byte[] destination)
+	{
+		Span<byte> path = stackalloc byte[16];
+		path[0] = (byte)'/';
+		path[1] = (byte)'p';
+		path[2] = (byte)'r';
+		path[3] = (byte)'o';
+		path[4] = (byte)'c';
+		path[5] = (byte)'/';
+		path[6] = (byte)'s';
+		path[7] = (byte)'e';
+		path[8] = (byte)'l';
+		path[9] = (byte)'f';
+		path[10] = (byte)'/';
+		path[11] = (byte)'m';
+		path[12] = (byte)'a';
+		path[13] = (byte)'p';
+		path[14] = (byte)'s';
+		path[15] = 0;
+
+		fixed (byte* pathPointer = path)
+		{
+			var fd = unix_open(pathPointer, O_RDONLY);
+			if (fd < 0)
+			{
+				return 0;
+			}
+
+			var total = 0;
+			try
+			{
+				fixed (byte* destinationPointer = destination)
+				{
+					while (total < destination.Length)
+					{
+						var read = unix_read(
+							fd,
+							destinationPointer + total,
+							(nuint)(destination.Length - total));
+						if (read <= 0)
+						{
+							break;
+						}
+
+						total += checked((int)read);
+					}
+				}
+			}
+			finally
+			{
+				_ = unix_close(fd);
+			}
+
+			return total;
+		}
+	}
+
+	private static bool TryParseHexBytes(byte[] bytes, int start, int end, out ulong value)
+	{
+		value = 0;
+		if (start >= end)
+		{
+			return false;
+		}
+
+		for (var i = start; i < end; i++)
+		{
+			var b = bytes[i];
+			uint digit;
+			if (b >= (byte)'0' && b <= (byte)'9')
+			{
+				digit = (uint)(b - (byte)'0');
+			}
+			else if (b >= (byte)'a' && b <= (byte)'f')
+			{
+				digit = (uint)(b - (byte)'a' + 10);
+			}
+			else if (b >= (byte)'A' && b <= (byte)'F')
+			{
+				digit = (uint)(b - (byte)'A' + 10);
+			}
+			else
+			{
+				return false;
+			}
+
+			value = (value << 4) | digit;
+		}
+
+		return true;
+	}
+
+	private static uint UnixPermsToProtection(byte[] bytes, int start, int lineEnd)
+	{
+		var read = start < lineEnd && bytes[start] == (byte)'r';
+		var write = start + 1 < lineEnd && bytes[start + 1] == (byte)'w';
+		var exec = start + 2 < lineEnd && bytes[start + 2] == (byte)'x';
+		if (exec)
+		{
+			return write ? PAGE_EXECUTE_READWRITE : PAGE_EXECUTE_READ;
+		}
+
+		return write ? PAGE_READWRITE : (read ? 2u : 1u);
+	}
+
+	[DllImport("libc", SetLastError = true)]
+	private static extern void* mmap(void* addr, nuint length, int prot, int flags, int fd, nint offset);
+
+	[DllImport("libc", SetLastError = true)]
+	private static extern int munmap(void* addr, nuint length);
+
+	[DllImport("libc", SetLastError = true)]
+	private static extern int mprotect(void* addr, nuint len, int prot);
+
+	[DllImport("libc", EntryPoint = "open", SetLastError = true)]
+	private static extern int unix_open(byte* pathname, int flags);
+
+	[DllImport("libc", EntryPoint = "read", SetLastError = true)]
+	private static extern nint unix_read(int fd, void* buffer, nuint count);
+
+	[DllImport("libc", EntryPoint = "close", SetLastError = true)]
+	private static extern int unix_close(int fd);
+}

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -155,7 +155,7 @@ public sealed partial class DirectExecutionBackend
 			for (int i = 1; i <= 4; i++)
 			{
 				ulong num8 = *(ulong*)(argPackPtr + 96 + i * 8);
-				if (IsLikelyReturnAddress(num8))
+				if (IsLikelyRepairedImportReturnAddress(importStubEntry.Address, num8))
 				{
 					*(ulong*)(argPackPtr + 96) = num8;
 					num7 = num8;
@@ -267,7 +267,7 @@ public sealed partial class DirectExecutionBackend
 				Console.Error.Flush();
 			}
 		}
-		if (!flag0 && !isGuestWorker)
+		if (!flag0)
 		{
 			RecordRecentImportTrace(
 				num,
@@ -697,6 +697,9 @@ public sealed partial class DirectExecutionBackend
 		var expectedMutexTrylockBusy =
 			string.Equals(nid, "K-jXhbt2gn4", StringComparison.Ordinal) &&
 			result == OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY;
+		var expectedMkdirAlreadyExists =
+			string.Equals(nid, "1-LFLmRFxxM", StringComparison.Ordinal) &&
+			result == OrbisGen2Result.ORBIS_GEN2_ERROR_ALREADY_EXISTS;
 		var expectedUserServiceNoEvent =
 			string.Equals(nid, "yH17Q6NWtVg", StringComparison.Ordinal) &&
 			resultValue == unchecked((int)0x80960007);
@@ -707,6 +710,7 @@ public sealed partial class DirectExecutionBackend
 			!expectedTimedWaitTimeout &&
 			!expectedEqueueTimeout &&
 			!expectedMutexTrylockBusy &&
+			!expectedMkdirAlreadyExists &&
 			!expectedUserServiceNoEvent &&
 			!expectedPrivacyInvalidParameter)
 		{
@@ -742,6 +746,73 @@ public sealed partial class DirectExecutionBackend
 			"1G3lF1Gg1k8" or // sceKernelOpen
 			"gEpBkcwxUjw";   // sceKernelAprResolveFilepathsToIdsAndFileSizes
 
+	private static bool IsLikelyRepairedImportReturnAddress(ulong importStubAddress, ulong returnAddress)
+	{
+		if (!IsLikelyReturnAddress(returnAddress))
+		{
+			return false;
+		}
+
+		if (TryReadByte(returnAddress - 5, out var relCallOpcode) &&
+			relCallOpcode == 0xE8 &&
+			TryReadInt32(returnAddress - 4, out var rel32))
+		{
+			var target = unchecked(returnAddress + (ulong)(long)rel32);
+			if (target == importStubAddress)
+			{
+				return true;
+			}
+		}
+
+		if (TryReadByte(returnAddress - 2, out var ffOpcode) &&
+			TryReadByte(returnAddress - 1, out var modrm) &&
+			ffOpcode == 0xFF &&
+			(modrm & 0x38) == 0x10)
+		{
+			return true;
+		}
+
+		if (TryReadByte(returnAddress - 3, out var rexPrefix) &&
+			TryReadByte(returnAddress - 2, out ffOpcode) &&
+			TryReadByte(returnAddress - 1, out modrm) &&
+			(rexPrefix & 0xF0) == 0x40 &&
+			ffOpcode == 0xFF &&
+			(modrm & 0x38) == 0x10)
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	private unsafe static bool TryReadByte(ulong address, out byte value)
+	{
+		try
+		{
+			value = *(byte*)address;
+			return true;
+		}
+		catch
+		{
+			value = 0;
+			return false;
+		}
+	}
+
+	private unsafe static bool TryReadInt32(ulong address, out int value)
+	{
+		try
+		{
+			value = *(int*)address;
+			return true;
+		}
+		catch
+		{
+			value = 0;
+			return false;
+		}
+	}
+
 	// LEAF-IMPORT REGISTRATION — scalar-only constraint.
 	//
 	// TryDispatchLeafImport is a fast path that never copies the trampoline's XMM
@@ -769,10 +840,6 @@ public sealed partial class DirectExecutionBackend
 		}
 
 		return nid is
-			"9UK1vLZQft4" or // scePthreadMutexLock
-			"tn3VlD0hG60" or // scePthreadMutexUnlock
-			"7H0iTOciTLo" or // pthread_mutex_lock
-			"2Z+PpY6CaJg" or // pthread_mutex_unlock
 			"8aI7R7WaOlc" or // sceAmprCommandBufferConstructor
 			"zgXifHT9ErY" or // sceVideoOutIsFlipPending
 			"V++UgBtQhn0" or // sceAgcGetDataPacketPayloadAddress

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -694,9 +694,21 @@ public sealed partial class DirectExecutionBackend
 		var expectedEqueueTimeout =
 			string.Equals(nid, "fzyMKs9kim0", StringComparison.Ordinal) &&
 			result == OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT;
+		var expectedEventFlagTimeout =
+			string.Equals(nid, "JTvBflhYazQ", StringComparison.Ordinal) &&
+			result == OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT;
 		var expectedMutexTrylockBusy =
-			string.Equals(nid, "K-jXhbt2gn4", StringComparison.Ordinal) &&
+			(string.Equals(nid, "K-jXhbt2gn4", StringComparison.Ordinal) ||
+			 string.Equals(nid, "upoVrzMHFeE", StringComparison.Ordinal)) &&
 			result == OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY;
+		var expectedMutexLockDeadlock =
+			(string.Equals(nid, "9UK1vLZQft4", StringComparison.Ordinal) ||
+			 string.Equals(nid, "7H0iTOciTLo", StringComparison.Ordinal)) &&
+			result == OrbisGen2Result.ORBIS_GEN2_ERROR_DEADLOCK;
+		var expectedMutexUnlockInvalid =
+			(string.Equals(nid, "tn3VlD0hG60", StringComparison.Ordinal) ||
+			 string.Equals(nid, "2Z+PpY6CaJg", StringComparison.Ordinal)) &&
+			result == OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
 		var expectedMkdirAlreadyExists =
 			string.Equals(nid, "1-LFLmRFxxM", StringComparison.Ordinal) &&
 			result == OrbisGen2Result.ORBIS_GEN2_ERROR_ALREADY_EXISTS;
@@ -709,7 +721,10 @@ public sealed partial class DirectExecutionBackend
 		if (!expectedFileProbeMiss &&
 			!expectedTimedWaitTimeout &&
 			!expectedEqueueTimeout &&
+			!expectedEventFlagTimeout &&
 			!expectedMutexTrylockBusy &&
+			!expectedMutexLockDeadlock &&
+			!expectedMutexUnlockInvalid &&
 			!expectedMkdirAlreadyExists &&
 			!expectedUserServiceNoEvent &&
 			!expectedPrivacyInvalidParameter)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.NativeWorker.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.NativeWorker.cs
@@ -244,18 +244,24 @@ public sealed partial class DirectExecutionBackend
 
 		private static bool EnsureKernel32Exports()
 		{
+			// The native worker is Windows-only; the kernel32 imports are unresolvable elsewhere.
+			if (!OperatingSystem.IsWindows())
+			{
+				return false;
+			}
+
 			if (_exitThreadAddress != 0)
 			{
 				return _waitForSingleObjectAddress != 0 && _setEventAddress != 0;
 			}
-			nint kernel32 = GetModuleHandle("kernel32.dll");
+			nint kernel32 = WindowsGetModuleHandle("kernel32.dll");
 			if (kernel32 == 0)
 			{
 				return false;
 			}
-			_waitForSingleObjectAddress = GetProcAddress(kernel32, "WaitForSingleObject");
-			_setEventAddress = GetProcAddress(kernel32, "SetEvent");
-			_exitThreadAddress = GetProcAddress(kernel32, "ExitThread");
+			_waitForSingleObjectAddress = WindowsGetProcAddress(kernel32, "WaitForSingleObject");
+			_setEventAddress = WindowsGetProcAddress(kernel32, "SetEvent");
+			_exitThreadAddress = WindowsGetProcAddress(kernel32, "ExitThread");
 			return _waitForSingleObjectAddress != 0 && _setEventAddress != 0 && _exitThreadAddress != 0;
 		}
 

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.UnixSignals.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.UnixSignals.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -9,8 +10,10 @@ namespace SharpEmu.Core.Cpu.Native;
 public sealed unsafe partial class DirectExecutionBackend
 {
 	private const int SIGILL = 4;
+	private const int SIGABRT = 6;
 	private const int SIGBUS = 7;
 	private const int SIGSEGV = 11;
+	private const int SIGURG = 23;
 	private const int SA_SIGINFO = 0x4;
 	private const uint EXCEPTION_ACCESS_VIOLATION = 0xC0000005u;
 	private const uint EXCEPTION_ILLEGAL_INSTRUCTION = 0xC000001Du;
@@ -34,6 +37,10 @@ public sealed unsafe partial class DirectExecutionBackend
 	private const int UnixRegRip = 16;
 	private const int UnixRegErr = 19;
 	private const int UnixRegCr2 = 22;
+
+	// Main guest executable is mapped at this base; IDA (which loads the ELF at its 0-based
+	// p_vaddr) address = guest RIP - this. Surfaced in crash dumps as module_offset.
+	private const ulong GuestModuleBaseForDiag = 0x800000000UL;
 
 	private static int _unixSignalHandlersInstalled;
 	private static readonly UnixSignalHandlerDelegate UnixSignalHandlerDelegateInstance = UnixSignalHandler;
@@ -64,24 +71,153 @@ public sealed unsafe partial class DirectExecutionBackend
 		InstallUnixSignalHandler(SIGSEGV);
 		InstallUnixSignalHandler(SIGBUS);
 		InstallUnixSignalHandler(SIGILL);
+		InstallUnixSignalHandler(SIGABRT);
+		InstallUnixSignalHandler(SIGURG);
 		Console.Error.WriteLine("[LOADER][INFO] Native Unix signal handlers installed.");
 	}
+
+	// coreclr's own handlers, saved at install time. The CLR converts hardware faults in
+	// managed code (null-reference reads, GC probes) into managed exceptions via its SIGSEGV
+	// handler; replacing it without chaining corrupts the runtime — any managed NRE then gets
+	// misrouted into the guest return stub and the process later dies with the misleading
+	// "UnmanagedCallersOnly" fail-fast or a SIGSEGV inside libcoreclr.
+	private static readonly UnixSigAction[] PreviousUnixSignalActions = new UnixSigAction[64];
 
 	private static void InstallUnixSignalHandler(int signal)
 	{
 		UnixSigAction action = default;
 		action.Handler = UnixSignalHandlerPtr;
 		action.Flags = SA_SIGINFO;
-		if (sigaction(signal, &action, null) != 0)
+		UnixSigAction previous = default;
+		if (sigaction(signal, &action, &previous) != 0)
 		{
 			Console.Error.WriteLine($"[LOADER][WARNING] sigaction({signal}) failed; native Unix fault recovery may be unavailable.");
+			return;
+		}
+
+		if ((uint)signal < (uint)PreviousUnixSignalActions.Length)
+		{
+			PreviousUnixSignalActions[signal] = previous;
 		}
 	}
 
+	private static bool TryChainPreviousUnixHandler(int signal, nint sigInfo, nint ucontext)
+	{
+		if ((uint)signal >= (uint)PreviousUnixSignalActions.Length)
+		{
+			return false;
+		}
+
+		var previous = PreviousUnixSignalActions[signal];
+		var handler = previous.Handler;
+		if (handler == 0 || handler == 1)
+		{
+			// SIG_DFL / SIG_IGN — nothing meaningful to chain to.
+			return false;
+		}
+
+		if ((previous.Flags & SA_SIGINFO) != 0)
+		{
+			((delegate* unmanaged[Cdecl]<int, nint, nint, void>)handler)(signal, sigInfo, ucontext);
+		}
+		else
+		{
+			((delegate* unmanaged[Cdecl]<int, void>)handler)(signal);
+		}
+
+		return true;
+	}
+
+	// Guest code lives at the module base (0x8_0000_0000) and in the vmem arena
+	// (0x10_0000_0000+); host JIT/CLR/libc code sits at 0x55…/0x7F… — far above.
+	private static bool IsGuestCodeRip(ulong rip) =>
+		rip >= 0x0000_0004_0000_0000UL && rip < 0x0000_5500_0000_0000UL;
+
+	// Context-sampling slots for TryCaptureUnixThreadContext: the watchdog sends SIGURG to a
+	// specific running guest thread via tgkill, and the handler copies that thread's ucontext
+	// registers here. Allocation-free by design — the sampled thread is normally executing
+	// raw guest code.
+	private static int _unixContextSampleGate;
+	private static int _unixContextSampleReady;
+	private static ulong _unixSampleRip;
+	private static ulong _unixSampleRsp;
+	private static ulong _unixSampleRbp;
+	private static ulong _unixSampleRax;
+	private static ulong _unixSampleRbx;
+	private static ulong _unixSampleRcx;
+	private static ulong _unixSampleRdx;
+
 	private static void UnixSignalHandler(int signal, nint sigInfo, nint ucontext)
 	{
+		if (signal == SIGURG)
+		{
+			if (ucontext != 0)
+			{
+				_unixSampleRip = ReadUnixCtxU64((void*)ucontext, UnixRegRip);
+				_unixSampleRsp = ReadUnixCtxU64((void*)ucontext, UnixRegRsp);
+				_unixSampleRbp = ReadUnixCtxU64((void*)ucontext, UnixRegRbp);
+				_unixSampleRax = ReadUnixCtxU64((void*)ucontext, UnixRegRax);
+				_unixSampleRbx = ReadUnixCtxU64((void*)ucontext, UnixRegRbx);
+				_unixSampleRcx = ReadUnixCtxU64((void*)ucontext, UnixRegRcx);
+				_unixSampleRdx = ReadUnixCtxU64((void*)ucontext, UnixRegRdx);
+				Volatile.Write(ref _unixContextSampleReady, 1);
+			}
+			return;
+		}
+
+		if (signal == SIGABRT)
+		{
+			if (_unixSignalDepth == 0)
+			{
+				_unixSignalDepth++;
+				try
+				{
+					var backend = _activeExecutionBackend;
+					if (backend is not null)
+					{
+						Console.Error.WriteLine("[LOADER][ERROR] SIGABRT caught (likely CLR heap-corruption fail-fast); dumping recent imports:");
+						backend.DumpRecentImportTrace();
+						Console.Error.Flush();
+					}
+				}
+				catch
+				{
+				}
+				finally
+				{
+					_unixSignalDepth--;
+				}
+			}
+
+			RestoreDefaultSignalActionAndReraise(signal);
+			return;
+		}
+
 		if (ucontext == 0 || _unixSignalDepth > 0)
 		{
+			// Unrecoverable: either no context, or a fault occurred while already handling one
+			// (nested/stack fault). We cannot safely recover, but capture the faulting RIP and
+			// fault address so the crash is not a black box (previously exited 139 with no RIP).
+			if (ucontext != 0)
+			{
+				var nestedRip = ReadUnixCtxU64((void*)ucontext, UnixRegRip);
+				var nestedTarget = signal == SIGILL ? nestedRip : ReadUnixCtxU64((void*)ucontext, UnixRegCr2);
+				if (nestedTarget == 0 && sigInfo != 0)
+				{
+					nestedTarget = (ulong)Marshal.ReadIntPtr(sigInfo + 16);
+				}
+				var moduleOffset = nestedRip >= GuestModuleBaseForDiag ? nestedRip - GuestModuleBaseForDiag : nestedRip;
+				try
+				{
+					Console.Error.WriteLine(
+						$"[LOADER][ERROR] Unrecoverable signal {signal} (depth={_unixSignalDepth}) at RIP=0x{nestedRip:X16} " +
+						$"(module_offset=0x{moduleOffset:X}) target=0x{nestedTarget:X16} — not caught, terminating.");
+					Console.Error.Flush();
+				}
+				catch
+				{
+				}
+			}
 			RestoreDefaultSignalActionAndReraise(signal);
 			return;
 		}
@@ -92,7 +228,10 @@ public sealed unsafe partial class DirectExecutionBackend
 			var backend = _activeExecutionBackend;
 			if (backend is null)
 			{
-				RestoreDefaultSignalActionAndReraise(signal);
+				if (!TryChainPreviousUnixHandler(signal, sigInfo, ucontext))
+				{
+					RestoreDefaultSignalActionAndReraise(signal);
+				}
 				return;
 			}
 
@@ -139,6 +278,19 @@ public sealed unsafe partial class DirectExecutionBackend
 			if (handled)
 			{
 				ApplyWindowsContextToUnix(windowsContext, (void*)ucontext);
+				return;
+			}
+
+			if (!IsGuestCodeRip(rip))
+			{
+				// Fault in host/CLR code that isn't a guest lazy-commit touch: this is the
+				// runtime's fault to process (managed NRE, GC probe). Hand it back to the
+				// handler coreclr installed instead of hijacking a CLR thread into the
+				// guest return stub, which corrupts the runtime.
+				if (!TryChainPreviousUnixHandler(signal, sigInfo, ucontext))
+				{
+					RestoreDefaultSignalActionAndReraise(signal);
+				}
 				return;
 			}
 
@@ -214,6 +366,68 @@ public sealed unsafe partial class DirectExecutionBackend
 		_ = sigaction(signal, &action, null);
 		_ = raise(signal);
 	}
+
+	// Linux counterpart of the Windows SuspendThread/GetThreadContext capture: signal the
+	// target thread with SIGURG (via tgkill so only that thread receives it) and wait briefly
+	// for its handler to publish the interrupted register state. Only meaningful for threads
+	// currently executing guest code; the watchdog uses it to find where a spinning guest
+	// thread is stuck.
+	private static bool TryCaptureUnixThreadContext(int hostThreadId, out HostThreadContextSnapshot snapshot)
+	{
+		snapshot = default;
+		if (hostThreadId == 0 || hostThreadId == unchecked((int)GetCurrentThreadId()))
+		{
+			return false;
+		}
+
+		if (Interlocked.CompareExchange(ref _unixContextSampleGate, 1, 0) != 0)
+		{
+			return false;
+		}
+
+		try
+		{
+			Volatile.Write(ref _unixContextSampleReady, 0);
+			if (syscall(TgkillSyscallNumber, getpid(), hostThreadId, SIGURG) != 0)
+			{
+				return false;
+			}
+
+			var spinWatch = Stopwatch.GetTimestamp();
+			var timeoutTicks = Stopwatch.Frequency / 100; // 10ms
+			while (Volatile.Read(ref _unixContextSampleReady) == 0)
+			{
+				if (Stopwatch.GetTimestamp() - spinWatch > timeoutTicks)
+				{
+					return false;
+				}
+				Thread.SpinWait(64);
+			}
+
+			snapshot = new HostThreadContextSnapshot(
+				true,
+				_unixSampleRip,
+				_unixSampleRsp,
+				_unixSampleRbp,
+				_unixSampleRax,
+				_unixSampleRbx,
+				_unixSampleRcx,
+				_unixSampleRdx);
+			return true;
+		}
+		finally
+		{
+			Volatile.Write(ref _unixContextSampleGate, 0);
+		}
+	}
+
+	private const long TgkillSyscallNumber = 234;
+
+	[DllImport("libc", SetLastError = true)]
+	private static extern long syscall(long number, long arg1, long arg2, long arg3);
+
+	[DllImport("libc")]
+	private static extern int getpid();
 
 	[DllImport("libc", SetLastError = true)]
 	private static extern int sigaction(int signum, UnixSigAction* act, UnixSigAction* oldact);

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.UnixSignals.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.UnixSignals.cs
@@ -133,7 +133,7 @@ public sealed unsafe partial class DirectExecutionBackend
 				backend.TryHandleLazyCommittedPage(&record, rip, rsp);
 			if (!handled)
 			{
-				backend.VectoredHandler(&pointers);
+				handled = backend.VectoredHandler(&pointers) == -1;
 			}
 
 			if (handled)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.UnixSignals.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.UnixSignals.cs
@@ -1,0 +1,223 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace SharpEmu.Core.Cpu.Native;
+
+public sealed unsafe partial class DirectExecutionBackend
+{
+	private const int SIGILL = 4;
+	private const int SIGBUS = 7;
+	private const int SIGSEGV = 11;
+	private const int SA_SIGINFO = 0x4;
+	private const uint EXCEPTION_ACCESS_VIOLATION = 0xC0000005u;
+	private const uint EXCEPTION_ILLEGAL_INSTRUCTION = 0xC000001Du;
+	private const int UnixGregsOffset = 40;
+	private const int UnixRegR8 = 0;
+	private const int UnixRegR9 = 1;
+	private const int UnixRegR10 = 2;
+	private const int UnixRegR11 = 3;
+	private const int UnixRegR12 = 4;
+	private const int UnixRegR13 = 5;
+	private const int UnixRegR14 = 6;
+	private const int UnixRegR15 = 7;
+	private const int UnixRegRdi = 8;
+	private const int UnixRegRsi = 9;
+	private const int UnixRegRbp = 10;
+	private const int UnixRegRbx = 11;
+	private const int UnixRegRdx = 12;
+	private const int UnixRegRax = 13;
+	private const int UnixRegRcx = 14;
+	private const int UnixRegRsp = 15;
+	private const int UnixRegRip = 16;
+	private const int UnixRegErr = 19;
+	private const int UnixRegCr2 = 22;
+
+	private static int _unixSignalHandlersInstalled;
+	private static readonly UnixSignalHandlerDelegate UnixSignalHandlerDelegateInstance = UnixSignalHandler;
+	private static readonly nint UnixSignalHandlerPtr = Marshal.GetFunctionPointerForDelegate(UnixSignalHandlerDelegateInstance);
+
+	[ThreadStatic]
+	private static int _unixSignalDepth;
+
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+	private delegate void UnixSignalHandlerDelegate(int signal, nint sigInfo, nint ucontext);
+
+	private unsafe struct UnixSigAction
+	{
+		public nint Handler;
+		public fixed ulong Mask[16];
+		public int Flags;
+		public nint Restorer;
+	}
+
+	private static void InstallUnixSignalHandlers()
+	{
+		if (Interlocked.Exchange(ref _unixSignalHandlersInstalled, 1) != 0)
+		{
+			Console.Error.WriteLine("[LOADER][INFO] Native Unix signal handlers already installed.");
+			return;
+		}
+
+		InstallUnixSignalHandler(SIGSEGV);
+		InstallUnixSignalHandler(SIGBUS);
+		InstallUnixSignalHandler(SIGILL);
+		Console.Error.WriteLine("[LOADER][INFO] Native Unix signal handlers installed.");
+	}
+
+	private static void InstallUnixSignalHandler(int signal)
+	{
+		UnixSigAction action = default;
+		action.Handler = UnixSignalHandlerPtr;
+		action.Flags = SA_SIGINFO;
+		if (sigaction(signal, &action, null) != 0)
+		{
+			Console.Error.WriteLine($"[LOADER][WARNING] sigaction({signal}) failed; native Unix fault recovery may be unavailable.");
+		}
+	}
+
+	private static void UnixSignalHandler(int signal, nint sigInfo, nint ucontext)
+	{
+		if (ucontext == 0 || _unixSignalDepth > 0)
+		{
+			RestoreDefaultSignalActionAndReraise(signal);
+			return;
+		}
+
+		_unixSignalDepth++;
+		try
+		{
+			var backend = _activeExecutionBackend;
+			if (backend is null)
+			{
+				RestoreDefaultSignalActionAndReraise(signal);
+				return;
+			}
+
+			var rip = ReadUnixCtxU64((void*)ucontext, UnixRegRip);
+			var rsp = ReadUnixCtxU64((void*)ucontext, UnixRegRsp);
+			var faultAddress = signal == SIGILL
+				? rip
+				: ReadUnixCtxU64((void*)ucontext, UnixRegCr2);
+			if (faultAddress == 0 && sigInfo != 0)
+			{
+				faultAddress = (ulong)Marshal.ReadIntPtr(sigInfo + 16);
+			}
+
+			var pageFaultError = signal == SIGILL ? 0x10UL : ReadUnixCtxU64((void*)ucontext, UnixRegErr);
+			var accessType = signal == SIGILL
+				? 8UL
+				: ((pageFaultError & 0x10) != 0 ? 8UL : ((pageFaultError & 0x2) != 0 ? 1UL : 0UL));
+
+			EXCEPTION_RECORD record = default;
+			record.ExceptionCode = signal == SIGILL ? EXCEPTION_ILLEGAL_INSTRUCTION : EXCEPTION_ACCESS_VIOLATION;
+			record.ExceptionAddress = (void*)rip;
+			record.NumberParameters = signal == SIGILL ? 0u : 2u;
+			if (signal != SIGILL)
+			{
+				record.ExceptionInformation[0] = accessType;
+				record.ExceptionInformation[1] = faultAddress;
+			}
+
+			byte* windowsContext = stackalloc byte[Win64ContextSize];
+			FillWindowsContextFromUnix((void*)ucontext, windowsContext);
+			EXCEPTION_POINTERS pointers = new()
+			{
+				ExceptionRecord = &record,
+				ContextRecord = windowsContext
+			};
+
+			var handled = record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION &&
+				backend.TryHandleLazyCommittedPage(&record, rip, rsp);
+			if (!handled)
+			{
+				backend.VectoredHandler(&pointers);
+			}
+
+			if (handled)
+			{
+				ApplyWindowsContextToUnix(windowsContext, (void*)ucontext);
+				return;
+			}
+
+			backend.LastError = $"Unix native signal {signal} at RIP=0x{rip:X16}, target=0x{faultAddress:X16}";
+			backend.ActiveForcedGuestExit = true;
+			if (backend._guestReturnStub != 0)
+			{
+				WriteUnixCtxU64((void*)ucontext, UnixRegRip, (ulong)backend._guestReturnStub);
+				WriteUnixCtxU64((void*)ucontext, UnixRegRax, 0xFFFF_FFFFu);
+				return;
+			}
+
+			RestoreDefaultSignalActionAndReraise(signal);
+		}
+		finally
+		{
+			_unixSignalDepth--;
+		}
+	}
+
+	private static void FillWindowsContextFromUnix(void* unixContext, byte* windowsContext)
+	{
+		*(ulong*)(windowsContext + CTX_RAX) = ReadUnixCtxU64(unixContext, UnixRegRax);
+		*(ulong*)(windowsContext + CTX_RCX) = ReadUnixCtxU64(unixContext, UnixRegRcx);
+		*(ulong*)(windowsContext + CTX_RDX) = ReadUnixCtxU64(unixContext, UnixRegRdx);
+		*(ulong*)(windowsContext + CTX_RBX) = ReadUnixCtxU64(unixContext, UnixRegRbx);
+		*(ulong*)(windowsContext + CTX_RSP) = ReadUnixCtxU64(unixContext, UnixRegRsp);
+		*(ulong*)(windowsContext + CTX_RBP) = ReadUnixCtxU64(unixContext, UnixRegRbp);
+		*(ulong*)(windowsContext + CTX_RSI) = ReadUnixCtxU64(unixContext, UnixRegRsi);
+		*(ulong*)(windowsContext + CTX_RDI) = ReadUnixCtxU64(unixContext, UnixRegRdi);
+		*(ulong*)(windowsContext + CTX_R8) = ReadUnixCtxU64(unixContext, UnixRegR8);
+		*(ulong*)(windowsContext + CTX_R9) = ReadUnixCtxU64(unixContext, UnixRegR9);
+		*(ulong*)(windowsContext + CTX_R10) = ReadUnixCtxU64(unixContext, UnixRegR10);
+		*(ulong*)(windowsContext + CTX_R11) = ReadUnixCtxU64(unixContext, UnixRegR11);
+		*(ulong*)(windowsContext + CTX_R12) = ReadUnixCtxU64(unixContext, UnixRegR12);
+		*(ulong*)(windowsContext + CTX_R13) = ReadUnixCtxU64(unixContext, UnixRegR13);
+		*(ulong*)(windowsContext + CTX_R14) = ReadUnixCtxU64(unixContext, UnixRegR14);
+		*(ulong*)(windowsContext + CTX_R15) = ReadUnixCtxU64(unixContext, UnixRegR15);
+		*(ulong*)(windowsContext + CTX_RIP) = ReadUnixCtxU64(unixContext, UnixRegRip);
+	}
+
+	private static void ApplyWindowsContextToUnix(byte* windowsContext, void* unixContext)
+	{
+		WriteUnixCtxU64(unixContext, UnixRegRax, *(ulong*)(windowsContext + CTX_RAX));
+		WriteUnixCtxU64(unixContext, UnixRegRcx, *(ulong*)(windowsContext + CTX_RCX));
+		WriteUnixCtxU64(unixContext, UnixRegRdx, *(ulong*)(windowsContext + CTX_RDX));
+		WriteUnixCtxU64(unixContext, UnixRegRbx, *(ulong*)(windowsContext + CTX_RBX));
+		WriteUnixCtxU64(unixContext, UnixRegRsp, *(ulong*)(windowsContext + CTX_RSP));
+		WriteUnixCtxU64(unixContext, UnixRegRbp, *(ulong*)(windowsContext + CTX_RBP));
+		WriteUnixCtxU64(unixContext, UnixRegRsi, *(ulong*)(windowsContext + CTX_RSI));
+		WriteUnixCtxU64(unixContext, UnixRegRdi, *(ulong*)(windowsContext + CTX_RDI));
+		WriteUnixCtxU64(unixContext, UnixRegR8, *(ulong*)(windowsContext + CTX_R8));
+		WriteUnixCtxU64(unixContext, UnixRegR9, *(ulong*)(windowsContext + CTX_R9));
+		WriteUnixCtxU64(unixContext, UnixRegR10, *(ulong*)(windowsContext + CTX_R10));
+		WriteUnixCtxU64(unixContext, UnixRegR11, *(ulong*)(windowsContext + CTX_R11));
+		WriteUnixCtxU64(unixContext, UnixRegR12, *(ulong*)(windowsContext + CTX_R12));
+		WriteUnixCtxU64(unixContext, UnixRegR13, *(ulong*)(windowsContext + CTX_R13));
+		WriteUnixCtxU64(unixContext, UnixRegR14, *(ulong*)(windowsContext + CTX_R14));
+		WriteUnixCtxU64(unixContext, UnixRegR15, *(ulong*)(windowsContext + CTX_R15));
+		WriteUnixCtxU64(unixContext, UnixRegRip, *(ulong*)(windowsContext + CTX_RIP));
+	}
+
+	private static ulong ReadUnixCtxU64(void* context, int gregIndex) =>
+		*(ulong*)((byte*)context + UnixGregsOffset + gregIndex * sizeof(ulong));
+
+	private static void WriteUnixCtxU64(void* context, int gregIndex, ulong value) =>
+		*(ulong*)((byte*)context + UnixGregsOffset + gregIndex * sizeof(ulong)) = value;
+
+	private static void RestoreDefaultSignalActionAndReraise(int signal)
+	{
+		UnixSigAction action = default;
+		action.Handler = 0;
+		_ = sigaction(signal, &action, null);
+		_ = raise(signal);
+	}
+
+	[DllImport("libc", SetLastError = true)]
+	private static extern int sigaction(int signum, UnixSigAction* act, UnixSigAction* oldact);
+
+	[DllImport("libc", SetLastError = true)]
+	private static extern int raise(int sig);
+}

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -510,7 +510,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	private static readonly RawExceptionHandlerDelegate RawUnhandledFilterDelegateInstance = RawUnhandledFilterManaged;
 
 	private static readonly nint ImportGatewayPtr =
-		Marshal.GetFunctionPointerForDelegate(ImportGatewayDelegateInstance);
+		CreateWin64ImportGatewayThunk(Marshal.GetFunctionPointerForDelegate(ImportGatewayDelegateInstance));
 
 	private static readonly nint RawVectoredHandlerPtrManaged =
 		Marshal.GetFunctionPointerForDelegate(RawVectoredHandlerDelegateInstance);
@@ -743,22 +743,21 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		{
 			throw new OutOfMemoryException("Failed to allocate native TLS slots");
 		}
-		nint kernel32 = GetModuleHandle("kernel32.dll");
-		_tlsGetValueAddress = kernel32 != 0 ? GetProcAddress(kernel32, "TlsGetValue") : 0;
+		_tlsGetValueAddress = ResolveHostProcedure("TlsGetValue");
 		if (_tlsGetValueAddress == 0)
 		{
-			throw new InvalidOperationException("Failed to resolve kernel32!TlsGetValue");
+			throw new InvalidOperationException("Failed to resolve host TlsGetValue");
 		}
-		_queryPerformanceCounterAddress = kernel32 != 0 ? GetProcAddress(kernel32, "QueryPerformanceCounter") : 0;
+		_queryPerformanceCounterAddress = ResolveHostProcedure("QueryPerformanceCounter");
 		if (_queryPerformanceCounterAddress == 0)
 		{
-			throw new InvalidOperationException("Failed to resolve kernel32!QueryPerformanceCounter");
+			throw new InvalidOperationException("Failed to resolve host QueryPerformanceCounter");
 		}
-		_switchToThreadAddress = kernel32 != 0 ? GetProcAddress(kernel32, "SwitchToThread") : 0;
-		_sleepAddress = kernel32 != 0 ? GetProcAddress(kernel32, "Sleep") : 0;
+		_switchToThreadAddress = ResolveHostProcedure("SwitchToThread");
+		_sleepAddress = ResolveHostProcedure("Sleep");
 		if (_switchToThreadAddress == 0 || _sleepAddress == 0)
 		{
-			throw new InvalidOperationException("Failed to resolve kernel32 thread timing functions");
+			throw new InvalidOperationException("Failed to resolve host thread timing functions");
 		}
 		_tlsBaseAddress = (nint)VirtualAlloc(null, 4096u, 12288u, 4u);
 		if (_tlsBaseAddress == 0)
@@ -4232,6 +4231,15 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					MarkExecutionProgress();
 					continue;
 				}
+				if (IsExpectedBlockingImportStall(out var blockingNid, out var blockingName))
+				{
+					Console.Error.WriteLine(
+						$"[LOADER][WARN] No import progress for {stallWatchdogSeconds}s while waiting in {blockingName} ({blockingNid}); continuing.");
+					LogStallWatchdogSnapshot();
+					Console.Error.Flush();
+					MarkExecutionProgress();
+					continue;
+				}
 				if (Interlocked.Exchange(ref _stallWatchdogTriggered, 1) != 0)
 				{
 					continue;
@@ -4262,6 +4270,37 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					return true;
 				}
 			}
+		}
+
+		return false;
+	}
+
+	private bool IsExpectedBlockingImportStall(out string nid, out string name)
+	{
+		nid = string.Empty;
+		name = string.Empty;
+		var cpuContext = _cpuContext;
+		if (cpuContext is null)
+		{
+			return false;
+		}
+
+		var importAddress = cpuContext.Rip & 0xFFFFFFFFFFFFFFF0uL;
+		foreach (var entry in _importEntries)
+		{
+			if (entry.Address != importAddress)
+			{
+				continue;
+			}
+
+			nid = entry.Nid;
+			name = _moduleManager.TryGetExport(nid, out var export)
+				? $"{export.LibraryName}:{export.Name}"
+				: nid;
+			return nid is
+				"Op8TBGY5KHg" or // pthread_cond_wait
+				"27bAgiJmOh0" or // pthread_cond_timedwait
+				"fzyMKs9kim0";   // sceKernelWaitEqueue
 		}
 
 		return false;
@@ -4427,58 +4466,58 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	}
 
 
-	[DllImport("kernel32.dll")]
-	private static extern uint TlsAlloc();
-
-	[DllImport("kernel32.dll")]
-	private static extern bool TlsFree(uint dwTlsIndex);
-
-	[DllImport("kernel32.dll")]
-	private static extern bool TlsSetValue(uint dwTlsIndex, nint lpTlsValue);
-
-	[DllImport("kernel32.dll")]
-	private static extern nint TlsGetValue(uint dwTlsIndex);
-
 	[DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-	private static extern nint GetModuleHandle(string lpModuleName);
+	private static extern nint WindowsGetModuleHandle(string lpModuleName);
 
 	[DllImport("kernel32.dll", CharSet = CharSet.Ansi)]
-	private static extern nint GetProcAddress(nint hModule, string procName);
+	private static extern nint WindowsGetProcAddress(nint hModule, string procName);
 
 	[DllImport("kernel32.dll")]
-	private unsafe static extern void* AddVectoredExceptionHandler(uint first, IntPtr handler);
+	private static extern uint WindowsTlsAlloc();
 
 	[DllImport("kernel32.dll")]
-	private unsafe static extern uint RemoveVectoredExceptionHandler(void* handle);
+	private static extern bool WindowsTlsFree(uint dwTlsIndex);
 
 	[DllImport("kernel32.dll")]
-	private static extern IntPtr SetUnhandledExceptionFilter(IntPtr lpTopLevelExceptionFilter);
+	private static extern bool WindowsTlsSetValue(uint dwTlsIndex, nint lpTlsValue);
 
 	[DllImport("kernel32.dll")]
-	private static extern uint GetCurrentThreadId();
+	private static extern nint WindowsTlsGetValue(uint dwTlsIndex);
 
 	[DllImport("kernel32.dll")]
-	private static extern nint GetCurrentThread();
+	private static extern void* WindowsAddVectoredExceptionHandler(uint first, nint handler);
+
+	[DllImport("kernel32.dll")]
+	private static extern uint WindowsRemoveVectoredExceptionHandler(void* handle);
+
+	[DllImport("kernel32.dll")]
+	private static extern nint WindowsSetUnhandledExceptionFilter(nint lpTopLevelExceptionFilter);
+
+	[DllImport("kernel32.dll")]
+	private static extern uint WindowsGetCurrentThreadId();
+
+	[DllImport("kernel32.dll")]
+	private static extern nint WindowsGetCurrentThread();
 
 	[DllImport("kernel32.dll", SetLastError = true)]
-	private static extern nuint SetThreadAffinityMask(nint hThread, nuint dwThreadAffinityMask);
+	private static extern nuint WindowsSetThreadAffinityMask(nint hThread, nuint dwThreadAffinityMask);
 
 	[DllImport("kernel32.dll", SetLastError = true)]
-	private static extern nint OpenThread(uint dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwThreadId);
+	private static extern nint WindowsOpenThread(uint dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwThreadId);
 
 	[DllImport("kernel32.dll", SetLastError = true)]
-	private static extern uint SuspendThread(nint hThread);
+	private static extern uint WindowsSuspendThread(nint hThread);
 
 	[DllImport("kernel32.dll", SetLastError = true)]
-	private static extern uint ResumeThread(nint hThread);
+	private static extern uint WindowsResumeThread(nint hThread);
 
 	[DllImport("kernel32.dll", SetLastError = true)]
 	[return: MarshalAs(UnmanagedType.Bool)]
-	private unsafe static extern bool GetThreadContext(nint hThread, void* lpContext);
+	private static extern bool WindowsGetThreadContext(nint hThread, void* lpContext);
 
 	[DllImport("kernel32.dll", SetLastError = true)]
 	[return: MarshalAs(UnmanagedType.Bool)]
-	private static extern bool CloseHandle(nint hObject);
+	private static extern bool WindowsCloseHandle(nint hObject);
 
 	public unsafe void Dispose()
 	{
@@ -4606,23 +4645,23 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	}
 
 	[DllImport("kernel32.dll")]
-	private unsafe static extern void* VirtualAlloc(void* lpAddress, nuint dwSize, uint flAllocationType, uint flProtect);
+	private static extern void* WindowsVirtualAlloc(void* lpAddress, nuint dwSize, uint flAllocationType, uint flProtect);
 
 	[DllImport("kernel32.dll")]
 	[return: MarshalAs(UnmanagedType.Bool)]
-	private unsafe static extern bool VirtualFree(void* lpAddress, nuint dwSize, uint dwFreeType);
+	private static extern bool WindowsVirtualFree(void* lpAddress, nuint dwSize, uint dwFreeType);
 
 	[DllImport("kernel32.dll")]
 	[return: MarshalAs(UnmanagedType.Bool)]
-	private unsafe static extern bool VirtualProtect(void* lpAddress, nuint dwSize, uint flNewProtect, uint* lpflOldProtect);
+	private static extern bool WindowsVirtualProtect(void* lpAddress, nuint dwSize, uint flNewProtect, uint* lpflOldProtect);
 
 	[DllImport("kernel32.dll")]
-	private unsafe static extern void* GetCurrentProcess();
+	private static extern void* WindowsGetCurrentProcess();
 
 	[DllImport("kernel32.dll")]
 	[return: MarshalAs(UnmanagedType.Bool)]
-	private unsafe static extern bool FlushInstructionCache(void* hProcess, void* lpBaseAddress, nuint dwSize);
+	private static extern bool WindowsFlushInstructionCache(void* hProcess, void* lpBaseAddress, nuint dwSize);
 
 	[DllImport("kernel32.dll")]
-	private unsafe static extern nuint VirtualQuery(void* lpAddress, out MEMORY_BASIC_INFORMATION64 lpBuffer, nuint dwLength);
+	private static extern nuint WindowsVirtualQuery(void* lpAddress, out MEMORY_BASIC_INFORMATION64 lpBuffer, nuint dwLength);
 }

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -2626,11 +2626,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		{
 			return;
 		}
-		if (_guestThreadPumpDepth != 0)
+		if (Interlocked.CompareExchange(ref _guestThreadPumpDepth, 1, 0) != 0)
 		{
 			return;
 		}
-		_guestThreadPumpDepth++;
 		try
 		{
 			for (int i = 0; i < 8; i++)
@@ -2676,7 +2675,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		}
 		finally
 		{
-			_guestThreadPumpDepth--;
+			Volatile.Write(ref _guestThreadPumpDepth, 0);
 		}
 	}
 
@@ -2719,9 +2718,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			}
 		}
 
-		if (wakeCount != 0 && _logGuestThreads)
+		if (wakeCount != 0)
 		{
-			Console.Error.WriteLine($"[LOADER][INFO] guest_threads.wake key={wakeKey} count={wakeCount}");
+			if (_logGuestThreads)
+			{
+				Console.Error.WriteLine($"[LOADER][INFO] guest_threads.wake key={wakeKey} count={wakeCount}");
+			}
+
+			if (_cpuContext is { } wakeContext)
+			{
+				Pump(wakeContext, "wake");
+			}
 		}
 
 		return wakeCount;
@@ -4203,6 +4210,23 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			return;
 		}
 		_stallWatchdogStop = false;
+		var dispatcherThread = new Thread(new ThreadStart(delegate
+		{
+			while (!_stallWatchdogStop)
+			{
+				Thread.Sleep(1);
+				WakeExpiredBlockedGuestThreads();
+				if (Volatile.Read(ref _readyGuestThreadCount) > 0 && _cpuContext is { } dispatchContext)
+				{
+					Pump(dispatchContext, "dispatcher");
+				}
+			}
+		}))
+		{
+			IsBackground = true,
+			Name = "SharpEmu-GuestThreadDispatcher"
+		};
+		dispatcherThread.Start();
 		long num = (long)((double)stallWatchdogSeconds * Stopwatch.Frequency);
 		_stallWatchdogThread = new Thread(new ThreadStart(delegate
 		{
@@ -4356,6 +4380,11 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				}
 				break;
 			}
+			if (SharpEmu.HLE.Diagnostics.StallDiagnostics.SyncObjectStateDumper is { } syncDumper &&
+				syncDumper(cpuContext[CpuRegister.Rdi]) is { } syncState)
+			{
+				Console.Error.WriteLine($"[LOADER][ERROR] Stall sync-object: {syncState}");
+			}
 			Span<byte> destination = stackalloc byte[16];
 			if (cpuContext.Memory.TryRead(cpuContext.Rip, destination))
 			{
@@ -4394,7 +4423,15 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 						$"[LOADER][ERROR] Stall guest-thread: handle=0x{thread.ThreadHandle:X16} name='{thread.Name}' " +
 						$"state={thread.State} imports={Interlocked.Read(ref thread.ImportCount)} " +
 						$"nid={Volatile.Read(ref thread.LastImportNid) ?? "none"} ret=0x{Volatile.Read(ref thread.LastReturnRip):X16} " +
-						$"block={thread.BlockReason ?? "none"}{hostContextText}");
+						$"block={thread.BlockReason ?? "none"} wait_on={thread.BlockWakeKey ?? "none"}{hostContextText}");
+					if (thread.BlockWakeKey is { } waitKey &&
+						waitKey.LastIndexOf("0x", StringComparison.Ordinal) is var hexIndex && hexIndex >= 0 &&
+						ulong.TryParse(waitKey.AsSpan(hexIndex + 2), System.Globalization.NumberStyles.HexNumber, null, out var waitAddress) &&
+						SharpEmu.HLE.Diagnostics.StallDiagnostics.SyncObjectStateDumper is { } waitDumper &&
+						waitDumper(waitAddress) is { } waitState)
+					{
+						Console.Error.WriteLine($"[LOADER][ERROR] Stall guest-thread:     waits-on-object: {waitState}");
+					}
 					logged++;
 					if (logged >= 48 && threads.Length > logged)
 					{

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -4228,6 +4228,12 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		};
 		dispatcherThread.Start();
 		long num = (long)((double)stallWatchdogSeconds * Stopwatch.Frequency);
+		// A livelock with a slow trickle of imports keeps resetting _lastProgressTimestamp
+		// (DispatchImport marks progress every 64 imports), so the no-progress path below
+		// never fires and the wedge is invisible. Track the import-count delta per watchdog
+		// period as well: a tiny nonzero delta means the guest is wedged but polling.
+		long trickleLastImportCount = Volatile.Read(ref _importDispatchCount);
+		long trickleLastTimestamp = Stopwatch.GetTimestamp();
 		_stallWatchdogThread = new Thread(new ThreadStart(delegate
 		{
 			while (!_stallWatchdogStop)
@@ -4237,7 +4243,23 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				{
 					break;
 				}
-				long num2 = Stopwatch.GetTimestamp() - Volatile.Read(ref _lastProgressTimestamp);
+				long nowTimestamp = Stopwatch.GetTimestamp();
+				if (nowTimestamp - trickleLastTimestamp >= num)
+				{
+					long currentImportCount = Volatile.Read(ref _importDispatchCount);
+					long trickleDelta = currentImportCount - trickleLastImportCount;
+					trickleLastImportCount = currentImportCount;
+					trickleLastTimestamp = nowTimestamp;
+					if (trickleDelta > 0 && trickleDelta < 4096)
+					{
+						Console.Error.WriteLine(
+							$"[LOADER][WARN] Import trickle: only {trickleDelta} imports in {stallWatchdogSeconds}s (total={currentImportCount}); likely livelock — dumping state.");
+						LogStallWatchdogSnapshot();
+						DumpRecentImportTrace();
+						Console.Error.Flush();
+					}
+				}
+				long num2 = nowTimestamp - Volatile.Read(ref _lastProgressTimestamp);
 				if (num2 < num)
 				{
 					continue;
@@ -4399,10 +4421,48 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				Console.Error.WriteLine($"[LOADER][ERROR] Stall stack: [rsp]=0x{value:X16} [rsp+8]=0x{value2:X16}");
 			}
 
+			// Guest caller chain for the main thread (the scheduler threads get this from
+			// DumpBlockedGuestThreadFrames; main is a host thread and never went through it).
+			var mainRbp = cpuContext[CpuRegister.Rbp];
+			for (var depth = 0; depth < 16 && mainRbp != 0; depth++)
+			{
+				if (!cpuContext.TryReadUInt64(mainRbp + 8, out var mainRet) ||
+					!cpuContext.TryReadUInt64(mainRbp, out var mainNextRbp) ||
+					mainRet == 0)
+				{
+					break;
+				}
+
+				var mainIda = mainRet >= GuestModuleBaseForDiag ? mainRet - GuestModuleBaseForDiag : mainRet;
+				Console.Error.WriteLine(
+					$"[LOADER][ERROR] Stall main-frame#{depth}: ret=0x{mainRet:X16} ida=0x{mainIda:X}");
+
+				if (mainNextRbp <= mainRbp)
+				{
+					break;
+				}
+
+				mainRbp = mainNextRbp;
+			}
+
+			// Same FEvent probe as the blocked guest threads, for the main (host) thread: when it
+			// is parked in pthread_cond_wait, rsi holds the mutex, so the event object is rsi-32.
+			var mainMutex = cpuContext[CpuRegister.Rsi];
+			if (mainMutex >= 32 &&
+				cpuContext.TryReadUInt32(mainMutex - 12, out var mainEventState) &&
+				cpuContext.TryReadUInt32(mainMutex - 8, out var mainEventWaiters))
+			{
+				Console.Error.WriteLine(
+					$"[LOADER][ERROR] Stall fevent(main): obj=0x{mainMutex - 32:X16} state={mainEventState} " +
+					$"guest_waiters={mainEventWaiters} " +
+					$"=> {(mainEventState != 0 ? "TRIGGERED-BUT-STILL-BLOCKED (lost wakeup on our side)" : "never triggered by guest")}");
+			}
+
 			var threads = SnapshotGuestThreads();
 			if (threads.Length != 0)
 			{
 				var logged = 0;
+				Span<byte> ripBytes = stackalloc byte[16];
 				foreach (var thread in threads)
 				{
 					var hostThreadId = Volatile.Read(ref thread.HostThreadId);
@@ -4424,6 +4484,15 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 						$"state={thread.State} imports={Interlocked.Read(ref thread.ImportCount)} " +
 						$"nid={Volatile.Read(ref thread.LastImportNid) ?? "none"} ret=0x{Volatile.Read(ref thread.LastReturnRip):X16} " +
 						$"block={thread.BlockReason ?? "none"} wait_on={thread.BlockWakeKey ?? "none"}{hostContextText}");
+					if (hostContextText.Contains("host_rip", StringComparison.Ordinal) && _cpuContext is { } byteContext)
+					{
+						if (byteContext.Memory.TryRead(hostContext.Rip, ripBytes))
+						{
+							Console.Error.WriteLine(
+								$"[LOADER][ERROR] Stall guest-thread:     bytes @host_rip: {BitConverter.ToString(ripBytes.ToArray()).Replace("-", " ")}");
+						}
+					}
+					DumpBlockedGuestThreadFrames(thread);
 					if (thread.BlockWakeKey is { } waitKey &&
 						waitKey.LastIndexOf("0x", StringComparison.Ordinal) is var hexIndex && hexIndex >= 0 &&
 						ulong.TryParse(waitKey.AsSpan(hexIndex + 2), System.Globalization.NumberStyles.HexNumber, null, out var waitAddress) &&
@@ -4446,8 +4515,76 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		}
 	}
 
+	// Walks the saved guest RBP chain of a blocked thread and prints each return address as an
+	// IDA offset (guest RIP - module base). The libkernel wrappers all park at the same address,
+	// so the caller chain is the only thing that identifies WHICH guest object a thread waits on.
+	private static void DumpBlockedGuestThreadFrames(GuestThreadState thread)
+	{
+		if (thread.State != GuestThreadRunState.Blocked || thread.Context is not { } context)
+		{
+			return;
+		}
+
+		try
+		{
+			var rbp = context[CpuRegister.Rbp];
+			var rdi = context[CpuRegister.Rdi];
+			var rsi = context[CpuRegister.Rsi];
+			Console.Error.WriteLine(
+				$"[LOADER][ERROR] Stall guest-thread:     blocked_ctx: rdi=0x{rdi:X16} rsi=0x{rsi:X16} " +
+				$"rsp=0x{context[CpuRegister.Rsp]:X16} rbp=0x{rbp:X16}");
+
+			// UE5 FPThreadEvent (guest sub_1D87280/sub_1D91700): manual_reset@+17, state@+20
+			// (0=untriggered, 1=signalled-one, 2=signalled-all), waiters@+24, mutex@+32, cond@+40.
+			// A thread parked in cond_wait with state==1 means Trigger ran and WE dropped the
+			// wakeup; state==0 means the guest never triggered it.
+			if (thread.BlockReason is "pthread_cond_wait" or "pthread_cond_timedwait" && rsi >= 32)
+			{
+				var eventObject = rsi - 32;
+				if (context.TryReadUInt32(eventObject + 20, out var eventState) &&
+					context.TryReadUInt32(eventObject + 24, out var eventWaiters) &&
+					context.TryReadUInt32(eventObject + 17, out var manualReset))
+				{
+					Console.Error.WriteLine(
+						$"[LOADER][ERROR] Stall guest-thread:     fevent: obj=0x{eventObject:X16} " +
+						$"state={eventState} guest_waiters={eventWaiters} manual_reset={manualReset & 0xFF} " +
+						$"=> {(eventState != 0 ? "TRIGGERED-BUT-STILL-BLOCKED (lost wakeup on our side)" : "never triggered by guest")}");
+				}
+			}
+
+			for (var depth = 0; depth < 12 && rbp != 0; depth++)
+			{
+				if (!context.TryReadUInt64(rbp + 8, out var returnRip) ||
+					!context.TryReadUInt64(rbp, out var nextRbp) ||
+					returnRip == 0)
+				{
+					break;
+				}
+
+				var ida = returnRip >= GuestModuleBaseForDiag ? returnRip - GuestModuleBaseForDiag : returnRip;
+				Console.Error.WriteLine(
+					$"[LOADER][ERROR] Stall guest-thread:     frame#{depth}: ret=0x{returnRip:X16} ida=0x{ida:X}");
+
+				if (nextRbp <= rbp)
+				{
+					break;
+				}
+
+				rbp = nextRbp;
+			}
+		}
+		catch
+		{
+		}
+	}
+
 	private unsafe static bool TryCaptureHostThreadContext(int hostThreadId, out HostThreadContextSnapshot snapshot)
 	{
+		if (!OperatingSystem.IsWindows())
+		{
+			return TryCaptureUnixThreadContext(hostThreadId, out snapshot);
+		}
+
 		snapshot = default;
 		if (hostThreadId == 0 || unchecked((uint)hostThreadId) == GetCurrentThreadId())
 		{
@@ -4503,56 +4640,56 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	}
 
 
-	[DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+	[DllImport("kernel32.dll", EntryPoint = "GetModuleHandle", CharSet = CharSet.Unicode)]
 	private static extern nint WindowsGetModuleHandle(string lpModuleName);
 
-	[DllImport("kernel32.dll", CharSet = CharSet.Ansi)]
+	[DllImport("kernel32.dll", EntryPoint = "GetProcAddress", CharSet = CharSet.Ansi)]
 	private static extern nint WindowsGetProcAddress(nint hModule, string procName);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "TlsAlloc")]
 	private static extern uint WindowsTlsAlloc();
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "TlsFree")]
 	private static extern bool WindowsTlsFree(uint dwTlsIndex);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "TlsSetValue")]
 	private static extern bool WindowsTlsSetValue(uint dwTlsIndex, nint lpTlsValue);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "TlsGetValue")]
 	private static extern nint WindowsTlsGetValue(uint dwTlsIndex);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "AddVectoredExceptionHandler")]
 	private static extern void* WindowsAddVectoredExceptionHandler(uint first, nint handler);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "RemoveVectoredExceptionHandler")]
 	private static extern uint WindowsRemoveVectoredExceptionHandler(void* handle);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "SetUnhandledExceptionFilter")]
 	private static extern nint WindowsSetUnhandledExceptionFilter(nint lpTopLevelExceptionFilter);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "GetCurrentThreadId")]
 	private static extern uint WindowsGetCurrentThreadId();
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "GetCurrentThread")]
 	private static extern nint WindowsGetCurrentThread();
 
-	[DllImport("kernel32.dll", SetLastError = true)]
+	[DllImport("kernel32.dll", EntryPoint = "SetThreadAffinityMask", SetLastError = true)]
 	private static extern nuint WindowsSetThreadAffinityMask(nint hThread, nuint dwThreadAffinityMask);
 
-	[DllImport("kernel32.dll", SetLastError = true)]
+	[DllImport("kernel32.dll", EntryPoint = "OpenThread", SetLastError = true)]
 	private static extern nint WindowsOpenThread(uint dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwThreadId);
 
-	[DllImport("kernel32.dll", SetLastError = true)]
+	[DllImport("kernel32.dll", EntryPoint = "SuspendThread", SetLastError = true)]
 	private static extern uint WindowsSuspendThread(nint hThread);
 
-	[DllImport("kernel32.dll", SetLastError = true)]
+	[DllImport("kernel32.dll", EntryPoint = "ResumeThread", SetLastError = true)]
 	private static extern uint WindowsResumeThread(nint hThread);
 
-	[DllImport("kernel32.dll", SetLastError = true)]
+	[DllImport("kernel32.dll", EntryPoint = "GetThreadContext", SetLastError = true)]
 	[return: MarshalAs(UnmanagedType.Bool)]
 	private static extern bool WindowsGetThreadContext(nint hThread, void* lpContext);
 
-	[DllImport("kernel32.dll", SetLastError = true)]
+	[DllImport("kernel32.dll", EntryPoint = "CloseHandle", SetLastError = true)]
 	[return: MarshalAs(UnmanagedType.Bool)]
 	private static extern bool WindowsCloseHandle(nint hObject);
 
@@ -4681,24 +4818,24 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		Volatile.Write(ref _globalUnresolvedReturnStub, 0uL);
 	}
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "VirtualAlloc")]
 	private static extern void* WindowsVirtualAlloc(void* lpAddress, nuint dwSize, uint flAllocationType, uint flProtect);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "VirtualFree")]
 	[return: MarshalAs(UnmanagedType.Bool)]
 	private static extern bool WindowsVirtualFree(void* lpAddress, nuint dwSize, uint dwFreeType);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "VirtualProtect")]
 	[return: MarshalAs(UnmanagedType.Bool)]
 	private static extern bool WindowsVirtualProtect(void* lpAddress, nuint dwSize, uint flNewProtect, uint* lpflOldProtect);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "GetCurrentProcess")]
 	private static extern void* WindowsGetCurrentProcess();
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "FlushInstructionCache")]
 	[return: MarshalAs(UnmanagedType.Bool)]
 	private static extern bool WindowsFlushInstructionCache(void* hProcess, void* lpBaseAddress, nuint dwSize);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", EntryPoint = "VirtualQuery")]
 	private static extern nuint WindowsVirtualQuery(void* lpAddress, out MEMORY_BASIC_INFORMATION64 lpBuffer, nuint dwLength);
 }

--- a/src/SharpEmu.Core/Cpu/Native/StubManager.cs
+++ b/src/SharpEmu.Core/Cpu/Native/StubManager.cs
@@ -17,11 +17,7 @@ public sealed unsafe class StubManager : IDisposable
 
     public StubManager()
     {
-        _pltMemory = (byte*)VirtualAlloc(
-            null,
-            (nuint)PltMemorySize,
-            AllocationType.Reserve | AllocationType.Commit,
-            MemoryProtection.ExecuteReadWrite);
+        _pltMemory = (byte*)AllocateExecutableMemory((nuint)PltMemorySize);
 
         if (_pltMemory == null)
         {
@@ -185,7 +181,7 @@ public sealed unsafe class StubManager : IDisposable
     {
         if (_pltMemory != null)
         {
-            VirtualFree(_pltMemory, 0, FreeType.Release);
+            FreeExecutableMemory(_pltMemory, (nuint)PltMemorySize);
             _pltMemory = null;
         }
 
@@ -194,11 +190,48 @@ public sealed unsafe class StubManager : IDisposable
         _stubAddresses.Clear();
     }
 
+    private static void* AllocateExecutableMemory(nuint size)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return VirtualAlloc(
+                null,
+                size,
+                AllocationType.Reserve | AllocationType.Commit,
+                MemoryProtection.ExecuteReadWrite);
+        }
+
+        var result = mmap(null, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        return result == (void*)-1 ? null : result;
+    }
+
+    private static bool FreeExecutableMemory(void* address, nuint size)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return VirtualFree(address, 0, FreeType.Release);
+        }
+
+        return munmap(address, size) == 0;
+    }
+
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern void* VirtualAlloc(void* lpAddress, nuint dwSize, AllocationType flAllocationType, MemoryProtection flProtect);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern bool VirtualFree(void* lpAddress, nuint dwSize, FreeType dwFreeType);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern void* mmap(void* addr, nuint length, int prot, int flags, int fd, nint offset);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int munmap(void* addr, nuint length);
+
+    private const int PROT_READ = 0x1;
+    private const int PROT_WRITE = 0x2;
+    private const int PROT_EXEC = 0x4;
+    private const int MAP_PRIVATE = 0x02;
+    private const int MAP_ANONYMOUS = 0x20;
 
     [Flags]
     private enum AllocationType : uint

--- a/src/SharpEmu.Core/Loader/SelfLoader.cs
+++ b/src/SharpEmu.Core/Loader/SelfLoader.cs
@@ -688,6 +688,12 @@ public sealed class SelfLoader : ISelfLoader
                 throw new InvalidDataException($"Failed to patch relocation at 0x{descriptor.TargetAddress:X16}.");
             }
 
+            if (descriptor.TargetAddress == 0x0000000808CEB0B8UL)
+            {
+                Console.Error.WriteLine(
+                    $"[LOADER][PLT] slot=0x74 got=0x{descriptor.TargetAddress:X16} value=0x{targetValue:X16} addend=0x{descriptor.Addend:X} nid={(descriptor.ImportNid ?? "<sym>")}");
+            }
+
             if (descriptor.TargetAddress >= 0x00000008030FC300UL &&
                 descriptor.TargetAddress <= 0x00000008030FC3F0UL)
             {

--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -38,6 +38,13 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
     private const uint PAGE_NOACCESS = 0x01;
     private const uint PAGE_READWRITE = 0x04;
     private const uint PAGE_READONLY = 0x02;
+    private const int PROT_NONE = 0x0;
+    private const int PROT_READ = 0x1;
+    private const int PROT_WRITE = 0x2;
+    private const int PROT_EXEC = 0x4;
+    private const int MAP_PRIVATE = 0x02;
+    private const int MAP_ANONYMOUS = 0x20;
+    private const int MAP_FIXED_NOREPLACE = 0x100000;
 
     private ulong _guestAllocationArenaBase;
     private ulong _guestAllocationOffset;
@@ -64,6 +71,15 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool FlushInstructionCache(void* hProcess, void* lpBaseAddress, nuint dwSize);
 
+    [DllImport("libc", SetLastError = true)]
+    private static extern void* mmap(void* addr, nuint length, int prot, int flags, int fd, nint offset);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int munmap(void* addr, nuint length);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int mprotect(void* addr, nuint len, int prot);
+
     public bool TryAllocateAtExact(ulong desiredAddress, ulong size, bool executable, out ulong actualAddress)
     {
         actualAddress = 0;
@@ -75,7 +91,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         var alignedSize = (size + 0xFFF) & ~0xFFFUL;
         var protection = executable ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE;
         var allocationType = MEM_COMMIT | MEM_RESERVE;
-        var result = VirtualAlloc((void*)desiredAddress, (nuint)alignedSize, allocationType, protection);
+        var result = AllocateHostMemory((void*)desiredAddress, (nuint)alignedSize, allocationType, protection);
         if (result == null)
         {
             return false;
@@ -84,7 +100,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         actualAddress = (ulong)result;
         if (actualAddress != desiredAddress)
         {
-            VirtualFree(result, 0, MEM_RELEASE);
+            FreeHostMemory(result, (nuint)alignedSize);
             actualAddress = 0;
             return false;
         }
@@ -128,10 +144,10 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         void* result = null;
         if (preferReserveOnly)
         {
-            result = VirtualAlloc((void*)desiredAddress, (nuint)alignedSize, MEM_RESERVE, PAGE_READWRITE);
+            result = AllocateHostMemory((void*)desiredAddress, (nuint)alignedSize, MEM_RESERVE, PAGE_READWRITE);
             if (result == null && allowAlternative)
             {
-                result = VirtualAlloc(null, (nuint)alignedSize, MEM_RESERVE, PAGE_READWRITE);
+                result = AllocateHostMemory(null, (nuint)alignedSize, MEM_RESERVE, PAGE_READWRITE);
             }
 
             if (result != null)
@@ -142,7 +158,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
 
         if (result == null)
         {
-            result = VirtualAlloc((void*)desiredAddress, (nuint)alignedSize, allocationType, protection);
+            result = AllocateHostMemory((void*)desiredAddress, (nuint)alignedSize, allocationType, protection);
         }
 
         if (result == null)
@@ -153,16 +169,16 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
             }
 
             TraceVmem($"Could not allocate at 0x{desiredAddress:X16}, trying any address...");
-            result = VirtualAlloc(null, (nuint)alignedSize, allocationType, protection);
+            result = AllocateHostMemory(null, (nuint)alignedSize, allocationType, protection);
 
             if (result == null)
             {
                 if (!executable)
                 {
-                    result = VirtualAlloc((void*)desiredAddress, (nuint)alignedSize, MEM_RESERVE, PAGE_READWRITE);
+                    result = AllocateHostMemory((void*)desiredAddress, (nuint)alignedSize, MEM_RESERVE, PAGE_READWRITE);
                     if (result == null && allowAlternative)
                     {
-                        result = VirtualAlloc(null, (nuint)alignedSize, MEM_RESERVE, PAGE_READWRITE);
+                        result = AllocateHostMemory(null, (nuint)alignedSize, MEM_RESERVE, PAGE_READWRITE);
                     }
 
                     if (result != null)
@@ -192,7 +208,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
                     var remaining = primeBytes - committedBytes;
                     var chunkBytes = Math.Min(remaining, LazyReservePrimeChunkBytes);
                     var commitAddress = (void*)(actualAddress + committedBytes);
-                    var committed = VirtualAlloc(commitAddress, (nuint)chunkBytes, MEM_COMMIT, PAGE_READWRITE);
+                    var committed = CommitHostMemory(commitAddress, (nuint)chunkBytes, PAGE_READWRITE);
                     if (committed == null)
                     {
                         break;
@@ -345,7 +361,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
             {
                 foreach (var region in _regions)
                 {
-                    VirtualFree((void*)region.VirtualAddress, 0, MEM_RELEASE);
+                    FreeHostMemory((void*)region.VirtualAddress, (nuint)region.Size);
                 }
                 _regions.Clear();
                 _pageProtections.Clear();
@@ -451,14 +467,14 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
             protection = PAGE_READONLY;
         }
 
-        if (!VirtualProtect((void*)address, (nuint)size, protection, out _))
+        if (!ProtectHostMemory((void*)address, (nuint)size, protection, out _))
         {
             throw new InvalidOperationException($"Failed to set memory protection at 0x{address:X16}");
         }
 
         if ((flags & ProgramHeaderFlags.Execute) != 0)
         {
-            FlushInstructionCache(GetCurrentProcess(), (void*)address, (nuint)size);
+            FlushHostInstructionCache((void*)address, (nuint)size);
         }
     }
 
@@ -689,7 +705,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
                 return true;
             }
 
-            if (!VirtualProtect(destPtr, (nuint)source.Length, PAGE_EXECUTE_READWRITE, out var oldProtect))
+            if (!TryTemporarilyProtectForWrite((ulong)destPtr, (ulong)source.Length, region, out var touchedPages))
             {
                 return false;
             }
@@ -703,11 +719,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
             }
             finally
             {
-                VirtualProtect(destPtr, (nuint)source.Length, oldProtect, out _);
-                if (IsExecutableProtection(oldProtect))
-                {
-                    FlushInstructionCache(GetCurrentProcess(), destPtr, (nuint)source.Length);
-                }
+                RestorePageProtections(touchedPages);
             }
 
             return true;
@@ -951,6 +963,17 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         var pageAddress = startPage;
         while (pageAddress < endPage)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                if (!ProtectHostMemory((void*)pageAddress, (nuint)PageSize, commitProtection, out _))
+                {
+                    return false;
+                }
+
+                pageAddress += PageSize;
+                continue;
+            }
+
             if (VirtualQuery((void*)pageAddress, out var info, (nuint)sizeof(MemoryBasicInformation64)) == 0)
             {
                 return false;
@@ -965,21 +988,18 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
                 return false;
             }
 
-            if (info.State == MEM_COMMIT)
+            if (info.State != MEM_COMMIT)
             {
-                pageAddress = rangeEnd;
-                continue;
-            }
+                if (info.State != MEM_RESERVE)
+                {
+                    return false;
+                }
 
-            if (info.State != MEM_RESERVE)
-            {
-                return false;
-            }
-
-            var commitSize = rangeEnd - pageAddress;
-            if (VirtualAlloc((void*)pageAddress, (nuint)commitSize, MEM_COMMIT, commitProtection) == null)
-            {
-                return false;
+                var commitSize = rangeEnd - pageAddress;
+                if (CommitHostMemory((void*)pageAddress, (nuint)commitSize, commitProtection) == null)
+                {
+                    return false;
+                }
             }
 
             pageAddress = rangeEnd;
@@ -1002,7 +1022,35 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
 
         for (var pageAddress = startPage; pageAddress < endPage; pageAddress += PageSize)
         {
-            if (!VirtualProtect((void*)pageAddress, (nuint)PageSize, temporaryProtection, out var oldProtection))
+            var oldProtection = GetEffectiveHostProtection(pageAddress, region);
+            if (!ProtectHostMemory((void*)pageAddress, (nuint)PageSize, temporaryProtection, out _))
+            {
+                RestorePageProtections(touchedPages);
+                touchedPages.Clear();
+                return false;
+            }
+
+            touchedPages.Add((pageAddress, oldProtection));
+        }
+
+        return true;
+    }
+
+    private bool TryTemporarilyProtectForWrite(
+        ulong address,
+        ulong size,
+        MemoryRegion region,
+        out List<(ulong Address, uint Protection)> touchedPages)
+    {
+        touchedPages = new List<(ulong Address, uint Protection)>();
+
+        var startPage = AlignDown(address, PageSize);
+        var endPage = AlignUp(address + size, PageSize);
+
+        for (var pageAddress = startPage; pageAddress < endPage; pageAddress += PageSize)
+        {
+            var oldProtection = GetEffectiveHostProtection(pageAddress, region);
+            if (!ProtectHostMemory((void*)pageAddress, (nuint)PageSize, PAGE_EXECUTE_READWRITE, out _))
             {
                 RestorePageProtections(touchedPages);
                 touchedPages.Clear();
@@ -1019,8 +1067,116 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
     {
         foreach (var (pageAddress, protection) in touchedPages)
         {
-            VirtualProtect((void*)pageAddress, (nuint)PageSize, protection, out _);
+            ProtectHostMemory((void*)pageAddress, (nuint)PageSize, protection, out _);
+            if (IsExecutableProtection(protection))
+            {
+                FlushHostInstructionCache((void*)pageAddress, (nuint)PageSize);
+            }
         }
+    }
+
+    private uint GetEffectiveHostProtection(ulong pageAddress, MemoryRegion region)
+    {
+        if (_pageProtections.TryGetValue(pageAddress, out var flags))
+        {
+            return ToHostProtection(flags);
+        }
+
+        return region.Protection;
+    }
+
+    private static uint ToHostProtection(ProgramHeaderFlags flags)
+    {
+        if (flags == ProgramHeaderFlags.None)
+        {
+            return PAGE_NOACCESS;
+        }
+
+        if ((flags & ProgramHeaderFlags.Execute) != 0)
+        {
+            return (flags & ProgramHeaderFlags.Write) != 0
+                ? PAGE_EXECUTE_READWRITE
+                : PAGE_EXECUTE_READ;
+        }
+
+        return (flags & ProgramHeaderFlags.Write) != 0
+            ? PAGE_READWRITE
+            : PAGE_READONLY;
+    }
+
+    private static void* AllocateHostMemory(void* address, nuint size, uint allocationType, uint protection)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return VirtualAlloc(address, size, allocationType, protection);
+        }
+
+        var prot = (allocationType & MEM_COMMIT) != 0
+            ? ToUnixProtection(protection)
+            : PROT_NONE;
+        var flags = MAP_PRIVATE | MAP_ANONYMOUS;
+        if (address != null)
+        {
+            flags |= MAP_FIXED_NOREPLACE;
+        }
+
+        var result = mmap(address, size, prot, flags, -1, 0);
+        return result == (void*)-1 ? null : result;
+    }
+
+    private static void* CommitHostMemory(void* address, nuint size, uint protection)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return VirtualAlloc(address, size, MEM_COMMIT, protection);
+        }
+
+        return mprotect(address, size, ToUnixProtection(protection)) == 0
+            ? address
+            : null;
+    }
+
+    private static bool FreeHostMemory(void* address, nuint size)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return VirtualFree(address, 0, MEM_RELEASE);
+        }
+
+        return munmap(address, size) == 0;
+    }
+
+    private static bool ProtectHostMemory(void* address, nuint size, uint protection, out uint oldProtection)
+    {
+        oldProtection = 0;
+        if (OperatingSystem.IsWindows())
+        {
+            return VirtualProtect(address, size, protection, out oldProtection);
+        }
+
+        return mprotect(address, size, ToUnixProtection(protection)) == 0;
+    }
+
+    private static void FlushHostInstructionCache(void* address, nuint size)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            FlushInstructionCache(null, address, size);
+        }
+    }
+
+    private static int ToUnixProtection(uint protection)
+    {
+        return protection switch
+        {
+            PAGE_NOACCESS => PROT_NONE,
+            PAGE_READONLY => PROT_READ,
+            PAGE_READWRITE => PROT_READ | PROT_WRITE,
+            PAGE_EXECUTE => PROT_EXEC,
+            PAGE_EXECUTE_READ => PROT_READ | PROT_EXEC,
+            PAGE_EXECUTE_READWRITE or PAGE_EXECUTE_WRITECOPY => PROT_READ | PROT_WRITE | PROT_EXEC,
+            _ => PROT_READ | PROT_WRITE
+        };
     }
 
     private static ulong AlignDown(ulong value, ulong alignment)

--- a/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
+++ b/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
@@ -787,6 +787,11 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
     {
         foreach (var nid in HleDataSymbols.EnumerateKnownNids())
         {
+            if (IsTlsBackedHleDataSymbol(nid))
+            {
+                continue;
+            }
+
             if (runtimeSymbols.ContainsKey(nid) ||
                 !HleDataSymbols.TryGetAddress(nid, out var symbolAddress) ||
                 !IsUsableRuntimeSymbolAddress(symbolAddress))
@@ -797,6 +802,9 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
             runtimeSymbols[nid] = symbolAddress;
         }
     }
+
+    private static bool IsTlsBackedHleDataSymbol(string nid) =>
+        string.Equals(nid, "f7uOxY9mM1U", StringComparison.Ordinal);
 
     private static int MergeImportStubs(
         IDictionary<ulong, string> destination,

--- a/src/SharpEmu.HLE/Diagnostics/StallDiagnostics.cs
+++ b/src/SharpEmu.HLE/Diagnostics/StallDiagnostics.cs
@@ -1,0 +1,9 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.HLE.Diagnostics;
+
+public static class StallDiagnostics
+{
+    public static Func<ulong, string?>? SyncObjectStateDumper { get; set; }
+}

--- a/src/SharpEmu.HLE/ModuleManager.cs
+++ b/src/SharpEmu.HLE/ModuleManager.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace SharpEmu.HLE;
 
@@ -12,6 +13,7 @@ public sealed class ModuleManager : IModuleManager
     private readonly ConcurrentDictionary<string, ExportedFunction> _exportTable = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, ExportedFunction> _exportNameTable = new(StringComparer.Ordinal);
     private readonly object _registrationGate = new();
+    private readonly HashSet<(Assembly Assembly, Generation Generation)> _scannedAssemblies = new();
     private bool _isFrozen;
 
     public int RegisterFromAssembly(Assembly assembly, Generation generation, ISymbolCatalog? symbolCatalog = null)
@@ -23,6 +25,14 @@ public sealed class ModuleManager : IModuleManager
             if (_isFrozen)
             {
                 throw new InvalidOperationException("Module registration is frozen.");
+            }
+
+            // Callers reference the same assembly through different types
+            // (VideoOutExports and KernelExports both live in SharpEmu.Libs),
+            // so scanning is deduplicated to avoid spurious duplicate-NID skips.
+            if (!_scannedAssemblies.Add((assembly, generation)))
+            {
+                return 0;
             }
 
             var registeredCount = 0;
@@ -73,7 +83,206 @@ public sealed class ModuleManager : IModuleManager
         {
             _isFrozen = true;
         }
+
+        WarmHleTypeInitializers();
     }
+
+    // Guest threads dispatch HLE exports on a hijacked, non-CLR-owned stack. If a type's static
+    // constructor (.cctor) runs for the FIRST time in that context, the CLR fail-fasts with the
+    // misleading "Invalid Program: attempted to call a UnmanagedCallersOnly method from managed
+    // code" (observed crashing in PthreadRwlockState..ctor, which touched a nested static). Force
+    // every type in the HLE-bearing assemblies to run its static constructor now, once, on this
+    // host thread — so no guest thread is ever the first to initialize a type.
+    private void WarmHleTypeInitializers()
+    {
+        Assembly[] assemblies;
+        lock (_registrationGate)
+        {
+            assemblies = _scannedAssemblies.Select(entry => entry.Assembly).Distinct().ToArray();
+        }
+
+        assemblies = WithGuestReachableDependencies(assemblies);
+        var bclWarmed = WarmFrameworkTypeInitializers();
+
+        var warmed = 0;
+        var failed = 0;
+        var jitted = 0;
+        var jitFailed = 0;
+        foreach (var assembly in assemblies)
+        {
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.Where(t => t is not null).ToArray()!;
+            }
+
+            const BindingFlags allMembers = BindingFlags.Public | BindingFlags.NonPublic |
+                BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+            foreach (var type in types)
+            {
+                if (type is null || type.ContainsGenericParameters)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    RuntimeHelpers.RunClassConstructor(type.TypeHandle);
+                    warmed++;
+                }
+                catch
+                {
+                    // A .cctor that throws here (on the host thread) is far better than one that
+                    // fail-fasts the whole CLR later on a guest thread; swallow and continue.
+                    failed++;
+                }
+
+                // Force-JIT every method and constructor so a guest thread is never the first to
+                // compile one. PrepareMethod only JITs — it does not execute — so this is
+                // side-effect-free (unlike instantiating types). This covers the crashing case:
+                // PthreadMutexState..ctor (which allocates a SemaphoreSlim) first-JIT'd on a
+                // guest thread fail-fasts the CLR with the misleading UnmanagedCallersOnly error.
+                MethodBase[] members;
+                try
+                {
+                    members = type.GetConstructors(allMembers)
+                        .Concat<MethodBase>(type.GetMethods(allMembers))
+                        .ToArray();
+                }
+                catch
+                {
+                    continue;
+                }
+
+                foreach (var member in members)
+                {
+                    if (member.ContainsGenericParameters || member.IsAbstract || member.MethodImplementationFlags.HasFlag(MethodImplAttributes.InternalCall))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        RuntimeHelpers.PrepareMethod(member.MethodHandle);
+                        jitted++;
+                    }
+                    catch
+                    {
+                        jitFailed++;
+                    }
+                }
+            }
+        }
+
+        Console.Error.WriteLine(
+            $"[HLE] Warmed {warmed} type initializers ({failed} threw) + JIT-compiled {jitted} methods ({jitFailed} skipped) across {assemblies.Length} HLE assemblies, plus {bclWarmed} framework type initializers.");
+    }
+
+    // The HLE reaches into the BCL, so run framework .cctors here too. Only .cctors — the BCL is
+    // far too large to force-JIT.
+    private static int WarmFrameworkTypeInitializers()
+    {
+        var warmed = 0;
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var name = assembly.GetName().Name;
+            if (name is null || !IsFrameworkAssembly(name))
+            {
+                continue;
+            }
+
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.Where(t => t is not null).ToArray()!;
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var type in types)
+            {
+                if (type is null || type.ContainsGenericParameters)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    RuntimeHelpers.RunClassConstructor(type.TypeHandle);
+                    warmed++;
+                }
+                catch
+                {
+                    // Better to throw here, on a host thread, than to fail-fast later on a guest one.
+                }
+            }
+        }
+
+        return warmed;
+    }
+
+    private static bool IsFrameworkAssembly(string assemblyName) =>
+        assemblyName.StartsWith("System", StringComparison.Ordinal) ||
+        string.Equals(assemblyName, "netstandard", StringComparison.Ordinal);
+
+    // Guest threads reach Silk.NET through the flip path, so warm the interop assemblies too.
+    private static Assembly[] WithGuestReachableDependencies(Assembly[] scanned)
+    {
+        var result = new Dictionary<string, Assembly>(StringComparer.Ordinal);
+        foreach (var assembly in scanned)
+        {
+            result[assembly.FullName ?? assembly.GetName().Name ?? string.Empty] = assembly;
+        }
+
+        foreach (var assembly in scanned)
+        {
+            AssemblyName[] references;
+            try
+            {
+                references = assembly.GetReferencedAssemblies();
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var reference in references)
+            {
+                var name = reference.Name;
+                if (name is null || !IsGuestReachableInterop(name))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var loaded = Assembly.Load(reference);
+                    result[loaded.FullName ?? name] = loaded;
+                }
+                catch
+                {
+                    // A dependency we cannot load is one a guest thread cannot reach either.
+                }
+            }
+        }
+
+        return result.Values.ToArray();
+    }
+
+    private static bool IsGuestReachableInterop(string assemblyName) =>
+        assemblyName.StartsWith("Silk.NET", StringComparison.Ordinal) ||
+        assemblyName.StartsWith("SharpEmu", StringComparison.Ordinal);
 
     public bool TryGetFunction(string nid, out Delegate function)
     {

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -54,6 +54,8 @@ public static class AgcExports
     private const uint RDmaData = 0x19;
     private const uint SpiShaderPgmLoPs = 0x8;
     private const uint SpiShaderPgmHiPs = 0x9;
+    private const uint SpiShaderPgmLoGs = 0x8A;
+    private const uint SpiShaderPgmHiGs = 0x8B;
     private const uint SpiShaderPgmLoEs = 0xC8;
     private const uint SpiShaderPgmHiEs = 0xC9;
     private const uint SpiShaderPgmLoLs = 0x148;
@@ -2053,6 +2055,10 @@ public static class AgcExports
             DrainResumableDcbs(ctx, gpuState, tracePackets);
         }
 
+        var triggeredEvents = KernelEventQueueCompatExports.TriggerRegisteredEventsByFilter(
+            KernelEventQueueCompatExports.KernelEventFilterGraphics,
+            commandAddress);
+        TraceAgc($"agc.driver_submit_dcb_complete events={triggeredEvents}");
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
@@ -2102,6 +2108,10 @@ public static class AgcExports
             DrainResumableDcbs(ctx, gpuState, tracePackets);
         }
 
+        var triggeredEvents = KernelEventQueueCompatExports.TriggerRegisteredEventsByFilter(
+            KernelEventQueueCompatExports.KernelEventFilterGraphics,
+            commandAddress);
+        TraceAgc($"agc.driver_submit_acb_complete owner={ownerHandle} events={triggeredEvents}");
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
@@ -2983,10 +2993,8 @@ public static class AgcExports
         uint vertexCount,
         bool indexed)
     {
-        var hasExportShader = TryGetShaderAddress(
+        var hasExportShader = TryGetExportShaderAddress(
             state.ShRegisters,
-            SpiShaderPgmLoEs,
-            SpiShaderPgmHiEs,
             out var exportShaderAddress);
         var hasPixelShader = TryGetShaderAddress(
             state.ShRegisters,
@@ -4887,6 +4895,18 @@ public static class AgcExports
 
         address = ((ulong)hi << 40) | ((ulong)lo << 8);
         return address != 0;
+    }
+
+    private static bool TryGetExportShaderAddress(
+        IReadOnlyDictionary<uint, uint> registers,
+        out ulong address)
+    {
+        if (TryGetShaderAddress(registers, SpiShaderPgmLoGs, SpiShaderPgmHiGs, out address))
+        {
+            return true;
+        }
+
+        return TryGetShaderAddress(registers, SpiShaderPgmLoEs, SpiShaderPgmHiEs, out address);
     }
 
     private static bool TryReadTextureDescriptor(

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -60,8 +60,6 @@ public static class AgcExports
     private const uint SpiShaderPgmHiEs = 0xC9;
     private const uint SpiShaderPgmLoLs = 0x148;
     private const uint SpiShaderPgmHiLs = 0x149;
-    private const uint SpiShaderPgmLoGs = 0x8A;
-    private const uint SpiShaderPgmHiGs = 0x8B;
     private const uint SpiPsInputEna = 0x1B3;
     private const uint SpiPsInputAddr = 0x1B4;
     private const uint ComputePgmLo = 0x20C;
@@ -2030,6 +2028,7 @@ public static class AgcExports
             Environment.GetEnvironmentVariable("SHARPEMU_LOG_AGC"), "1", StringComparison.Ordinal);
 
         var gpuState = _submittedGpuStates.GetValue(ctx.Memory, static _ => new SubmittedGpuState());
+        ulong lastCommandAddress = 0;
         lock (gpuState.Gate)
         {
             for (uint i = 0; i < bufferCount; i++)
@@ -2050,6 +2049,7 @@ public static class AgcExports
                 }
 
                 ParseSubmittedDcb(ctx, gpuState, gpuState.Graphics, commandAddress, dwordCount, tracePackets);
+                lastCommandAddress = commandAddress;
             }
 
             DrainResumableDcbs(ctx, gpuState, tracePackets);
@@ -2057,7 +2057,7 @@ public static class AgcExports
 
         var triggeredEvents = KernelEventQueueCompatExports.TriggerRegisteredEventsByFilter(
             KernelEventQueueCompatExports.KernelEventFilterGraphics,
-            commandAddress);
+            lastCommandAddress);
         TraceAgc($"agc.driver_submit_dcb_complete events={triggeredEvents}");
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -52,6 +52,68 @@ public static class AgcExports
     private const uint RFlip = 0x17;
     private const uint RReleaseMem = 0x18;
     private const uint RDmaData = 0x19;
+
+    // Monotonic counter emitted for RELEASE_MEM DATA_SEL=3 (GPU timestamp) EOP fences.
+    private static ulong _gpuEopTimestamp;
+
+    // EOP fences are delivered on this host thread with a short delay instead of
+    // synchronously inside the submit import. On real hardware the end-of-pipe
+    // interrupt fires after the submitting thread has finished rotating its
+    // command-buffer chunks; signalling completion mid-submit lets the guest's
+    // chunk allocator recycle a chunk the submitter still holds (the null-vtable
+    // UAF at guest 0x2034C09). SHARPEMU_AGC_SYNC_EOP=1 restores the old behavior.
+    private sealed record PendingEopEvent(
+        CpuContext Ctx,
+        ulong DestinationAddress,
+        uint DataSelection,
+        uint DataLo,
+        ulong Data,
+        uint InterruptContextId,
+        uint Interrupt,
+        bool TracePacket);
+
+    private static readonly System.Collections.Concurrent.BlockingCollection<PendingEopEvent> _pendingEopEvents = new();
+    private static int _eopDeliveryThreadStarted;
+    private static readonly bool _synchronousEop =
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_AGC_SYNC_EOP"), "1", StringComparison.Ordinal);
+
+    private static void EnsureEopDeliveryThread()
+    {
+        if (Interlocked.Exchange(ref _eopDeliveryThreadStarted, 1) != 0)
+        {
+            return;
+        }
+
+        var thread = new Thread(static () =>
+        {
+            foreach (var pending in _pendingEopEvents.GetConsumingEnumerable())
+            {
+                Thread.Sleep(1);
+                DeliverEopEventGuarded(pending);
+                while (_pendingEopEvents.TryTake(out var more))
+                {
+                    DeliverEopEventGuarded(more);
+                }
+            }
+
+            static void DeliverEopEventGuarded(PendingEopEvent pending)
+            {
+                try
+                {
+                    DeliverEopEvent(pending);
+                }
+                catch (Exception exception)
+                {
+                    Console.Error.WriteLine($"[LOADER][ERROR] AgcEopDelivery failed: {exception}");
+                }
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "AgcEopDelivery",
+        };
+        thread.Start();
+    }
     private const uint SpiShaderPgmLoPs = 0x8;
     private const uint SpiShaderPgmHiPs = 0x9;
     private const uint SpiShaderPgmLoGs = 0x8A;
@@ -2842,28 +2904,94 @@ public static class AgcExports
             !ctx.TryReadUInt32(packetAddress + 12, out var destinationLo) ||
             !ctx.TryReadUInt32(packetAddress + 16, out var destinationHi) ||
             !ctx.TryReadUInt32(packetAddress + 20, out var dataLo) ||
-            !ctx.TryReadUInt32(packetAddress + 24, out var dataHi))
+            !ctx.TryReadUInt32(packetAddress + 24, out var dataHi) ||
+            !ctx.TryReadUInt32(packetAddress + 28, out var interruptContextId))
         {
             return;
         }
 
         var dataSelection = (control >> 16) & 0xFFu;
+        var interrupt = (control >> 24) & 0xFFu;
         var destinationAddress = ((ulong)destinationHi << 32) | destinationLo;
         var data = ((ulong)dataHi << 32) | dataLo;
 
+        // The fence label MUST be written synchronously. Our command-buffer submit completes
+        // inside the submit import, so by the time it returns the guest may already be spinning
+        // on this label (often while holding a lock). Deferring the write wedges that spin.
+        // DATA_SEL=3 means "write the 64-bit GPU clock/timestamp", not the immediate data
+        // (which is 0 for EOP fences). Emit a monotonically increasing nonzero value so any
+        // CPU-side label poll that waits for the fence to advance is satisfied.
         var wroteData = dataSelection switch
         {
             1 => ctx.TryWriteUInt32(destinationAddress, dataLo),
-            2 or 3 => ctx.TryWriteUInt64(destinationAddress, data),
+            2 => ctx.TryWriteUInt64(destinationAddress, data),
+            3 => ctx.TryWriteUInt64(destinationAddress, Interlocked.Increment(ref _gpuEopTimestamp)),
             _ => false,
         };
 
+        var pending = new PendingEopEvent(
+            ctx,
+            destinationAddress,
+            dataSelection,
+            dataLo,
+            data,
+            interruptContextId,
+            interrupt,
+            tracePacket);
+
+        if (pending.Interrupt == 0)
+        {
+            if (tracePacket)
+            {
+                TraceReleaseMem(pending, wroteData, triggeredQueues: 0);
+            }
+
+            return;
+        }
+
+        // Only the INTERRUPT is deferred. On real hardware the end-of-pipe interrupt lands after
+        // the submitting thread has finished rotating its command-buffer chunks; raising it
+        // synchronously lets the guest's chunk allocator recycle a chunk the submitter still
+        // holds (the null-vtable UAF at guest 0x2034C09).
+        if (_synchronousEop)
+        {
+            DeliverEopEvent(pending);
+            return;
+        }
+
+        EnsureEopDeliveryThread();
+        _pendingEopEvents.Add(pending);
+
         if (tracePacket)
         {
-            TraceAgc(
-                $"agc.dcb.release_mem dst=0x{destinationAddress:X16} data_sel={dataSelection} " +
-                $"data=0x{data:X16} wrote={wroteData}");
+            TraceReleaseMem(pending, wroteData, triggeredQueues: -1);
         }
+    }
+
+    private static void DeliverEopEvent(PendingEopEvent pending)
+    {
+        // RELEASE_MEM with the interrupt bit set is the GPU end-of-pipe interrupt. On real
+        // hardware it wakes the driver's interrupt thread (here AgcInterruptThread, blocked on
+        // sceKernelWaitEqueue) via a graphics equeue event keyed by the interrupt context id
+        // registered through sceAgcDriverAddEqEvent. Without this the GPU-completion callback
+        // never runs and the game never submits a flip.
+        var triggeredQueues = KernelEventQueueCompatExports.TriggerRegisteredEvents(
+            pending.InterruptContextId,
+            KernelEventQueueCompatExports.KernelEventFilterGraphics,
+            pending.InterruptContextId);
+
+        if (pending.TracePacket)
+        {
+            TraceReleaseMem(pending, wroteData: true, triggeredQueues);
+        }
+    }
+
+    private static void TraceReleaseMem(PendingEopEvent pending, bool wroteData, int triggeredQueues)
+    {
+        TraceAgc(
+            $"agc.dcb.release_mem dst=0x{pending.DestinationAddress:X16} data_sel={pending.DataSelection} " +
+            $"data=0x{pending.Data:X16} wrote={wroteData} int={pending.Interrupt} " +
+            $"int_ctx=0x{pending.InterruptContextId:X} queues={(triggeredQueues < 0 ? "deferred" : triggeredQueues.ToString())}");
     }
 
     private static void ApplySubmittedRegisters(

--- a/src/SharpEmu.Libs/CxxAbiExports.cs
+++ b/src/SharpEmu.Libs/CxxAbiExports.cs
@@ -78,8 +78,17 @@ public static class CxaGuardExports
             {
                 if (state.OwnerThreadId == currentThreadId)
                 {
-                    ctx[CpuRegister.Rax] = 0;
-                    LogGuardResult("guard_acquire", guardPtr, result: 0, initialized, inProgress: true, ownerThreadId: state.OwnerThreadId);
+                    // Recursive acquire: this thread is already constructing this static and has
+                    // re-entered its own initializer. Returning 0 ("already done, use it") makes
+                    // the guest deref a still-null singleton; blindly returning 1 lets a pair of
+                    // mutually-referencing statics (E41E28<->E38CD0) construct each other forever
+                    // → 7700-deep stack overflow. Allow ONE re-entrant construction (which lets a
+                    // static that legitimately needs building on re-entry proceed), but break the
+                    // cycle after that by returning 0 so the recursion terminates.
+                    var depth = ++state.RecursionDepth;
+                    var doConstruct = depth <= 2;
+                    ctx[CpuRegister.Rax] = (ulong)(doConstruct ? 1 : 0);
+                    LogGuardResult("guard_acquire", guardPtr, result: doConstruct ? 1 : 0, initialized, inProgress: true, ownerThreadId: state.OwnerThreadId);
                     return (int)OrbisGen2Result.ORBIS_GEN2_OK;
                 }
             }

--- a/src/SharpEmu.Libs/Json/JsonExports.cs
+++ b/src/SharpEmu.Libs/Json/JsonExports.cs
@@ -78,6 +78,67 @@ public static class JsonExports
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
+    [SysAbiExport(
+        Nid = "WSOuge5IsCg",
+        ExportName = "_ZN3sce4Json14InitParameter2C1Ev",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceJson")]
+    public static int InitParameter2Constructor(CpuContext ctx)
+    {
+        var thisAddress = ctx[CpuRegister.Rdi];
+        TraceJson("InitParameter2.ctor", thisAddress, 0);
+        ctx[CpuRegister.Rax] = thisAddress;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "I2QC8PYhJWY",
+        ExportName = "_ZN3sce4Json14InitParameter212setAllocatorEPNS0_12MemAllocatorEPv",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceJson")]
+    public static int InitParameter2SetAllocator(CpuContext ctx)
+    {
+        var thisAddress = ctx[CpuRegister.Rdi];
+        var allocatorAddress = ctx[CpuRegister.Rsi];
+        TraceJson("InitParameter2.setAllocator", thisAddress, allocatorAddress);
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "Eu95jmqn5Rw",
+        ExportName = "_ZN3sce4Json14InitParameter217setFileBufferSizeEm",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceJson")]
+    public static int InitParameter2SetFileBufferSize(CpuContext ctx)
+    {
+        var thisAddress = ctx[CpuRegister.Rdi];
+        var fileBufferSize = ctx[CpuRegister.Rsi];
+        TraceJson("InitParameter2.setFileBufferSize", thisAddress, fileBufferSize);
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "IXW-z8pggfg",
+        ExportName = "_ZN3sce4Json11Initializer10initializeEPKNS0_14InitParameter2E",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceJson")]
+    public static int InitializerInitialize2(CpuContext ctx)
+    {
+        var thisAddress = ctx[CpuRegister.Rdi];
+        var initParameterAddress = ctx[CpuRegister.Rsi];
+        if (thisAddress == 0)
+        {
+            ctx[CpuRegister.Rax] = unchecked((ulong)(int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        TraceJson("Initializer.initialize2", thisAddress, initParameterAddress);
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
     private static void TraceJson(string operation, ulong thisAddress, ulong argument)
     {
         if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_JSON"), "1", StringComparison.Ordinal))

--- a/src/SharpEmu.Libs/Kernel/KernelAprCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelAprCompatExports.cs
@@ -80,11 +80,16 @@ public static class KernelAprCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
         }
 
+        // The command buffer already completed synchronously (AmprExports.CompleteCommandBuffer
+        // at submit time), so the wait itself has succeeded. The result write is best-effort:
+        // the game sometimes passes a small non-pointer value in waitArg2 (observed 0xF) that the
+        // heuristic can misread as a result address, and writing there faults. That must NOT fail
+        // the wait — returning MEMORY_FAULT makes the guest retry the wait forever in a tight loop
+        // and never progress past GPU submission.
         var resultAddress = ResolveWaitResultAddress(waitArg1, waitArg2, submission.ResultAddress);
         if (resultAddress != 0 && !TryWriteAprResult(ctx, resultAddress))
         {
             TraceAprWaitFailure(ctx, "wait_result_fault", submissionId, submission.CommandBuffer, waitArg1, waitArg2);
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
         TraceApr(ctx, "wait", submissionId, submission.CommandBuffer, waitArg1, resultAddress);

--- a/src/SharpEmu.Libs/Kernel/KernelEventFlagCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventFlagCompatExports.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Text;
 using SharpEmu.HLE;
 using SharpEmu.Libs.Fiber;
@@ -231,23 +232,47 @@ public static class KernelEventFlagCompatExports
                 return ctx.SetReturn(immediateWaitResult);
             }
 
-            if (timeoutAddress != 0)
-            {
-                _ = ctx.TryWriteUInt32(timeoutAddress, 0);
-                _ = TryWriteResultPattern(ctx, resultAddress, state.Bits);
-                TraceEventFlag($"wait-timeout handle=0x{handle:X16} pattern=0x{pattern:X16} timeout={timeoutUsec} ret=0x{returnRip:X16}");
-                return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT);
-            }
+            var deadlineTimestamp = timeoutAddress != 0
+                ? GuestThreadExecution.ComputeDeadlineTimestamp(TimeSpan.FromTicks((long)timeoutUsec * 10))
+                : 0L;
 
             var currentGuestThread = GuestThreadExecution.CurrentGuestThreadHandle;
             var currentFiber = FiberExports.GetCurrentFiberAddressForDiagnostics(ctx);
             var managedThread = Environment.CurrentManagedThreadId;
+            var completedByWake = false;
             var blockedWaitResult = OrbisGen2Result.ORBIS_GEN2_OK;
             var requestedBlock = GuestThreadExecution.RequestCurrentThreadBlock(
                 ctx,
                 "sceKernelWaitEventFlag",
                 GetEventFlagWakeKey(handle),
-                () => (int)blockedWaitResult,
+                () =>
+                {
+                    if (completedByWake)
+                    {
+                        return (int)blockedWaitResult;
+                    }
+
+                    // Deadline expiry (timed wait) or spurious resume: re-check
+                    // satisfaction before reporting a timeout.
+                    lock (state.Gate)
+                    {
+                        state.WaitingThreads = Math.Max(0, state.WaitingThreads - 1);
+                        if (TryCompleteSatisfiedWait(ctx, state, pattern, waitMode, resultAddress, out var resumedResult))
+                        {
+                            return (int)resumedResult;
+                        }
+
+                        if (timeoutAddress == 0)
+                        {
+                            return (int)blockedWaitResult;
+                        }
+
+                        _ = ctx.TryWriteUInt32(timeoutAddress, 0);
+                        _ = TryWriteResultPattern(ctx, resultAddress, state.Bits);
+                        TraceEventFlag($"wait-timeout handle=0x{handle:X16} pattern=0x{pattern:X16} timeout={timeoutUsec} ret=0x{returnRip:X16}");
+                        return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT;
+                    }
+                },
                 () =>
                 {
                     if (!TryPrepareBlockedWait(
@@ -262,8 +287,10 @@ public static class KernelEventFlagCompatExports
                     }
 
                     blockedWaitResult = preparedResult;
+                    completedByWake = true;
                     return true;
-                });
+                },
+                deadlineTimestamp);
             TraceEventFlag($"wait-unsatisfied handle=0x{handle:X16} pattern=0x{pattern:X16} bits=0x{state.Bits:X16} guest_thread=0x{currentGuestThread:X16} fiber=0x{currentFiber:X16} managed={managedThread} block={requestedBlock} ret=0x{returnRip:X16} frames={FormatFrameChain(ctx)}");
             TraceEventFlag($"wait-object handle=0x{handle:X16} name='{state.Name}' {FormatGuestWaitObject(ctx)}");
             if (!requestedBlock)
@@ -297,6 +324,16 @@ public static class KernelEventFlagCompatExports
                             releaseWaiter = false;
                             TraceEventFlag($"wait-wake handle=0x{handle:X16} pattern=0x{pattern:X16} bits=0x{state.Bits:X16} waiters={state.WaitingThreads} ret=0x{returnRip:X16}");
                             return ctx.SetReturn(pumpedWaitResult);
+                        }
+
+                        if (timeoutAddress != 0 && Stopwatch.GetTimestamp() >= deadlineTimestamp)
+                        {
+                            state.WaitingThreads = Math.Max(0, state.WaitingThreads - 1);
+                            releaseWaiter = false;
+                            _ = ctx.TryWriteUInt32(timeoutAddress, 0);
+                            _ = TryWriteResultPattern(ctx, resultAddress, state.Bits);
+                            TraceEventFlag($"wait-timeout handle=0x{handle:X16} pattern=0x{pattern:X16} timeout={timeoutUsec} ret=0x{returnRip:X16}");
+                            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT);
                         }
 
                         Monitor.Wait(state.Gate, HostWaitPumpMilliseconds);

--- a/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
@@ -433,10 +433,12 @@ public static class KernelEventQueueCompatExports
         short filter,
         ulong data)
     {
-        List<ulong>? wakeHandles = null;
+        ulong[]? wakeHandles = null;
+        var wakeHandleCount = 0;
         var triggeredCount = 0;
         lock (_eventQueueGate)
         {
+            wakeHandles = GC.AllocateUninitializedArray<ulong>(_registeredEvents.Count);
             foreach (var (handle, registrations) in _registeredEvents)
             {
                 if (!registrations.TryGetValue((ident, filter), out var registration))
@@ -459,17 +461,78 @@ public static class KernelEventQueueCompatExports
                         1,
                         data,
                         registration.UserData));
-                (wakeHandles ??= new List<ulong>()).Add(handle);
+                wakeHandles[wakeHandleCount++] = handle;
                 triggeredCount++;
+            }
+
+            if (triggeredCount != 0)
+            {
+                Monitor.PulseAll(_eventQueueGate);
             }
         }
 
-        if (wakeHandles is not null)
+        for (var i = 0; i < wakeHandleCount; i++)
         {
-            foreach (var handle in wakeHandles)
+            WakeEventQueue(wakeHandles![i]);
+        }
+
+        return triggeredCount;
+    }
+
+    public static int TriggerRegisteredEventsByFilter(
+        short filter,
+        ulong data)
+    {
+        ulong[]? wakeHandles = null;
+        var wakeHandleCount = 0;
+        var triggeredCount = 0;
+        lock (_eventQueueGate)
+        {
+            var registrationCapacity = 0;
+            foreach (var registrations in _registeredEvents.Values)
             {
-                WakeEventQueue(handle);
+                registrationCapacity += registrations.Count;
             }
+
+            wakeHandles = GC.AllocateUninitializedArray<ulong>(registrationCapacity);
+            foreach (var (handle, registrations) in _registeredEvents)
+            {
+                foreach (var registration in registrations.Values)
+                {
+                    if (registration.Filter != filter)
+                    {
+                        continue;
+                    }
+
+                    if (!_pendingEvents.TryGetValue(handle, out var queue))
+                    {
+                        queue = new LinkedList<KernelQueuedEvent>();
+                        _pendingEvents[handle] = queue;
+                    }
+
+                    QueueOrUpdateEvent(
+                        queue,
+                        new KernelQueuedEvent(
+                            registration.Ident,
+                            registration.Filter,
+                            0,
+                            1,
+                            data,
+                            registration.UserData));
+                    wakeHandles[wakeHandleCount++] = handle;
+                    triggeredCount++;
+                }
+            }
+
+            if (triggeredCount != 0)
+            {
+                Monitor.PulseAll(_eventQueueGate);
+            }
+        }
+
+        for (var i = 0; i < wakeHandleCount; i++)
+        {
+            WakeEventQueue(wakeHandles![i]);
         }
 
         return triggeredCount;

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -1848,9 +1848,19 @@ public static class KernelMemoryCompatExports
             }
 
             var parentDirectory = Path.GetDirectoryName(hostPath);
-            if (string.IsNullOrWhiteSpace(parentDirectory) || !Directory.Exists(parentDirectory))
+            if (string.IsNullOrWhiteSpace(parentDirectory))
             {
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            }
+
+            if (!Directory.Exists(parentDirectory))
+            {
+                if (!IsKnownWritableGuestPath(guestPath))
+                {
+                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                }
+
+                Directory.CreateDirectory(parentDirectory);
             }
 
             Directory.CreateDirectory(hostPath);
@@ -1903,8 +1913,17 @@ public static class KernelMemoryCompatExports
         {
             if (!Directory.Exists(hostPath))
             {
+                if (!IsKnownWritableGuestPath(guestPath))
+                {
+                    AddNegativeStatCacheForGuestPath(guestPath);
+                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                }
+
+                InvalidateNegativeStatCacheForPathAndAncestors(guestPath);
                 AddNegativeStatCacheForGuestPath(guestPath);
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                LogOpenTrace($"rmdir missing-ok path='{guestPath}' host='{hostPath}'");
+                ctx[CpuRegister.Rax] = 0;
+                return (int)OrbisGen2Result.ORBIS_GEN2_OK;
             }
 
             Directory.Delete(hostPath, recursive: false);
@@ -4756,6 +4775,22 @@ public static class KernelMemoryCompatExports
                  !IsApp0WritableOverlayPath(normalized)));
     }
 
+    private static bool IsKnownWritableGuestPath(string guestPath)
+    {
+        var normalized = NormalizeGuestStatCachePath(guestPath);
+        return normalized is not null &&
+               (string.Equals(normalized, "/temp0", StringComparison.OrdinalIgnoreCase) ||
+                normalized.StartsWith("/temp0/", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(normalized, "/download0", StringComparison.OrdinalIgnoreCase) ||
+                normalized.StartsWith("/download0/", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(normalized, "/devlog/app", StringComparison.OrdinalIgnoreCase) ||
+                normalized.StartsWith("/devlog/app/", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(normalized, "/hostapp", StringComparison.OrdinalIgnoreCase) ||
+                normalized.StartsWith("/hostapp/", StringComparison.OrdinalIgnoreCase) ||
+                (normalized.StartsWith("/app0/", StringComparison.OrdinalIgnoreCase) &&
+                 IsApp0WritableOverlayPath(normalized)));
+    }
+
     private static bool IsApp0WritableOverlayPath(string normalizedGuestPath)
     {
         var relativePath = normalizedGuestPath.StartsWith("/app0/", StringComparison.OrdinalIgnoreCase)
@@ -5980,7 +6015,7 @@ public static class KernelMemoryCompatExports
 
             var alignedAddress = AlignUp(unchecked((ulong)baseAddress) + (ulong)pageSize, (ulong)effectiveAlignment);
             var guardAddress = alignedAddress + (ulong)usableSize;
-            if (!VirtualProtect((nint)guardAddress, pageSize, HostPageNoAccess, out _))
+            if (!ProtectHostMemory((nint)guardAddress, pageSize, HostPageNoAccess))
             {
                 _ = VirtualFree(baseAddress, 0, MemRelease);
                 return false;

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -144,7 +144,10 @@ public static class KernelMemoryCompatExports
 
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool VirtualProtect(nint lpAddress, nuint dwSize, uint flNewProtect, out uint lpflOldProtect);
+    private static extern bool WindowsVirtualProtect(nint lpAddress, nuint dwSize, uint flNewProtect, out uint lpflOldProtect);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int mprotect(nint addr, nuint len, int prot);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern nint VirtualAlloc(nint lpAddress, nuint dwSize, uint flAllocationType, uint flProtect);
@@ -4500,12 +4503,22 @@ public static class KernelMemoryCompatExports
             if (guestPath.StartsWith("/app0/", StringComparison.OrdinalIgnoreCase))
             {
                 var relative = NormalizeMountRelativePath(guestPath["/app0/".Length..]);
+                if (TryResolveApp0WritableOverlayPath(relative, out var overlayPath))
+                {
+                    return overlayPath;
+                }
+
                 return Path.Combine(app0Root, relative);
             }
 
             if (guestPath.StartsWith("app0/", StringComparison.OrdinalIgnoreCase))
             {
                 var relative = NormalizeMountRelativePath(guestPath["app0/".Length..]);
+                if (TryResolveApp0WritableOverlayPath(relative, out var overlayPath))
+                {
+                    return overlayPath;
+                }
+
                 return Path.Combine(app0Root, relative);
             }
 
@@ -4519,6 +4532,19 @@ public static class KernelMemoryCompatExports
         }
 
         return guestPath;
+    }
+
+    private static bool TryResolveApp0WritableOverlayPath(string relativePath, out string hostPath)
+    {
+        var normalizedRelativePath = NormalizeMountRelativePath(relativePath);
+        if (PathContainsWritableOverlaySegment(normalizedRelativePath, Path.DirectorySeparatorChar))
+        {
+            hostPath = Path.Combine(GetPerAppWritableRoot(), "app0", normalizedRelativePath);
+            return true;
+        }
+
+        hostPath = string.Empty;
+        return false;
     }
 
     private static bool TryResolveRegisteredGuestMount(string guestPath, out string hostPath)
@@ -4726,7 +4752,40 @@ public static class KernelMemoryCompatExports
         var normalized = NormalizeGuestStatCachePath(guestPath);
         return normalized is not null &&
                (string.Equals(normalized, "/app0", StringComparison.OrdinalIgnoreCase) ||
-                normalized.StartsWith("/app0/", StringComparison.OrdinalIgnoreCase));
+                (normalized.StartsWith("/app0/", StringComparison.OrdinalIgnoreCase) &&
+                 !IsApp0WritableOverlayPath(normalized)));
+    }
+
+    private static bool IsApp0WritableOverlayPath(string normalizedGuestPath)
+    {
+        var relativePath = normalizedGuestPath.StartsWith("/app0/", StringComparison.OrdinalIgnoreCase)
+            ? normalizedGuestPath["/app0/".Length..]
+            : normalizedGuestPath;
+        return PathContainsWritableOverlaySegment(relativePath, '/');
+    }
+
+    private static bool PathContainsWritableOverlaySegment(string path, char separator)
+    {
+        var segmentStart = 0;
+        for (var i = 0; i <= path.Length; i++)
+        {
+            if (i != path.Length && path[i] != separator)
+            {
+                continue;
+            }
+
+            var segmentLength = i - segmentStart;
+            if (segmentLength != 0 &&
+                (string.Compare(path, segmentStart, "saved", 0, segmentLength, StringComparison.OrdinalIgnoreCase) == 0 ||
+                 string.Compare(path, segmentStart, "intermediate", 0, segmentLength, StringComparison.OrdinalIgnoreCase) == 0))
+            {
+                return true;
+            }
+
+            segmentStart = i + 1;
+        }
+
+        return false;
     }
 
     private static bool TryReadCString(CpuContext ctx, ulong address, ulong maxLength, out byte[] bytes)
@@ -4754,32 +4813,10 @@ public static class KernelMemoryCompatExports
         }
 
         const int maxChunkSize = 4096;
-        const int inlineChunkSize = 256;
-        Span<byte> inlineChunk = stackalloc byte[inlineChunkSize];
-        var firstPageRemaining = maxChunkSize - (int)(address & (maxChunkSize - 1));
-        var firstReadLength = Math.Min(limit, Math.Min(inlineChunkSize, firstPageRemaining));
-        var firstSpan = inlineChunk[..firstReadLength];
-        ulong offset = 0;
-        if (TryReadCompat(ctx, address, firstSpan))
-        {
-            var nulIndex = firstSpan.IndexOf((byte)0);
-            if (nulIndex >= 0)
-            {
-                bytes = firstSpan[..nulIndex].ToArray();
-                return true;
-            }
-
-            offset = unchecked((ulong)firstReadLength);
-        }
-
+        var buffer = GC.AllocateUninitializedArray<byte>(limit);
         var chunk = GC.AllocateUninitializedArray<byte>(Math.Min(maxChunkSize, limit));
-        var writer = new ArrayBufferWriter<byte>(Math.Min(limit, 256));
-        if (offset != 0)
-        {
-            firstSpan.CopyTo(writer.GetSpan(firstReadLength));
-            writer.Advance(firstReadLength);
-        }
-
+        var count = 0;
+        ulong offset = 0;
         while (offset < (ulong)limit)
         {
             var current = address + offset;
@@ -4793,18 +4830,16 @@ public static class KernelMemoryCompatExports
             var span = chunk.AsSpan(0, remaining);
             if (TryReadCompat(ctx, current, span))
             {
-                var nulIndex = span.IndexOf((byte)0);
-                var copyLength = nulIndex >= 0 ? nulIndex : remaining;
-                if (copyLength > 0)
+                for (var i = 0; i < remaining; i++)
                 {
-                    span[..copyLength].CopyTo(writer.GetSpan(copyLength));
-                    writer.Advance(copyLength);
-                }
+                    var value = chunk[i];
+                    if (value == 0)
+                    {
+                        bytes = TrimBytes(buffer, count);
+                        return true;
+                    }
 
-                if (nulIndex >= 0)
-                {
-                    bytes = writer.WrittenSpan.ToArray();
-                    return true;
+                    buffer[count++] = value;
                 }
 
                 offset += (ulong)remaining;
@@ -4819,17 +4854,37 @@ public static class KernelMemoryCompatExports
 
             if (one[0] == 0)
             {
-                bytes = writer.WrittenSpan.ToArray();
+                bytes = TrimBytes(buffer, count);
                 return true;
             }
 
-            one.CopyTo(writer.GetSpan(1));
-            writer.Advance(1);
+            buffer[count++] = one[0];
             offset++;
         }
 
-        bytes = writer.WrittenSpan.ToArray();
+        bytes = TrimBytes(buffer, count);
         return true;
+    }
+
+    private static byte[] TrimBytes(byte[] buffer, int length)
+    {
+        if (length == buffer.Length)
+        {
+            return buffer;
+        }
+
+        if (length == 0)
+        {
+            return [];
+        }
+
+        var trimmed = GC.AllocateUninitializedArray<byte>(length);
+        for (var i = 0; i < length; i++)
+        {
+            trimmed[i] = buffer[i];
+        }
+
+        return trimmed;
     }
 
     private static bool TryCompareStrings(CpuContext ctx, ulong left, ulong right, ulong limit, out int compare)
@@ -4871,7 +4926,7 @@ public static class KernelMemoryCompatExports
         }
 
         var limit = (int)Math.Min(maxLength, 1_048_576UL);
-        var buffer = new List<ushort>(Math.Min(limit, 256));
+        var buffer = GC.AllocateUninitializedArray<ushort>(limit);
         for (var i = 0; i < limit; i++)
         {
             if (!TryReadUInt16Compat(ctx, address + ((ulong)i * WideCharSize), out var unit))
@@ -4881,14 +4936,14 @@ public static class KernelMemoryCompatExports
 
             if (unit == 0)
             {
-                units = buffer.ToArray();
+                units = TrimWideUnits(buffer, i);
                 return true;
             }
 
-            buffer.Add(unit);
+            buffer[i] = unit;
         }
 
-        units = buffer.ToArray();
+        units = buffer;
         return true;
     }
 
@@ -4902,7 +4957,7 @@ public static class KernelMemoryCompatExports
         }
 
         var limit = (int)Math.Min(maxLength, 1_048_576UL);
-        var buffer = new List<ushort>(Math.Min(limit, 256));
+        var buffer = GC.AllocateUninitializedArray<ushort>(limit);
         for (var i = 0; i < limit; i++)
         {
             if (!TryReadUInt16Compat(ctx, address + ((ulong)i * WideCharSize), out var unit))
@@ -4913,15 +4968,36 @@ public static class KernelMemoryCompatExports
             if (unit == 0)
             {
                 terminated = true;
-                units = buffer.ToArray();
+                units = TrimWideUnits(buffer, i);
                 return true;
             }
 
-            buffer.Add(unit);
+            buffer[i] = unit;
         }
 
-        units = buffer.ToArray();
+        units = buffer;
         return true;
+    }
+
+    private static ushort[] TrimWideUnits(ushort[] buffer, int length)
+    {
+        if (length == buffer.Length)
+        {
+            return buffer;
+        }
+
+        if (length == 0)
+        {
+            return [];
+        }
+
+        var trimmed = GC.AllocateUninitializedArray<ushort>(length);
+        for (var i = 0; i < length; i++)
+        {
+            trimmed[i] = buffer[i];
+        }
+
+        return trimmed;
     }
 
     private static bool TryCompareWideStrings(CpuContext ctx, ulong left, ulong right, ulong limit, out int compare)
@@ -5461,13 +5537,35 @@ public static class KernelMemoryCompatExports
         }
 
         var hostProtection = ResolveHostProtection(orbisProtection);
-        if (!VirtualProtect((nint)address, (nuint)length, hostProtection, out _))
+        if (!ProtectHostMemory((nint)address, (nuint)length, hostProtection))
         {
             return false;
         }
 
         return true;
     }
+
+    private static bool ProtectHostMemory(nint address, nuint length, uint protection)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return WindowsVirtualProtect(address, length, protection, out _);
+        }
+
+        return mprotect(address, length, ToUnixProtection(protection)) == 0;
+    }
+
+    private static int ToUnixProtection(uint protection) =>
+        protection switch
+        {
+            HostPageNoAccess => 0,
+            HostPageReadOnly => 1,
+            HostPageReadWrite => 1 | 2,
+            HostPageExecute => 4,
+            HostPageExecuteRead => 1 | 4,
+            HostPageExecuteReadWrite => 1 | 2 | 4,
+            _ => 1 | 2
+        };
 
     private static uint ResolveHostProtection(int orbisProtection)
     {

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -15,6 +15,14 @@ namespace SharpEmu.Libs.Kernel;
 public static class KernelMemoryCompatExports
 {
     private const int MaxGuestStringLength = 4096;
+
+    // Upper bound on any single guest-controlled allocation performed by an HLE export.
+    // A garbage/absurd count from a corrupted guest call context must never reach a
+    // multi-GB managed allocation: doing so corrupts the CLR heap outright and surfaces
+    // later as the misleading "Invalid Program: attempted to call a UnmanagedCallersOnly
+    // method from managed code" fatal. Reject anything above this before allocating.
+    private const ulong MaxSaneGuestAllocationBytes = 512UL * 1024 * 1024;
+
     private const int WideCharSize = sizeof(ushort);
     private const int MemsetChunkSize = 16 * 1024;
     private const int TlsModuleBlockSize = 0x10000;
@@ -142,7 +150,7 @@ public static class KernelMemoryCompatExports
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern nuint VirtualQuery(nint lpAddress, out MemoryBasicInformation lpBuffer, nuint dwLength);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
+    [DllImport("kernel32.dll", EntryPoint = "VirtualProtect", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool WindowsVirtualProtect(nint lpAddress, nuint dwSize, uint flNewProtect, out uint lpflOldProtect);
 
@@ -920,12 +928,14 @@ public static class KernelMemoryCompatExports
     {
         var destination = ctx[CpuRegister.Rdi];
         var source = ctx[CpuRegister.Rsi];
-        var count = (int)Math.Min(ctx[CpuRegister.Rdx], int.MaxValue);
-        if (count < 0)
+        var rawCount = ctx[CpuRegister.Rdx];
+        if (rawCount > MaxSaneGuestAllocationBytes)
         {
+            Console.Error.WriteLine($"[LOADER][WARNING] strncpy oversized count rejected: dst=0x{destination:X16} src=0x{source:X16} count=0x{rawCount:X}");
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
+        var count = (int)rawCount;
         var payload = new byte[count];
         Span<byte> one = stackalloc byte[1];
         var copied = 0;
@@ -965,12 +975,13 @@ public static class KernelMemoryCompatExports
 
     private static int WcsncpyCore(CpuContext ctx, ulong destination, ulong source, ulong countValue)
     {
-        var count = (int)Math.Min(countValue, int.MaxValue);
-        if (count < 0 || count > (int.MaxValue / WideCharSize))
+        if (countValue > MaxSaneGuestAllocationBytes / WideCharSize)
         {
+            Console.Error.WriteLine($"[LOADER][WARNING] wcsncpy oversized count rejected: dst=0x{destination:X16} src=0x{source:X16} count=0x{countValue:X}");
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
+        var count = (int)countValue;
         var payload = new byte[count * WideCharSize];
         for (var copied = 0; copied < count; copied++)
         {
@@ -1172,8 +1183,7 @@ public static class KernelMemoryCompatExports
         // call context corrupted the CLR outright ("Invalid Program: attempted to call a
         // UnmanagedCallersOnly method from managed code") instead of throwing a normal
         // exception. Reject anything above a sane bound before allocating.
-        const ulong maxSaneCount = 512UL * 1024 * 1024;
-        if (rawCount > maxSaneCount)
+        if (rawCount > MaxSaneGuestAllocationBytes)
         {
             Console.Error.WriteLine($"[LOADER][WARNING] memcpy oversized count rejected: dst=0x{destination:X16} src=0x{source:X16} count=0x{rawCount:X}");
             ctx[CpuRegister.Rax] = destination;
@@ -1572,6 +1582,18 @@ public static class KernelMemoryCompatExports
                 LogOpenTrace($"_open dir path='{guestPath}' host='{hostPath}' flags=0x{flags:X8} fd={directoryFd}");
                 ctx[CpuRegister.Rax] = unchecked((ulong)directoryFd);
                 return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+            }
+
+            // Opening a missing file without O_CREAT always fails with NOT_FOUND. Handle it
+            // explicitly instead of letting `new FileStream` throw: the guest probes many
+            // absent files, and .NET's IOException path lazily runs ResourceReader..cctor /
+            // resource-string loading, which is unsafe on a guest-thread call context and
+            // fail-fasts the whole CLR ("Invalid Program: attempted to call a
+            // UnmanagedCallersOnly method from managed code") before this catch can run.
+            if ((flags & O_CREAT) == 0 && !File.Exists(hostPath))
+            {
+                LogOpenTrace($"_open miss path='{guestPath}' host='{hostPath}' flags=0x{flags:X8}");
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
             }
 
             EnsureOpenParentDirectoryExists(guestPath, hostPath, flags);
@@ -1982,7 +2004,7 @@ public static class KernelMemoryCompatExports
     {
         var fd = unchecked((int)ctx[CpuRegister.Rdi]);
         var bufferAddress = ctx[CpuRegister.Rsi];
-        var requested = (int)Math.Min(ctx[CpuRegister.Rdx], int.MaxValue);
+        var requested = (int)Math.Min(ctx[CpuRegister.Rdx], MaxSaneGuestAllocationBytes);
         if (requested < 0 || (requested > 0 && bufferAddress == 0))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
@@ -2191,7 +2213,7 @@ public static class KernelMemoryCompatExports
     {
         var fd = unchecked((int)ctx[CpuRegister.Rdi]);
         var bufferAddress = ctx[CpuRegister.Rsi];
-        var requested = (int)Math.Min(ctx[CpuRegister.Rdx], int.MaxValue);
+        var requested = (int)Math.Min(ctx[CpuRegister.Rdx], MaxSaneGuestAllocationBytes);
         if (requested < 0 || (requested > 0 && bufferAddress == 0))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
@@ -2867,6 +2889,16 @@ public static class KernelMemoryCompatExports
         }
 
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "BQQniolj9tQ",
+        ExportName = "sceKernelMapDirectMemory2",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelMapDirectMemory2(CpuContext ctx)
+    {
+        return KernelMapDirectMemory(ctx);
     }
 
     [SysAbiExport(
@@ -4421,6 +4453,71 @@ public static class KernelMemoryCompatExports
 
     public static string ResolveGuestPath(string guestPath)
     {
+        return ResolveHostPathCaseInsensitive(ResolveGuestPathCore(guestPath));
+    }
+
+    private static string ResolveHostPathCaseInsensitive(string hostPath)
+    {
+        if (OperatingSystem.IsWindows() ||
+            string.IsNullOrWhiteSpace(hostPath) ||
+            Path.Exists(hostPath))
+        {
+            return hostPath;
+        }
+
+        var root = Path.IsPathRooted(hostPath) ? Path.GetPathRoot(hostPath)! : string.Empty;
+        var remainder = hostPath[root.Length..];
+        if (remainder.Length == 0)
+        {
+            return hostPath;
+        }
+
+        var resolved = root.Length == 0 ? "." : root;
+        var usedFallback = false;
+        foreach (var segment in remainder.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var candidate = Path.Combine(resolved, segment);
+            if (Path.Exists(candidate))
+            {
+                resolved = candidate;
+                continue;
+            }
+
+            string? match = null;
+            try
+            {
+                foreach (var entry in Directory.EnumerateFileSystemEntries(resolved))
+                {
+                    if (string.Equals(Path.GetFileName(entry), segment, StringComparison.OrdinalIgnoreCase))
+                    {
+                        match = entry;
+                        break;
+                    }
+                }
+            }
+            catch (IOException)
+            {
+                return hostPath;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return hostPath;
+            }
+
+            if (match is null)
+            {
+                return usedFallback ? Path.Combine(resolved, segment) : hostPath;
+            }
+
+            resolved = match;
+            usedFallback = true;
+        }
+
+        return usedFallback ? resolved : hostPath;
+    }
+
+    private static string ResolveGuestPathCore(string guestPath)
+    {
         if (string.IsNullOrWhiteSpace(guestPath))
         {
             return guestPath;
@@ -4545,8 +4642,8 @@ public static class KernelMemoryCompatExports
                 !guestPath.StartsWith("/", StringComparison.Ordinal) &&
                 !guestPath.StartsWith("\\", StringComparison.Ordinal))
             {
-                var relative = guestPath.Replace('/', Path.DirectorySeparatorChar);
-                return Path.Combine(app0Root, relative);
+                var relative = NormalizeMountRelativePath(guestPath);
+                return relative.Length == 0 ? app0Root : Path.Combine(app0Root, relative);
             }
         }
 
@@ -4631,10 +4728,44 @@ public static class KernelMemoryCompatExports
 
     private static string NormalizeMountRelativePath(string relativePath)
     {
-        return relativePath
+        var trimmed = relativePath
             .TrimStart('/', '\\')
             .Replace('/', Path.DirectorySeparatorChar)
             .Replace('\\', Path.DirectorySeparatorChar);
+
+        return CollapseMountRelativeSegments(trimmed);
+    }
+
+    private static string CollapseMountRelativeSegments(string relativePath)
+    {
+        if (relativePath.Length == 0 ||
+            (!relativePath.Contains('.') && !relativePath.Contains(Path.DirectorySeparatorChar)))
+        {
+            return relativePath;
+        }
+
+        var segments = new List<string>();
+        foreach (var segment in relativePath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (segment == ".")
+            {
+                continue;
+            }
+
+            if (segment == "..")
+            {
+                if (segments.Count > 0)
+                {
+                    segments.RemoveAt(segments.Count - 1);
+                }
+
+                continue;
+            }
+
+            segments.Add(segment);
+        }
+
+        return string.Join(Path.DirectorySeparatorChar, segments);
     }
 
     private static string ResolveDevlogAppRoot()
@@ -4953,35 +5084,10 @@ public static class KernelMemoryCompatExports
     }
 
     private static bool TryReadWideCString(CpuContext ctx, ulong address, ulong maxLength, out ushort[] units)
-    {
-        units = Array.Empty<ushort>();
-        if (address == 0)
-        {
-            return false;
-        }
+        => TryReadWideCStringBounded(ctx, address, maxLength, out units, out _);
 
-        var limit = (int)Math.Min(maxLength, 1_048_576UL);
-        var buffer = GC.AllocateUninitializedArray<ushort>(limit);
-        for (var i = 0; i < limit; i++)
-        {
-            if (!TryReadUInt16Compat(ctx, address + ((ulong)i * WideCharSize), out var unit))
-            {
-                return false;
-            }
-
-            if (unit == 0)
-            {
-                units = TrimWideUnits(buffer, i);
-                return true;
-            }
-
-            buffer[i] = unit;
-        }
-
-        units = buffer;
-        return true;
-    }
-
+    // Measure first, then allocate exactly the length. Allocating the 1 MiB ceiling up front put a
+    // 2 MB array on the LOH every call, and the GC it forced fail-fasted on the guest stack.
     private static bool TryReadWideCStringBounded(CpuContext ctx, ulong address, ulong maxLength, out ushort[] units, out bool terminated)
     {
         units = Array.Empty<ushort>();
@@ -4992,10 +5098,11 @@ public static class KernelMemoryCompatExports
         }
 
         var limit = (int)Math.Min(maxLength, 1_048_576UL);
-        var buffer = GC.AllocateUninitializedArray<ushort>(limit);
-        for (var i = 0; i < limit; i++)
+
+        var length = 0;
+        while (length < limit)
         {
-            if (!TryReadUInt16Compat(ctx, address + ((ulong)i * WideCharSize), out var unit))
+            if (!TryReadUInt16Compat(ctx, address + ((ulong)length * WideCharSize), out var unit))
             {
                 return false;
             }
@@ -5003,8 +5110,23 @@ public static class KernelMemoryCompatExports
             if (unit == 0)
             {
                 terminated = true;
-                units = TrimWideUnits(buffer, i);
-                return true;
+                break;
+            }
+
+            length++;
+        }
+
+        if (length == 0)
+        {
+            return true;
+        }
+
+        var buffer = GC.AllocateUninitializedArray<ushort>(length);
+        for (var i = 0; i < length; i++)
+        {
+            if (!TryReadUInt16Compat(ctx, address + ((ulong)i * WideCharSize), out var unit))
+            {
+                return false;
             }
 
             buffer[i] = unit;
@@ -6270,6 +6392,24 @@ public static class KernelMemoryCompatExports
     private static bool TryQueryHostPage(ulong address, out MemoryBasicInformation info)
     {
         info = default;
+
+        if (!OperatingSystem.IsWindows())
+        {
+            // kernel32!VirtualQuery does not exist on Linux (crashed with
+            // "libkernel32.dll: cannot open shared object file"). Probe mapped-ness with msync:
+            // it returns ENOMEM(-1) for an unmapped range and 0 for a mapped one. Guest pages we
+            // hand out are read/write, so report RW when mapped.
+            var pageBase = (nint)(address & ~0xFFFUL);
+            if (msync(pageBase, 0x1000, MS_ASYNC) != 0)
+            {
+                return false;
+            }
+
+            info.State = MemCommit;
+            info.Protect = HostPageReadWrite;
+            return true;
+        }
+
         var size = (nuint)Marshal.SizeOf<MemoryBasicInformation>();
         if (VirtualQuery((nint)address, out info, size) == 0)
         {
@@ -6278,6 +6418,11 @@ public static class KernelMemoryCompatExports
 
         return info.State == MemCommit;
     }
+
+    private const int MS_ASYNC = 1;
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int msync(nint addr, nuint length, int flags);
 
     private static bool HasRequiredProtection(uint protect, bool writeAccess)
     {

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -38,6 +38,15 @@ public static class KernelPthreadCompatExports
     private static readonly HashSet<ulong>? _tracePthreadMutexFilter = ParseTraceAddressFilter(
         Environment.GetEnvironmentVariable("SHARPEMU_LOG_PTHREAD_MUTEX_FILTER"));
 
+    // Wake-id counters live on the OUTER class on purpose. Putting a static field on the nested
+    // state classes gives them a type initializer, which then runs for the FIRST time on a guest
+    // thread (whose hijacked stack the CLR cannot walk) and fail-fasts the process with the
+    // misleading "Invalid Program: attempted to call a UnmanagedCallersOnly method from managed
+    // code". The outer class is already initialized by the time any export runs, so touching its
+    // statics from a state constructor is safe.
+    private static long _nextMutexWakeId;
+    private static long _nextCondWakeId;
+
     private sealed class PthreadMutexState
     {
         public SemaphoreSlim Semaphore { get; } = new(1, 1);
@@ -45,6 +54,15 @@ public static class KernelPthreadCompatExports
         public int RecursionCount { get; set; }
         public int Type { get; set; } = MutexTypeErrorCheck;
         public int Protocol { get; set; }
+
+        // Stable per-state block/wake key. A single mutex state is reachable through several
+        // guest addresses (the guest pointer plus our opaque handle), and TryResolveMutexState
+        // can return different resolvedAddress values for the same state depending on the path
+        // taken. Deriving the wake key from resolvedAddress therefore let a lock() and its
+        // unlock() compute DIFFERENT keys, stranding the blocked waiter forever (observed: an
+        // idle RHIThread parked on a mutex whose owner=0 semaphore_count=1). Keying on the
+        // state's own identity makes lock/unlock always agree.
+        public string WakeKey { get; } = "pthread_mutex#" + Interlocked.Increment(ref _nextMutexWakeId).ToString("X");
     }
 
     private sealed class PthreadMutexWaiter
@@ -58,6 +76,26 @@ public static class KernelPthreadCompatExports
         public object SyncRoot { get; } = new();
         public ulong SignalEpoch { get; set; }
         public int Waiters { get; set; }
+
+        // Stable per-state block/wake key (see PthreadMutexState.WakeKey) — avoids a
+        // lock/unlock wake-key mismatch when a cond is reachable via multiple aliased addresses.
+        public string WakeKey { get; } = "pthread_cond#" + Interlocked.Increment(ref _nextCondWakeId).ToString("X");
+
+        // A signal raised while no thread is waiting stays pending so the next
+        // waiter consumes it instead of blocking: the guest signals after
+        // dropping the mutex, so the wakeup regularly precedes the wait.
+        public int PendingSignals { get; set; }
+
+        public bool TryConsumePendingSignal()
+        {
+            if (PendingSignals <= 0)
+            {
+                return false;
+            }
+
+            PendingSignals--;
+            return true;
+        }
     }
 
     private readonly record struct PthreadMutexAttrState(int Type, int Protocol);
@@ -111,6 +149,27 @@ public static class KernelPthreadCompatExports
     {
         _ = ctx;
         Thread.Yield();
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "GBUY7ywdULE",
+        ExportName = "scePthreadRename",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PthreadRename(CpuContext ctx)
+    {
+        if (_tracePthreads)
+        {
+            var nameAddress = ctx[CpuRegister.Rsi];
+            var name = nameAddress != 0 &&
+                KernelMemoryCompatExports.TryReadNullTerminatedUtf8(ctx, nameAddress, 64, out var value)
+                    ? value
+                    : "<unreadable>";
+            Console.Error.WriteLine(
+                $"[LOADER][TRACE] pthread.rename thread=0x{ctx[CpuRegister.Rdi]:X16} name=\"{name}\"");
+        }
+
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -561,6 +620,10 @@ public static class KernelPthreadCompatExports
                         TracePthreadMutex(ctx, "trylock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY);
                         return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY;
                     }
+
+                    state.RecursionCount++;
+                    TracePthreadMutex(ctx, "lock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_OK);
+                    return (int)OrbisGen2Result.ORBIS_GEN2_OK;
                 }
                 else
                 {
@@ -583,7 +646,7 @@ public static class KernelPthreadCompatExports
                 GuestThreadExecution.RequestCurrentThreadBlock(
                     ctx,
                     "pthread_mutex_lock",
-                    GetMutexWakeKey(resolvedAddress),
+                    state.WakeKey,
                     () => CompleteBlockedMutexLock(ctx, mutexAddress, resolvedAddress, state, waiter),
                     () => TryReserveBlockedMutexLock(ctx, mutexAddress, resolvedAddress, state, waiter)))
             {
@@ -606,6 +669,7 @@ public static class KernelPthreadCompatExports
 
         lock (state)
         {
+            DetectMutexDoubleOwner(resolvedAddress, state, currentThreadId, "lock");
             state.OwnerThreadId = currentThreadId;
             state.RecursionCount = 1;
         }
@@ -664,7 +728,7 @@ public static class KernelPthreadCompatExports
             try
             {
                 state.Semaphore.Release();
-                _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetMutexWakeKey(resolvedAddress), 1);
+                _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(state.WakeKey, 1);
             }
             catch (SemaphoreFullException)
             {
@@ -1108,7 +1172,14 @@ public static class KernelPthreadCompatExports
         {
             state.Waiters++;
             var observedEpoch = state.SignalEpoch;
-            TracePthreadCond("wait-enter", condAddress, mutexAddress, state, timed, waitResult);
+            var consumedPendingSignal = state.TryConsumePendingSignal();
+            TracePthreadCond(
+                consumedPendingSignal ? "wait-enter-pending" : "wait-enter",
+                condAddress,
+                mutexAddress,
+                state,
+                timed,
+                waitResult);
 
             var unlockResult = PthreadMutexFullUnlockForCondWait(ctx, mutexAddress, out releasedRecursion);
             if (unlockResult != (int)OrbisGen2Result.ORBIS_GEN2_OK)
@@ -1118,12 +1189,20 @@ public static class KernelPthreadCompatExports
                 return unlockResult;
             }
 
+            if (consumedPendingSignal)
+            {
+                state.Waiters = Math.Max(0, state.Waiters - 1);
+                TracePthreadCond("wait-wake-pending", condAddress, mutexAddress, state, timed, waitResult);
+                var pendingLockResult = PthreadMutexRelockForCondWait(ctx, mutexAddress, releasedRecursion);
+                return pendingLockResult != (int)OrbisGen2Result.ORBIS_GEN2_OK ? pendingLockResult : waitResult;
+            }
+
             var scheduler = GuestThreadExecution.Scheduler;
             if (GuestThreadExecution.IsGuestThread &&
                 GuestThreadExecution.RequestCurrentThreadBlock(
                     ctx,
                     timed ? "pthread_cond_timedwait" : "pthread_cond_wait",
-                    GetCondWakeKey(resolvedCondAddress),
+                    state.WakeKey,
                     () => ResumePthreadCondWait(ctx, condAddress, mutexAddress, state, observedEpoch, timed, releasedRecursion),
                     () => state.SignalEpoch != observedEpoch,
                     timed ? GuestThreadExecution.ComputeDeadlineTimestamp(GetCondWaitTimeout(timeoutUsec)) : 0))
@@ -1226,9 +1305,13 @@ public static class KernelPthreadCompatExports
         var shouldWakeScheduler = false;
         lock (state.SyncRoot)
         {
+            // The epoch is the wait predicate, so it must advance even when no
+            // waiter has registered yet: the guest routinely signals after
+            // dropping the mutex, before the waiter reaches cond_wait, and a
+            // dropped epoch bump would strand that waiter forever.
+            state.SignalEpoch++;
             if (state.Waiters > 0)
             {
-                state.SignalEpoch++;
                 shouldWakeScheduler = true;
                 if (broadcast)
                 {
@@ -1239,6 +1322,10 @@ public static class KernelPthreadCompatExports
                     Monitor.Pulse(state.SyncRoot);
                 }
             }
+            else
+            {
+                state.PendingSignals++;
+            }
 
             TracePthreadCond(broadcast ? "broadcast" : "signal", condAddress, mutexAddress: 0, state, timed: false, (int)OrbisGen2Result.ORBIS_GEN2_OK);
         }
@@ -1246,7 +1333,7 @@ public static class KernelPthreadCompatExports
         if (shouldWakeScheduler)
         {
             _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(
-                GetCondWakeKey(resolvedCondAddress),
+                state.WakeKey,
                 broadcast ? int.MaxValue : 1);
         }
 
@@ -1386,6 +1473,7 @@ public static class KernelPthreadCompatExports
                 return false;
             }
 
+            DetectMutexDoubleOwner(resolvedAddress, state, waiter.ThreadId, "reserve");
             state.OwnerThreadId = waiter.ThreadId;
             state.RecursionCount = 1;
             Interlocked.Exchange(ref waiter.Reserved, 1);
@@ -1417,12 +1505,29 @@ public static class KernelPthreadCompatExports
 
         lock (state)
         {
+            DetectMutexDoubleOwner(resolvedAddress, state, currentThreadId, "resume");
             state.OwnerThreadId = currentThreadId;
             state.RecursionCount = 1;
         }
 
         TracePthreadMutex(ctx, "lock-resume", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_OK);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    // Invariant guard: a thread takes ownership only after acquiring the binary semaphore, so
+    // the prior owner must be 0 (cleared before release). A nonzero foreign owner here means two
+    // guest threads are simultaneously inside the same mutex's critical section — the
+    // suspected cause of the AGC command-buffer use-after-free (null-vtable) crash. Must be
+    // called while holding lock(state).
+    private static void DetectMutexDoubleOwner(ulong resolvedAddress, PthreadMutexState state, ulong currentThreadId, string site)
+    {
+        var priorOwner = state.OwnerThreadId;
+        if (priorOwner != 0 && priorOwner != currentThreadId)
+        {
+            Console.Error.WriteLine(
+                $"[LOADER][ERROR] MUTEX DOUBLE-OWNER at {site}: resolved=0x{resolvedAddress:X} acquirer=0x{currentThreadId:X} " +
+                $"prior_owner=0x{priorOwner:X} recursion={state.RecursionCount} type={state.Type} sem_count={state.Semaphore.CurrentCount}");
+        }
     }
 
     private static TimeSpan GetCondWaitTimeout(uint timeoutUsec)
@@ -1562,7 +1667,8 @@ public static class KernelPthreadCompatExports
             $"[LOADER][TRACE] pthread_{operation}: mutex=0x{mutexAddress:X16} resolved=0x{resolvedAddress:X16} " +
             $"guest[0]=0x{guestWord0:X16} guest[8]=0x{guestWord1:X16} " +
             $"current=0x{currentThreadId:X16} owner=0x{(state?.OwnerThreadId ?? 0):X16} " +
-            $"recursion={(state?.RecursionCount ?? 0)} type={(state?.Type ?? 0)} result=0x{unchecked((uint)result):X8}");
+            $"recursion={(state?.RecursionCount ?? 0)} type={(state?.Type ?? 0)} result=0x{unchecked((uint)result):X8} " +
+            $"guest_thread=0x{GuestThreadExecution.CurrentGuestThreadHandle:X16} managed={Environment.CurrentManagedThreadId}");
     }
 
     private static void TracePthreadCond(string operation, ulong condAddress, ulong mutexAddress, PthreadCondState? state, bool timed, int result)

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -24,6 +24,8 @@ public static class KernelPthreadCompatExports
 
     private static readonly object _stateGate = new();
     private static readonly ConcurrentDictionary<ulong, PthreadMutexState> _mutexStates = new();
+    private static readonly ConcurrentDictionary<ulong, string> _mutexWakeKeys = new();
+    private static readonly ConcurrentDictionary<ulong, string> _condWakeKeys = new();
     private static readonly Dictionary<ulong, PthreadMutexAttrState> _mutexAttrStates = new();
     private static readonly Dictionary<ulong, PthreadCondState> _condStates = new();
     private static readonly Dictionary<ulong, object> _onceGates = new();
@@ -292,6 +294,13 @@ public static class KernelPthreadCompatExports
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libKernel")]
     public static int PthreadCondTimedwait(CpuContext ctx) => PthreadCondWaitCore(ctx, ctx[CpuRegister.Rdi], ctx[CpuRegister.Rsi], timed: true, timeoutUsec: unchecked((uint)ctx[CpuRegister.Rdx]));
+
+    [SysAbiExport(
+        Nid = "27bAgiJmOh0",
+        ExportName = "pthread_cond_timedwait",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixPthreadCondTimedwait(CpuContext ctx) => PthreadCondTimedwait(ctx);
 
     [SysAbiExport(
         Nid = "kDh-NfxgMtE",
@@ -579,9 +588,7 @@ public static class KernelPthreadCompatExports
         var acquired = state.Semaphore.Wait(0);
         if (!acquired)
         {
-            // Guest-thread blocking for pthread_mutex_lock is currently disabled.
-            // Demon's Souls deadlocks during PS5SyncEvent initialization.
-            /* var waiter = new PthreadMutexWaiter { ThreadId = currentThreadId };
+            var waiter = new PthreadMutexWaiter { ThreadId = currentThreadId };
             if (!tryOnly &&
                 GuestThreadExecution.IsGuestThread &&
                 GuestThreadExecution.TryGetCurrentImportCallFrame(out _) &&
@@ -594,7 +601,7 @@ public static class KernelPthreadCompatExports
             {
                 TracePthreadMutex(ctx, "lock-block", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_OK);
                 return (int)OrbisGen2Result.ORBIS_GEN2_OK;
-            } */
+            }
 
             if (!tryOnly)
             {
@@ -633,16 +640,24 @@ public static class KernelPthreadCompatExports
         }
 
         var currentThreadId = KernelPthreadState.GetCurrentThreadHandle();
+        var lenientOwnership = state.Type is MutexTypeNormal or MutexTypeAdaptiveNp;
+
         var shouldRelease = false;
         lock (state)
         {
             if (state.RecursionCount <= 0)
             {
+                if (lenientOwnership)
+                {
+                    TracePthreadMutex(ctx, "unlock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_OK);
+                    return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                }
+
                 TracePthreadMutex(ctx, "unlock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
             }
 
-            if (requireOwner && state.OwnerThreadId != currentThreadId)
+            if (requireOwner && !lenientOwnership && state.OwnerThreadId != currentThreadId)
             {
                 TracePthreadMutex(ctx, "unlock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_PERMISSION_DENIED);
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_PERMISSION_DENIED;
@@ -665,8 +680,11 @@ public static class KernelPthreadCompatExports
             }
             catch (SemaphoreFullException)
             {
-                TracePthreadMutex(ctx, "unlock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+                if (!lenientOwnership)
+                {
+                    TracePthreadMutex(ctx, "unlock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+                }
             }
         }
 
@@ -1090,7 +1108,7 @@ public static class KernelPthreadCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
-        if (!TryResolveCondState(ctx, condAddress, createIfZero: true, out _, out var state))
+        if (!TryResolveCondState(ctx, condAddress, createIfZero: true, out var resolvedCondAddress, out var state))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
         }
@@ -1112,9 +1130,16 @@ public static class KernelPthreadCompatExports
             }
 
             var scheduler = GuestThreadExecution.Scheduler;
-            if (!timed && GuestThreadExecution.RequestCurrentThreadBlock("pthread_cond_wait"))
+            if (GuestThreadExecution.IsGuestThread &&
+                GuestThreadExecution.RequestCurrentThreadBlock(
+                    ctx,
+                    timed ? "pthread_cond_timedwait" : "pthread_cond_wait",
+                    GetCondWakeKey(resolvedCondAddress),
+                    () => ResumePthreadCondWait(ctx, condAddress, mutexAddress, state, observedEpoch, timed),
+                    () => state.SignalEpoch != observedEpoch,
+                    timed ? GuestThreadExecution.ComputeDeadlineTimestamp(GetCondWaitTimeout(timeoutUsec)) : 0))
             {
-                TracePthreadCond("wait-block", condAddress, mutexAddress, state, timed, waitResult);
+                TracePthreadCond(timed ? "wait-block-timed" : "wait-block", condAddress, mutexAddress, state, timed, waitResult);
                 return waitResult;
             }
 
@@ -1137,6 +1162,21 @@ public static class KernelPthreadCompatExports
                 {
                     if (!Monitor.Wait(state.SyncRoot, GetCondSpuriousWakeTimeout()))
                     {
+                        if (scheduler is not null && !GuestThreadExecution.IsGuestThread)
+                        {
+                            Monitor.Exit(state.SyncRoot);
+                            try
+                            {
+                                scheduler.Pump(ctx, "pthread_cond_wait");
+                            }
+                            finally
+                            {
+                                Monitor.Enter(state.SyncRoot);
+                            }
+
+                            continue;
+                        }
+
                         spuriousWake = true;
                         break;
                     }
@@ -1189,16 +1229,18 @@ public static class KernelPthreadCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
-        if (!TryResolveCondState(ctx, condAddress, createIfZero: true, out _, out var state))
+        if (!TryResolveCondState(ctx, condAddress, createIfZero: true, out var resolvedCondAddress, out var state))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
         }
 
+        var shouldWakeScheduler = false;
         lock (state.SyncRoot)
         {
             if (state.Waiters > 0)
             {
                 state.SignalEpoch++;
+                shouldWakeScheduler = true;
                 if (broadcast)
                 {
                     Monitor.PulseAll(state.SyncRoot);
@@ -1212,11 +1254,65 @@ public static class KernelPthreadCompatExports
             TracePthreadCond(broadcast ? "broadcast" : "signal", condAddress, mutexAddress: 0, state, timed: false, (int)OrbisGen2Result.ORBIS_GEN2_OK);
         }
 
+        if (shouldWakeScheduler)
+        {
+            _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(
+                GetCondWakeKey(resolvedCondAddress),
+                broadcast ? int.MaxValue : 1);
+        }
+
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
+    private static int ResumePthreadCondWait(
+        CpuContext ctx,
+        ulong condAddress,
+        ulong mutexAddress,
+        PthreadCondState state,
+        ulong observedEpoch,
+        bool timed)
+    {
+        var waitResult = (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        lock (state.SyncRoot)
+        {
+            state.Waiters = Math.Max(0, state.Waiters - 1);
+            if (timed && state.SignalEpoch == observedEpoch)
+            {
+                waitResult = (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT;
+            }
+
+            TracePthreadCond(
+                waitResult == (int)OrbisGen2Result.ORBIS_GEN2_OK ? "wait-resume" : "wait-resume-timeout",
+                condAddress,
+                mutexAddress,
+                state,
+                timed,
+                waitResult);
+        }
+
+        var lockResult = PthreadMutexLockCore(ctx, mutexAddress, tryOnly: false);
+        return lockResult == (int)OrbisGen2Result.ORBIS_GEN2_OK ? waitResult : lockResult;
+    }
+
+    private static string GetCondWakeKey(ulong resolvedCondAddress) =>
+        _condWakeKeys.GetOrAdd(resolvedCondAddress, static address => string.Create(
+            31,
+            address,
+            static (destination, value) =>
+            {
+                "pthread_cond:0x".AsSpan().CopyTo(destination);
+                _ = value.TryFormat(destination[15..], out _, "X16");
+            }));
+
     private static string GetMutexWakeKey(ulong resolvedMutexAddress) =>
-        $"pthread_mutex:0x{resolvedMutexAddress:X16}";
+        _mutexWakeKeys.GetOrAdd(resolvedMutexAddress, static address => string.Create(
+            32,
+            address,
+            static (destination, value) =>
+            {
+                "pthread_mutex:0x".AsSpan().CopyTo(destination);
+                _ = value.TryFormat(destination[16..], out _, "X16");
+            }));
 
     private static bool TryReserveBlockedMutexLock(
         CpuContext ctx,

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -336,12 +336,6 @@ public static class KernelPthreadCompatExports
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libKernel")]
     public static int PosixPthreadCondSignal(CpuContext ctx) => PthreadCondSignalCore(ctx, ctx[CpuRegister.Rdi], broadcast: false);
-    [SysAbiExport(
-        Nid = "27bAgiJmOh0",
-        ExportName = "pthread_cond_timedwait",
-        Target = Generation.Gen4 | Generation.Gen5,
-        LibraryName = "libKernel")]
-    public static int PosixPthreadCondTimedwait(CpuContext ctx) => PthreadCondWaitCore(ctx, ctx[CpuRegister.Rdi], ctx[CpuRegister.Rsi], timed: true, timeoutUsec: unchecked((uint)ctx[CpuRegister.Rdx]));
 
     [SysAbiExport(
         Nid = "m5-2bsNfv7s",
@@ -567,21 +561,15 @@ public static class KernelPthreadCompatExports
                         TracePthreadMutex(ctx, "trylock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY);
                         return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY;
                     }
-
-                    // Normal/adaptive mutexes do not report EDEADLK on self-lock.
-                    // Under the current single-host-thread guest execution model,
-                    // treating them as nested ownership keeps init paths moving
-                    // without turning a would-block path into a hard error.
-                    state.RecursionCount++;
-                    TracePthreadMutex(ctx, "lock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_OK);
-                    return (int)OrbisGen2Result.ORBIS_GEN2_OK;
                 }
-
-                var ownedResult = tryOnly
-                    ? (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY
-                    : (int)OrbisGen2Result.ORBIS_GEN2_ERROR_DEADLOCK;
-                TracePthreadMutex(ctx, tryOnly ? "trylock" : "lock", mutexAddress, resolvedAddress, state, currentThreadId, ownedResult);
-                return ownedResult;
+                else
+                {
+                    var ownedResult = tryOnly
+                        ? (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY
+                        : (int)OrbisGen2Result.ORBIS_GEN2_ERROR_DEADLOCK;
+                    TracePthreadMutex(ctx, tryOnly ? "trylock" : "lock", mutexAddress, resolvedAddress, state, currentThreadId, ownedResult);
+                    return ownedResult;
+                }
             }
         }
 
@@ -1115,13 +1103,14 @@ public static class KernelPthreadCompatExports
 
         var waitResult = (int)OrbisGen2Result.ORBIS_GEN2_OK;
         var spuriousWake = false;
+        var releasedRecursion = 0;
         lock (state.SyncRoot)
         {
             state.Waiters++;
             var observedEpoch = state.SignalEpoch;
             TracePthreadCond("wait-enter", condAddress, mutexAddress, state, timed, waitResult);
 
-            var unlockResult = PthreadMutexUnlockCore(ctx, mutexAddress, requireOwner: true);
+            var unlockResult = PthreadMutexFullUnlockForCondWait(ctx, mutexAddress, out releasedRecursion);
             if (unlockResult != (int)OrbisGen2Result.ORBIS_GEN2_OK)
             {
                 state.Waiters--;
@@ -1135,7 +1124,7 @@ public static class KernelPthreadCompatExports
                     ctx,
                     timed ? "pthread_cond_timedwait" : "pthread_cond_wait",
                     GetCondWakeKey(resolvedCondAddress),
-                    () => ResumePthreadCondWait(ctx, condAddress, mutexAddress, state, observedEpoch, timed),
+                    () => ResumePthreadCondWait(ctx, condAddress, mutexAddress, state, observedEpoch, timed, releasedRecursion),
                     () => state.SignalEpoch != observedEpoch,
                     timed ? GuestThreadExecution.ComputeDeadlineTimestamp(GetCondWaitTimeout(timeoutUsec)) : 0))
             {
@@ -1203,7 +1192,7 @@ public static class KernelPthreadCompatExports
                 waitResult);
         }
 
-        var lockResult = PthreadMutexLockCore(ctx, mutexAddress, tryOnly: false);
+        var lockResult = PthreadMutexRelockForCondWait(ctx, mutexAddress, releasedRecursion);
         if (lockResult != (int)OrbisGen2Result.ORBIS_GEN2_OK)
         {
             TracePthreadCond("wait-relock-fail", condAddress, mutexAddress, state, timed, lockResult);
@@ -1270,7 +1259,8 @@ public static class KernelPthreadCompatExports
         ulong mutexAddress,
         PthreadCondState state,
         ulong observedEpoch,
-        bool timed)
+        bool timed,
+        int releasedRecursion)
     {
         var waitResult = (int)OrbisGen2Result.ORBIS_GEN2_OK;
         lock (state.SyncRoot)
@@ -1290,7 +1280,7 @@ public static class KernelPthreadCompatExports
                 waitResult);
         }
 
-        var lockResult = PthreadMutexLockCore(ctx, mutexAddress, tryOnly: false);
+        var lockResult = PthreadMutexRelockForCondWait(ctx, mutexAddress, releasedRecursion);
         return lockResult == (int)OrbisGen2Result.ORBIS_GEN2_OK ? waitResult : lockResult;
     }
 
@@ -1303,6 +1293,67 @@ public static class KernelPthreadCompatExports
                 "pthread_cond:0x".AsSpan().CopyTo(destination);
                 _ = value.TryFormat(destination[15..], out _, "X16");
             }));
+
+    private static int PthreadMutexFullUnlockForCondWait(CpuContext ctx, ulong mutexAddress, out int releasedRecursion)
+    {
+        releasedRecursion = 0;
+        if (!TryResolveMutexState(ctx, mutexAddress, createIfZero: false, out _, out var state))
+        {
+            return PthreadMutexUnlockCore(ctx, mutexAddress, requireOwner: true);
+        }
+
+        var currentThreadId = KernelPthreadState.GetCurrentThreadHandle();
+        lock (state)
+        {
+            if (state.RecursionCount <= 0 || state.OwnerThreadId != currentThreadId)
+            {
+                return PthreadMutexUnlockCore(ctx, mutexAddress, requireOwner: true);
+            }
+
+            releasedRecursion = state.RecursionCount;
+            state.RecursionCount = 1;
+        }
+
+        return PthreadMutexUnlockCore(ctx, mutexAddress, requireOwner: true);
+    }
+
+    private static int PthreadMutexRelockForCondWait(CpuContext ctx, ulong mutexAddress, int releasedRecursion)
+    {
+        var result = PthreadMutexLockCore(ctx, mutexAddress, tryOnly: false);
+        if (result != (int)OrbisGen2Result.ORBIS_GEN2_OK)
+        {
+            return result;
+        }
+
+        if (releasedRecursion > 1 &&
+            TryResolveMutexState(ctx, mutexAddress, createIfZero: false, out _, out var state))
+        {
+            lock (state)
+            {
+                if (state.OwnerThreadId == KernelPthreadState.GetCurrentThreadHandle())
+                {
+                    state.RecursionCount = releasedRecursion;
+                }
+            }
+        }
+
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    public static string? DumpMutexStateForStall(ulong mutexAddress)
+    {
+        if (!_mutexStates.TryGetValue(mutexAddress, out var state))
+        {
+            return null;
+        }
+
+        var waiterThreads = string.Join(",", _mutexStates
+            .Where(pair => ReferenceEquals(pair.Value, state))
+            .Select(pair => $"0x{pair.Key:X}"));
+
+        return $"mutex=0x{mutexAddress:X16} owner=0x{state.OwnerThreadId:X} recursion={state.RecursionCount} " +
+               $"type={state.Type} semaphore_count={state.Semaphore.CurrentCount} aliases=[{waiterThreads}]";
+    }
 
     private static string GetMutexWakeKey(ulong resolvedMutexAddress) =>
         _mutexWakeKeys.GetOrAdd(resolvedMutexAddress, static address => string.Create(
@@ -1324,6 +1375,12 @@ public static class KernelPthreadCompatExports
         lock (state)
         {
             if (state.OwnerThreadId != 0 || state.RecursionCount != 0)
+            {
+                TracePthreadMutex(ctx, "lock-reserve-busy", mutexAddress, resolvedAddress, state, waiter.ThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY);
+                return false;
+            }
+
+            if (!state.Semaphore.Wait(0))
             {
                 TracePthreadMutex(ctx, "lock-reserve-busy", mutexAddress, resolvedAddress, state, waiter.ThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY);
                 return false;

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
@@ -87,6 +87,13 @@ public static class KernelPthreadExtendedCompatExports
         public PthreadAttrState Attributes { get; set; } = PthreadAttrState.Default;
     }
 
+    // Counter lives on the OUTER class deliberately: a static field on the nested state class
+    // gives it a type initializer that first runs on a GUEST thread, whose hijacked stack the CLR
+    // cannot walk — that fail-fasts the process with the misleading "Invalid Program: attempted to
+    // call a UnmanagedCallersOnly method from managed code" (observed crashing in
+    // PthreadRwlockState..ctor). The outer class is already initialized when any export runs.
+    private static long _nextRwlockWakeId;
+
     private sealed class PthreadRwlockState
     {
         public object SyncRoot { get; } = new();
@@ -96,6 +103,10 @@ public static class KernelPthreadExtendedCompatExports
         public int CompatWriterTotalCount { get; set; }
         public ulong WriterThreadId { get; set; }
         public int WaitingWriters { get; set; }
+
+        // Stable per-state block/wake key (see PthreadMutexState.WakeKey) — avoids a
+        // lock/unlock wake-key mismatch when an rwlock is reachable via aliased addresses.
+        public string WakeKey { get; } = "pthread_rwlock#" + Interlocked.Increment(ref _nextRwlockWakeId).ToString("X");
 
         public int GetReaderCount(ulong threadId)
         {
@@ -1072,7 +1083,7 @@ public static class KernelPthreadExtendedCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_PERMISSION_DENIED;
         }
 
-        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetRwlockWakeKey(resolvedAddress));
+        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(rwlock.WakeKey);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -1296,6 +1307,7 @@ public static class KernelPthreadExtendedCompatExports
 
                 if (rwlock.WriterThreadId == 0 && rwlock.ReaderTotalCount == 0 && rwlock.CompatWriterTotalCount == 0)
                 {
+                    DetectRwlockWriterConflict(resolvedAddress, rwlock, currentThreadId, "wrlock");
                     rwlock.WriterThreadId = currentThreadId;
                     return (int)OrbisGen2Result.ORBIS_GEN2_OK;
                 }
@@ -1309,7 +1321,7 @@ public static class KernelPthreadExtendedCompatExports
                         GuestThreadExecution.RequestCurrentThreadBlock(
                             ctx,
                             "pthread_rwlock_wrlock",
-                            GetRwlockWakeKey(resolvedAddress),
+                            rwlock.WakeKey,
                             static () => (int)OrbisGen2Result.ORBIS_GEN2_OK,
                             () => TryAcquireBlockedRwlock(rwlock, currentThreadId, write: true)))
                     {
@@ -1346,7 +1358,7 @@ public static class KernelPthreadExtendedCompatExports
                         GuestThreadExecution.RequestCurrentThreadBlock(
                             ctx,
                             "pthread_rwlock_rdlock",
-                            GetRwlockWakeKey(resolvedAddress),
+                            rwlock.WakeKey,
                             static () => (int)OrbisGen2Result.ORBIS_GEN2_OK,
                             () => TryAcquireBlockedRwlock(rwlock, currentThreadId, write: false)))
                     {
@@ -1356,6 +1368,13 @@ public static class KernelPthreadExtendedCompatExports
                     Monitor.Wait(rwlock.SyncRoot);
                 }
 
+                if (rwlock.WriterThreadId != 0 ||
+                    rwlock.CompatWriterTotalCount > rwlock.CompatWriterCounts.GetValueOrDefault(currentThreadId))
+                {
+                    Console.Error.WriteLine(
+                        $"[LOADER][ERROR] RWLOCK READER/WRITER COEXIST: resolved=0x{resolvedAddress:X} reader=0x{currentThreadId:X} " +
+                        $"writer=0x{rwlock.WriterThreadId:X} compat_total={rwlock.CompatWriterTotalCount} readers_total={rwlock.ReaderTotalCount}");
+                }
                 rwlock.AddReader(currentThreadId);
             }
         }
@@ -1374,6 +1393,7 @@ public static class KernelPthreadExtendedCompatExports
                     return false;
                 }
 
+                DetectRwlockWriterConflict(0, rwlock, currentThreadId, "wrlock-resume");
                 rwlock.WriterThreadId = currentThreadId;
                 rwlock.WaitingWriters = Math.Max(0, rwlock.WaitingWriters - 1);
                 return true;
@@ -1386,6 +1406,22 @@ public static class KernelPthreadExtendedCompatExports
 
             rwlock.AddReader(currentThreadId);
             return true;
+        }
+    }
+
+    // Called while holding lock(rwlock.SyncRoot) just before granting an exclusive write lock:
+    // any existing reader/writer/foreign-compat-writer means two threads would hold the rwlock
+    // with a writer present — a data race. Suspected source of the AGC command-buffer
+    // use-after-free (null-vtable) crash.
+    private static void DetectRwlockWriterConflict(ulong resolvedAddress, PthreadRwlockState rwlock, ulong currentThreadId, string site)
+    {
+        if (rwlock.WriterThreadId != 0 ||
+            rwlock.ReaderTotalCount != 0 ||
+            rwlock.CompatWriterTotalCount > rwlock.CompatWriterCounts.GetValueOrDefault(currentThreadId))
+        {
+            Console.Error.WriteLine(
+                $"[LOADER][ERROR] RWLOCK WRITER CONFLICT at {site}: resolved=0x{resolvedAddress:X} writer=0x{currentThreadId:X} " +
+                $"existing_writer=0x{rwlock.WriterThreadId:X} readers_total={rwlock.ReaderTotalCount} compat_total={rwlock.CompatWriterTotalCount}");
         }
     }
 

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
@@ -31,6 +31,8 @@ public static class KernelPthreadExtendedCompatExports
     private static long _nextSyntheticRwlockHandleId = 1;
     private static long _nextSyntheticPthreadAttrHandleId = 1;
     private static long _nextSyntheticRwlockAttrHandleId = 1;
+    private static readonly bool _strictRwlockWriterPreference =
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_STRICT_RWLOCK_WRITER_PREFERENCE"), "1", StringComparison.Ordinal);
 
     private static readonly ConcurrentDictionary<ulong, ConcurrentDictionary<int, ulong>> _threadLocalSpecific = new();
 
@@ -89,7 +91,9 @@ public static class KernelPthreadExtendedCompatExports
     {
         public object SyncRoot { get; } = new();
         public Dictionary<ulong, int> ReaderCounts { get; } = new();
+        public Dictionary<ulong, int> CompatWriterCounts { get; } = new();
         public int ReaderTotalCount { get; set; }
+        public int CompatWriterTotalCount { get; set; }
         public ulong WriterThreadId { get; set; }
         public int WaitingWriters { get; set; }
 
@@ -103,6 +107,33 @@ public static class KernelPthreadExtendedCompatExports
             ReaderCounts.TryGetValue(threadId, out var currentCount);
             ReaderCounts[threadId] = currentCount + 1;
             ReaderTotalCount++;
+        }
+
+        public void AddCompatWriter(ulong threadId)
+        {
+            CompatWriterCounts.TryGetValue(threadId, out var currentCount);
+            CompatWriterCounts[threadId] = currentCount + 1;
+            CompatWriterTotalCount++;
+        }
+
+        public bool RemoveCompatWriter(ulong threadId)
+        {
+            if (!CompatWriterCounts.TryGetValue(threadId, out var currentCount) || currentCount <= 0)
+            {
+                return false;
+            }
+
+            if (currentCount == 1)
+            {
+                CompatWriterCounts.Remove(threadId);
+            }
+            else
+            {
+                CompatWriterCounts[threadId] = currentCount - 1;
+            }
+
+            CompatWriterTotalCount = Math.Max(0, CompatWriterTotalCount - 1);
+            return true;
         }
 
         public bool RemoveReader(ulong threadId)
@@ -935,7 +966,7 @@ public static class KernelPthreadExtendedCompatExports
 
         lock (state.SyncRoot)
         {
-            if (state.WriterThreadId != 0 || state.ReaderTotalCount != 0 || state.WaitingWriters != 0)
+            if (state.WriterThreadId != 0 || state.ReaderTotalCount != 0 || state.WaitingWriters != 0 || state.CompatWriterTotalCount != 0)
             {
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY;
             }
@@ -1014,7 +1045,11 @@ public static class KernelPthreadExtendedCompatExports
         {
             lock (rwlock.SyncRoot)
             {
-                if (rwlock.WriterThreadId == currentThreadId)
+                if (rwlock.RemoveCompatWriter(currentThreadId))
+                {
+                    Monitor.PulseAll(rwlock.SyncRoot);
+                }
+                else if (rwlock.WriterThreadId == currentThreadId)
                 {
                     rwlock.WriterThreadId = 0;
                     Monitor.PulseAll(rwlock.SyncRoot);
@@ -1243,6 +1278,28 @@ public static class KernelPthreadExtendedCompatExports
                     return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_DEADLOCK;
                 }
 
+                if (rwlock.CompatWriterCounts.GetValueOrDefault(currentThreadId) > 0)
+                {
+                    rwlock.AddCompatWriter(currentThreadId);
+                    return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                }
+
+                if (GuestThreadExecution.IsGuestThread &&
+                    !_strictRwlockWriterPreference &&
+                    rwlock.WriterThreadId == 0 &&
+                    rwlock.ReaderTotalCount == 0 &&
+                    rwlock.CompatWriterTotalCount == 0)
+                {
+                    rwlock.AddCompatWriter(currentThreadId);
+                    return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                }
+
+                if (rwlock.WriterThreadId == 0 && rwlock.ReaderTotalCount == 0 && rwlock.CompatWriterTotalCount == 0)
+                {
+                    rwlock.WriterThreadId = currentThreadId;
+                    return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                }
+
                 rwlock.WaitingWriters++;
                 var transferredToScheduler = false;
                 try
@@ -1260,7 +1317,7 @@ public static class KernelPthreadExtendedCompatExports
                         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
                     }
 
-                    while (rwlock.WriterThreadId != 0 || rwlock.ReaderTotalCount != 0)
+                    while (rwlock.WriterThreadId != 0 || rwlock.ReaderTotalCount != 0 || rwlock.CompatWriterTotalCount != 0)
                     {
                         Monitor.Wait(rwlock.SyncRoot);
                     }
@@ -1269,7 +1326,7 @@ public static class KernelPthreadExtendedCompatExports
                 }
                 finally
                 {
-                    if (!transferredToScheduler && rwlock.WriterThreadId != currentThreadId)
+                    if (!transferredToScheduler)
                     {
                         rwlock.WaitingWriters = Math.Max(0, rwlock.WaitingWriters - 1);
                     }
@@ -1282,8 +1339,7 @@ public static class KernelPthreadExtendedCompatExports
                     return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_DEADLOCK;
                 }
 
-                while (rwlock.WriterThreadId != 0 ||
-                       (rwlock.WaitingWriters > 0 && rwlock.GetReaderCount(currentThreadId) == 0))
+                while (ReaderMustWaitForRwlock(rwlock, currentThreadId))
                 {
                     if (GuestThreadExecution.IsGuestThread &&
                         GuestThreadExecution.TryGetCurrentImportCallFrame(out _) &&
@@ -1313,7 +1369,7 @@ public static class KernelPthreadExtendedCompatExports
         {
             if (write)
             {
-                if (rwlock.WriterThreadId != 0 || rwlock.ReaderTotalCount != 0)
+                if (rwlock.WriterThreadId != 0 || rwlock.ReaderTotalCount != 0 || rwlock.CompatWriterTotalCount != 0)
                 {
                     return false;
                 }
@@ -1323,8 +1379,7 @@ public static class KernelPthreadExtendedCompatExports
                 return true;
             }
 
-            if (rwlock.WriterThreadId != 0 ||
-                (rwlock.WaitingWriters > 0 && rwlock.GetReaderCount(currentThreadId) == 0))
+            if (ReaderMustWaitForRwlock(rwlock, currentThreadId))
             {
                 return false;
             }
@@ -1334,7 +1389,44 @@ public static class KernelPthreadExtendedCompatExports
         }
     }
 
+    private static bool ReaderMustWaitForRwlock(PthreadRwlockState rwlock, ulong currentThreadId)
+    {
+        if (rwlock.WriterThreadId != 0)
+        {
+            return true;
+        }
+
+        if (rwlock.CompatWriterTotalCount > rwlock.CompatWriterCounts.GetValueOrDefault(currentThreadId))
+        {
+            return true;
+        }
+
+        return rwlock.WaitingWriters > 0 &&
+               rwlock.GetReaderCount(currentThreadId) == 0;
+    }
+
     private static string GetRwlockWakeKey(ulong rwlockAddress) => $"pthread_rwlock:0x{rwlockAddress:X16}";
+
+    public static string? DumpRwlockStateForStall(ulong rwlockAddress)
+    {
+        PthreadRwlockState? rwlock;
+        lock (_stateGate)
+        {
+            if (!_rwlockStates.TryGetValue(rwlockAddress, out rwlock))
+            {
+                return null;
+            }
+        }
+
+        lock (rwlock.SyncRoot)
+        {
+            var readers = string.Join(",", rwlock.ReaderCounts.Select(pair => $"0x{pair.Key:X}x{pair.Value}"));
+            var compatWriters = string.Join(",", rwlock.CompatWriterCounts.Select(pair => $"0x{pair.Key:X}x{pair.Value}"));
+            return $"rwlock=0x{rwlockAddress:X16} writer=0x{rwlock.WriterThreadId:X} waiting_writers={rwlock.WaitingWriters} " +
+                   $"readers_total={rwlock.ReaderTotalCount} readers=[{readers}] " +
+                   $"compat_writers_total={rwlock.CompatWriterTotalCount} compat_writers=[{compatWriters}]";
+        }
+    }
 
     private static ulong ResolveRwlockHandle(CpuContext ctx, ulong rwlockAddress)
     {

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
@@ -1003,7 +1003,7 @@ public static class KernelPthreadExtendedCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
-        if (!TryResolveRwlockState(ctx, rwlockAddress, createIfZero: false, out _, out var rwlock))
+        if (!TryResolveRwlockState(ctx, rwlockAddress, createIfZero: false, out var resolvedAddress, out var rwlock))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
         }
@@ -1037,6 +1037,7 @@ public static class KernelPthreadExtendedCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_PERMISSION_DENIED;
         }
 
+        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetRwlockWakeKey(resolvedAddress));
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -1227,7 +1228,7 @@ public static class KernelPthreadExtendedCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
-        if (!TryResolveRwlockState(ctx, rwlockAddress, createIfZero: true, out _, out var rwlock))
+        if (!TryResolveRwlockState(ctx, rwlockAddress, createIfZero: true, out var resolvedAddress, out var rwlock))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
         }
@@ -1243,19 +1244,36 @@ public static class KernelPthreadExtendedCompatExports
                 }
 
                 rwlock.WaitingWriters++;
+                var transferredToScheduler = false;
                 try
                 {
+                    if (GuestThreadExecution.IsGuestThread &&
+                        GuestThreadExecution.TryGetCurrentImportCallFrame(out _) &&
+                        GuestThreadExecution.RequestCurrentThreadBlock(
+                            ctx,
+                            "pthread_rwlock_wrlock",
+                            GetRwlockWakeKey(resolvedAddress),
+                            static () => (int)OrbisGen2Result.ORBIS_GEN2_OK,
+                            () => TryAcquireBlockedRwlock(rwlock, currentThreadId, write: true)))
+                    {
+                        transferredToScheduler = true;
+                        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                    }
+
                     while (rwlock.WriterThreadId != 0 || rwlock.ReaderTotalCount != 0)
                     {
                         Monitor.Wait(rwlock.SyncRoot);
                     }
+
+                    rwlock.WriterThreadId = currentThreadId;
                 }
                 finally
                 {
-                    rwlock.WaitingWriters--;
+                    if (!transferredToScheduler && rwlock.WriterThreadId != currentThreadId)
+                    {
+                        rwlock.WaitingWriters = Math.Max(0, rwlock.WaitingWriters - 1);
+                    }
                 }
-
-                rwlock.WriterThreadId = currentThreadId;
             }
             else
             {
@@ -1267,6 +1285,18 @@ public static class KernelPthreadExtendedCompatExports
                 while (rwlock.WriterThreadId != 0 ||
                        (rwlock.WaitingWriters > 0 && rwlock.GetReaderCount(currentThreadId) == 0))
                 {
+                    if (GuestThreadExecution.IsGuestThread &&
+                        GuestThreadExecution.TryGetCurrentImportCallFrame(out _) &&
+                        GuestThreadExecution.RequestCurrentThreadBlock(
+                            ctx,
+                            "pthread_rwlock_rdlock",
+                            GetRwlockWakeKey(resolvedAddress),
+                            static () => (int)OrbisGen2Result.ORBIS_GEN2_OK,
+                            () => TryAcquireBlockedRwlock(rwlock, currentThreadId, write: false)))
+                    {
+                        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                    }
+
                     Monitor.Wait(rwlock.SyncRoot);
                 }
 
@@ -1276,6 +1306,35 @@ public static class KernelPthreadExtendedCompatExports
 
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
+
+    private static bool TryAcquireBlockedRwlock(PthreadRwlockState rwlock, ulong currentThreadId, bool write)
+    {
+        lock (rwlock.SyncRoot)
+        {
+            if (write)
+            {
+                if (rwlock.WriterThreadId != 0 || rwlock.ReaderTotalCount != 0)
+                {
+                    return false;
+                }
+
+                rwlock.WriterThreadId = currentThreadId;
+                rwlock.WaitingWriters = Math.Max(0, rwlock.WaitingWriters - 1);
+                return true;
+            }
+
+            if (rwlock.WriterThreadId != 0 ||
+                (rwlock.WaitingWriters > 0 && rwlock.GetReaderCount(currentThreadId) == 0))
+            {
+                return false;
+            }
+
+            rwlock.AddReader(currentThreadId);
+            return true;
+        }
+    }
+
+    private static string GetRwlockWakeKey(ulong rwlockAddress) => $"pthread_rwlock:0x{rwlockAddress:X16}";
 
     private static ulong ResolveRwlockHandle(CpuContext ctx, ulong rwlockAddress)
     {

--- a/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
@@ -1112,14 +1112,19 @@ public static class KernelRuntimeCompatExports
         LibraryName = "libKernel")]
     public static int StackCheckGuard(CpuContext ctx)
     {
-        var baseAddress = _stackChkGuardObjectAddress != 0
-            ? unchecked((ulong)_stackChkGuardObjectAddress)
-            : GetTlsScratchAddress(ctx, TlsStackChkGuardBaseOffset);
+        var tlsAddress = GetTlsScratchAddress(ctx, TlsStackChkGuardBaseOffset);
+        var baseAddress = tlsAddress != 0
+            ? tlsAddress
+            : (_stackChkGuardObjectAddress != 0
+                ? unchecked((ulong)_stackChkGuardObjectAddress)
+                : 0);
         if (baseAddress == 0)
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
+        _ = ctx.TryWriteUInt64(baseAddress, _stackChkGuardValue);
+        _ = ctx.TryWriteUInt64(baseAddress + sizeof(ulong), _stackChkGuardValue);
         if (_stackChkGuardObjectAddress != 0)
         {
             try

--- a/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
@@ -31,6 +31,8 @@ public static class KernelRuntimeCompatExports
     private const ulong TlsProcParamOffset = 0x100;
     private const ulong TlsMallocReplaceOffset = 0x200;
     private const ulong TlsNewReplaceOffset = 0x300;
+    private const ulong TlsArgvArrayOffset = 0x400;
+    private const ulong TlsArgvStringOffset = 0x440;
     private const int MallocReplaceSize = 0x70;
     private const int NewReplaceSize = 0x68;
     private const int OrbisTimesecSize = sizeof(long) + sizeof(uint) + sizeof(uint);
@@ -461,6 +463,54 @@ public static class KernelRuntimeCompatExports
         TraceProcParam(ctx, address);
 
         ctx[CpuRegister.Rax] = address;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "FJmglmTMdr4",
+        ExportName = "sceKernelGetArgv",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelGetArgv(CpuContext ctx)
+    {
+        var outArgcAddress = ctx[CpuRegister.Rdi];
+
+        var argvArrayAddress = GetTlsScratchAddress(ctx, TlsArgvArrayOffset);
+        var argvStringAddress = GetTlsScratchAddress(ctx, TlsArgvStringOffset);
+        if (argvArrayAddress == 0 || argvStringAddress == 0)
+        {
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        // A single argv[0] (the executable path); real titles only read the
+        // count and the program name from here.
+        Span<byte> argv0 = stackalloc byte[] { (byte)'/', (byte)'a', (byte)'p', (byte)'p', (byte)'0', (byte)'/', (byte)'e', (byte)'b', (byte)'o', (byte)'o', (byte)'t', (byte)'.', (byte)'b', (byte)'i', (byte)'n', 0 };
+        if (!ctx.Memory.TryWrite(argvStringAddress, argv0) ||
+            !ctx.TryWriteUInt64(argvArrayAddress + 0, argvStringAddress) ||
+            !ctx.TryWriteUInt64(argvArrayAddress + 8, 0))
+        {
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        if (outArgcAddress != 0)
+        {
+            _ = ctx.TryWriteUInt32(outArgcAddress, 1);
+        }
+
+        ctx[CpuRegister.Rax] = argvArrayAddress;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "iKJMWrAumPE",
+        ExportName = "sceKernelGetArgc",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelGetArgc(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 1;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 

--- a/src/SharpEmu.Libs/Network/VoiceQoSExports.cs
+++ b/src/SharpEmu.Libs/Network/VoiceQoSExports.cs
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System;
+using SharpEmu.HLE;
+
+namespace SharpEmu.Libs.Network;
+
+public static class VoiceQoSExports
+{
+    [SysAbiExport(
+        Nid = "U8IfNl6-Css",
+        ExportName = "sceVoiceQoSInit",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceVoiceQoS")]
+    public static int VoiceQoSInit(CpuContext ctx)
+    {
+        TraceVoiceQoS("init", ctx[CpuRegister.Rdi], ctx[CpuRegister.Rsi]);
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    private static void TraceVoiceQoS(string operation, ulong arg0, ulong arg1)
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_VOICE_QOS"), "1", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        Console.Error.WriteLine(
+            $"[LOADER][TRACE] voiceqos.{operation} arg0=0x{arg0:X16} arg1=0x{arg1:X16}");
+    }
+}

--- a/src/SharpEmu.Libs/Np/NpEntitlementAccessExports.cs
+++ b/src/SharpEmu.Libs/Np/NpEntitlementAccessExports.cs
@@ -58,6 +58,31 @@ public static class NpEntitlementAccessExports
         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
+    [SysAbiExport(
+        Nid = "lPDO62PpJIA",
+        ExportName = "sceNpEntitlementAccessGetSkuFlag",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceNpEntitlementAccess")]
+    public static int NpEntitlementAccessGetSkuFlag(CpuContext ctx)
+    {
+        var primaryOutAddress = ctx[CpuRegister.Rdi];
+        var secondaryOutAddress = ctx[CpuRegister.Rsi];
+
+        if (primaryOutAddress != 0 && !ctx.TryWriteUInt32(primaryOutAddress, 0))
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        if (secondaryOutAddress != 0 && !ctx.TryWriteUInt32(secondaryOutAddress, 0))
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceNpEntitlementAccess(
+            $"get_sku_flag out0=0x{primaryOutAddress:X16} out1=0x{secondaryOutAddress:X16} -> disabled");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
     private static void TraceNpEntitlementAccess(string message)
     {
         if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_NP"), "1", StringComparison.Ordinal))

--- a/src/SharpEmu.Libs/Np/NpWebApi2Exports.cs
+++ b/src/SharpEmu.Libs/Np/NpWebApi2Exports.cs
@@ -10,6 +10,7 @@ public static class NpWebApi2Exports
     private const int NpWebApi2ErrorInvalidArgument = unchecked((int)0x80553402);
 
     private static int _initialized;
+    private static int _nextPushEventHandle = 1;
 
     [SysAbiExport(
         Nid = "+o9816YQhqQ",
@@ -42,6 +43,24 @@ public static class NpWebApi2Exports
         Interlocked.Exchange(ref _initialized, 0);
         TraceNpWebApi2("term", libraryContextId, 0);
         return ctx.SetReturn(0);
+    }
+
+    [SysAbiExport(
+        Nid = "WV1GwM32NgY",
+        ExportName = "sceNpWebApi2PushEventCreateHandle",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceNpWebApi2")]
+    public static int NpWebApi2PushEventCreateHandle(CpuContext ctx)
+    {
+        var libraryContextId = unchecked((int)ctx[CpuRegister.Rdi]);
+        if (libraryContextId < 0)
+        {
+            return ctx.SetReturn(NpWebApi2ErrorInvalidArgument);
+        }
+
+        var handle = Interlocked.Increment(ref _nextPushEventHandle);
+        TraceNpWebApi2("push_event_create_handle", libraryContextId, (uint)handle);
+        return ctx.SetReturn(handle);
     }
 
     private static void TraceNpWebApi2(string operation, int id, ulong arg0)

--- a/src/SharpEmu.Libs/PlayGo/PlayGoExports.cs
+++ b/src/SharpEmu.Libs/PlayGo/PlayGoExports.cs
@@ -128,11 +128,6 @@ public static class PlayGoExports
                 return OrbisPlayGoErrorNotInitialized;
             }
 
-            if (!_metadata.Available)
-            {
-                return OrbisPlayGoErrorNotSupportPlayGo;
-            }
-
             _opened = true;
             TracePlayGo($"open handle={PlayGoHandle} chunks={_metadata.ChunkIds.Length}");
         }

--- a/src/SharpEmu.Libs/Random/RandomExports.cs
+++ b/src/SharpEmu.Libs/Random/RandomExports.cs
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using System.Security.Cryptography;
+
+namespace SharpEmu.Libs.Random;
+
+public static class RandomExports
+{
+    private const int SceRandomErrorInvalid = unchecked((int)0x817C0002);
+    private const ulong MaximumRandomLength = 64;
+
+    [SysAbiExport(
+        Nid = "PI7jIZj4pcE",
+        ExportName = "sceRandomGetRandomNumber",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceRandom")]
+    public static int RandomGetRandomNumber(CpuContext ctx)
+    {
+        var bufferAddress = ctx[CpuRegister.Rdi];
+        var length = ctx[CpuRegister.Rsi];
+
+        if (bufferAddress == 0 || length == 0 || length > MaximumRandomLength)
+        {
+            return ctx.SetReturn(SceRandomErrorInvalid);
+        }
+
+        var bytes = new byte[length];
+        RandomNumberGenerator.Fill(bytes);
+
+        return ctx.Memory.TryWrite(bufferAddress, bytes)
+            ? ctx.SetReturn(0)
+            : ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+    }
+}

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -45,6 +45,47 @@ public static class VideoOutExports
     private static readonly object _stateGate = new();
     private static readonly object _frameDumpGate = new();
     private static readonly Dictionary<int, VideoOutPortState> _ports = new();
+
+    // The display generates vblanks autonomously on real hardware; UE arms a
+    // vblank event and blocks its frame loop on it, so without an independent
+    // driver every render thread idles forever. This pump ticks all open ports
+    // at ~60 Hz to keep the frame clock running.
+    private static Timer? _vblankPumpTimer;
+    private const int VblankPumpIntervalMs = 16;
+
+    private static void EnsureVblankPumpStarted()
+    {
+        if (_vblankPumpTimer is not null)
+        {
+            return;
+        }
+
+        _vblankPumpTimer = new Timer(
+            static _ => PumpVblanks(),
+            null,
+            VblankPumpIntervalMs,
+            VblankPumpIntervalMs);
+    }
+
+    private static void PumpVblanks()
+    {
+        VideoOutPortState[] ports;
+        lock (_stateGate)
+        {
+            if (_ports.Count == 0)
+            {
+                return;
+            }
+
+            ports = new VideoOutPortState[_ports.Count];
+            _ports.Values.CopyTo(ports, 0);
+        }
+
+        foreach (var port in ports)
+        {
+            SignalVblank(port);
+        }
+    }
     private static readonly Dictionary<(int Handle, int BufferIndex, ulong Address), ulong> _lastFrameFingerprints = new();
     private static int _nextHandle = 1;
     private static int _frameDumpCount;
@@ -176,6 +217,7 @@ public static class VideoOutExports
             {
                 Handle = handle,
             };
+            EnsureVblankPumpStarted();
             return handle;
         }
     }

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -847,6 +847,8 @@ internal static unsafe class VulkanVideoPresenter
         }
     }
 
+    private static int _presentBlockTraceCount;
+
     private static bool TryTakePresentation(long presentedSequence, out Presentation presentation)
     {
         lock (_gate)
@@ -855,6 +857,24 @@ internal static unsafe class VulkanVideoPresenter
                 latest.Sequence == presentedSequence ||
                 latest.RequiredGuestWorkSequence > _completedGuestWorkSequence)
             {
+                if (Interlocked.Increment(ref _presentBlockTraceCount) is var n &&
+                    (n <= 5 || n % 2000 == 0))
+                {
+                    var reason = _latestPresentation is null
+                        ? "no-presentation"
+                        : _latestPresentation.Value.Sequence == presentedSequence
+                            ? "already-presented"
+                            : "waiting-guest-work";
+                    Console.Error.WriteLine(
+                        $"[LOADER][TRACE] vk.present_blocked#{n} reason={reason} " +
+                        $"latest_seq={_latestPresentation?.Sequence.ToString() ?? "-"} " +
+                        $"presented_seq={presentedSequence} " +
+                        $"required_work={_latestPresentation?.RequiredGuestWorkSequence.ToString() ?? "-"} " +
+                        $"enqueued_work={_enqueuedGuestWorkSequence} " +
+                        $"completed_work={_completedGuestWorkSequence} " +
+                        $"pending={_pendingGuestWork.Count}");
+                }
+
                 presentation = default;
                 return false;
             }
@@ -5014,11 +5034,22 @@ internal static unsafe class VulkanVideoPresenter
                 _ => 0,
             };
 
-        private void Render(double _)
+        // vkQueuePresentKHR is the only thing throttling the window loop, so a RenderCore that
+        // presents nothing would otherwise spin the callback and peg a core. Yield instead.
+        private void Render(double delta)
+        {
+            var startedPresent = RenderCore(delta);
+            if (!startedPresent)
+            {
+                Thread.Sleep(1);
+            }
+        }
+
+        private bool RenderCore(double _)
         {
             if (!_vulkanReady)
             {
-                return;
+                return false;
             }
 
             _commandBuffer = _presentationCommandBuffer;
@@ -5053,7 +5084,7 @@ internal static unsafe class VulkanVideoPresenter
 
             if (!TryTakePresentation(_presentedSequence, out var presentation))
             {
-                return;
+                return false;
             }
 
             if (presentation.Pixels is null &&
@@ -5061,7 +5092,7 @@ internal static unsafe class VulkanVideoPresenter
                 presentation.TranslatedDraw is null &&
                 presentation.GuestImageAddress == 0)
             {
-                return;
+                return false;
             }
 
             byte[]? pixels = null;
@@ -5077,7 +5108,7 @@ internal static unsafe class VulkanVideoPresenter
                         _extent.Height);
                 if ((ulong)pixels.Length > _stagingSize)
                 {
-                    return;
+                    return false;
                 }
             }
 
@@ -5089,7 +5120,7 @@ internal static unsafe class VulkanVideoPresenter
                     out presentedGuestImage) ||
                  !presentedGuestImage.Initialized))
             {
-                return;
+                return false;
             }
             if (presentedGuestImage is not null)
             {
@@ -5133,7 +5164,7 @@ internal static unsafe class VulkanVideoPresenter
                     _presentedSequence = presentation.Sequence;
                     Console.Error.WriteLine(
                         $"[LOADER][ERROR] Vulkan VideoOut translated draw setup failed: {exception.Message}");
-                    return;
+                    return false;
                 }
             }
 
@@ -5153,7 +5184,7 @@ internal static unsafe class VulkanVideoPresenter
                     DestroyTranslatedDrawResources(translatedResources);
                 }
 
-                return;
+                return false;
             }
 
             CheckSwapchainResult(acquireResult, "vkAcquireNextImageKHR");
@@ -5265,7 +5296,7 @@ internal static unsafe class VulkanVideoPresenter
                 }
 
                 RecreateSwapchainResources("vkQueuePresentKHR", presentResult);
-                return;
+                return false;
             }
 
             CheckSwapchainResult(presentResult, "vkQueuePresentKHR");
@@ -5318,6 +5349,8 @@ internal static unsafe class VulkanVideoPresenter
             {
                 RecreateSwapchainResources("present suboptimal", Result.SuboptimalKhr);
             }
+
+            return true;
         }
 
         private void TraceGuestImageContents(GuestImageResource image)


### PR DESCRIPTION
Brings the emulator up on Linux and fixes several runtime crashes that
blocked titles from reaching the Vulkan presenter.

### Linux platform support
- Replace the kernel32-based memory backend with an mmap/POSIX path so
  `PhysicalVirtualMemory` works off Windows.
- Route the Win32 host procedure lookups through Linux thunks, and
  short-circuit the kernel32-only native worker off Windows.
- Unix signal handling for guest access faults.

### Guest-thread scheduling and pthread semantics
- Fix mutex identity so an object reachable through aliased addresses
  resolves to one state, and correct rwlock/condvar wake-key handling.
- PlayGo open and assorted HLE export fixes.

### GC fail-fast on guest threads
Guest threads execute managed HLE on a hijacked stack that the GC cannot
walk, so any collection landing mid-export fail-fasts the runtime with a
misleading "attempted to call an UnmanagedCallersOnly method from managed
code" error.

`TryReadWideCString` was the reliable trigger: it allocated its 1 MiB
ceiling up front, putting a 2 MB array on the Large Object Heap for every
`vswprintf` call, and an LOH allocation forces a GC. It now measures the
string first and allocates exactly its length. Type initializers for the
Silk.NET and framework assemblies are also warmed on the host thread, so a
guest thread is never the first to run a `.cctor`.

### Presenter
`vkQueuePresentKHR` is the only throttle on the window loop, so a
`RenderCore` with nothing to present spun the callback flat out, pegging a
core and starving the guest threads it was waiting on. It now yields.