### PR TITLE
[HLE] Avoid duplicate export registration

### DIFF
--- a/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
+++ b/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
@@ -83,7 +83,6 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
             ImportTraceLimit = Math.Max(0, options.ImportTraceLimit),
         };
         var moduleManager = new ModuleManager();
-        moduleManager.RegisterFromAssembly(typeof(VideoOutExports).Assembly, Generation.Gen4 | Generation.Gen5, Aerolib.Instance);
         moduleManager.RegisterFromAssembly(typeof(KernelExports).Assembly, Generation.Gen4 | Generation.Gen5, Aerolib.Instance);
         moduleManager.Freeze();
 


### PR DESCRIPTION
## What changed

Register the `SharpEmu.Libs` assembly once when creating the default runtime. `VideoOutExports` and `KernelExports` are part of the same assembly, so scanning both assembly references registered every HLE export twice.

## Why

The second scan did not add exports because duplicate NIDs were skipped, but it produced 585 warnings on every startup and performed unnecessary reflection work. Removing the redundant scan keeps the existing export set and makes startup logs useful again.

## Verification

The contributor built the change locally and ran the same title before and after it:

- Duplicate NID warnings decreased from 585 to 0.
- Total warnings decreased from 586 to 1.
- HLE resolutions remained at 567.
- Direct bridges remained at 711.
- Import trampolines remained at 2,112.

`git diff --check` also passes.