### PR TITLE
[AGC] Fix v_fmac_f32 family decoding in Gen5 VOP2 table

### DIFF
--- a/src/SharpEmu.Libs/Agc/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5ShaderTranslator.cs
@@ -718,7 +718,7 @@ internal static class Gen5ShaderTranslator
         }
 
         var src0 = word & 0x1FF;
-        sizeDwords = opcode is 0x20 or 0x21 || src0 is 0xF9 or 0xFA or 0xFF ? 2u : 1u;
+        sizeDwords = opcode is 0x20 or 0x21 or 0x2C or 0x2D || src0 is 0xF9 or 0xFA or 0xFF ? 2u : 1u;
         error = string.Empty;
         name = opcode switch
         {
@@ -757,7 +757,9 @@ internal static class Gen5ShaderTranslator
             0x28 => "VAddcU32",
             0x29 => "VSubbU32",
             0x2A => "VSubbrevU32",
-            0x2B => "VLdexpF32",
+            0x2B => "VFmacF32",
+            0x2C => "VFmamkF32",
+            0x2D => "VFmaakF32",
             0x2F => "VCvtPkrtzF16F32",
             0x30 => "VCvtPkU16U32",
             0x31 => "VCvtPkI16I32",
@@ -870,6 +872,7 @@ internal static class Gen5ShaderTranslator
             0x10F => "VMinF32",
             0x110 => "VMaxF32",
             0x11F => "VMacF32",
+            0x12B => "VFmacF32",
             0x12F => "VCvtPkrtzF16F32",
             0x141 => "VMadF32",
             0x143 => "VMadU32U24",
@@ -1379,7 +1382,7 @@ internal static class Gen5ShaderTranslator
                         Gen5Operand.Source(word & 0x1FF, literal),
                         Gen5Operand.Vector((word >> 9) & 0xFF),
                     ];
-                    if (opcode == "VMadMkF32" && literal.HasValue)
+                    if (opcode is "VMadMkF32" or "VFmamkF32" && literal.HasValue)
                     {
                         sources =
                         [
@@ -1388,7 +1391,7 @@ internal static class Gen5ShaderTranslator
                             sources[1],
                         ];
                     }
-                    else if (opcode == "VMadAkF32" && literal.HasValue)
+                    else if (opcode is "VMadAkF32" or "VFmaakF32" && literal.HasValue)
                     {
                         sources =
                         [

--- a/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
@@ -255,6 +255,8 @@ internal static partial class Gen5SpirvTranslator
                 case "VFmaF32":
                 case "VMadMkF32":
                 case "VMadAkF32":
+                case "VFmamkF32":
+                case "VFmaakF32":
                     result = EmitFloatResult(
                         instruction,
                         Ext(
@@ -265,6 +267,7 @@ internal static partial class Gen5SpirvTranslator
                             GetFloatSource(instruction, 2)));
                     break;
                 case "VMacF32":
+                case "VFmacF32":
                 {
                     var addend = Bitcast(_floatType, LoadV(destination));
                     result = EmitFloatResult(


### PR DESCRIPTION
## What this fixes

The Gen5 VOP2 decode table maps opcode `0x2B` to `v_ldexp_f32`. That is the **gfx6/gfx7 (GCN1/2)** assignment. On gfx10-class hardware — which is what Gen5 shaders use — VOP2 `0x2B` is **`v_fmac_f32`**, the standard fused multiply-accumulate that RDNA compilers emit constantly.

The consequences today:

- A shader containing `v_fmac_f32 dst, a, b` (`dst += a * b`) decodes as `VLdexpF32` and is translated to `ldexp(a, b)` — **silently wrong math, no error reported**.
- `v_fmamk_f32` (`0x2C`) and `v_fmaak_f32` (`0x2D`), which carry a mandatory 32-bit literal K, are unknown to the decoder, so any shader containing one fails to decode entirely (`unknown-vop2 op=0x2C`).

## Why I'm confident the current mapping is wrong

1. **LLVM's AMDGPU backend** ([`VOP2Instructions.td`](https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AMDGPU/VOP2Instructions.td)):
   - `V_FMAC_F32 : VOP2_Real_gfx10<0x02b>`, `V_FMAMK_F32 <0x02c>`, `V_FMAAK_F32 <0x02d>`
   - `V_LDEXP_F32 : VOP2_Real_gfx6_gfx7<0x02b>` — the ldexp meaning of `0x2B` exists **only** on gfx6/gfx7
   - `V_LDEXP_F32 : VOP3Only_Real_gfx10<0x362>` — on gfx10, ldexp is VOP3-only at `0x362`
2. **This repo's own tables agree it targets gfx10 numbering**: the VOP3 table already maps `0x362 => VLdexpF32` (a gfx10-only slot — the gfx6 VOP3 promotion would have been `0x12B`), and the embedded fixed-function shader blobs in `Gen5ShaderTranslator.cs` decode correctly only under gfx10 rules (e.g. `0xBFA00001` = `s_inst_prefetch 1`, `0xD7460002` = VOP3 `0x346` `v_lshl_add_u32` — both gfx10-only opcodes already present in the tables).

So the `0x2B => VLdexpF32` row is a gfx6-era leftover in an otherwise gfx10 table.

## Changes

`Gen5ShaderTranslator.cs`:
- VOP2 table: `0x2B => VFmacF32` (was `VLdexpF32`), add `0x2C => VFmamkF32`, `0x2D => VFmaakF32`.
- Instruction sizing: count the mandatory literal dword for `0x2C`/`0x2D`, same as the existing `v_madmk`/`v_madak` (`0x20`/`0x21`) handling.
- Operand construction: fmamk/fmaak reuse the existing madmk/madak literal-placement logic (K is the middle source for *mk, the last source for *ak).
- VOP3 table: add `0x12B => VFmacF32` (the VOP3-encoded form, `0x100 + 0x2B`, used when source modifiers are present — same pattern as the existing `0x11F => VMacF32`).

`Gen5SpirvTranslator.Alu.cs`:
- `VFmacF32` joins the `VMacF32` case (already emits `fma(s0, s1, dst)`, which is exactly fmac's semantics).
- `VFmamkF32`/`VFmaakF32` join the `VMadF32`/`VFmaF32`/`VMadMkF32`/`VMadAkF32` case (emits `fma(s0, s1, s2)`).

No new files; net +10/−4 lines.

## How it was verified

I don't currently own PS5 game dumps, so verification is synthetic (no console-derived bytes):

1. Hand-assembled gfx1013 words, cross-checked against LLVM's encodings, fed through `Gen5ShaderTranslator.Describe` with a fake `ICpuMemory`:
   - **Before**: `v_fmac_f32 v5, v1, v2` (`0x560A0501`) decoded as `ops=VLdexpF32:1`; a `v_fmamk_f32` program failed with `error=unknown-vop2 op=0x2C`.
   - **After**: `ops=VFmacF32:1` and the second program decodes fully: `VFmamkF32:1, VFmaakF32:1, VFmacF32:1 (VOP3 0x12B), VLdexpF32:1 (VOP3 0x362 — regression check, unchanged), SEndpgm:1` — with the literal dwords consumed correctly (5 instructions from 9 words).
2. Full solution builds with 0 warnings / 0 errors (`dotnet build SharpEmu.slnx`, SDK 10.0.103).
3. Anyone with llvm-mc can double-check the encodings: `echo "v_fmac_f32 v5, v1, v2" | llvm-mc -triple=amdgcn -mcpu=gfx1013 -show-encoding`.

I'd appreciate a regression run from anyone with game dumps handy (e.g. the #2 / #9 reporters), since fmac appearing in previously-"working" shaders would have been producing wrong values rather than errors.

## Notes

- Per the AI-assisted contribution policy: this change was developed with AI assistance; I understand and can explain every line, and the commit is marked accordingly.
- Related follow-ups I noticed but kept out of this PR to stay single-topic (happy to file issues): VOP3 `0x16B` is labeled `VMulLoI32` but is gfx10's `v_mul_hi_i32` (currently a hard emit failure), and SOPP is missing the gfx10 hint ops `s_clause`/`s_waitcnt_depctr`/`s_round_mode`/`s_denorm_mode` (`0x21`–`0x25`), which currently fail whole-shader decode even though emission would no-op them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
