### PR TITLE
[CPU] Preserve guest return value across TLS lookup

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -1992,9 +1992,16 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 		byte* code = (byte*)ptr;
 		int offset = 0;
-		EmitByte(code, ref offset, 0x48); // sub rsp, 0x20
+		// TlsGetValue returns its TLS pointer in RAX. Preserve the guest return value
+		// above the 32-byte Windows shadow space while keeping the call site aligned.
+		EmitByte(code, ref offset, 0x48); // sub rsp, 0x30
 		EmitByte(code, ref offset, 0x83);
 		EmitByte(code, ref offset, 0xEC);
+		EmitByte(code, ref offset, 0x30);
+		EmitByte(code, ref offset, 0x48); // mov [rsp+0x20], rax
+		EmitByte(code, ref offset, 0x89);
+		EmitByte(code, ref offset, 0x44);
+		EmitByte(code, ref offset, 0x24);
 		EmitByte(code, ref offset, 0x20);
 		EmitByte(code, ref offset, 0xB9); // mov ecx, tlsIndex
 		EmitUInt32(code, ref offset, _hostRspSlotTlsIndex);
@@ -2004,13 +2011,21 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		offset += sizeof(ulong);
 		EmitByte(code, ref offset, 0xFF); // call rax
 		EmitByte(code, ref offset, 0xD0);
-		EmitByte(code, ref offset, 0x48); // add rsp, 0x20
+		EmitByte(code, ref offset, 0x49); // mov r11, rax
+		EmitByte(code, ref offset, 0x89);
+		EmitByte(code, ref offset, 0xC3);
+		EmitByte(code, ref offset, 0x48); // mov rax, [rsp+0x20]
+		EmitByte(code, ref offset, 0x8B);
+		EmitByte(code, ref offset, 0x44);
+		EmitByte(code, ref offset, 0x24);
+		EmitByte(code, ref offset, 0x20);
+		EmitByte(code, ref offset, 0x48); // add rsp, 0x30
 		EmitByte(code, ref offset, 0x83);
 		EmitByte(code, ref offset, 0xC4);
-		EmitByte(code, ref offset, 0x20);
-		EmitByte(code, ref offset, 0x48); // mov rsp, [rax]
+		EmitByte(code, ref offset, 0x30);
+		EmitByte(code, ref offset, 0x49); // mov rsp, [r11]
 		EmitByte(code, ref offset, 0x8B);
-		EmitByte(code, ref offset, 0x20);
+		EmitByte(code, ref offset, 0x23);
 		EmitHostNonvolatileXmmRestore(code, ref offset);
 		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5F);
 		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5E);


### PR DESCRIPTION
## What does this change do?

Preserves the guest scalar return value in `RAX` while the native return stub retrieves the saved host stack pointer with `TlsGetValue`.

The stub now:

- reserves 32 bytes of Windows shadow space plus aligned local storage;
- saves the guest `RAX` value outside the shadow space;
- calls `TlsGetValue` and keeps its TLS pointer in volatile register `R11`;
- restores the original guest `RAX` value before switching back to the host stack.

## Why is this needed?

The previous stub called `TlsGetValue` directly after the guest returned. Since both scalar function return values and the result of `TlsGetValue` use `RAX`, the TLS pointer replaced the guest return value. Its low bits could then be interpreted as a non-zero guest result, causing an otherwise successful native execution to be reported as failed.

This follows Microsoft's x64 ABI documentation:

- Scalar return values are returned in `RAX`, and `RAX`/`R11` are volatile registers: https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170
- The caller provides 32 bytes of shadow space and maintains 16-byte stack alignment: https://learn.microsoft.com/en-us/cpp/build/stack-usage?view=msvc-170
- `TlsGetValue` returns the value stored in the requested TLS slot: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-tlsgetvalue

## Verification

Seven fresh execution logs were reviewed after rebuilding with this change. They contained 19 completed guest returns, all reported with the expected zero value, with no `Guest entry point returned non-zero` or `Native backend FAILED` messages caused by the return path.

All completed return cases in this test set were zero-valued. The emitted stub preserves and restores the full 64-bit `RAX` value without changing it.