### PR TITLE
[AGC] Support VOP3 signed 32-bit multiplies (v_mul_lo_i32, v_mul_hi_i32)

### DIFF
--- a/src/SharpEmu.Libs/Agc/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5ShaderTranslator.cs
@@ -900,6 +900,7 @@ internal static class Gen5ShaderTranslator
             0x169 => "VMulLoU32",
             0x16A => "VMulHiU32",
             0x16B => "VMulLoI32",
+            0x16C => "VMulHiI32",
             0x360 => "VMadU32U16",
             0x361 => "VMulLoU32",
             0x362 => "VLdexpF32",

--- a/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
@@ -337,6 +337,7 @@ internal static partial class Gen5SpirvTranslator
                     result = EmitSubtractWithBorrow(instruction, reverse: true);
                     break;
                 case "VMulLoU32":
+                case "VMulLoI32":
                 case "VMulU32U24":
                     result = EmitIntegerBinary(instruction, SpirvOp.IMul);
                     break;
@@ -369,6 +370,29 @@ internal static partial class Gen5SpirvTranslator
                         _uintType,
                         ShiftRightLogical64(
                             product,
+                            _module.Constant64(_ulongType, 32)));
+                    break;
+                }
+                case "VMulHiI32":
+                {
+                    var wideLeft = _module.AddInstruction(
+                        SpirvOp.SConvert,
+                        _longType,
+                        Bitcast(_intType, GetRawSource(instruction, 0)));
+                    var wideRight = _module.AddInstruction(
+                        SpirvOp.SConvert,
+                        _longType,
+                        Bitcast(_intType, GetRawSource(instruction, 1)));
+                    var product = _module.AddInstruction(
+                        SpirvOp.IMul,
+                        _longType,
+                        wideLeft,
+                        wideRight);
+                    result = _module.AddInstruction(
+                        SpirvOp.UConvert,
+                        _uintType,
+                        ShiftRightLogical64(
+                            Bitcast(_ulongType, product),
                             _module.Constant64(_ulongType, 32)));
                     break;
                 }


### PR DESCRIPTION
## What this fixes

Follow-up to #103, in the same spirit: two gaps around the VOP3 signed 32-bit multiplies, each of which fails an entire shader today:

- **`v_mul_lo_i32` (VOP3 `0x16B`)** decodes correctly but has **no emission case**, so any shader containing it fails SPIR-V compilation with `unsupported vector opcode VMulLoI32`.
- **`v_mul_hi_i32` (VOP3 `0x16C`)** is **missing from the decode table** entirely — it decodes as an opaque `Vop3Raw16C`, which likewise fails at emission.

One correction for the record: the notes in #103 guessed that `0x16B` was mislabeled. On closer investigation that was wrong — LLVM confirms `V_MUL_LO_I32` really is gfx10 `0x16b` (`VOP3_Real_gfx10<0x16b>` in [`VOP3Instructions.td`](https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AMDGPU/VOP3Instructions.td)), so the existing label stays. The actual gaps were the missing emit case and the missing `0x16C` entry. The full confirmed sequence:

| opcode | instruction | in decode table? | in emitter? |
|--------|-------------|------------------|-------------|
| `0x169` | `v_mul_lo_u32` | yes | yes |
| `0x16A` | `v_mul_hi_u32` | yes | yes |
| `0x16B` | `v_mul_lo_i32` | yes | **no → added** |
| `0x16C` | `v_mul_hi_i32` | **no → added** | **no → added** |

## Changes

`Gen5ShaderTranslator.cs`: add `0x16C => VMulHiI32` to the VOP3 table.

`Gen5SpirvTranslator.Alu.cs`:
- `VMulLoI32` joins the existing `VMulLoU32`/`VMulU32U24` `IMul` case — in two's complement the low 32 bits of a product are identical for signed and unsigned operands, which is exactly why gfx10 kept only one *hi* per signedness but the *lo* results coincide.
- `VMulHiI32` gets a new case mirroring the existing `VMulHiU32` pattern, with sign extension instead of zero extension: bitcast operands to int, `SConvert` to 64-bit, multiply, take bits 63:32 of the product.

+25 lines, no new files.

## Verification (no game dumps used)

Same synthetic approach as #103, extended to cover emission this time since that's where the failure lives. A test program containing all four multiplies (`0x169`/`0x16A`/`0x16B`/`0x16C`, words cross-checked against LLVM's encodings) was fed through `Gen5ShaderTranslator` decode **and** `Gen5SpirvTranslator.TryCompileVertexShader` end-to-end:

- **Before**: decode shows `...VMulLoI32:1,Vop3Raw16C:1...`; compilation fails with `block=0x0: pc=0x10 VMulLoI32: unsupported vector opcode VMulLoI32`.
- **After**: decode shows all four by name (`VMulLoU32:1,VMulHiU32:1,VMulLoI32:1,VMulHiI32:1`); the program **compiles to 2384 bytes of SPIR-V**. The two unsigned multiplies serve as regression checks.

Full solution builds with 0 warnings / 0 errors (SDK 10.0.103).

**CI on my fork is green for this branch, including REUSE compliance:** https://github.com/Deeptanshuu/sharpemu/actions/runs/29261484460 — the run's `sharpemu-win64-d77895c` artifact is a Windows build containing this fix for anyone who wants to regression-test with real dumps.

## Notes

- Per the AI-assisted contribution policy: developed with AI assistance; I understand the change and can walk through it in review.
- Remaining known gap in the same family, left out to stay single-topic: the gfx10 SOPP hint ops (`s_clause`/`s_waitcnt_depctr`/`s_round_mode`/`s_denorm_mode`, `0x21`–`0x25`) are still missing from the decoder and fail whole-shader decode, even though emission already no-ops non-branch SOPP instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
