### PR TITLE
[AGC] Decode gfx10 SOPP hint instructions

### DIFF
--- a/src/SharpEmu.Libs/Agc/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5ShaderTranslator.cs
@@ -621,6 +621,10 @@ internal static class Gen5ShaderTranslator
             0x10 => "SSendmsg",
             0x16 => "STtraceData",
             0x20 => "SInstPrefetch",
+            0x21 => "SClause",
+            0x23 => "SWaitcntDepctr",
+            0x24 => "SRoundMode",
+            0x25 => "SDenormMode",
             _ => string.Empty,
         };
 

--- a/src/SharpEmu.Libs/Agc/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5ShaderTranslator.cs
@@ -623,8 +623,6 @@ internal static class Gen5ShaderTranslator
             0x20 => "SInstPrefetch",
             0x21 => "SClause",
             0x23 => "SWaitcntDepctr",
-            0x24 => "SRoundMode",
-            0x25 => "SDenormMode",
             _ => string.Empty,
         };
 


### PR DESCRIPTION
## What this fixes

Follow-up to #103 / #106. The SOPP decode table currently ends at `s_inst_prefetch` (`0x20`), so gfx10 scheduling-hint instructions are unknown to the decoder:

| opcode | instruction | purpose |
|--------|-------------|---------|
| `0x21` | `s_clause` | marks a memory-instruction clause for the hardware scheduler |
| `0x23` | `s_waitcnt_depctr` | fine-grained dependency-counter wait hint |

An unknown SOPP opcode is a hard decode error (`unknown-sopp op=0x21`), which rejects the **entire shader**. `s_clause` in particular is routinely emitted by RDNA compilers ahead of clustered memory loads, so this failure mode is likely common in real shader binaries — I don't own game dumps to quantify that, so regression reports from dump owners are very welcome.

**Scope note (updated per review):** the first revision also added `s_round_mode` (`0x24`) and `s_denorm_mode` (`0x25`). As the review below points out, those two write the shader floating-point MODE state (RDNA2 ISA §6.4), and the emitter's blanket SOPP no-op would have silently ignored their `simm16` payloads — converting an explicit decode failure into a potential silent FP-semantics mismatch. They've been removed and continue to fail decode loudly. Follow-up options are in the review thread.

## Changes

Two entries in the `DecodeSopp` table (`Gen5ShaderTranslator.cs`). +2 lines, nothing else.

**No emitter changes are needed:** `Gen5SpirvTranslator.TryEmitInstruction` already emits every non-branch SOPP instruction as a no-op. For these two that is semantically exact — they are pure scheduler/dependency hints with no effect on computed values.

## Evidence for the opcode numbers

LLVM's AMDGPU backend ([`SOPInstructions.td`](https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AMDGPU/SOPInstructions.td)):

```
defm S_CLAUSE          : SOPP_Real_32_gfx10_gfx13<0x021>;
defm S_WAITCNT_DEPCTR  : SOPP_Real_32_gfx10_Renamed_gfx13<0x023, "s_wait_alu">;
```

(gfx11/gfx12 renumbered these instructions; the additions here follow gfx10, consistent with the numbering evidence established in #103/#106.)

## Verification (synthetic, no game dumps used)

Same approach as #103/#106: hand-assembled programs fed through decode and full SPIR-V compilation:

- **Before:** `s_clause 0x1; s_waitcnt_depctr 0; s_endpgm` fails with `error=unknown-sopp op=0x21` — the whole shader is rejected at decode.
- **After:** both decode by name (`SClause:1,SWaitcntDepctr:1,SEndpgm:1`) and the program compiles end-to-end to 1288 bytes of SPIR-V through the existing SOPP no-op emit path.
- **Unchanged:** a program containing `s_round_mode` still fails loudly (`error=unknown-sopp op=0x24`), preserving the explicit-failure behavior for the FP-mode instructions.

Full solution builds with 0 warnings / 0 errors (SDK 10.0.103).

**CI on my fork is green for this branch, including REUSE compliance:** https://github.com/Deeptanshuu/sharpemu/actions/runs/29272654233

## Notes

Developed with AI assistance per the contribution policy; I understand the change and can walk through it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
