### PR TITLE
[AGC] Support scalar high 32-bit multiplies

### DIFF
--- a/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
@@ -1136,6 +1136,52 @@ internal static partial class Gen5SpirvTranslator
                                 left,
                                 right);
                             break;
+                        case "SMulHiU32":
+                        {
+                            var wideLeft = _module.AddInstruction(
+                                SpirvOp.UConvert,
+                                _ulongType,
+                                left);
+                            var wideRight = _module.AddInstruction(
+                                SpirvOp.UConvert,
+                                _ulongType,
+                                right);
+                            var product = _module.AddInstruction(
+                                SpirvOp.IMul,
+                                _ulongType,
+                                wideLeft,
+                                wideRight);
+                            result = _module.AddInstruction(
+                                SpirvOp.UConvert,
+                                _uintType,
+                                ShiftRightLogical64(
+                                    product,
+                                    _module.Constant64(_ulongType, 32)));
+                            break;
+                        }
+                        case "SMulHiI32":
+                        {
+                            var wideLeft = _module.AddInstruction(
+                                SpirvOp.SConvert,
+                                _longType,
+                                Bitcast(_intType, left));
+                            var wideRight = _module.AddInstruction(
+                                SpirvOp.SConvert,
+                                _longType,
+                                Bitcast(_intType, right));
+                            var product = _module.AddInstruction(
+                                SpirvOp.IMul,
+                                _longType,
+                                wideLeft,
+                                wideRight);
+                            result = _module.AddInstruction(
+                                SpirvOp.UConvert,
+                                _uintType,
+                                ShiftRightLogical64(
+                                    Bitcast(_ulongType, product),
+                                    _module.Constant64(_ulongType, 32)));
+                            break;
+                        }
                         case "SAndB32":
                             result = BitwiseAnd(left, right);
                             Store(_scc, IsNotZero(result));


### PR DESCRIPTION
## What this fixes

The gfx10 SOP2 decoder already recognizes `s_mul_hi_u32` (`0x35`) and `s_mul_hi_i32` (`0x36`), but the scalar SPIR-V emitter has no cases for them. Encountering either instruction therefore rejects the shader as an unsupported scalar opcode.

## Changes

- Emit `s_mul_hi_u32` by zero-extending both operands to 64 bits, multiplying, and extracting bits 63:32.
- Emit `s_mul_hi_i32` by sign-extending both operands to 64 bits, multiplying, and extracting the high 32-bit two's-complement pattern.
- Preserve SCC for both instructions, matching their ISA semantics.

The change is limited to `Gen5SpirvTranslator.Alu.cs` and follows the existing `VMulHiU32` / `VMulHiI32` SPIR-V patterns. No decoder, helper, package, solution, or CI changes are included.

## Verification

Using the repository-pinned .NET SDK 10.0.103:

- `dotnet restore SharpEmu.slnx --locked-mode`
- `dotnet build SharpEmu.slnx -c Release --no-restore` — 0 warnings, 0 errors
- `git diff --check`

The high-half arithmetic was also checked for these boundary cases:

- unsigned: `FFFFFFFF*FFFFFFFF -> FFFFFFFE`, `1*1 -> 0`, `80000000*2 -> 1`, `0*0 -> 0`
- signed: `-1*-1 -> 0`, `INT_MIN*INT_MIN -> 40000000`, `INT_MAX*2 -> 0`, `-1*1 -> FFFFFFFF`

## Test coverage

There is not yet a shader test project on upstream `main`; the proposed minimal harness in #36 has not landed. This PR deliberately does not introduce a competing test project or package/solution changes. A focused regression test can follow once the project has accepted test conventions.

## AI assistance

Developed with AI assistance per the contribution policy. I independently reviewed the emitted SPIR-V types, arithmetic semantics, scope, and build output and can explain and maintain the change.