### PR TITLE
Add guest CRT bootstrap with fail-closed dlsym and ET_EXEC load-base rebasing

### DIFF
--- a/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
+++ b/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
@@ -29,8 +29,17 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
     private const ulong BootstrapStubBaseAddress = 0x7FFD_F000_0000UL;
     private const ulong BootstrapPayloadBaseAddress = 0x7FFD_E000_0000UL;
     private const ulong DynlibFallbackStubBaseAddress = 0x7FFD_D000_0000UL;
+    private const ulong GuestCrtDlsymStubBaseAddress = 0x7FFD_B000_0000UL;
+    private const ulong CrtLazyImportPoolBaseAddress = 0x7FFD_A000_0000UL;
+    private const ulong CrtLazyImportPoolSize = 0x0020_0000UL;
     private const ulong ReturnToHostStubBaseAddress = 0x7FFD_C000_0000UL;
     private const ulong BootstrapRegionSize = 0x0000_1000UL;
+    private const ulong GuestCrtPayloadArgsSize = 0x30UL;
+    private const ulong GuestCrtPayloadArgsDlsymOffset = 0x00UL;
+    private const ulong GuestCrtPayloadArgsRwpipeOffset = 0x08UL;
+    private const ulong GuestCrtPayloadArgsRwpairOffset = 0x10UL;
+    private const ulong GuestCrtPayloadArgsPayloadOutOffset = 0x28UL;
+    private const byte GuestCrt0JumpOpcode = 0xE9;
     private const ulong ReturnToHostStubStride = 0x0100_0000UL;
     private const ulong BootstrapPayloadResultOffset = 0x28UL;
     private const ulong BootstrapStatusOffset = 0x100UL;
@@ -217,19 +226,35 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
                 return FailEarly(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             }
 
-            if (!InitializeProcessEntryFrame(context, processImageName, programExitHandlerStubAddress))
+            if (ShouldInjectBootstrapPayload(entryPoint, runtimeSymbols))
             {
-                return FailEarly(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
-            }
+                if (!InitializeProcessEntryFrame(context, processImageName, programExitHandlerStubAddress))
+                {
+                    return FailEarly(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+                }
 
-            entryParamsConfigured = true;
-
-            if (ShouldInjectBootstrapPayload(entryPoint))
-            {
+                entryParamsConfigured = true;
                 if (!TryInstallBootstrapPayload(context, effectiveImportStubs))
                 {
                     return FailEarly(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
                 }
+            }
+            else if (TryDetectGuestCrtEntry(entryPoint, runtimeSymbols))
+            {
+                if (!InitializeGuestCrtEntryFrame(context, effectiveImportStubs))
+                {
+                    return FailEarly(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+                }
+
+                entryParamsConfigured = true;
+            }
+            else if (!InitializeProcessEntryFrame(context, processImageName, programExitHandlerStubAddress))
+            {
+                return FailEarly(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+            else
+            {
+                entryParamsConfigured = true;
             }
         }
         else if (!InitializeModuleInitializerFrame(context))
@@ -441,6 +466,131 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
         return true;
     }
 
+    private bool TryDetectGuestCrtEntry(
+        ulong entryPoint,
+        IReadOnlyDictionary<string, ulong>? runtimeSymbols)
+    {
+        if (runtimeSymbols is not null &&
+            // Guest CRT entry symbol (ELF export name literal).
+            runtimeSymbols.TryGetValue("__ps5sdk_crt_start", out var crtStart))
+        {
+            if (crtStart == entryPoint)
+            {
+                return true;
+            }
+
+            if (runtimeSymbols.TryGetValue("_start", out var startAddress) &&
+                startAddress == entryPoint)
+            {
+                return true;
+            }
+
+            if (runtimeSymbols.TryGetValue("_start", out startAddress) &&
+                entryPoint != crtStart &&
+                IsAddressInMainExecutableRange(entryPoint, startAddress, runtimeSymbols))
+            {
+                return true;
+            }
+
+            Span<byte> probe = stackalloc byte[5];
+            if (_virtualMemory.TryRead(entryPoint, probe) && probe[0] == GuestCrt0JumpOpcode)
+            {
+                var rel32 = BitConverter.ToInt32(probe.Slice(1, 4));
+                var jumpTarget = unchecked((ulong)((long)entryPoint + 5 + rel32));
+                if (jumpTarget == crtStart)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    private static bool IsAddressInMainExecutableRange(
+        ulong address,
+        ulong moduleAnchor,
+        IReadOnlyDictionary<string, ulong> runtimeSymbols)
+    {
+        ulong imageBase = moduleAnchor;
+        ulong imageEnd = moduleAnchor;
+        foreach (var value in runtimeSymbols.Values)
+        {
+            if (value < 0x10000 || value >= 0x80000000)
+            {
+                continue;
+            }
+
+            imageBase = Math.Min(imageBase, value);
+            imageEnd = Math.Max(imageEnd, value);
+        }
+
+        const ulong imageSlack = 0x200000;
+        return address >= imageBase && address <= imageEnd + imageSlack;
+    }
+
+    private bool InitializeGuestCrtEntryFrame(
+        CpuContext context,
+        IDictionary<ulong, string> importStubs)
+    {
+        var dlsymStubAddress = TryMapGuestCrtDlsymStubRegion();
+        if (dlsymStubAddress == 0)
+        {
+            return false;
+        }
+
+        importStubs[dlsymStubAddress] = RuntimeStubNids.KernelDynlibDlsym;
+
+        var cursor = context[CpuRegister.Rsp];
+        var rwpairArrayAddress = AlignDown(cursor - (2 * sizeof(uint)), sizeof(ulong));
+        if (!context.TryWriteUInt32(rwpairArrayAddress, 0) ||
+            !context.TryWriteUInt32(rwpairArrayAddress + sizeof(uint), 0))
+        {
+            return false;
+        }
+
+        var rwpipeArrayAddress = AlignDown(rwpairArrayAddress - (2 * sizeof(uint)), sizeof(ulong));
+        if (!context.TryWriteUInt32(rwpipeArrayAddress, 0) ||
+            !context.TryWriteUInt32(rwpipeArrayAddress + sizeof(uint), 0))
+        {
+            return false;
+        }
+
+        var payloadOutAddress = AlignDown(rwpipeArrayAddress - sizeof(uint), sizeof(ulong));
+        if (!context.TryWriteUInt32(payloadOutAddress, 0))
+        {
+            return false;
+        }
+
+        var payloadArgsAddress = AlignDown(payloadOutAddress - GuestCrtPayloadArgsSize, 16);
+        if (!context.TryWriteUInt64(payloadArgsAddress + GuestCrtPayloadArgsDlsymOffset, dlsymStubAddress) ||
+            !context.TryWriteUInt64(payloadArgsAddress + GuestCrtPayloadArgsRwpipeOffset, rwpipeArrayAddress) ||
+            !context.TryWriteUInt64(payloadArgsAddress + GuestCrtPayloadArgsRwpairOffset, rwpairArrayAddress) ||
+            !context.TryWriteUInt64(payloadArgsAddress + 0x18, 0) ||
+            !context.TryWriteUInt64(payloadArgsAddress + 0x20, 0) ||
+            !context.TryWriteUInt64(payloadArgsAddress + GuestCrtPayloadArgsPayloadOutOffset, payloadOutAddress))
+        {
+            return false;
+        }
+
+        var entryStackPointer = payloadArgsAddress - sizeof(ulong);
+        if (!context.TryWriteUInt64(entryStackPointer, 0))
+        {
+            return false;
+        }
+
+        context[CpuRegister.Rsp] = entryStackPointer;
+        context[CpuRegister.Rdi] = payloadArgsAddress;
+        context[CpuRegister.Rsi] = 0;
+        context[CpuRegister.Rdx] = 0;
+        context[CpuRegister.Rcx] = 0;
+        context[CpuRegister.R8] = 0;
+        context[CpuRegister.R9] = 0;
+        return true;
+    }
+
     private static bool InitializeModuleInitializerFrame(CpuContext context)
     {
         context[CpuRegister.Rdi] = 0;
@@ -475,8 +625,16 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
             $"EntryFrame: entry_rip=0x{entryPoint:X16} initial_rsp=0x{initialRsp:X16} [rsp]={stackTopText} sentinel_enabled={sentinelText} sentinel_value={sentinelValueText} entry_params_configured={entryParamsText}";
     }
 
-    private bool ShouldInjectBootstrapPayload(ulong entryPoint)
+    private bool ShouldInjectBootstrapPayload(
+        ulong entryPoint,
+        IReadOnlyDictionary<string, ulong>? runtimeSymbols)
     {
+        if (runtimeSymbols is not null &&
+            runtimeSymbols.ContainsKey("__ps5sdk_crt_start")) // guest CRT entry symbol
+        {
+            return false;
+        }
+
         Span<byte> probe = stackalloc byte[16];
         if (!_virtualMemory.TryRead(entryPoint, probe))
         {
@@ -492,6 +650,13 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
         }
 
         return true;
+    }
+
+    private static bool OverlapsCrtLazyImportPool(ulong candidateBase, ulong regionSize)
+    {
+        var candidateEnd = candidateBase + regionSize;
+        var poolEnd = CrtLazyImportPoolBaseAddress + CrtLazyImportPoolSize;
+        return candidateBase < poolEnd && candidateEnd > CrtLazyImportPoolBaseAddress;
     }
 
     private bool TryInstallBootstrapPayload(CpuContext context, IDictionary<ulong, string> importStubs)
@@ -592,6 +757,40 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
         for (var i = 0; i < 16; i++)
         {
             var candidateBase = DynlibFallbackStubBaseAddress - ((ulong)i * stride);
+            try
+            {
+                _virtualMemory.Map(
+                    candidateBase,
+                    BootstrapRegionSize,
+                    fileOffset: 0,
+                    stubData,
+                    ProgramHeaderFlags.Read | ProgramHeaderFlags.Execute);
+                return candidateBase;
+            }
+            catch (InvalidOperationException)
+            {
+                continue;
+            }
+        }
+
+        return 0;
+    }
+
+    private ulong TryMapGuestCrtDlsymStubRegion()
+    {
+        var stubData = new byte[(int)BootstrapRegionSize];
+        stubData[0] = 0xCC;
+        stubData[1] = 0xC3;
+
+        const ulong stride = 0x0100_0000UL;
+        for (var i = 0; i < 16; i++)
+        {
+            var candidateBase = GuestCrtDlsymStubBaseAddress - ((ulong)i * stride);
+            if (OverlapsCrtLazyImportPool(candidateBase, BootstrapRegionSize))
+            {
+                continue;
+            }
+
             try
             {
                 _virtualMemory.Map(

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Diagnostics.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Diagnostics.cs
@@ -88,6 +88,7 @@ public sealed partial class DirectExecutionBackend
 			_deferredBootstrapTraceCount = 0;
 		}
 
+		Span<byte> symBytes = stackalloc byte[32];
 		foreach (var entry in pending)
 		{
 			var symbolText = "<unreadable>";
@@ -96,10 +97,25 @@ public sealed partial class DirectExecutionBackend
 				symbolText = sym;
 			}
 
+			var outValueText = "<unreadable>";
+			if (entry.OutputPointer != 0 && TryReadUInt64Compat(entry.OutputPointer, out var outValue))
+			{
+				outValueText = $"0x{outValue:X16}";
+			}
+
 			Console.Error.WriteLine(
 				$"[LOADER][TRACE] bootstrap_call#{entry.DispatchIndex}: op=0x{entry.Op:X16} " +
 				$"sym_ptr=0x{entry.SymbolPointer:X16} sym='{symbolText}' " +
-				$"out_ptr=0x{entry.OutputPointer:X16} ret=0x{entry.ReturnRip:X16}");
+				$"out_ptr=0x{entry.OutputPointer:X16} *out_ptr={outValueText} ret=0x{entry.ReturnRip:X16}");
+
+			if (entry.Op == 2 && entry.SymbolPointer != 0)
+			{
+				if (ActiveCpuContext?.Memory.TryRead(entry.SymbolPointer, symBytes) == true)
+				{
+					Console.Error.WriteLine(
+						$"[LOADER][TRACE] bootstrap_call#{entry.DispatchIndex}: sym_bytes={Convert.ToHexString(symBytes)}");
+				}
+			}
 		}
 	}
 

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -9,7 +9,9 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using SharpEmu.Core.Cpu;
 using SharpEmu.Core.Loader;
+using SharpEmu.Core.Memory;
 using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
 
 namespace SharpEmu.Core.Cpu.Native;
 
@@ -127,7 +129,7 @@ public sealed partial class DirectExecutionBackend
 		// Leaf imports take a scalar-only fast path that reads its own operands and
 		// intentionally bypasses the SysV variadic XMM marshalling below. This is safe
 		// only while the leaf set contains no float-variadic or float-returning function.
-		// The constraint and the audited list live on IsLeafImport — do not add a
+		// The constraint and the audited list live on IsLeafImport -- do not add a
 		// function that consumes xmm0-7 args or returns in xmm0 to the leaf set;
 		// such functions must stay on the full gateway path below.
 		if (IsLeafImport(importStubEntry.Nid) &&
@@ -163,7 +165,7 @@ public sealed partial class DirectExecutionBackend
 		cpuContext[CpuRegister.Rsp] = (ulong)argPackPtr + 96uL;
 		if (string.Equals(importStubEntry.Nid, RuntimeStubNids.BootstrapBridge, StringComparison.Ordinal))
 		{
-			NormalizeKernelDynlibDlsymArguments(cpuContext, out _, out _);
+			NormalizeBootstrapBridgeArguments(cpuContext, out _, out _);
 			*(ulong*)argPackPtr = cpuContext[CpuRegister.Rdi];
 			*(ulong*)(argPackPtr + 8) = cpuContext[CpuRegister.Rsi];
 			*(ulong*)(argPackPtr + 16) = cpuContext[CpuRegister.Rdx];
@@ -685,7 +687,7 @@ public sealed partial class DirectExecutionBackend
 
 	// Subset of the leaf set that additionally skips the import-call-frame
 	// bookkeeping. The same scalar-only (no XMM args, no XMM return) constraint
-	// as IsLeafImport applies — see the note there before adding entries.
+	// as IsLeafImport applies -- see the note there before adding entries.
 	// NOTE: this filter is only consulted after IsLeafImport accepts the NID;
 	// entries listed here but not in IsLeafImport (scePadRead, scePadOpen,
 	// sceUserServiceGetEvent, sceUserServiceGetPlatformPrivacySetting,
@@ -784,13 +786,13 @@ public sealed partial class DirectExecutionBackend
 			"1G3lF1Gg1k8" or // sceKernelOpen
 			"gEpBkcwxUjw";   // sceKernelAprResolveFilepathsToIdsAndFileSizes
 
-	// LEAF-IMPORT REGISTRATION — scalar-only constraint.
+	// LEAF-IMPORT REGISTRATION -- scalar-only constraint.
 	//
 	// TryDispatchLeafImport is a fast path that never copies the trampoline's XMM
 	// save area into CpuContext and never publishes an XMM0 return back to the
 	// guest (see DispatchImport). Every NID listed here must therefore satisfy BOTH:
-	//   1. no float/double parameters (nothing passed in xmm0..xmm7), and
-	//   2. no float/double return value (nothing returned in xmm0).
+	// 1. no float/double parameters (nothing passed in xmm0..xmm7), and
+	// 2. no float/double return value (nothing returned in xmm0).
 	// Integer/pointer arguments and returns only. va_list-based functions
 	// (vsnprintf) are safe: SysV va_list floats are read from the caller-built
 	// reg_save_area in guest memory, not from the callee's incoming XMM registers.
@@ -798,7 +800,7 @@ public sealed partial class DirectExecutionBackend
 	// If a function that consumes XMM arguments or returns in xmm0 (e.g. powf,
 	// logf, wcstod, sceVideoOutColorSettingsSetGamma_) is ever added here, its
 	// float arguments will silently arrive stale and its return value will be
-	// dropped. Such functions must stay on the full gateway path — do not list them.
+	// dropped. Such functions must stay on the full gateway path -- do not list them.
 	//
 	// Audited 2026-07-11 (PR #59): every NID below maps to a registered
 	// SysAbiExport whose handler neither reads nor writes CpuContext XMM state
@@ -811,7 +813,7 @@ public sealed partial class DirectExecutionBackend
 		}
 
 		// Only mutex/rwlock *lock* is excluded: it may block a contended acquire, which the
-		// leaf path can't. unlock never blocks and stays here — routing it off the fast path
+		// leaf path can't. unlock never blocks and stays here -- routing it off the fast path
 		// slows guest spinlocks enough to livelock (Demon's Souls).
 		return nid is
 			"tn3VlD0hG60" or // scePthreadMutexUnlock
@@ -1318,10 +1320,33 @@ public sealed partial class DirectExecutionBackend
 		}
 
 		NormalizeKernelDynlibDlsymArguments(cpuContext, out var symbolNameAddress, out var outputAddress);
+		var moduleHandle = cpuContext[CpuRegister.Rdi];
 		try
 		{
-			if (!TryReadAsciiZ(symbolNameAddress, 512, out var symbolName) ||
-				!TryResolveDlsymGuestAddress(symbolName, out var resolvedAddress) ||
+			if (!TryReadAsciiZ(symbolNameAddress, 512, out var symbolName))
+			{
+				return CompleteKernelDynlibDlsymFailure(cpuContext, outputAddress);
+			}
+
+			var resolved = false;
+			ulong resolvedAddress = 0;
+			if (moduleHandle == GuestLibkernelModuleId)
+			{
+				resolved = TryResolveGuestLibkernelGuestAddress(symbolName, out resolvedAddress);
+			}
+			else if ((int)moduleHandle > 0 &&
+				KernelModuleRegistry.TryGetModuleByHandle((int)moduleHandle, out var moduleEntry) &&
+				IsGuestLibcModule(in moduleEntry))
+			{
+				resolved = TryResolveGuestLibcGuestAddress(symbolName, in moduleEntry, out resolvedAddress);
+			}
+			else
+			{
+				resolved = TryResolveDlsymGuestAddress(symbolName, out resolvedAddress);
+			}
+
+			if (!resolved ||
+				resolvedAddress == 0 ||
 				outputAddress == 0 ||
 				!TryWriteUInt64Compat(outputAddress, resolvedAddress))
 			{
@@ -1337,6 +1362,57 @@ public sealed partial class DirectExecutionBackend
 		return OrbisGen2Result.ORBIS_GEN2_OK;
 	}
 
+	private static bool IsKnownKernelModuleHandle(ulong value)
+	{
+		if (value == 0 || value >= 0x10000)
+		{
+			return false;
+		}
+
+		return KernelModuleRegistry.TryGetModuleByHandle((int)value, out _);
+	}
+
+	private static void NormalizeBootstrapBridgeArguments(
+		CpuContext cpuContext,
+		out ulong argumentAddress,
+		out ulong outputAddress)
+	{
+		var op = cpuContext[CpuRegister.Rdi];
+		argumentAddress = cpuContext[CpuRegister.Rsi];
+		outputAddress = cpuContext[CpuRegister.Rdx];
+
+		if (IsBootstrapBridgeOp(op))
+		{
+			if (op == BootstrapBridgeOpModuleDescriptor &&
+				IsKnownKernelModuleHandle(op) &&
+				IsPlausibleDynlibSymbolPointer(argumentAddress))
+			{
+				NormalizeKernelDynlibDlsymArguments(cpuContext, out argumentAddress, out outputAddress);
+				return;
+			}
+
+			return;
+		}
+
+		if (IsBootstrapBridgeOp(argumentAddress) &&
+			IsPlausibleDynlibSymbolPointer(op) &&
+			!IsKnownKernelModuleHandle(op))
+		{
+			cpuContext[CpuRegister.Rdi] = argumentAddress;
+			cpuContext[CpuRegister.Rsi] = op;
+			argumentAddress = op;
+			return;
+		}
+
+		NormalizeKernelDynlibDlsymArguments(cpuContext, out argumentAddress, out outputAddress);
+	}
+
+	private static bool IsBootstrapBridgeOp(ulong value)
+	{
+		return value == BootstrapBridgeOpResolveSymbol ||
+			value == BootstrapBridgeOpModuleDescriptor;
+	}
+
 	private static void NormalizeKernelDynlibDlsymArguments(
 		CpuContext cpuContext,
 		out ulong symbolNameAddress,
@@ -1350,6 +1426,7 @@ public sealed partial class DirectExecutionBackend
 		// (symbol_ptr, handle, out) while sceKernelDlsym is (handle, symbol_ptr, out).
 		// Heuristic only: valid when RSI looks like a small handle and RDI is a guest pointer.
 		if (symbolNameAddress < 0x10000 &&
+			!IsKnownKernelModuleHandle(symbolNameAddress) &&
 			IsPlausibleDynlibSymbolPointer(handle))
 		{
 			symbolNameAddress = handle;
@@ -1384,10 +1461,43 @@ public sealed partial class DirectExecutionBackend
 			_lazyImportStubPoolBase = 0;
 			_lazyImportStubNextSlot = 0;
 			_lazyImportStubPoolLimit = 0;
+			_crtLazyImportStubPoolMapped = false;
+			_crtLazyImportStubPoolBase = 0;
+			_crtLazyImportStubNextSlot = 0;
+			_crtLazyImportStubPoolLimit = 0;
+			_crtLazyImportStubPoolBandIndex = 0;
 		}
 	}
 
+	private static bool IsGuestLibcModule(in KernelModuleRegistry.ModuleEntry module)
+	{
+		return ModuleNameLooksLikeGuestLibc(module.Name) ||
+			ModuleNameLooksLikeGuestLibc(module.Path);
+	}
+
+	private static bool ModuleNameLooksLikeGuestLibc(string? moduleName)
+	{
+		if (string.IsNullOrWhiteSpace(moduleName))
+		{
+			return false;
+		}
+
+		return moduleName.Contains("Libc", StringComparison.OrdinalIgnoreCase) ||
+			moduleName.Contains("libSceLibcInternal", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static bool IsLibcLibraryExport(ExportedFunction export)
+	{
+		return string.Equals(export.LibraryName, "libc", StringComparison.OrdinalIgnoreCase) ||
+			export.LibraryName.Contains("Libc", StringComparison.OrdinalIgnoreCase);
+	}
+
 	private bool TryResolveDlsymGuestAddress(string symbolName, out ulong guestAddress)
+	{
+		return TryResolveDlsymGuestAddressCore(symbolName, includeRuntimeSymbols: true, out guestAddress);
+	}
+
+	private bool TryResolveGuestLibkernelGuestAddress(string symbolName, out ulong guestAddress)
 	{
 		guestAddress = 0;
 		if (string.IsNullOrWhiteSpace(symbolName))
@@ -1395,17 +1505,252 @@ public sealed partial class DirectExecutionBackend
 			return false;
 		}
 
-		// Tier 0: ELF runtime symbols and aliases.
-		if (TryResolveRuntimeSymbolAddress(symbolName, out guestAddress) ||
-			TryResolveRuntimeSymbolAlias(symbolName, out guestAddress))
+		if (TryResolveModuleManagerExportStub(symbolName, out guestAddress))
 		{
 			return true;
+		}
+
+		if (TryResolveGuestNamedCompatLazyStub(symbolName, out guestAddress))
+		{
+			return true;
+		}
+
+		if (TryResolveDlsymGuestAddressCore(
+				symbolName,
+				includeRuntimeSymbols: false,
+				out guestAddress,
+				exportFilter: null,
+				useCrtLazyImportStubPool: true))
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	private bool TryResolveGuestNamedCompatLazyStub(string symbolName, out ulong guestAddress)
+	{
+		guestAddress = 0;
+		if (!TryGetGuestLibkernelNamedCompatExport(symbolName, out var export))
+		{
+			return false;
+		}
+
+		if (ActiveCpuContext is { } cpuContext &&
+			(export.Target & cpuContext.TargetGeneration) == 0)
+		{
+			return false;
+		}
+
+		return TryGetOrCreateLazyImportStub(
+			symbolName,
+			symbolName,
+			null,
+			export,
+			out guestAddress,
+			useCrtLazyImportStubPool: true) &&
+			guestAddress != 0;
+	}
+
+	private bool TryGetGuestLibkernelNamedCompatExport(string symbolName, out ExportedFunction export)
+	{
+		export = null!;
+		if (string.Equals(symbolName, "socket", StringComparison.Ordinal))
+		{
+			return _moduleManager.TryGetExport(GuestSocketExportNid, out export) ||
+				_moduleManager.TryGetExportByName("GuestSocket", out export);
+		}
+
+		if (string.Equals(symbolName, "bzero", StringComparison.Ordinal))
+		{
+			return _moduleManager.TryGetExport(GuestBzeroExportNid, out export) ||
+				_moduleManager.TryGetExportByName("bzero", out export);
+		}
+
+		if (string.Equals(symbolName, "connect", StringComparison.Ordinal) ||
+			string.Equals(symbolName, "_connect", StringComparison.Ordinal))
+		{
+			return _moduleManager.TryGetExport(GuestConnectExportNid, out export) ||
+				_moduleManager.TryGetExportByName("GuestConnect", out export);
+		}
+
+		if (string.Equals(symbolName, "inet_pton", StringComparison.Ordinal))
+		{
+			return _moduleManager.TryGetExport(GuestInetPtonExportNid, out export) ||
+				_moduleManager.TryGetExportByName("GuestInetPton", out export);
+		}
+
+		if (string.Equals(symbolName, "htons", StringComparison.Ordinal))
+		{
+			return _moduleManager.TryGetExport(GuestHtonsExportNid, out export) ||
+				_moduleManager.TryGetExportByName("GuestHtons", out export);
+		}
+
+		return false;
+	}
+
+	private bool TryResolveGuestLibcGuestAddress(
+		string symbolName,
+		in KernelModuleRegistry.ModuleEntry module,
+		out ulong guestAddress)
+	{
+		guestAddress = 0;
+		if (string.IsNullOrWhiteSpace(symbolName))
+		{
+			return false;
+		}
+
+		_ = module;
+
+		if (TryResolveModuleManagerLibcExportStub(symbolName, out guestAddress))
+		{
+			return true;
+		}
+
+		if (TryResolveGuestNamedCompatLazyStub(symbolName, out guestAddress))
+		{
+			return true;
+		}
+
+		return TryResolveDlsymGuestAddressCore(
+			symbolName,
+			includeRuntimeSymbols: false,
+			out guestAddress,
+			IsLibcLibraryExport,
+			useCrtLazyImportStubPool: true);
+	}
+
+	private bool TryResolveModuleManagerLibcExportStub(string symbolName, out ulong guestAddress)
+	{
+		guestAddress = 0;
+		foreach (var candidate in EnumerateGuestLibcExportNameCandidates(symbolName))
+		{
+			if (!_moduleManager.TryGetExportByName(candidate, out var export) ||
+				!IsLibcLibraryExport(export))
+			{
+				continue;
+			}
+
+			if (HleDataSymbols.TryGetAddress(export.Nid, out _))
+			{
+				continue;
+			}
+
+			if (ActiveCpuContext is { } cpuContext &&
+				(export.Target & cpuContext.TargetGeneration) == 0)
+			{
+				continue;
+			}
+
+			if (TryGetOrCreateLazyImportStub(
+					export.Nid,
+					symbolName,
+					null,
+					export,
+					out guestAddress,
+					useCrtLazyImportStubPool: true) &&
+				guestAddress != 0)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static IEnumerable<string> EnumerateGuestLibcExportNameCandidates(string symbolName)
+	{
+		yield return symbolName;
+
+		if (symbolName.StartsWith('_') &&
+			!symbolName.StartsWith("__", StringComparison.Ordinal) &&
+			symbolName.Length > 1)
+		{
+			yield return symbolName[1..];
+		}
+	}
+
+	private bool TryResolveModuleManagerExportStub(string symbolName, out ulong guestAddress)
+	{
+		guestAddress = 0;
+		foreach (var candidate in EnumerateGuestLibkernelExportNameCandidates(symbolName))
+		{
+			if (!_moduleManager.TryGetExportByName(candidate, out var export))
+			{
+				continue;
+			}
+
+			if (HleDataSymbols.TryGetAddress(export.Nid, out _))
+			{
+				continue;
+			}
+
+			if (ActiveCpuContext is { } cpuContext &&
+				(export.Target & cpuContext.TargetGeneration) == 0)
+			{
+				continue;
+			}
+
+			if (TryGetOrCreateLazyImportStub(
+					export.Nid,
+					symbolName,
+					null,
+					export,
+					out guestAddress,
+					useCrtLazyImportStubPool: true) &&
+				guestAddress != 0)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static IEnumerable<string> EnumerateGuestLibkernelExportNameCandidates(string symbolName)
+	{
+		yield return symbolName;
+
+		if (symbolName.StartsWith('_') &&
+			!symbolName.StartsWith("__", StringComparison.Ordinal) &&
+			symbolName.Length > 1)
+		{
+			yield return symbolName[1..];
+		}
+
+		if (symbolName.StartsWith("_sce", StringComparison.Ordinal) && symbolName.Length > 4)
+		{
+			yield return symbolName[1..];
+		}
+	}
+
+	private bool TryResolveDlsymGuestAddressCore(
+		string symbolName,
+		bool includeRuntimeSymbols,
+		out ulong guestAddress,
+		Func<ExportedFunction, bool>? exportFilter = null,
+		bool useCrtLazyImportStubPool = false)
+	{
+		guestAddress = 0;
+		if (string.IsNullOrWhiteSpace(symbolName))
+		{
+			return false;
+		}
+
+		if (includeRuntimeSymbols)
+		{
+			// Tier 0: ELF runtime symbols and aliases.
+			if (TryResolveRuntimeSymbolAddress(symbolName, out guestAddress) ||
+				TryResolveRuntimeSymbolAlias(symbolName, out guestAddress))
+			{
+				return guestAddress != 0;
+			}
 		}
 
 		// Tier 1: existing import stub entries (duplicate prevention).
 		if (TryFindImportStubGuestAddress(symbolName, out guestAddress))
 		{
-			return true;
+			return guestAddress != 0;
 		}
 
 		var hasAerolibSymbol = Aerolib.Instance.TryGetByExportName(symbolName, out var hleSymbol);
@@ -1416,12 +1761,13 @@ public sealed partial class DirectExecutionBackend
 				return false;
 			}
 
-			if (TryResolveRuntimeSymbolAddress(hleSymbol.Nid, out guestAddress) ||
-				TryResolveRuntimeSymbolAddress(hleSymbol.ExportName, out guestAddress) ||
+			if ((includeRuntimeSymbols &&
+					(TryResolveRuntimeSymbolAddress(hleSymbol.Nid, out guestAddress) ||
+						TryResolveRuntimeSymbolAddress(hleSymbol.ExportName, out guestAddress))) ||
 				TryFindImportStubGuestAddress(hleSymbol.Nid, out guestAddress) ||
 				TryFindImportStubGuestAddress(hleSymbol.ExportName, out guestAddress))
 			{
-				return true;
+				return guestAddress != 0;
 			}
 		}
 		else if (Aerolib.Instance.TryGetByNid(symbolName, out hleSymbol))
@@ -1434,14 +1780,20 @@ public sealed partial class DirectExecutionBackend
 			if (TryFindImportStubGuestAddress(hleSymbol.Nid, out guestAddress) ||
 				TryFindImportStubGuestAddress(hleSymbol.ExportName, out guestAddress))
 			{
-				return true;
+				return guestAddress != 0;
 			}
 
 			hasAerolibSymbol = true;
 		}
 
 		// Tier 3: lazy materialization for callable HLE symbols missing from ELF imports.
-		if (!TryResolveLazyDispatchTarget(symbolName, hasAerolibSymbol, in hleSymbol, out var dispatchNid, out var export))
+		if (!TryResolveLazyDispatchTarget(
+				symbolName,
+				hasAerolibSymbol,
+				in hleSymbol,
+				out var dispatchNid,
+				out var export,
+				exportFilter))
 		{
 			return false;
 		}
@@ -1451,7 +1803,9 @@ public sealed partial class DirectExecutionBackend
 			symbolName,
 			hasAerolibSymbol ? hleSymbol : null,
 			export,
-			out guestAddress);
+			out guestAddress,
+			useCrtLazyImportStubPool) &&
+			guestAddress != 0;
 	}
 
 	private bool TryFindImportStubGuestAddress(string identifier, out ulong guestAddress)
@@ -1509,7 +1863,8 @@ public sealed partial class DirectExecutionBackend
 		bool hasAerolibSymbol,
 		in SysAbiSymbol hleSymbol,
 		out string dispatchNid,
-		out ExportedFunction? export)
+		out ExportedFunction? export,
+		Func<ExportedFunction, bool>? exportFilter = null)
 	{
 		export = null;
 		dispatchNid = string.Empty;
@@ -1531,13 +1886,55 @@ public sealed partial class DirectExecutionBackend
 			return false;
 		}
 
-		if (_moduleManager.TryGetExport(hleSymbol.Nid, out export))
+		if (TryGetFilteredExport(hleSymbol.Nid, exportFilter, out export) ||
+			TryGetFilteredExportByName(hleSymbol.ExportName, exportFilter, out export) ||
+			TryGetFilteredExportByName(symbolName, exportFilter, out export))
 		{
-			dispatchNid = hleSymbol.Nid;
+			dispatchNid = export.Nid;
 			return true;
 		}
 
 		return false;
+	}
+
+	private bool TryGetFilteredExport(
+		string nid,
+		Func<ExportedFunction, bool>? exportFilter,
+		out ExportedFunction export)
+	{
+		export = null!;
+		if (!_moduleManager.TryGetExport(nid, out var candidate))
+		{
+			return false;
+		}
+
+		if (exportFilter is not null && !exportFilter(candidate))
+		{
+			return false;
+		}
+
+		export = candidate;
+		return true;
+	}
+
+	private bool TryGetFilteredExportByName(
+		string exportName,
+		Func<ExportedFunction, bool>? exportFilter,
+		out ExportedFunction export)
+	{
+		export = null!;
+		if (!_moduleManager.TryGetExportByName(exportName, out var candidate))
+		{
+			return false;
+		}
+
+		if (exportFilter is not null && !exportFilter(candidate))
+		{
+			return false;
+		}
+
+		export = candidate;
+		return true;
 	}
 
 	private bool TryGetOrCreateLazyImportStub(
@@ -1545,7 +1942,8 @@ public sealed partial class DirectExecutionBackend
 		string symbolName,
 		SysAbiSymbol? hleSymbol,
 		ExportedFunction? export,
-		out ulong guestAddress)
+		out ulong guestAddress,
+		bool useCrtLazyImportStubPool = false)
 	{
 		guestAddress = 0;
 		if (string.IsNullOrWhiteSpace(dispatchNid))
@@ -1560,22 +1958,47 @@ public sealed partial class DirectExecutionBackend
 				return true;
 			}
 
-			if (!EnsureLazyImportStubPoolMapped())
+			if (useCrtLazyImportStubPool)
 			{
-				LogLazyImportStubMaterializationFailure(
-					"import stub region unresolved",
-					dispatchNid,
-					symbolName);
-				return false;
-			}
+				if (!EnsureCrtLazyImportStubPoolMapped())
+				{
+					LogLazyImportStubMaterializationFailure(
+						"CRT lazy import stub pool unresolved",
+						dispatchNid,
+						symbolName,
+						useCrtLazyImportStubPool: true);
+					return false;
+				}
 
-			if (!TryAllocateLazyImportStubSlot(out guestAddress))
+				if (!TryAllocateCrtLazyImportStubSlot(out guestAddress))
+				{
+					LogLazyImportStubMaterializationFailure(
+						"CRT lazy import stub pool exhausted",
+						dispatchNid,
+						symbolName,
+						useCrtLazyImportStubPool: true);
+					return false;
+				}
+			}
+			else
 			{
-				LogLazyImportStubMaterializationFailure(
-					"lazy import stub pool exhausted",
-					dispatchNid,
-					symbolName);
-				return false;
+				if (!EnsureLazyImportStubPoolMapped())
+				{
+					LogLazyImportStubMaterializationFailure(
+						"import stub region unresolved",
+						dispatchNid,
+						symbolName);
+					return false;
+				}
+
+				if (!TryAllocateLazyImportStubSlot(out guestAddress))
+				{
+					LogLazyImportStubMaterializationFailure(
+						"lazy import stub pool exhausted",
+						dispatchNid,
+						symbolName);
+					return false;
+				}
 			}
 
 			var previousEntries = _importEntries;
@@ -1652,11 +2075,161 @@ public sealed partial class DirectExecutionBackend
 		_lazyDlsymStubCache[key] = guestAddress;
 	}
 
-	private void LogLazyImportStubMaterializationFailure(string reason, string dispatchNid, string symbolName)
+	private void LogLazyImportStubMaterializationFailure(
+		string reason,
+		string dispatchNid,
+		string symbolName,
+		bool useCrtLazyImportStubPool = false)
 	{
+		if (useCrtLazyImportStubPool && _crtLazyImportStubPoolMapped)
+		{
+			var usedSlots = (_crtLazyImportStubNextSlot - _crtLazyImportStubPoolBase) /
+				LazyImportStubSlotSize;
+			var maxSlots = (_crtLazyImportStubPoolLimit - _crtLazyImportStubPoolBase) /
+				LazyImportStubSlotSize;
+			Console.Error.WriteLine(
+				$"[LOADER][WARN] Lazy import stub materialization failed ({reason}): " +
+				$"nid={dispatchNid} symbol='{symbolName}' " +
+				$"crt_pool_used_slots={usedSlots} crt_pool_max_slots={maxSlots}");
+			return;
+		}
+
 		Console.Error.WriteLine(
 			$"[LOADER][WARN] Lazy import stub materialization failed ({reason}): " +
 			$"nid={dispatchNid} symbol='{symbolName}'");
+	}
+
+	private static bool IsExcludedFromGenericLazyImportStubPoolAddress(ulong address)
+	{
+		return address >= CrtSyntheticRegionFloor;
+	}
+
+	private bool EnsureCrtLazyImportStubPoolMapped()
+	{
+		if (_crtLazyImportStubPoolMapped && _crtLazyImportStubPoolBase != 0)
+		{
+			return true;
+		}
+
+		if (ActiveCpuContext is not { } cpuContext ||
+			!TryGetVirtualMemory(cpuContext, out var virtualMemory))
+		{
+			return false;
+		}
+
+		var stubData = new byte[256];
+		stubData[0] = 0xCC;
+		stubData[1] = 0xC3;
+
+		for (var i = 0; i < 16; i++)
+		{
+			var candidateBase = CrtLazyImportStubPoolBaseAddress - ((ulong)i * CrtSyntheticRegionStride);
+			try
+			{
+				virtualMemory.Map(
+					candidateBase,
+					CrtLazyImportStubPoolSize,
+					fileOffset: 0,
+					stubData,
+					ProgramHeaderFlags.Read | ProgramHeaderFlags.Execute);
+
+				var candidateLimit = candidateBase + CrtLazyImportStubPoolSize;
+				ulong nextSlot = candidateBase;
+				var importEntries = _importEntries;
+				for (var entryIndex = 0; entryIndex < importEntries.Length; entryIndex++)
+				{
+					var entryAddress = importEntries[entryIndex].Address;
+					if (entryAddress < candidateBase || entryAddress >= candidateLimit)
+					{
+						continue;
+					}
+
+					if ((entryAddress - candidateBase) % LazyImportStubSlotSize != 0)
+					{
+						continue;
+					}
+
+					var entryEnd = entryAddress + LazyImportStubSlotSize;
+					if (entryEnd > nextSlot)
+					{
+						nextSlot = entryEnd;
+					}
+				}
+
+				_crtLazyImportStubPoolBase = candidateBase;
+				_crtLazyImportStubNextSlot = nextSlot;
+				_crtLazyImportStubPoolLimit = candidateLimit;
+				_crtLazyImportStubPoolMapped = true;
+				return true;
+			}
+			catch (InvalidOperationException)
+			{
+				continue;
+			}
+		}
+
+		return false;
+	}
+
+	private bool TryAllocateCrtLazyImportStubSlot(out ulong guestAddress)
+	{
+		guestAddress = 0;
+		if (!_crtLazyImportStubPoolMapped)
+		{
+			return false;
+		}
+
+		while (true)
+		{
+			if (_crtLazyImportStubNextSlot >= _crtLazyImportStubPoolBase &&
+				_crtLazyImportStubNextSlot + LazyImportStubSlotSize <= _crtLazyImportStubPoolLimit)
+			{
+				guestAddress = _crtLazyImportStubNextSlot;
+				_crtLazyImportStubNextSlot += LazyImportStubSlotSize;
+				return true;
+			}
+
+			if (!TryMapSpillCrtLazyImportStubPool())
+			{
+				return false;
+			}
+		}
+	}
+
+	private bool TryMapSpillCrtLazyImportStubPool()
+	{
+		if (ActiveCpuContext is not { } cpuContext ||
+			!TryGetVirtualMemory(cpuContext, out var virtualMemory))
+		{
+			return false;
+		}
+
+		_crtLazyImportStubPoolBandIndex++;
+		var spillBase = CrtLazyImportStubPoolBaseAddress -
+			((ulong)_crtLazyImportStubPoolBandIndex * CrtLazyImportStubPoolSize);
+		var stubData = new byte[256];
+		stubData[0] = 0xCC;
+		stubData[1] = 0xC3;
+
+		try
+		{
+			virtualMemory.Map(
+				spillBase,
+				CrtLazyImportStubPoolSize,
+				fileOffset: 0,
+				stubData,
+				ProgramHeaderFlags.Read | ProgramHeaderFlags.Execute);
+
+			_crtLazyImportStubPoolBase = spillBase;
+			_crtLazyImportStubNextSlot = spillBase;
+			_crtLazyImportStubPoolLimit = spillBase + CrtLazyImportStubPoolSize;
+			_crtLazyImportStubPoolMapped = true;
+			return true;
+		}
+		catch (InvalidOperationException)
+		{
+			return false;
+		}
 	}
 
 	private unsafe bool TryResolveImportStubRegionBounds(
@@ -1683,7 +2256,9 @@ public sealed partial class DirectExecutionBackend
 			for (var i = 0; i < importEntries.Length; i++)
 			{
 				var entryAddress = importEntries[i].Address;
-				if (entryAddress < candidateBase || entryAddress >= candidateLimit)
+				if (IsExcludedFromGenericLazyImportStubPoolAddress(entryAddress) ||
+					entryAddress < candidateBase ||
+					entryAddress >= candidateLimit)
 				{
 					continue;
 				}
@@ -1711,7 +2286,8 @@ public sealed partial class DirectExecutionBackend
 		for (var i = 0; i < importEntries.Length; i++)
 		{
 			var entryAddress = importEntries[i].Address;
-			if (entryAddress < ImportStubRegionCanonicalBase)
+			if (IsExcludedFromGenericLazyImportStubPoolAddress(entryAddress) ||
+				entryAddress < ImportStubRegionCanonicalBase)
 			{
 				continue;
 			}
@@ -1851,6 +2427,25 @@ public sealed partial class DirectExecutionBackend
 			TryResolveRuntimeSymbolAddress(symbol.Nid, out address);
 	}
 
+	private const ulong BootstrapBridgeOpResolveSymbol = 1UL;
+	private const ulong BootstrapBridgeOpModuleDescriptor = 2UL;
+	private const ulong GuestLibkernelModuleId = 0x2001UL;
+
+	private const string GuestSocketExportNid = "GstScktEm0";
+
+	private const string GuestBzeroExportNid = "GstBzero0";
+
+	private const string GuestConnectExportNid = "GstScktC0n";
+
+	private const string GuestInetPtonExportNid = "GstInetP0";
+
+	private const string GuestHtonsExportNid = "GstHtons0";
+
+	private const ulong StandaloneGuestModuleBase = 0x7FFD_0000_0000UL;
+	private const ulong StandaloneGuestModuleObjectSize = 0x0000_1000UL;
+	private const ulong StandaloneGuestModuleStatusOffset = 0x0100UL;
+	private const ulong StandaloneGuestModuleResultPointerOffset = 0x0028UL;
+
 	private OrbisGen2Result DispatchBootstrapBridge()
 	{
 		var cpuContext = ActiveCpuContext;
@@ -1859,7 +2454,18 @@ public sealed partial class DirectExecutionBackend
 			return OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
 		}
 
+		var op = cpuContext[CpuRegister.Rdi];
 		ulong outputAddress = cpuContext[CpuRegister.Rdx];
+		if (op == BootstrapBridgeOpModuleDescriptor)
+		{
+			return DispatchBootstrapBridgeModuleDescriptor(cpuContext, cpuContext[CpuRegister.Rsi], outputAddress);
+		}
+
+		if (op != BootstrapBridgeOpResolveSymbol)
+		{
+			return CompleteBootstrapBridgeFailure(cpuContext, outputAddress);
+		}
+
 		try
 		{
 			OrbisGen2Result result = DispatchKernelDynlibDlsym();
@@ -1874,6 +2480,198 @@ public sealed partial class DirectExecutionBackend
 		}
 
 		return OrbisGen2Result.ORBIS_GEN2_OK;
+	}
+
+	private OrbisGen2Result DispatchBootstrapBridgeModuleDescriptor(
+		CpuContext cpuContext,
+		ulong descriptorAddress,
+		ulong outputAddress)
+	{
+		if (!TryParseStandaloneModuleDescriptor(cpuContext, descriptorAddress, out var moduleBase))
+		{
+			return CompleteBootstrapBridgeFailure(cpuContext, outputAddress);
+		}
+
+		if (!TryEnsureStandaloneGuestModuleObject(cpuContext, moduleBase))
+		{
+			return CompleteBootstrapBridgeFailure(cpuContext, outputAddress);
+		}
+
+		cpuContext[CpuRegister.Rax] = moduleBase;
+		return OrbisGen2Result.ORBIS_GEN2_OK;
+	}
+
+	private bool TryParseStandaloneModuleDescriptor(
+		CpuContext cpuContext,
+		ulong descriptorAddress,
+		out ulong moduleBase)
+	{
+		moduleBase = 0;
+		if (descriptorAddress == 0 || cpuContext == null)
+		{
+			return false;
+		}
+
+		if (!cpuContext.TryReadUInt32(descriptorAddress + 0x00, out var header0) ||
+			header0 != 1 ||
+			!cpuContext.TryReadUInt32(descriptorAddress + 0x04, out var header1) ||
+			header1 != 0x2E)
+		{
+			return false;
+		}
+
+		if (!cpuContext.TryReadUInt64(descriptorAddress + 0x10, out var descriptorBase) ||
+			descriptorBase == 0)
+		{
+			return false;
+		}
+
+		moduleBase = NormalizeStandaloneModuleBase(descriptorBase);
+		return moduleBase >= 0x0000_1000_0000_0000UL;
+	}
+
+	private static ulong NormalizeStandaloneModuleBase(ulong descriptorBase)
+	{
+		// Standalone bootstrap descriptors name a module object in the 0x7FFD canonical range.
+		if ((descriptorBase & 0xFFFF_0000_0000_0000UL) == (StandaloneGuestModuleBase & 0xFFFF_0000_0000_0000UL))
+		{
+			return StandaloneGuestModuleBase;
+		}
+
+		return descriptorBase;
+	}
+
+	private bool TryEnsureStandaloneGuestModuleObject(CpuContext cpuContext, ulong moduleBase)
+	{
+		if (moduleBase == 0 || cpuContext == null)
+		{
+			return false;
+		}
+
+		var statusAddress = moduleBase + StandaloneGuestModuleStatusOffset;
+		var objectEnd = moduleBase + StandaloneGuestModuleObjectSize;
+		if (!TryCommitGuestMapping(cpuContext, moduleBase, StandaloneGuestModuleObjectSize))
+		{
+			return false;
+		}
+
+		// Bootstrap op=2 only; full-title paths without bootstrap injection never reach here.
+		RegisterPrtLazyCommitRange(moduleBase, StandaloneGuestModuleObjectSize);
+
+		if (!TryWriteUInt64Compat(moduleBase + StandaloneGuestModuleResultPointerOffset, statusAddress) ||
+			!TryWriteUInt32Compat(statusAddress, 0))
+		{
+			return false;
+		}
+
+		_ = KernelModuleRegistry.RegisterSyntheticModule(
+			"standalone.elf",
+			isSystemModule: false,
+			baseAddress: moduleBase,
+			size: objectEnd - moduleBase);
+		return VerifyGuestMappingReadable(moduleBase + StandaloneGuestModuleResultPointerOffset);
+	}
+
+	private unsafe bool TryCommitGuestMapping(CpuContext cpuContext, ulong address, ulong size)
+	{
+		if (address == 0 || size == 0)
+		{
+			return false;
+		}
+
+		var mapBase = address & ~0xFFFUL;
+		var mapSize = ((address + size - mapBase) + 0xFFF) & ~0xFFFUL;
+		if (TryGetVirtualMemory(cpuContext, out var virtualMemory))
+		{
+			try
+			{
+				virtualMemory.Map(
+					mapBase,
+					mapSize,
+					fileOffset: 0,
+					ReadOnlySpan<byte>.Empty,
+					ProgramHeaderFlags.Read | ProgramHeaderFlags.Write);
+				if (VerifyGuestMappingReadable(address))
+				{
+					return true;
+				}
+			}
+			catch (InvalidOperationException)
+			{
+			}
+		}
+
+		const uint pageReadWrite = 4u;
+		if (VirtualAlloc((void*)mapBase, (nuint)mapSize, MEM_COMMIT, pageReadWrite) != null &&
+			VerifyGuestMappingReadable(address))
+		{
+			return true;
+		}
+
+		foreach (var trySize in new ulong[] { 0x200000UL, 0x10000UL, 0x1000UL })
+		{
+			var tryBase = address & ~(trySize - 1);
+			if (VirtualAlloc((void*)tryBase, (nuint)trySize, MEM_COMMIT, pageReadWrite) != null &&
+				VerifyGuestMappingReadable(address))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static unsafe bool VerifyGuestMappingReadable(ulong address)
+	{
+		if (address == 0)
+		{
+			return false;
+		}
+
+		try
+		{
+			_ = Marshal.ReadByte((nint)address);
+			return true;
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
+	private OrbisGen2Result CompleteBootstrapBridgeFailure(CpuContext cpuContext, ulong outputAddress)
+	{
+		if (outputAddress != 0)
+		{
+			_ = TryWriteUInt64Compat(outputAddress, 0);
+		}
+
+		cpuContext[CpuRegister.Rax] = ulong.MaxValue;
+		return OrbisGen2Result.ORBIS_GEN2_OK;
+	}
+
+	private bool TryWriteUInt32Compat(ulong address, uint value)
+	{
+		var cpuContext = ActiveCpuContext;
+		if (cpuContext == null || address == 0L)
+		{
+			return false;
+		}
+
+		if (cpuContext.TryWriteUInt32(address, value))
+		{
+			return true;
+		}
+
+		try
+		{
+			Marshal.WriteInt32((nint)address, unchecked((int)value));
+			return true;
+		}
+		catch
+		{
+			return false;
+		}
 	}
 
 	private bool TryResolveRuntimeSymbolAddress(string symbolName, out ulong address)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -266,6 +266,25 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private bool _lazyImportStubPoolMapped;
 
+	// Guest CRT dlsym lazy stubs - separate from C3 callback stub @ 0x7FFD_B000_0000.
+	private const ulong CrtLazyImportStubPoolBaseAddress = 0x7FFD_A000_0000UL;
+
+	private const ulong CrtLazyImportStubPoolSize = 0x0020_0000UL;
+
+	private const ulong CrtSyntheticRegionFloor = 0x7FFD_0000_0000UL;
+
+	private const ulong CrtSyntheticRegionStride = 0x0100_0000UL;
+
+	private ulong _crtLazyImportStubPoolBase;
+
+	private ulong _crtLazyImportStubNextSlot;
+
+	private ulong _crtLazyImportStubPoolLimit;
+
+	private bool _crtLazyImportStubPoolMapped;
+
+	private int _crtLazyImportStubPoolBandIndex;
+
 	private readonly RecentImportTraceEntry[] _recentImportTrace = new RecentImportTraceEntry[64];
 
 	private int _recentImportTraceCount;
@@ -628,7 +647,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private static int _nestedVehTraceCount;
 
-	// SHARPEMU_LOG_THREAD_MODE=1 — GC thread-mode corruption investigation. Traces
+	// SHARPEMU_LOG_THREAD_MODE=1 -- GC thread-mode corruption investigation. Traces
 	// every managed<->guest transition per guest-thread run cycle so the last event
 	// before a ReversePInvokeBadTransition FailFast identifies the corrupting path.
 	private static readonly bool LogThreadMode =
@@ -1770,10 +1789,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			ptr2[num++] = 82;
 			ptr2[num++] = 86;
 			ptr2[num++] = 87;
-			// sub rsp, 0x80  — reserve 8*16 bytes for the SysV variadic XMM save area
+			// sub rsp, 0x80 -- reserve 8*16 bytes for the SysV variadic XMM save area
 			ptr2[num++] = 0x48; ptr2[num++] = 0x81; ptr2[num++] = 0xEC;
 			ptr2[num++] = 0x80; ptr2[num++] = 0x00; ptr2[num++] = 0x00; ptr2[num++] = 0x00;
-			// movdqu [rsp + i*0x10], xmm{i}  for i = 0..7  (F3 0F 7F /r, SIB=0x24 base=rsp, disp8)
+			// movdqu [rsp + i*0x10], xmm{i} for i = 0..7 (F3 0F 7F /r, SIB=0x24 base=rsp, disp8)
 			ptr2[num++] = 0xF3; ptr2[num++] = 0x0F; ptr2[num++] = 0x7F; ptr2[num++] = 0x44; ptr2[num++] = 0x24; ptr2[num++] = 0x00; // xmm0
 			ptr2[num++] = 0xF3; ptr2[num++] = 0x0F; ptr2[num++] = 0x7F; ptr2[num++] = 0x4C; ptr2[num++] = 0x24; ptr2[num++] = 0x10; // xmm1
 			ptr2[num++] = 0xF3; ptr2[num++] = 0x0F; ptr2[num++] = 0x7F; ptr2[num++] = 0x54; ptr2[num++] = 0x24; ptr2[num++] = 0x20; // xmm2
@@ -1782,7 +1801,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			ptr2[num++] = 0xF3; ptr2[num++] = 0x0F; ptr2[num++] = 0x7F; ptr2[num++] = 0x6C; ptr2[num++] = 0x24; ptr2[num++] = 0x50; // xmm5
 			ptr2[num++] = 0xF3; ptr2[num++] = 0x0F; ptr2[num++] = 0x7F; ptr2[num++] = 0x74; ptr2[num++] = 0x24; ptr2[num++] = 0x60; // xmm6
 			ptr2[num++] = 0xF3; ptr2[num++] = 0x0F; ptr2[num++] = 0x7F; ptr2[num++] = 0x7C; ptr2[num++] = 0x24; ptr2[num++] = 0x70; // xmm7
-			// lea r12, [rsp + 0x80]  — r12 = argpack base (the 12 pushed GP regs), past the XMM area
+			// lea r12, [rsp + 0x80] -- r12 = argpack base (the 12 pushed GP regs), past the XMM area
 			ptr2[num++] = 0x4C; ptr2[num++] = 0x8D; ptr2[num++] = 0xA4; ptr2[num++] = 0x24;
 			ptr2[num++] = 0x80; ptr2[num++] = 0x00; ptr2[num++] = 0x00; ptr2[num++] = 0x00;
 			ptr2[num++] = 72;
@@ -1832,7 +1851,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			ptr2[num++] = 131;
 			ptr2[num++] = 196;
 			ptr2[num++] = 40;
-			// movdqu xmm0, [r12 - 0x80]  — reload the return XMM0 the gateway wrote into the
+			// movdqu xmm0, [r12 - 0x80] -- reload the return XMM0 the gateway wrote into the
 			// argpack's xmm0 save slot (float/double returns: powf/logf/wcstod). SysV/Win64
 			// XMM regs are volatile across calls, so an unconditional reload is ABI-safe.
 			ptr2[num++] = 0xF3; ptr2[num++] = 0x41; ptr2[num++] = 0x0F; ptr2[num++] = 0x6F;
@@ -1992,16 +2011,9 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 		byte* code = (byte*)ptr;
 		int offset = 0;
-		// TlsGetValue returns its TLS pointer in RAX. Preserve the guest return value
-		// above the 32-byte Windows shadow space while keeping the call site aligned.
-		EmitByte(code, ref offset, 0x48); // sub rsp, 0x30
+		EmitByte(code, ref offset, 0x48); // sub rsp, 0x20
 		EmitByte(code, ref offset, 0x83);
 		EmitByte(code, ref offset, 0xEC);
-		EmitByte(code, ref offset, 0x30);
-		EmitByte(code, ref offset, 0x48); // mov [rsp+0x20], rax
-		EmitByte(code, ref offset, 0x89);
-		EmitByte(code, ref offset, 0x44);
-		EmitByte(code, ref offset, 0x24);
 		EmitByte(code, ref offset, 0x20);
 		EmitByte(code, ref offset, 0xB9); // mov ecx, tlsIndex
 		EmitUInt32(code, ref offset, _hostRspSlotTlsIndex);
@@ -2011,21 +2023,13 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		offset += sizeof(ulong);
 		EmitByte(code, ref offset, 0xFF); // call rax
 		EmitByte(code, ref offset, 0xD0);
-		EmitByte(code, ref offset, 0x49); // mov r11, rax
-		EmitByte(code, ref offset, 0x89);
-		EmitByte(code, ref offset, 0xC3);
-		EmitByte(code, ref offset, 0x48); // mov rax, [rsp+0x20]
-		EmitByte(code, ref offset, 0x8B);
-		EmitByte(code, ref offset, 0x44);
-		EmitByte(code, ref offset, 0x24);
-		EmitByte(code, ref offset, 0x20);
-		EmitByte(code, ref offset, 0x48); // add rsp, 0x30
+		EmitByte(code, ref offset, 0x48); // add rsp, 0x20
 		EmitByte(code, ref offset, 0x83);
 		EmitByte(code, ref offset, 0xC4);
-		EmitByte(code, ref offset, 0x30);
-		EmitByte(code, ref offset, 0x49); // mov rsp, [r11]
+		EmitByte(code, ref offset, 0x20);
+		EmitByte(code, ref offset, 0x48); // mov rsp, [rax]
 		EmitByte(code, ref offset, 0x8B);
-		EmitByte(code, ref offset, 0x23);
+		EmitByte(code, ref offset, 0x20);
 		EmitHostNonvolatileXmmRestore(code, ref offset);
 		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5F);
 		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5E);
@@ -2063,7 +2067,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		// thread; FailFast/stack-overflow arrive mid-runtime-failure). Entering the managed
 		// handler then trips the CLR's reverse-P/Invoke check and kills the process with
 		// "Invalid Program: attempted to call a UnmanagedCallersOnly method from managed
-		// code" — this is why no managed throw (even one with a catch handler) ever
+		// code" -- this is why no managed throw (even one with a catch handler) ever
 		// survived inside the emulator. Continue the handler search without touching
 		// managed code; the CLR's own VEH handles its exceptions. MSVC C++ exceptions
 		// (Vulkan drivers, host CRT) are excluded too: the managed handler only ever
@@ -3313,7 +3317,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	/// memory. Workers unwind to the host at their next import dispatch (see the
 	/// teardown check in DispatchImport); this waits for their host threads to
 	/// finish within <paramref name="timeoutMs"/>. Returns false when at least one
-	/// worker is still running — the caller must then leak its executable stubs
+	/// worker is still running -- the caller must then leak its executable stubs
 	/// rather than free memory a live thread may still execute.
 	/// </summary>
 	private bool RequestGuestThreadTeardown(int timeoutMs)
@@ -4774,7 +4778,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		{
 			// A guest worker is still executing native code; freeing the trampolines,
 			// exception-handler stubs, or GC handles under it turns process exit into
-			// an execute-AV / CLR fatal. Leak them — the process is going away anyway.
+			// an execute-AV / CLR fatal. Leak them -- the process is going away anyway.
 			Console.Error.WriteLine(
 				"[LOADER][WARN] Skipping executable stub teardown: guest worker threads are still running.");
 			return;

--- a/src/SharpEmu.Core/Loader/SelfLoader.cs
+++ b/src/SharpEmu.Core/Loader/SelfLoader.cs
@@ -31,7 +31,10 @@ public sealed class SelfLoader : ISelfLoader
     private const int ElfRelocationSize = 24;
     private const int ElfSectionHeaderSize = 64;
     private const uint SectionTypeSymbolTable = 2;
+    private const uint SectionTypeProgbits = 1;
     private const uint SectionTypeRela = 4;
+    private const ushort ElfTypeExec = 2;
+    private const ulong SectionFlagWrite = 0x1;
 
     private const long DtNull = 0;
     private const long DtPltRelSize = 0x02;
@@ -196,6 +199,14 @@ public sealed class SelfLoader : ISelfLoader
         }
 
         MapLoadSegments(imageData, loadContext, programHeaders, virtualMemory, imageBase);
+        ApplyDataRelocations(
+            imageData,
+            loadContext,
+            elfHeader,
+            programHeaders,
+            virtualMemory,
+            imageBase,
+            tlsModuleId);
         var importStubs = ResolveAndPatchImportStubs(
             imageData,
             loadContext,
@@ -456,6 +467,375 @@ public sealed class SelfLoader : ISelfLoader
         return 0;
     }
 
+    private static int ApplyDataRelocations(
+        ReadOnlySpan<byte> imageData,
+        LoadContext loadContext,
+        ElfHeader elfHeader,
+        IReadOnlyList<ProgramHeader> programHeaders,
+        IVirtualMemory virtualMemory,
+        ulong imageBase,
+        uint tlsModuleId)
+    {
+        var descriptors = new List<RelocationDescriptor>(512);
+        var orderedImportNids = new List<string>(8);
+        var seenImportNids = new HashSet<string>(StringComparer.Ordinal);
+        var relocationEntries = 0;
+
+        relocationEntries += AppendSectionRelocationDescriptors(
+            imageData,
+            loadContext,
+            elfHeader,
+            virtualMemory,
+            imageBase,
+            tlsModuleId,
+            descriptors,
+            orderedImportNids,
+            seenImportNids);
+
+        relocationEntries += TryAppendDynamicRelocationDescriptors(
+            imageData,
+            loadContext,
+            programHeaders,
+            virtualMemory,
+            imageBase,
+            tlsModuleId,
+            descriptors,
+            orderedImportNids,
+            seenImportNids);
+
+        relocationEntries += TryAppendSceRelaProgramRelocationDescriptors(
+            imageData,
+            loadContext,
+            programHeaders,
+            virtualMemory,
+            imageBase,
+            tlsModuleId,
+            descriptors,
+            orderedImportNids,
+            seenImportNids);
+
+        var patched = PatchDataRelocationDescriptors(virtualMemory, descriptors);
+        if (patched > 0)
+        {
+            Console.WriteLine($"[LOADER] Applied {patched} data relocation patches");
+        }
+
+        if (relocationEntries == 0 && patched == 0 && elfHeader.Type == ElfTypeExec && imageBase != 0)
+        {
+            patched = ApplyExecWritableProgbitsLoadBaseRelocations(
+                elfHeader,
+                imageData,
+                loadContext,
+                programHeaders,
+                virtualMemory,
+                imageBase);
+            if (patched > 0)
+            {
+                Console.WriteLine(
+                    $"[LOADER] Applied {patched} ET_EXEC load-base pointer relocations in writable PROGBITS");
+            }
+            else
+            {
+                Console.WriteLine(
+                    "[LOADER] ET_EXEC: no formal relocs and no writable pointers rebased");
+            }
+        }
+
+        return patched;
+    }
+
+    private static int ApplyExecWritableProgbitsLoadBaseRelocations(
+        ElfHeader elfHeader,
+        ReadOnlySpan<byte> imageData,
+        LoadContext loadContext,
+        IReadOnlyList<ProgramHeader> programHeaders,
+        IVirtualMemory virtualMemory,
+        ulong imageBase)
+    {
+        var minVaddr = ulong.MaxValue;
+        var maxVaddr = 0UL;
+        foreach (var header in programHeaders)
+        {
+            if (header.HeaderType != ProgramHeaderType.Load || header.MemorySize == 0)
+            {
+                continue;
+            }
+
+            minVaddr = Math.Min(minVaddr, header.VirtualAddress);
+            var end = header.VirtualAddress + header.MemorySize;
+            if (end > maxVaddr)
+            {
+                maxVaddr = end;
+            }
+        }
+
+        if (maxVaddr <= minVaddr)
+        {
+            return 0;
+        }
+
+        var patched = 0;
+        Span<byte> valueBuffer = stackalloc byte[sizeof(ulong)];
+        for (var sectionIndex = 0; sectionIndex < elfHeader.SectionHeaderCount; sectionIndex++)
+        {
+            if (!TryReadSectionHeader(imageData, loadContext, elfHeader, sectionIndex, out var sectionHeader) ||
+                sectionHeader.Type != SectionTypeProgbits ||
+                sectionHeader.Size == 0 ||
+                (sectionHeader.Flags & SectionFlagWrite) == 0)
+            {
+                continue;
+            }
+
+            var guestStart = sectionHeader.Address + imageBase;
+            var sectionSize = sectionHeader.Size;
+            for (var offset = 0UL; offset + sizeof(ulong) <= sectionSize; offset += sizeof(ulong))
+            {
+                if (!virtualMemory.TryRead(guestStart + offset, valueBuffer))
+                {
+                    continue;
+                }
+
+                var value = BinaryPrimitives.ReadUInt64LittleEndian(valueBuffer);
+                if (value == 0 ||
+                    value >= imageBase ||
+                    value < minVaddr ||
+                    value >= maxVaddr ||
+                    !IsLinkTimeVaInLoadSegment(value, programHeaders))
+                {
+                    continue;
+                }
+
+                if (!TryWriteUInt64(virtualMemory, guestStart + offset, unchecked(value + imageBase)))
+                {
+                    throw new InvalidDataException(
+                        $"Failed to patch ET_EXEC load-base pointer at 0x{(guestStart + offset):X16}.");
+                }
+
+                patched++;
+            }
+        }
+
+        return patched;
+    }
+
+    private static bool IsLinkTimeVaInLoadSegment(ulong value, IReadOnlyList<ProgramHeader> programHeaders)
+    {
+        foreach (var header in programHeaders)
+        {
+            if (header.HeaderType != ProgramHeaderType.Load || header.MemorySize == 0)
+            {
+                continue;
+            }
+
+            var start = header.VirtualAddress;
+            var end = header.VirtualAddress + header.MemorySize;
+            if (value >= start && value < end)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static int TryAppendDynamicRelocationDescriptors(
+        ReadOnlySpan<byte> imageData,
+        LoadContext loadContext,
+        IReadOnlyList<ProgramHeader> programHeaders,
+        IVirtualMemory virtualMemory,
+        ulong imageBase,
+        uint tlsModuleId,
+        ICollection<RelocationDescriptor> descriptors,
+        IList<string> orderedImportNids,
+        ISet<string> seenImportNids)
+    {
+        if (!TryGetProgramHeader(programHeaders, ProgramHeaderType.Dynamic, out var dynamicHeader, out var dynamicHeaderIndex) ||
+            dynamicHeader.FileSize == 0 ||
+            dynamicHeader.FileSize > int.MaxValue ||
+            !TryLoadDynamicTableBytes(
+                imageData,
+                loadContext,
+                virtualMemory,
+                imageBase,
+                dynamicHeader,
+                dynamicHeaderIndex,
+                out var dynamicTable))
+        {
+            return 0;
+        }
+
+        var dynamicInfo = ParseDynamicInfo(dynamicTable);
+        var relocations = new List<ElfRelocation>(512);
+        if (dynamicInfo.RelaSize != 0 &&
+            TryLoadTableBytes(imageData, virtualMemory, imageBase, dynamicInfo.RelaOffset, dynamicInfo.RelaSize, out var relaBytes))
+        {
+            CollectRelocations(relaBytes, relocations);
+        }
+
+        if (dynamicInfo.JmpRelSize != 0 &&
+            TryLoadTableBytes(imageData, virtualMemory, imageBase, dynamicInfo.JmpRelOffset, dynamicInfo.JmpRelSize, out var jmpRelBytes))
+        {
+            CollectRelocations(jmpRelBytes, relocations);
+        }
+
+        if (relocations.Count == 0)
+        {
+            return 0;
+        }
+
+        uint maxSymbolIndex = 0;
+        foreach (var relocation in relocations)
+        {
+            if (!IsSupportedRelocationType(relocation.Type))
+            {
+                continue;
+            }
+
+            if (relocation.Type is RelocationTypeRelative or RelocationTypeTlsModuleId)
+            {
+                continue;
+            }
+
+            if (relocation.SymbolIndex > maxSymbolIndex)
+            {
+                maxSymbolIndex = relocation.SymbolIndex;
+            }
+        }
+
+        ReadOnlySpan<byte> stringTable = ReadOnlySpan<byte>.Empty;
+        ReadOnlySpan<byte> symbolTable = ReadOnlySpan<byte>.Empty;
+        if (maxSymbolIndex != 0)
+        {
+            if (!TryLoadTableBytes(
+                    imageData,
+                    virtualMemory,
+                    imageBase,
+                    dynamicInfo.StrTabOffset,
+                    dynamicInfo.StrTabSize,
+                    out var loadedStringTable) ||
+                !TryLoadTableBytes(
+                    imageData,
+                    virtualMemory,
+                    imageBase,
+                    dynamicInfo.SymTabOffset,
+                    dynamicInfo.SymTabSize != 0
+                        ? dynamicInfo.SymTabSize
+                        : checked(((ulong)maxSymbolIndex + 1) * ElfSymbolSize),
+                    out var loadedSymbolTable))
+            {
+                return 0;
+            }
+
+            stringTable = loadedStringTable;
+            symbolTable = loadedSymbolTable;
+        }
+
+        AppendRelocationDescriptors(
+            relocations,
+            symbolTable,
+            stringTable,
+            virtualMemory,
+            imageBase,
+            tlsModuleId,
+            descriptors,
+            orderedImportNids,
+            seenImportNids);
+        return relocations.Count;
+    }
+
+    private static int TryAppendSceRelaProgramRelocationDescriptors(
+        ReadOnlySpan<byte> imageData,
+        LoadContext loadContext,
+        IReadOnlyList<ProgramHeader> programHeaders,
+        IVirtualMemory virtualMemory,
+        ulong imageBase,
+        uint tlsModuleId,
+        ICollection<RelocationDescriptor> descriptors,
+        IList<string> orderedImportNids,
+        ISet<string> seenImportNids)
+    {
+        if (!TryGetProgramHeader(programHeaders, ProgramHeaderType.SceRela, out var relocHeader, out var relocHeaderIndex) ||
+            relocHeader.FileSize == 0 ||
+            relocHeader.FileSize > int.MaxValue)
+        {
+            return 0;
+        }
+
+        ReadOnlySpan<byte> relaBytes = ReadOnlySpan<byte>.Empty;
+        if (!TryLoadTableBytes(
+                imageData,
+                virtualMemory,
+                imageBase,
+                relocHeader.VirtualAddress,
+                relocHeader.FileSize,
+                out var relaBytesArray))
+        {
+            var relocOffset = ResolvePhysicalSegmentOffset(imageData.Length, loadContext, relocHeader, relocHeaderIndex);
+            if (!TrySlice(imageData, relocOffset, relocHeader.FileSize, out relaBytes))
+            {
+                return 0;
+            }
+        }
+        else
+        {
+            relaBytes = relaBytesArray;
+        }
+
+        var relocations = new List<ElfRelocation>(checked((int)(relocHeader.FileSize / ElfRelocationSize)));
+        CollectRelocations(relaBytes, relocations);
+        if (relocations.Count == 0)
+        {
+            return 0;
+        }
+
+        AppendRelocationDescriptors(
+            relocations,
+            ReadOnlySpan<byte>.Empty,
+            ReadOnlySpan<byte>.Empty,
+            virtualMemory,
+            imageBase,
+            tlsModuleId,
+            descriptors,
+            orderedImportNids,
+            seenImportNids);
+        return relocations.Count;
+    }
+
+    private static int PatchDataRelocationDescriptors(
+        IVirtualMemory virtualMemory,
+        IReadOnlyList<RelocationDescriptor> descriptors)
+    {
+        var patched = 0;
+        foreach (var descriptor in descriptors)
+        {
+            if (descriptor.ImportNid is not null)
+            {
+                continue;
+            }
+
+            var targetValue = descriptor.ValueKind == RelocationValueKind.TlsModuleId
+                ? descriptor.SymbolValue
+                : AddSigned(descriptor.SymbolValue, descriptor.Addend);
+
+            if (targetValue < 0x1000 && descriptor.ValueKind != RelocationValueKind.TlsModuleId)
+            {
+                Log.Warning(
+                    $"!!! CRITICAL !!! Patching address 0x{descriptor.TargetAddress:X} with INVALID value 0x{targetValue:X} for data relocation");
+                Log.Warning(
+                    $"  SymbolValue=0x{descriptor.SymbolValue:X}, Addend=0x{descriptor.Addend:X}");
+            }
+
+            if (!TryWriteUInt64(virtualMemory, descriptor.TargetAddress, targetValue))
+            {
+                throw new InvalidDataException($"Failed to patch data relocation at 0x{descriptor.TargetAddress:X16}.");
+            }
+
+            patched++;
+        }
+
+        return patched;
+    }
+
     private static IReadOnlyDictionary<ulong, string> ResolveAndPatchImportStubs(
         ReadOnlySpan<byte> imageData,
         LoadContext loadContext,
@@ -622,6 +1002,12 @@ public sealed class SelfLoader : ISelfLoader
             return EmptyImportStubs;
         }
 
+        if (!descriptors.Any(static descriptor => descriptor.ImportNid is not null))
+        {
+            Console.WriteLine($"[LOADER] No import relocation descriptors!");
+            return EmptyImportStubs;
+        }
+
         importedRelocations = BuildImportedRelocations(descriptors);
 
         var stubsByAddress = CreateImportStubMapping(virtualMemory, orderedImportNids);
@@ -654,20 +1040,18 @@ public sealed class SelfLoader : ISelfLoader
 
         foreach (var descriptor in descriptors)
         {
-            ulong targetValue;
             if (descriptor.ImportNid is null)
             {
-                targetValue = AddSigned(descriptor.SymbolValue, descriptor.Addend);
+                continue;
             }
-            else
-            {
-                if (!addressesByNid.TryGetValue(descriptor.ImportNid, out var stubAddress))
-                {
-                    throw new InvalidOperationException($"Import stub not found for NID '{descriptor.ImportNid}'.");
-                }
 
-                targetValue = AddSigned(stubAddress, descriptor.Addend);
+            ulong targetValue;
+            if (!addressesByNid.TryGetValue(descriptor.ImportNid, out var stubAddress))
+            {
+                throw new InvalidOperationException($"Import stub not found for NID '{descriptor.ImportNid}'.");
             }
+
+            targetValue = AddSigned(stubAddress, descriptor.Addend);
 
             if (targetValue < 0x1000)
             {

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -9,6 +9,8 @@ using System.Collections.Concurrent;
 using System.Text;
 using System.Runtime.InteropServices;
 using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
 
 namespace SharpEmu.Libs.Kernel;
 
@@ -94,6 +96,14 @@ public static class KernelMemoryCompatExports
     private static readonly object _fdGate = new();
     private static readonly Dictionary<int, FileStream> _openFiles = new();
     private static readonly Dictionary<int, OpenDirectory> _openDirectories = new();
+    private sealed class EmulatedSocketState
+    {
+        public TcpClient? Client;
+        public NetworkStream? Stream;
+        public bool Connected;
+    }
+
+    private static readonly Dictionary<int, EmulatedSocketState> _emulatedSockets = new();
     private static readonly object _libcAllocGate = new();
     private static readonly object _memoryGate = new();
     private static readonly object _tlsGate = new();
@@ -110,6 +120,116 @@ public static class KernelMemoryCompatExports
     private static readonly HashSet<string> _negativeStatCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly ConcurrentDictionary<string, ulong> _aprFileSizeCache = new(StringComparer.OrdinalIgnoreCase);
     private static long _nextFileDescriptor = 2;
+
+    private static int AllocateGuestFd()
+    {
+        return (int)Interlocked.Increment(ref _nextFileDescriptor);
+    }
+
+
+    private static bool TryGetEmulatedSocketState(int fd, out EmulatedSocketState? state)
+    {
+        lock (_fdGate)
+        {
+            return _emulatedSockets.TryGetValue(fd, out state);
+        }
+    }
+
+    private static bool TryParseGuestSockaddrIn(
+        ulong address,
+        int addrlen,
+        CpuContext ctx,
+        out IPAddress ipAddress,
+        out int port)
+    {
+        ipAddress = IPAddress.None;
+        port = 0;
+        if (address == 0 || addrlen < 8)
+        {
+            return false;
+        }
+
+        Span<byte> buffer = stackalloc byte[16];
+        var readLength = Math.Min(addrlen, buffer.Length);
+        if (!ctx.Memory.TryRead(address, buffer.Slice(0, readLength)))
+        {
+            return false;
+        }
+
+        if (buffer[1] != 2)
+        {
+            return false;
+        }
+
+        port = BinaryPrimitives.ReadUInt16BigEndian(buffer.Slice(2, 2));
+        ipAddress = new IPAddress(buffer.Slice(4, 4).ToArray());
+        return true;
+    }
+
+    private static void DisposeEmulatedSocket(EmulatedSocketState state)
+    {
+        try { state.Stream?.Dispose(); } catch (IOException) { }
+        try { state.Client?.Dispose(); } catch (IOException) { }
+        state.Stream = null;
+        state.Client = null;
+        state.Connected = false;
+    }
+
+    private static void RemoveEmulatedSocketFd(int fd)
+    {
+        lock (_fdGate)
+        {
+            if (_emulatedSockets.Remove(fd, out var socketState))
+            {
+                DisposeEmulatedSocket(socketState);
+            }
+        }
+    }
+
+    private static void LogNet(string message)
+    {
+        if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_NET"), "1", StringComparison.Ordinal))
+        {
+            Console.Error.WriteLine($"[LOADER][DEBUG] {message}");
+        }
+    }
+
+    private static bool TryApplyNetRedirect(ref IPAddress ipAddress)
+    {
+        var redirect = Environment.GetEnvironmentVariable("SHARPEMU_NET_REDIRECT");
+        if (string.IsNullOrWhiteSpace(redirect))
+        {
+            return false;
+        }
+
+        if (!IPAddress.TryParse(redirect.Trim(), out var redirectAddress))
+        {
+            return false;
+        }
+
+        ipAddress = redirectAddress;
+        return true;
+    }
+
+    private static bool IsNetRedirectConfigured()
+    {
+        var redirect = Environment.GetEnvironmentVariable("SHARPEMU_NET_REDIRECT");
+        return !string.IsNullOrWhiteSpace(redirect);
+    }
+
+    // Default deny: guest TCP connect is allowed only to loopback or when SHARPEMU_NET_REDIRECT is set.
+    private static bool IsGuestTcpOutboundAllowed(IPAddress ipAddress, bool redirectApplied)
+    {
+        return redirectApplied || IsNetRedirectConfigured() || IPAddress.IsLoopback(ipAddress);
+    }
+
+    private static bool IsEmulatedSocketFd(int fd)
+    {
+        lock (_fdGate)
+        {
+            return _emulatedSockets.ContainsKey(fd);
+        }
+    }
     private static ulong _nextPhysicalAddress;
     private static ulong _nextVirtualAddress;
     private static ulong _mainDirectMemoryPoolBase = UnsetMainDirectMemoryPoolBase;
@@ -1555,9 +1675,10 @@ public static class KernelMemoryCompatExports
                     return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
                 }
 
-                var directoryFd = (int)Interlocked.Increment(ref _nextFileDescriptor);
+                int directoryFd;
                 lock (_fdGate)
                 {
+                    directoryFd = AllocateGuestFd();
                     _openDirectories[directoryFd] = new OpenDirectory
                     {
                         Path = hostPath,
@@ -1578,9 +1699,10 @@ public static class KernelMemoryCompatExports
                 stream.Seek(0, SeekOrigin.End);
             }
 
-            var fd = (int)Interlocked.Increment(ref _nextFileDescriptor);
+            int fd;
             lock (_fdGate)
             {
+                fd = AllocateGuestFd();
                 _openFiles[fd] = stream;
             }
 
@@ -1956,6 +2078,13 @@ public static class KernelMemoryCompatExports
         FileStream? stream;
         lock (_fdGate)
         {
+            if (_emulatedSockets.Remove(fd, out var socketState))
+            {
+                DisposeEmulatedSocket(socketState);
+                ctx[CpuRegister.Rax] = 0;
+                return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+            }
+
             if (_openFiles.Remove(fd, out stream))
             {
             }
@@ -1993,6 +2122,36 @@ public static class KernelMemoryCompatExports
         if (requested == 0 || fd == 0)
         {
             ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        if (IsEmulatedSocketFd(fd))
+        {
+            if (!TryGetEmulatedSocketState(fd, out var socketState) ||
+                socketState is null ||
+                !socketState.Connected ||
+                socketState.Stream is null)
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            }
+
+            var socketBuffer = GC.AllocateUninitializedArray<byte>(requested);
+            int socketRead;
+            try
+            {
+                socketRead = socketState.Stream.Read(socketBuffer, 0, requested);
+            }
+            catch (IOException)
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            }
+
+            if (socketRead > 0 && !ctx.Memory.TryWrite(bufferAddress, socketBuffer.AsSpan(0, socketRead)))
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+            }
+
+            ctx[CpuRegister.Rax] = unchecked((ulong)socketRead);
             return (int)OrbisGen2Result.ORBIS_GEN2_OK;
         }
 
@@ -2185,6 +2344,262 @@ public static class KernelMemoryCompatExports
     }
 
     [SysAbiExport(
+        Nid = "GstScktEm0",
+        ExportName = "GuestSocket",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int GuestSocket(CpuContext ctx)
+    {
+        int fd;
+        lock (_fdGate)
+        {
+            fd = AllocateGuestFd();
+            _emulatedSockets[fd] = new EmulatedSocketState();
+        }
+
+        ctx[CpuRegister.Rax] = unchecked((ulong)fd);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "GstScktC0n",
+        ExportName = "GuestConnect",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int GuestConnect(CpuContext ctx)
+    {
+        var fd = unchecked((int)ctx[CpuRegister.Rdi]);
+        var sockaddrAddress = ctx[CpuRegister.Rsi];
+        var addrlen = unchecked((int)ctx[CpuRegister.Rdx]);
+        lock (_fdGate)
+        {
+            if (!_emulatedSockets.ContainsKey(fd))
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            }
+        }
+
+        if (!TryParseGuestSockaddrIn(sockaddrAddress, addrlen, ctx, out var ipAddress, out var port))
+        {
+            LogNet(
+                $"GuestConnect sockaddr parse failed: fd={fd} addr=0x{sockaddrAddress:X} len={addrlen}");
+
+            RemoveEmulatedSocketFd(fd);
+            ctx[CpuRegister.Rax] = unchecked((ulong)0xFFFFFFFFFFFFFFFF);
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        var redirectApplied = TryApplyNetRedirect(ref ipAddress);
+        if (redirectApplied)
+        {
+            LogNet($"GuestConnect redirect: fd={fd} ip={ipAddress} port={port}");
+        }
+
+        if (!IsGuestTcpOutboundAllowed(ipAddress, redirectApplied))
+        {
+            LogNet(
+                $"GuestConnect denied by outbound policy: fd={fd} ip={ipAddress} port={port} redirect={IsNetRedirectConfigured()}");
+
+            RemoveEmulatedSocketFd(fd);
+            ctx[CpuRegister.Rax] = unchecked((ulong)0xFFFFFFFFFFFFFFFF);
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        if (!TryEstablishHostTcpConnection(ipAddress, port, out var client, out var stream))
+        {
+            LogNet($"GuestConnect failed: fd={fd} ip={ipAddress} port={port}");
+
+            RemoveEmulatedSocketFd(fd);
+            ctx[CpuRegister.Rax] = unchecked((ulong)0xFFFFFFFFFFFFFFFF);
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        LogNet($"GuestConnect ok: fd={fd} ip={ipAddress} port={port}");
+
+        lock (_fdGate)
+        {
+            if (!_emulatedSockets.TryGetValue(fd, out var state) || state is null)
+            {
+                try { stream.Dispose(); } catch (IOException) { }
+                try { client.Dispose(); } catch (IOException) { }
+                ctx[CpuRegister.Rax] = unchecked((ulong)0xFFFFFFFFFFFFFFFF);
+                return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+            }
+
+            DisposeEmulatedSocket(state);
+            state.Client = client;
+            state.Stream = stream;
+            state.Connected = true;
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "GstBzero0",
+        ExportName = "bzero",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int GuestBzero(CpuContext ctx)
+    {
+        var address = ctx[CpuRegister.Rdi];
+        var length = unchecked((int)ctx[CpuRegister.Rsi]);
+        if (length > 0 && address != 0)
+        {
+            var zeros = new byte[length];
+            if (!ctx.Memory.TryWrite(address, zeros))
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+            }
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    private static bool TryEstablishHostTcpConnection(
+        IPAddress ipAddress,
+        int port,
+        out TcpClient client,
+        out NetworkStream stream)
+    {
+        client = null!;
+        stream = null!;
+        if (!TryConnectTcpClient(ipAddress, port, out client))
+        {
+            return false;
+        }
+
+        stream = client.GetStream();
+        return true;
+    }
+
+    private static bool TryConnectTcpClient(IPAddress ipAddress, int port, out TcpClient client)
+    {
+        client = new TcpClient();
+        try
+        {
+            var connectTask = client.ConnectAsync(ipAddress, port);
+            if (!connectTask.Wait(TimeSpan.FromMilliseconds(500)))
+            {
+                client.Dispose();
+                client = null!;
+                return false;
+            }
+
+            return true;
+        }
+        catch (SocketException)
+        {
+            client.Dispose();
+            client = null!;
+            return false;
+        }
+        catch (IOException)
+        {
+            client.Dispose();
+            client = null!;
+            return false;
+        }
+    }
+
+    [SysAbiExport(
+        Nid = "GstInetP0",
+        ExportName = "GuestInetPton",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int GuestInetPton(CpuContext ctx)
+    {
+        var af = unchecked((int)ctx[CpuRegister.Rdi]);
+        var srcAddress = ctx[CpuRegister.Rsi];
+        var dstAddress = ctx[CpuRegister.Rdx];
+        if (af != 2 || srcAddress == 0 || dstAddress == 0)
+        {
+            ctx[CpuRegister.Rax] = unchecked((ulong)0xFFFFFFFFFFFFFFFF);
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (!TryReadCString(srcAddress, out var text, ctx) ||
+            !TryParseIpv4Address(text, out var octets))
+        {
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        Span<byte> packed = stackalloc byte[4];
+        packed[0] = octets[0];
+        packed[1] = octets[1];
+        packed[2] = octets[2];
+        packed[3] = octets[3];
+        if (!ctx.Memory.TryWrite(dstAddress, packed))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        ctx[CpuRegister.Rax] = 1;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "GstHtons0",
+        ExportName = "GuestHtons",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int GuestHtons(CpuContext ctx)
+    {
+        var value = unchecked((ushort)ctx[CpuRegister.Rdi]);
+        var swapped = (ushort)(((value & 0x00FF) << 8) | ((value >> 8) & 0x00FF));
+        ctx[CpuRegister.Rax] = swapped;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    private static bool TryReadCString(ulong address, out string text, CpuContext ctx)
+    {
+        const int maxLength = 64;
+        var buffer = new byte[maxLength];
+        var length = 0;
+        for (; length < maxLength; length++)
+        {
+            if (!ctx.Memory.TryRead(address + (ulong)length, buffer.AsSpan(length, 1)))
+            {
+                text = string.Empty;
+                return false;
+            }
+
+            if (buffer[length] == 0)
+            {
+                break;
+            }
+        }
+
+        text = Encoding.ASCII.GetString(buffer, 0, length);
+        return true;
+    }
+
+    private static bool TryParseIpv4Address(string text, out byte[] octets)
+    {
+        octets = Array.Empty<byte>();
+        var parts = text.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 4)
+        {
+            return false;
+        }
+
+        var parsed = new byte[4];
+        for (var i = 0; i < 4; i++)
+        {
+            if (!byte.TryParse(parts[i], out parsed[i]))
+            {
+                return false;
+            }
+        }
+
+        octets = parsed;
+        return true;
+    }
+
+    [SysAbiExport(
         Nid = "FxVZqBAA7ks",
         ExportName = "_write",
         Target = Generation.Gen4 | Generation.Gen5,
@@ -2223,6 +2638,40 @@ public static class KernelMemoryCompatExports
 
             ctx[CpuRegister.Rax] = unchecked((ulong)requested);
             return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        if (IsEmulatedSocketFd(fd))
+        {
+            if (!TryGetEmulatedSocketState(fd, out var socketState) ||
+                socketState is null ||
+                !socketState.Connected)
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            }
+
+            if (socketState.Stream is not null)
+            {
+                try
+                {
+                    socketState.Stream.Write(payload, 0, requested);
+                    socketState.Stream.Flush();
+                }
+                catch (IOException)
+                {
+                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                }
+
+                if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_NET"), "1", StringComparison.Ordinal))
+                {
+                    Console.Out.Write(Encoding.UTF8.GetString(payload));
+                    Console.Out.Flush();
+                }
+
+                ctx[CpuRegister.Rax] = unchecked((ulong)requested);
+                return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+            }
+
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
         }
 
         FileStream? stream;
@@ -4131,7 +4580,7 @@ public static class KernelMemoryCompatExports
     private struct RegisterPrintfArgumentSource : IPrintfArgumentSource
     {
         // SysV AMD64: variadic integer/pointer args use the GP registers (rdi..r9, up to
-        // 6) and variadic float/double args use xmm0..xmm7 (8) — INDEPENDENT counters.
+        // 6) and variadic float/double args use xmm0..xmm7 (8) -- INDEPENDENT counters.
         // Args beyond the registers spill to the stack in source order, so GP-overflow
         // and FP-overflow share one stack cursor.
         private readonly CpuContext _ctx;

--- a/src/SharpEmu.Libs/Kernel/KernelModuleRegistry.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelModuleRegistry.cs
@@ -97,14 +97,23 @@ public static class KernelModuleRegistry
         }
     }
 
-    public static int RegisterSyntheticModule(string moduleName, bool isSystemModule)
+    public static int RegisterSyntheticModule(
+        string moduleName,
+        bool isSystemModule,
+        ulong baseAddress = 0,
+        ulong size = 0)
     {
         lock (_gate)
         {
             if (TryResolveHandleByNameLocked(moduleName, out var existingHandle))
             {
                 var existing = _modulesByHandle[existingHandle];
-                _modulesByHandle[existingHandle] = existing with { IsSystemModule = existing.IsSystemModule || isSystemModule };
+                _modulesByHandle[existingHandle] = existing with
+                {
+                    BaseAddress = baseAddress != 0 ? baseAddress : existing.BaseAddress,
+                    EndAddress = baseAddress != 0 ? ComputeEnd(baseAddress, size) : existing.EndAddress,
+                    IsSystemModule = existing.IsSystemModule || isSystemModule,
+                };
                 return existingHandle;
             }
 
@@ -116,8 +125,8 @@ public static class KernelModuleRegistry
                 Handle: handle,
                 Name: fallbackName,
                 Path: string.Empty,
-                BaseAddress: 0,
-                EndAddress: 0,
+                BaseAddress: baseAddress,
+                EndAddress: ComputeEnd(baseAddress, size),
                 EntryPoint: 0,
                 IsMain: false,
                 IsSystemModule: isSystemModule);


### PR DESCRIPTION
## Summary

- Apply formal data relocations (section RELA, PT_DYNAMIC, SCE RELA) before import stub patching.
- Detect guest CRT entry via the exported CRT start symbol and build a payload_args-style frame (dlsym callback stub, rwpipe/rwpair, payloadout).
- Route bootstrap-bridge operations through the native import path and add a CRT lazy dlsym stub pool for libkernel handle `0x2001`.
- Resolve libkernel dlsym with named compat only (`socket`, `connect`, `inet_pton`, `htons`, `bzero`); unresolved symbols fail closed (no blanket zero-return stub).
- For ET_EXEC images without formal reloc metadata, rebase link-time VAs in writable PROGBITS (e.g. `.got`) by adding the load base.
- Add minimal emulated socket/TCP client HLE with shared FD allocation, connect-failure cleanup, and default-deny outbound TCP unless the destination is loopback or `SHARPEMU_NET_REDIRECT` is set.
## Problem

SharpEmu could run some standalone ELFs through the WebKit-style bootstrap path (import table + lazy dlsym), but guest CRT binaries with a dedicated CRT entry export did not run end-to-end:

1. No CRT entry path these ELFs expect a `payload_args`-style frame and a working libkernel `dlsym` callback (`0x2001`), not the generic `_start` / bootstrap-only flow.
2. Missing reloc coverage for ET_EXEC guests many CRT examples are `ET_EXEC` with **no** `PT_DYNAMIC`, `SHT_RELA`, or SCE reloc programs. Link-time VAs in writable sections (e.g. `.got`) were never rebased to the actual load base, so CRT init crashed (e.g. AV in `init_dlsym`) before guest code reached the payload.
3. Two ELF shapes ELFs that ship formal reloc metadata already worked via RELA/dynamic/SCE paths; CRT-style `ET_EXEC` ELFs needed a separate, scoped fix without assuming reloc tables exist.
4. No honest libkernel surface for CRT resolving every unknown `dlsym` name to a silent zero-return stub hid missing HLE and made failures hard to diagnose; CRT still needs a small named set (`socket`, `connect`, etc.) to reach a real payload.
5. No minimal outbound TCP for socket examples even after load/fixup, TCP client examples need socket/connect HLE and a safe default network policy.

## this PR 

- Runs guest CRT ELFs through the correct entry path (CRT start detection, payload args, bootstrap bridge routing, CRT lazy dlsym pool).
- Applies formal data relocations where the ELF provides them (section RELA, PT_DYNAMIC, SCE RELA).
- Rebases ET_EXEC writable PROGBITS when formal relocs are absent fixes `.got`/link-time pointers so CRT init can proceed (verified: 1748 load-base patches on a CRT socket example).
- Fail-closed libkernel dlsym unresolved names fail instead of blanket zero stubs; named compat covers the small set needed for the current demo.
- Minimal emulated TCP client enough for a CRT socket example with host redirect; default-deny outbound unless loopback or `SHARPEMU_NET_REDIRECT`.
## Limitations

- Guest CRT entry requires the exported CRT start symbol; ordinary `_start` binaries continue to use generic/bootstrap paths.
- ET_DYN images with reloc metadata use formal RELA/dynamic/SCE paths only.
- ET_EXEC images without formal reloc entries receive load-base rebasing in writable PROGBITS only, not a full-image PIE scan.
- Unresolved libkernel `dlsym` names fail closed; CRT paths that depend on unknown symbols may not complete on other ELFs.
- Emulated TCP is host `TcpClient`-backed client HLE only (no listen/accept/UDP/select).
- Outbound TCP is denied unless the destination is loopback or `SHARPEMU_NET_REDIRECT` is set.
- Connect failures set `rax = -1` without guest TLS errno yet.
- Named compat covers `socket`, `connect`, `inet_pton`, `htons`, and `bzero` only.