### PR TITLE
[VideoOut] Display game icon (icon0.png) in window title bar

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/PngSplashLoader.cs
+++ b/src/SharpEmu.Libs/VideoOut/PngSplashLoader.cs
@@ -14,6 +14,17 @@ internal static class PngSplashLoader
     ];
 
     public static bool TryLoad(out byte[] pixels, out uint width, out uint height)
+        => TryLoad("pic0.png", requestRgba: false, out pixels, out width, out height);
+
+    public static bool TryLoadIcon(out byte[] pixels, out uint width, out uint height)
+        => TryLoad("icon0.png", requestRgba: true, out pixels, out width, out height);
+
+    private static bool TryLoad(
+        string fileName,
+        bool requestRgba,
+        out byte[] pixels,
+        out uint width,
+        out uint height)
     {
         pixels = [];
         width = 0;
@@ -27,13 +38,18 @@ internal static class PngSplashLoader
                 return false;
             }
 
-            var path = Path.Combine(app0Root, "sce_sys", "pic0.png");
+            var path = Path.Combine(app0Root, "sce_sys", fileName);
             if (!File.Exists(path))
             {
                 return false;
             }
 
-            return TryDecode(File.ReadAllBytes(path), out pixels, out width, out height);
+            return TryDecode(
+                File.ReadAllBytes(path),
+                out pixels,
+                out width,
+                out height,
+                requestRgba);
         }
         catch
         {
@@ -48,7 +64,8 @@ internal static class PngSplashLoader
         ReadOnlySpan<byte> png,
         out byte[] pixels,
         out uint width,
-        out uint height)
+        out uint height,
+        bool requestRgba)
     {
         pixels = [];
         width = 0;
@@ -154,9 +171,13 @@ internal static class PngSplashLoader
              sourceOffset < reconstructed.Length;
              sourceOffset += sourceBytesPerPixel, targetOffset += 4)
         {
-            pixels[targetOffset] = reconstructed[sourceOffset + 2];
+            pixels[targetOffset] = requestRgba
+                ? reconstructed[sourceOffset]
+                : reconstructed[sourceOffset + 2];
             pixels[targetOffset + 1] = reconstructed[sourceOffset + 1];
-            pixels[targetOffset + 2] = reconstructed[sourceOffset];
+            pixels[targetOffset + 2] = requestRgba
+                ? reconstructed[sourceOffset + 2]
+                : reconstructed[sourceOffset];
             pixels[targetOffset + 3] = sourceBytesPerPixel == 4
                 ? reconstructed[sourceOffset + 3]
                 : (byte)0xFF;

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1138,6 +1138,12 @@ internal static unsafe class VulkanVideoPresenter
 
         private void Initialize()
         {
+            if (PngSplashLoader.TryLoadIcon(out var iconPixels, out var iconWidth, out var iconHeight))
+            {
+                var icon = new RawImage((int)iconWidth, (int)iconHeight, iconPixels);
+                _window.SetWindowIcon(ref icon);
+            }
+
             WaitForRenderDocAttachIfRequested();
             _vk = Vk.GetApi();
             CreateInstance();


### PR DESCRIPTION
This PR loads the game's icon (icon0.png) from the sce_sys directory and sets it as the main window icon.

It falls back gracefully if the icon is missing or fails to load.

Tested on Windows 11 in Dead Cells, Dreaming Sarah, and Void Terrarium. Also verified that splash screen logic still works with Void Terrarium.

<img width="1282" height="752" alt="SharpEmu_KuMyJ4YDKH" src="https://github.com/user-attachments/assets/ecc29c3b-c8e0-4574-8e96-aa5af5404f85" />
<img width="1282" height="752" alt="SharpEmu_QkSvq5Uize" src="https://github.com/user-attachments/assets/194fb25d-863e-42cd-8199-eed6fcd99d1f" />
<img width="1282" height="752" alt="SharpEmu_FA67zmGIk0" src="https://github.com/user-attachments/assets/ed66553d-68d1-4904-813e-d4a5c08f4eb2" />
