### PR TITLE
Fix WaitSema import-loop guard boundary

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -1082,7 +1082,7 @@ public sealed partial class DirectExecutionBackend
         "1jfXLRVzisc" => true, // sceKernelUsleep
         "QcteRwbsnV0" => true, // usleep
         "n88vx3C5nW8" => true, // gettimeofday
-        "Zxa0VhQVIsk" => true,
+        "Zxa0VhQVTsk" => true, // sceKernelWaitSema
         "T72hz6ffq08" => true, // scePthreadYield
         _ => false
     };


### PR DESCRIPTION
## Summary

- Restore the sceKernelWaitSema NID in the import-loop guard boundary table.
- Keep legitimate repeated semaphore waits from reaching the forced guest-exit path.

## Validation

- Locked dependency restore completed.
- Release solution build completed with zero warnings and zero errors.
