### PR TITLE
[AGC] Emit Gen5 packed-integer and bit-count ALU ops

### DIFF
--- a/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
@@ -396,6 +396,14 @@ internal static partial class Gen5SpirvTranslator
                             _module.Constant64(_ulongType, 32)));
                     break;
                 }
+                case "VBcntU32B32":
+                    result = IAdd(
+                        _module.AddInstruction(
+                            SpirvOp.BitCount,
+                            _uintType,
+                            GetRawSource(instruction, 0)),
+                        GetRawSource(instruction, 1));
+                    break;
                 case "VMadU32U24":
                 {
                     var left = BitwiseAnd(
@@ -702,6 +710,14 @@ internal static partial class Gen5SpirvTranslator
                     result = Ext(58, _uintType, vector);
                     break;
                 }
+                case "VCvtPkU16U32":
+                case "VCvtPkI16I32":
+                    result = BitwiseOr(
+                        BitwiseAnd(GetRawSource(instruction, 0), UInt(0xFFFF)),
+                        ShiftLeftLogical(
+                            BitwiseAnd(GetRawSource(instruction, 1), UInt(0xFFFF)),
+                            UInt(16)));
+                    break;
                 default:
                     error = $"unsupported vector opcode {instruction.Opcode}";
                     return false;
@@ -1303,6 +1319,43 @@ internal static partial class Gen5SpirvTranslator
                             Store(_scc, IsNotZero(result));
                             break;
                         }
+                        case "SAbsdiffI32":
+                        {
+                            var wideLeft = _module.AddInstruction(
+                                SpirvOp.SConvert,
+                                _longType,
+                                Bitcast(_intType, left));
+                            var wideRight = _module.AddInstruction(
+                                SpirvOp.SConvert,
+                                _longType,
+                                Bitcast(_intType, right));
+                            var difference = _module.AddInstruction(
+                                SpirvOp.ISub,
+                                _longType,
+                                wideLeft,
+                                wideRight);
+                            result = _module.AddInstruction(
+                                SpirvOp.UConvert,
+                                _uintType,
+                                Ext(5, _longType, difference));
+                            Store(_scc, IsNotZero(result));
+                            break;
+                        }
+                        case "SPackLlB32B16":
+                            result = BitwiseOr(
+                                BitwiseAnd(left, UInt(0xFFFF)),
+                                ShiftLeftLogical(right, UInt(16)));
+                            break;
+                        case "SPackLhB32B16":
+                            result = BitwiseOr(
+                                BitwiseAnd(left, UInt(0xFFFF)),
+                                BitwiseAnd(right, UInt(0xFFFF0000)));
+                            break;
+                        case "SPackHhB32B16":
+                            result = BitwiseOr(
+                                ShiftRightLogical(left, UInt(16)),
+                                BitwiseAnd(right, UInt(0xFFFF0000)));
+                            break;
                         case "SCselectB32":
                             result = _module.AddInstruction(
                                 SpirvOp.Select,


### PR DESCRIPTION
## What changed

Emit SPIR-V for seven Gen5 ALU instructions that the decoder already recognizes:

- `v_bcnt_u32_b32`
- `v_cvt_pk_u16_u32`
- `v_cvt_pk_i16_i32`
- `s_absdiff_i32`
- `s_pack_ll_b32_b16`
- `s_pack_lh_b32_b16`
- `s_pack_hh_b32_b16`

## Why

These instructions currently decode successfully but fail the SPIR-V stage with `unsupported vector opcode` / `unsupported scalar opcode`, rejecting the whole guest shader. The scalar evaluator already implements the four SALU operations, so this also closes an internal evaluator/emitter mismatch.

`v_bcnt_u32_b32` maps directly to `OpBitCount` plus the accumulator source. The packed conversions preserve the low 16 bits of each source, matching AMDGPU's `<2 x i16>` operation and the established shadPS4 lowering. `s_absdiff_i32` widens before subtracting so the full unsigned result up to `0xffffffff` is preserved.

## Impact

Vertex, pixel, or compute shaders using these operations can now reach Vulkan pipeline creation instead of falling back when translation stops at the first unsupported opcode. This is generic shader coverage and contains no game-specific handling.

## Validation

- `dotnet build SharpEmu.slnx --configuration Release --no-restore --no-incremental` — 0 warnings, 0 errors
- synthetic gfx10 program containing all seven operations:
  - current `main`: vertex and compute emission both fail at `VBcntU32B32`
  - this branch: vertex and compute emission both succeed
- `spirv-val --target-env vulkan1.3 pack-bitcount.spv`
- `spirv-val --target-env vulkan1.3 pack-bitcount-cs.spv`
- inspected disassembly for `OpBitCount`, 64-bit `SAbs`, and the expected mask/shift/or packing sequence

The synthetic words were assembled against the existing decoder tables and run through the real `Gen5ShaderTranslator -> Gen5SpirvTranslator` pipeline using the shader dump harness from #111.
