### PR TITLE
Align SysAbi export names with Aerolib NID catalog

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -877,7 +877,7 @@ public sealed partial class DirectExecutionBackend
 			"Q2V+iqvjgC0" or // vsnprintf
 			"j4ViWNHEgww" or // strlen
 			"5jNubw4vlAA" or // strnlen
-			"LHMrG7e8G78" or // wcslen
+			"LHMrG7e8G78" or // wcsmisc
 			"WkkeywLJcgU" or // wcslen
 			"Ovb2dSJOAuE" or // strcmp
 			"aesyjrHVWy4" or // strncmp

--- a/src/SharpEmu.Libs/Json/JsonExports.cs
+++ b/src/SharpEmu.Libs/Json/JsonExports.cs
@@ -80,7 +80,7 @@ public static class JsonExports
 
     [SysAbiExport(
         Nid = "WSOuge5IsCg",
-        ExportName = "_ZN3sce4Json15InitParameter2C2Ev",
+        ExportName = "_ZN3sce4Json14InitParameter2C1Ev",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libSceJson2")]
     public static int InitParameter2Constructor(CpuContext ctx)
@@ -93,7 +93,7 @@ public static class JsonExports
 
     [SysAbiExport(
         Nid = "I2QC8PYhJWY",
-        ExportName = "_ZN3sce4Json15InitParameter212setAllocatorERNS0_12MemAllocatorE",
+        ExportName = "_ZN3sce4Json14InitParameter212setAllocatorEPNS0_12MemAllocatorEPv",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libSceJson2")]
     public static int InitParameter2SetAllocator(CpuContext ctx)
@@ -106,7 +106,7 @@ public static class JsonExports
 
     [SysAbiExport(
         Nid = "Eu95jmqn5Rw",
-        ExportName = "_ZN3sce4Json15InitParameter217setFileBufferSizeEm",
+        ExportName = "_ZN3sce4Json14InitParameter217setFileBufferSizeEm",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libSceJson2")]
     public static int InitParameter2SetFileBufferSize(CpuContext ctx)
@@ -119,7 +119,7 @@ public static class JsonExports
 
     [SysAbiExport(
         Nid = "IXW-z8pggfg",
-        ExportName = "_ZN3sce4Json12Initializer2C1Ev",
+        ExportName = "_ZN3sce4Json11Initializer10initializeEPKNS0_14InitParameter2E",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libSceJson2")]
     public static int Initializer2Constructor(CpuContext ctx)

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -478,7 +478,7 @@ public static class KernelMemoryCompatExports
 
     [SysAbiExport(
         Nid = "LHMrG7e8G78",
-        ExportName = "wcslen",
+        ExportName = "wcsmisc",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libc")]
     public static int Wcslen(CpuContext ctx)
@@ -3013,7 +3013,7 @@ public static class KernelMemoryCompatExports
 
     [SysAbiExport(
         Nid = "4h6F1LLbTiw",
-        ExportName = "sceKernelMapFlexibleMemoryInternal",
+        ExportName = "sceKernelMapNamedFlexibleMemoryInternal",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libKernel")]
     public static int KernelMapFlexibleMemoryInternal(CpuContext ctx)

--- a/src/SharpEmu.Libs/LibcInternalExports.cs
+++ b/src/SharpEmu.Libs/LibcInternalExports.cs
@@ -19,7 +19,7 @@ public static class LibcInternalExports
 
     [SysAbiExport(
         Nid = "NWtTN10cJzE",
-        ExportName = "LibcHeapGetTraceInfo",
+        ExportName = "sceLibcHeapGetTraceInfo",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "LibcInternalExt")]
     public static int LibcHeapGetTraceInfo(CpuContext ctx)


### PR DESCRIPTION
## Summary

- Align `SysAbiExport.ExportName` with the Aerolib / `name2nid` catalog for seven NIDs whose registered names did not hash to their NID
- Leave `Nid=` and handler bodies unchanged; import dispatch by NID is unaffected
- Fix the leaf-import comment that incorrectly labeled `LHMrG7e8G78` as `wcslen` (it is `wcsmisc`; real `wcslen` remains `WkkeywLJcgU`)

Renames: `sceLibcHeapGetTraceInfo`, `sceKernelMapNamedFlexibleMemoryInternal`, `wcsmisc`, and 4 libSceJson2 mangled names