### PR TITLE
[AGC] Emit Gen5 v_sad_u32

### DIFF
--- a/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
@@ -593,6 +593,18 @@ internal static partial class Gen5SpirvTranslator
                         Ext(38, _uintType, high, right));
                     break;
                 }
+                case "VSadU32":
+                {
+                    var left = GetRawSource(instruction, 0);
+                    var right = GetRawSource(instruction, 1);
+                    var difference = _module.AddInstruction(
+                        SpirvOp.ISub,
+                        _uintType,
+                        Ext(41, _uintType, left, right),
+                        Ext(38, _uintType, left, right));
+                    result = IAdd(difference, GetRawSource(instruction, 2));
+                    break;
+                }
                 case "VMed3I32":
                 {
                     var left = Bitcast(_intType, GetRawSource(instruction, 0));


### PR DESCRIPTION
## Summary
- emit the already-decoded Gen5 `v_sad_u32` vector ALU instruction
- lower unsigned absolute difference as `UMax - UMin`, then add the third source
- allow shaders using this common SAD primitive to reach SPIR-V instead of failing on an unsupported opcode

## Validation
- `dotnet build SharpEmu.slnx --no-restore` (0 warnings, 0 errors)
- synthetic Gen5 shader containing `v_sad_u32 v5, v1, v2, v3` emits successfully for vertex and compute paths (both failed before this change)
- `spirv-val --target-env vulkan1.3` passes for both generated modules
- disassembly confirms `UMax`, `UMin`, `OpISub`, and `OpIAdd`