### PR TITLE
[Pad] Approximate trigger vibration on XInput

### DIFF
--- a/src/SharpEmu.Libs/Pad/PadExports.cs
+++ b/src/SharpEmu.Libs/Pad/PadExports.cs
@@ -192,7 +192,41 @@ public static class PadExports
         LibraryName = "libScePad")]
     public static int PadSetTriggerEffect(CpuContext ctx)
     {
+        var handle = unchecked((int)ctx[CpuRegister.Rdi]);
+        var parameterAddress = ctx[CpuRegister.Rsi];
+        if (handle != PrimaryPadHandle)
+        {
+            return ctx.SetReturn(OrbisPadErrorInvalidHandle);
+        }
+
+        if (parameterAddress == 0)
+        {
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        Span<byte> parameter = stackalloc byte[120];
+        if (!ctx.Memory.TryRead(parameterAddress, parameter))
+        {
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        var triggerMask = parameter[0];
+        XInputReader.SetTriggerRumble(
+            (triggerMask & 0x01) != 0 ? DecodeTriggerVibration(parameter[8..64]) : null,
+            (triggerMask & 0x02) != 0 ? DecodeTriggerVibration(parameter[64..120]) : null);
         return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    private static byte DecodeTriggerVibration(ReadOnlySpan<byte> command)
+    {
+        var mode = BinaryPrimitives.ReadUInt32LittleEndian(command);
+        var amplitude = mode switch
+        {
+            3 when command[10] != 0 => command[9],
+            6 when command[8] != 0 => command[9..19].ToArray().Max(),
+            _ => (byte)0,
+        };
+        return (byte)(Math.Min(amplitude, (byte)8) * 255 / 8);
     }
 
     [SysAbiExport(

--- a/src/SharpEmu.Libs/Pad/XInputReader.cs
+++ b/src/SharpEmu.Libs/Pad/XInputReader.cs
@@ -39,6 +39,8 @@ internal static class XInputReader
     private static int _slot = -1; // connected XInput user index, -1 when none
     private static byte _motorLeft;
     private static byte _motorRight;
+    private static byte _triggerLeft;
+    private static byte _triggerRight;
 
     /// <summary>Starts the background reader once; safe to call repeatedly.</summary>
     internal static void EnsureStarted()
@@ -99,6 +101,31 @@ internal static class XInputReader
         }
     }
 
+    /// <summary>Approximates per-trigger vibration on the two XInput body motors.</summary>
+    internal static void SetTriggerRumble(byte? leftTrigger, byte? rightTrigger)
+    {
+        lock (Gate)
+        {
+            var changed = false;
+            if (leftTrigger is { } left)
+            {
+                changed |= _triggerLeft != left;
+                _triggerLeft = left;
+            }
+
+            if (rightTrigger is { } right)
+            {
+                changed |= _triggerRight != right;
+                _triggerRight = right;
+            }
+
+            if (changed)
+            {
+                SendRumbleLocked();
+            }
+        }
+    }
+
     private static void SendRumbleLocked()
     {
         if (_slot < 0)
@@ -108,8 +135,8 @@ internal static class XInputReader
 
         var vibration = new XInputVibration
         {
-            LeftMotorSpeed = (ushort)(_motorLeft * 257),   // 0..255 -> 0..65535
-            RightMotorSpeed = (ushort)(_motorRight * 257),
+            LeftMotorSpeed = (ushort)(Math.Max(_motorLeft, _triggerLeft) * 257),
+            RightMotorSpeed = (ushort)(Math.Max(_motorRight, _triggerRight) * 257),
         };
         _ = XInputSetState((uint)_slot, ref vibration);
     }
@@ -147,6 +174,8 @@ internal static class XInputReader
                     _slot = -1;
                     _motorLeft = 0;
                     _motorRight = 0;
+                    _triggerLeft = 0;
+                    _triggerRight = 0;
                     _state = default;
                 }
 


### PR DESCRIPTION
## Summary
- implement the previously stubbed `scePadSetTriggerEffect` parameter read and validation
- approximate DualSense vibration trigger modes on XInput's two available body motors
- combine trigger effects with ordinary rumble instead of letting either path overwrite the other

## Behavior
`VIBRATION` and `MULTIPLE_POSITION_VIBRATION` amplitudes are scaled from the ScePad 0..8 range to XInput 0..255. L2 feeds the left/low-frequency motor and R2 feeds the right/high-frequency motor. Frequency zero and non-vibration modes stop the corresponding approximation; resistance and weapon modes are deliberately not presented as continuous rumble because XInput cannot reproduce adaptive-trigger resistance.

This remains a fallback approximation: XInput exposes only the two body motors, not the Series controller's impulse-trigger motors. It nevertheless gives Xbox users tactile feedback for effects that were previously ignored completely.

## Validation
- `dotnet build SharpEmu.slnx --no-restore` (0 warnings, 0 errors)
- end-to-end `CpuContext` harness covering single-trigger vibration, multi-position amplitude selection, 0..8 to 0..255 scaling, partial trigger masks, and OFF/reset behavior