### PR TITLE
[Vulkan] Add safe guest buffer allocation cache

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Validate synthetic shaders
         run: dotnet run --project tools/SharpEmu.Tools.ShaderDump/SharpEmu.Tools.ShaderDump.csproj -c Release -- artifacts/shader-dump
 
+      - name: Test guest buffer allocation cache
+        run: dotnet run --project tests/SharpEmu.Tests.GuestBufferCache/SharpEmu.Tests.GuestBufferCache.csproj -c Release --no-build
+
       - name: Publish win-x64 CLI
         run: dotnet publish src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r win-x64 --self-contained true --no-restore -p:PublishDir="${env:PUBLISH_DIR}"
 

--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -14,5 +14,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj" />
+    <Project Path="tests/SharpEmu.Tests.GuestBufferCache/SharpEmu.Tests.GuestBufferCache.csproj" />
   </Folder>
 </Solution>

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -3771,7 +3771,7 @@ public static class AgcExports
         var address = state.IndexBufferAddress + byteOffset;
         return (ctx.Memory.TryRead(address, data) ||
                 KernelMemoryCompatExports.TryReadTrackedLibcHeap(address, data))
-            ? new VulkanGuestIndexBuffer(data, is32Bit)
+            ? new VulkanGuestIndexBuffer(data, is32Bit, address)
             : null;
     }
 
@@ -3817,7 +3817,10 @@ public static class AgcExports
             data[offset + 3] = (byte)(value >> 24);
         }
 
-        return new Gen5GlobalMemoryBinding(0, 0, [], data);
+        return new Gen5GlobalMemoryBinding(0, 0, [], data)
+        {
+            Access = Gen5GlobalMemoryAccess.Read,
+        };
     }
 
     private static ulong ComputeShaderStructureFingerprint(Gen5ShaderEvaluation evaluation)
@@ -4339,7 +4342,14 @@ public static class AgcExports
         {
             buffers[index] = new VulkanGuestMemoryBuffer(
                 bindings[index].BaseAddress,
-                bindings[index].Data);
+                bindings[index].Data,
+                bindings[index].Access switch
+                {
+                    Gen5GlobalMemoryAccess.Read => GuestBufferAccess.Read,
+                    Gen5GlobalMemoryAccess.Write => GuestBufferAccess.Write,
+                    Gen5GlobalMemoryAccess.ReadWrite => GuestBufferAccess.ReadWrite,
+                    _ => GuestBufferAccess.None,
+                });
         }
 
         return buffers;

--- a/src/SharpEmu.Libs/Agc/Gen5ShaderIr.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5ShaderIr.cs
@@ -271,11 +271,23 @@ internal sealed record Gen5ImageBinding(
     IReadOnlyList<uint> SamplerDescriptor,
     uint? MipLevel);
 
+[Flags]
+internal enum Gen5GlobalMemoryAccess
+{
+    None = 0,
+    Read = 1,
+    Write = 2,
+    ReadWrite = Read | Write,
+}
+
 internal sealed record Gen5GlobalMemoryBinding(
     uint ScalarAddress,
     ulong BaseAddress,
     IReadOnlyList<uint> InstructionPcs,
-    byte[] Data);
+    byte[] Data)
+{
+    public required Gen5GlobalMemoryAccess Access { get; set; }
+}
 
 internal sealed record Gen5VertexInputBinding(
     uint Pc,

--- a/src/SharpEmu.Libs/Agc/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5ShaderScalarEvaluator.cs
@@ -215,6 +215,7 @@ internal static class Gen5ShaderScalarEvaluator
                 var key = (globalMemory.ScalarAddress, baseAddress);
                 if (globalMemoryByAddress.TryGetValue(key, out var existingBinding))
                 {
+                    existingBinding.Access |= ClassifyGlobalMemoryAccess(instruction.Opcode);
                     if (existingBinding.InstructionPcs is List<uint> instructionPcs)
                     {
                         instructionPcs.Add(instruction.Pc);
@@ -235,7 +236,10 @@ internal static class Gen5ShaderScalarEvaluator
                         globalMemory.ScalarAddress,
                         baseAddress,
                         new List<uint> { instruction.Pc },
-                        data);
+                        data)
+                    {
+                        Access = ClassifyGlobalMemoryAccess(instruction.Opcode),
+                    };
                     globalMemoryByAddress.Add(key, binding);
                     globalMemoryBindings.Add(binding);
                 }
@@ -328,6 +332,7 @@ internal static class Gen5ShaderScalarEvaluator
                 var key = (bufferMemory.ScalarResource, bufferDescriptor.BaseAddress);
                 if (globalMemoryByAddress.TryGetValue(key, out var existingBinding))
                 {
+                    existingBinding.Access |= ClassifyGlobalMemoryAccess(instruction.Opcode);
                     if (existingBinding.InstructionPcs is List<uint> instructionPcs)
                     {
                         instructionPcs.Add(instruction.Pc);
@@ -358,7 +363,10 @@ internal static class Gen5ShaderScalarEvaluator
                         bufferMemory.ScalarResource,
                         bufferDescriptor.BaseAddress,
                         new List<uint> { instruction.Pc },
-                        data);
+                        data)
+                    {
+                        Access = ClassifyGlobalMemoryAccess(instruction.Opcode),
+                    };
                     globalMemoryByAddress.Add(key, binding);
                     globalMemoryBindings.Add(binding);
                 }
@@ -1417,12 +1425,20 @@ internal static class Gen5ShaderScalarEvaluator
             var key = (scalarBase.Value, bufferDescriptor.BaseAddress);
             if (globalMemoryByAddress.TryGetValue(key, out var existingBinding))
             {
+                existingBinding.Access |= Gen5GlobalMemoryAccess.Read;
                 if (existingBinding.InstructionPcs is List<uint> instructionPcs) instructionPcs.Add(instruction.Pc);
             }
             else
             {
                 TryReadGlobalMemory(ctx, bufferDescriptor.BaseAddress, bufferDescriptor.SizeBytes, out var data);
-                var binding = new Gen5GlobalMemoryBinding(scalarBase.Value, bufferDescriptor.BaseAddress, new List<uint> { instruction.Pc }, data);
+                var binding = new Gen5GlobalMemoryBinding(
+                    scalarBase.Value,
+                    bufferDescriptor.BaseAddress,
+                    new List<uint> { instruction.Pc },
+                    data)
+                {
+                    Access = Gen5GlobalMemoryAccess.Read,
+                };
                 globalMemoryByAddress.Add(key, binding);
                 globalMemoryBindings.Add(binding);
             }
@@ -1432,6 +1448,7 @@ internal static class Gen5ShaderScalarEvaluator
             var key = (scalarBase.Value, baseAddress);
             if (globalMemoryByAddress.TryGetValue(key, out var existingBinding))
             {
+                existingBinding.Access |= Gen5GlobalMemoryAccess.Read;
                 if (existingBinding.InstructionPcs is List<uint> instructionPcs)
                 {
                     instructionPcs.Add(instruction.Pc);
@@ -1461,7 +1478,10 @@ internal static class Gen5ShaderScalarEvaluator
                     scalarBase.Value,
                     baseAddress,
                     new List<uint> { instruction.Pc },
-                    data);
+                    data)
+                {
+                    Access = Gen5GlobalMemoryAccess.Read,
+                };
                 globalMemoryByAddress.Add(key, binding);
                 globalMemoryBindings.Add(binding);
             }
@@ -1829,5 +1849,22 @@ internal static class Gen5ShaderScalarEvaluator
     private static bool UsesSampler(string opcode) =>
         opcode.StartsWith("ImageSample", StringComparison.Ordinal) ||
         opcode.StartsWith("ImageGather", StringComparison.Ordinal);
+
+    private static Gen5GlobalMemoryAccess ClassifyGlobalMemoryAccess(string opcode)
+    {
+        if (opcode.Contains("Atomic", StringComparison.Ordinal))
+        {
+            return Gen5GlobalMemoryAccess.ReadWrite;
+        }
+        if (opcode.Contains("Store", StringComparison.Ordinal))
+        {
+            return Gen5GlobalMemoryAccess.Write;
+        }
+        if (opcode.Contains("Load", StringComparison.Ordinal))
+        {
+            return Gen5GlobalMemoryAccess.Read;
+        }
+        return Gen5GlobalMemoryAccess.None;
+    }
 
 }

--- a/src/SharpEmu.Libs/SharpEmu.Libs.csproj
+++ b/src/SharpEmu.Libs/SharpEmu.Libs.csproj
@@ -19,6 +19,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <PackageReference Include="Silk.NET.Windowing" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SharpEmu.Tests.GuestBufferCache" />
+  </ItemGroup>
+
   <PropertyGroup>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/SharpEmu.Libs/VideoOut/GuestBufferCache.cs
+++ b/src/SharpEmu.Libs/VideoOut/GuestBufferCache.cs
@@ -1,0 +1,218 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Silk.NET.Vulkan;
+using VkBuffer = Silk.NET.Vulkan.Buffer;
+
+namespace SharpEmu.Libs.VideoOut;
+
+[Flags]
+internal enum GuestBufferUsage
+{
+    None = 0,
+    Storage = 1,
+    Vertex = 2,
+    Index = 4,
+}
+
+[Flags]
+internal enum GuestBufferAccess
+{
+    None = 0,
+    Read = 1,
+    Write = 2,
+    ReadWrite = Read | Write,
+}
+
+internal readonly record struct GuestBufferAllocation(
+    VkBuffer Buffer,
+    DeviceMemory Memory);
+
+internal sealed class GuestBufferResource
+{
+    public required ulong GuestAddress;
+    public required ulong Size;
+    public required VkBuffer Buffer;
+    public required DeviceMemory Memory;
+    public required bool Cached;
+    public ulong Generation;
+    public ulong LastSubmission;
+    public int InFlightReferences;
+}
+
+internal sealed class GuestBufferBinding
+{
+    public required GuestBufferResource Resource { get; init; }
+    public required ulong Offset { get; init; }
+    public required ulong Size { get; init; }
+    public required GuestBufferUsage Usage { get; init; }
+    public required GuestBufferAccess Access { get; init; }
+}
+
+internal delegate void WriteGuestBuffer(
+    GuestBufferResource resource,
+    ulong offset,
+    ReadOnlySpan<byte> data);
+
+internal sealed class GuestBufferCache : IDisposable
+{
+    internal const ulong DefaultMaximumCachedBytes = 64UL * 1024 * 1024;
+
+    private readonly Func<ulong, GuestBufferAllocation> _allocate;
+    private readonly Action<GuestBufferResource> _destroy;
+    private readonly WriteGuestBuffer _write;
+    private readonly ulong _maximumCachedBytes;
+    private readonly List<GuestBufferResource> _resources = [];
+    private readonly Dictionary<(ulong Address, ulong Size), List<GuestBufferResource>>
+        _resourcesByRange = [];
+    private ulong _nextGeneration;
+
+    public GuestBufferCache(
+        Func<ulong, GuestBufferAllocation> allocate,
+        Action<GuestBufferResource> destroy,
+        WriteGuestBuffer write,
+        ulong maximumCachedBytes = DefaultMaximumCachedBytes)
+    {
+        _allocate = allocate;
+        _destroy = destroy;
+        _write = write;
+        _maximumCachedBytes = maximumCachedBytes;
+    }
+
+    public int Count => _resources.Count;
+    public ulong CachedBytes { get; private set; }
+
+    public GuestBufferBinding ObtainBuffer(
+        ulong address,
+        ReadOnlySpan<byte> cpuData,
+        GuestBufferUsage usage,
+        GuestBufferAccess access,
+        ulong submission,
+        bool allowCaching)
+    {
+        var size = (ulong)Math.Max(cpuData.Length, sizeof(uint));
+        allowCaching = allowCaching &&
+            address != 0 &&
+            (access & GuestBufferAccess.Write) != 0;
+
+        var resource = allowCaching
+            ? FindReusableExact(address, size) ?? CreateResource(address, size, cached: true)
+            : CreateResource(address, size, cached: false);
+
+        // CPU memory remains authoritative until page-fault dirty tracking and
+        // GPU-to-CPU readback exist. Never infer ownership from byte equality.
+        if (!cpuData.IsEmpty)
+        {
+            _write(resource, 0, cpuData);
+        }
+
+        resource.LastSubmission = submission;
+        resource.InFlightReferences++;
+        return new GuestBufferBinding
+        {
+            Resource = resource,
+            Offset = 0,
+            Size = size,
+            Usage = usage,
+            Access = access,
+        };
+    }
+
+    public void Release(GuestBufferBinding binding)
+    {
+        var resource = binding.Resource;
+        if (resource.InFlightReferences <= 0)
+        {
+            throw new InvalidOperationException("guest buffer reference count underflow");
+        }
+
+        resource.InFlightReferences--;
+        if (!resource.Cached && resource.InFlightReferences == 0)
+        {
+            _destroy(resource);
+        }
+    }
+
+    public void Collect(ulong completedSubmission)
+    {
+        if (CachedBytes <= _maximumCachedBytes)
+        {
+            return;
+        }
+
+        foreach (var resource in _resources
+            .Where(resource =>
+                resource.InFlightReferences == 0 &&
+                resource.LastSubmission <= completedSubmission)
+            .OrderBy(resource => resource.LastSubmission)
+            .ToArray())
+        {
+            RemoveCached(resource);
+            if (CachedBytes <= _maximumCachedBytes)
+            {
+                break;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_resources.Any(resource => resource.InFlightReferences != 0))
+        {
+            throw new InvalidOperationException("guest buffer cache disposed with in-flight resources");
+        }
+
+        foreach (var resource in _resources)
+        {
+            _destroy(resource);
+        }
+        _resources.Clear();
+        _resourcesByRange.Clear();
+        CachedBytes = 0;
+    }
+
+    private GuestBufferResource? FindReusableExact(ulong address, ulong size) =>
+        _resourcesByRange.TryGetValue((address, size), out var resources)
+            ? resources.LastOrDefault(resource => resource.InFlightReferences == 0)
+            : null;
+
+    private GuestBufferResource CreateResource(ulong address, ulong size, bool cached)
+    {
+        var allocation = _allocate(size);
+        var resource = new GuestBufferResource
+        {
+            GuestAddress = address,
+            Size = size,
+            Buffer = allocation.Buffer,
+            Memory = allocation.Memory,
+            Cached = cached,
+            Generation = ++_nextGeneration,
+        };
+        if (cached)
+        {
+            _resources.Add(resource);
+            if (!_resourcesByRange.TryGetValue((address, size), out var resources))
+            {
+                resources = [];
+                _resourcesByRange.Add((address, size), resources);
+            }
+            resources.Add(resource);
+            CachedBytes = checked(CachedBytes + size);
+        }
+        return resource;
+    }
+
+    private void RemoveCached(GuestBufferResource resource)
+    {
+        _resources.Remove(resource);
+        var key = (resource.GuestAddress, resource.Size);
+        var resources = _resourcesByRange[key];
+        resources.Remove(resource);
+        if (resources.Count == 0)
+        {
+            _resourcesByRange.Remove(key);
+        }
+        CachedBytes -= resource.Size;
+        _destroy(resource);
+    }
+}

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -50,7 +50,8 @@ internal readonly record struct VulkanGuestSampler(
 
 internal sealed record VulkanGuestMemoryBuffer(
     ulong BaseAddress,
-    byte[] Data);
+    byte[] Data,
+    GuestBufferAccess Access);
 
 internal sealed record VulkanGuestVertexBuffer(
     uint Location,
@@ -64,7 +65,8 @@ internal sealed record VulkanGuestVertexBuffer(
 
 internal sealed record VulkanGuestIndexBuffer(
     byte[] Data,
-    bool Is32Bit);
+    bool Is32Bit,
+    ulong BaseAddress);
 
 internal readonly record struct VulkanGuestRect(
     int X,
@@ -178,6 +180,11 @@ internal static unsafe class VulkanVideoPresenter
     private const uint GuestFormatR16G16B16A16Sint = 0x2000C;
 
     private static readonly object _gate = new();
+    private static readonly bool _persistentGuestBufferAllocationsEnabled =
+        string.Equals(
+            Environment.GetEnvironmentVariable("SHARPEMU_PERSISTENT_GUEST_BUFFERS"),
+            "1",
+            StringComparison.Ordinal);
     private static readonly Queue<object> _pendingGuestWork = new();
     private static readonly Dictionary<ulong, uint> _availableGuestImages = new();
     private static readonly Dictionary<ulong, uint> _gpuGuestImages = new();
@@ -636,7 +643,7 @@ internal static unsafe class VulkanVideoPresenter
             groupCountX == 0 ||
             groupCountY == 0 ||
             groupCountZ == 0 ||
-            textures.All(texture => !texture.IsStorage))
+            (textures.All(texture => !texture.IsStorage) && globalMemoryBuffers.Count == 0))
         {
             return;
         }
@@ -1147,6 +1154,7 @@ internal static unsafe class VulkanVideoPresenter
         private readonly HashSet<(ulong Address, int Size)> _tracedGlobalBuffers = new();
         private readonly HashSet<ulong> _tracedGuestImageContents = new();
         private readonly Dictionary<ulong, int> _tracedGuestWriteCounts = new();
+        private readonly Dictionary<ulong, int> _tracedGuestBufferWriteCounts = new();
         private int _tracedVertexBufferCount;
         private readonly Dictionary<byte[], Pipeline> _computePipelines =
             new(ReferenceEqualityComparer.Instance);
@@ -1160,6 +1168,9 @@ internal static unsafe class VulkanVideoPresenter
             _hostBufferPool = new();
         private readonly Dictionary<ulong, HostBufferAllocation> _hostBufferAllocations = new();
         private readonly Queue<PendingGuestSubmission> _pendingGuestSubmissions = new();
+        private GuestBufferCache _guestBufferCache = null!;
+        private ulong _guestBufferSubmission;
+        private ulong _completedGuestBufferSubmission;
 
         private readonly record struct GraphicsPipelineKey(
             string VertexShader,
@@ -1200,9 +1211,9 @@ internal static unsafe class VulkanVideoPresenter
             public TextureResource[] Textures = [];
             public GlobalBufferResource[] GlobalMemoryBuffers = [];
             public VertexBufferResource[] VertexBuffers = [];
-            public VkBuffer IndexBuffer;
-            public DeviceMemory IndexMemory;
+            public GuestBufferBinding? IndexBuffer;
             public bool Index32Bit;
+            public ulong BufferSubmission;
             public uint VertexCount = 3;
             public uint InstanceCount = 1;
             public PrimitiveTopology Topology = PrimitiveTopology.TriangleList;
@@ -1237,22 +1248,23 @@ internal static unsafe class VulkanVideoPresenter
 
         private sealed class GlobalBufferResource
         {
-            public VkBuffer Buffer;
-            public DeviceMemory Memory;
-            public ulong Size;
+            public required GuestBufferBinding Binding;
+            public VkBuffer Buffer => Binding.Resource.Buffer;
+            public ulong Offset => Binding.Offset;
+            public ulong Size => Binding.Size;
         }
 
         private sealed class VertexBufferResource
         {
-            public VkBuffer Buffer;
-            public DeviceMemory Memory;
-            public ulong Size;
+            public required GuestBufferBinding Binding;
+            public VkBuffer Buffer => Binding.Resource.Buffer;
+            public ulong Size => Binding.Size;
             public uint Location;
             public uint ComponentCount;
             public uint DataFormat;
             public uint NumberFormat;
             public uint Stride;
-            public uint OffsetBytes;
+            public ulong OffsetBytes;
         }
 
         private sealed class GuestImageResource
@@ -1336,6 +1348,7 @@ internal static unsafe class VulkanVideoPresenter
             CreateSurface();
             SelectPhysicalDevice();
             CreateDevice();
+            CreateGuestBufferCache();
             CreatePipelineCache();
             CreateSwapchain();
             CreateCommandResources();
@@ -2333,7 +2346,12 @@ internal static unsafe class VulkanVideoPresenter
                     TraceGuestImageContents(image);
                 }
 
+                TraceGuestBufferContents(submission.Resources);
                 DestroyTranslatedDrawResources(submission.Resources);
+                _completedGuestBufferSubmission = Math.Max(
+                    _completedGuestBufferSubmission,
+                    submission.Resources.BufferSubmission);
+                _guestBufferCache.Collect(_completedGuestBufferSubmission);
                 var commandBuffer = submission.CommandBuffer;
                 _vk.FreeCommandBuffers(
                     _device,
@@ -2607,6 +2625,7 @@ internal static unsafe class VulkanVideoPresenter
             var resources = new TranslatedDrawResources
             {
                 DebugName = "SharpEmu draw",
+                BufferSubmission = ++_guestBufferSubmission,
                 Textures = new TextureResource[draw.Textures.Count],
                 GlobalMemoryBuffers =
                     new GlobalBufferResource[draw.GlobalMemoryBuffers.Count],
@@ -2637,21 +2656,28 @@ internal static unsafe class VulkanVideoPresenter
                 for (var index = 0; index < draw.GlobalMemoryBuffers.Count; index++)
                 {
                     resources.GlobalMemoryBuffers[index] =
-                        CreateGlobalBufferResource(draw.GlobalMemoryBuffers[index]);
+                        CreateGlobalBufferResource(
+                            draw.GlobalMemoryBuffers[index],
+                            resources.BufferSubmission);
                 }
 
                 for (var index = 0; index < draw.VertexBuffers.Count; index++)
                 {
                     resources.VertexBuffers[index] =
-                        CreateVertexBufferResource(draw.VertexBuffers[index]);
+                        CreateVertexBufferResource(
+                            draw.VertexBuffers[index],
+                            resources.BufferSubmission);
                 }
 
                 if (draw.IndexBuffer is { Data.Length: > 0 } indexBuffer)
                 {
-                    resources.IndexBuffer = CreateHostBuffer(
+                    resources.IndexBuffer = _guestBufferCache.ObtainBuffer(
+                        indexBuffer.BaseAddress,
                         indexBuffer.Data,
-                        BufferUsageFlags.IndexBufferBit,
-                        out resources.IndexMemory);
+                        GuestBufferUsage.Index,
+                        GuestBufferAccess.Read,
+                        resources.BufferSubmission,
+                        allowCaching: false);
                     resources.Index32Bit = indexBuffer.Is32Bit;
                 }
 
@@ -2689,6 +2715,7 @@ internal static unsafe class VulkanVideoPresenter
             var resources = new TranslatedDrawResources
             {
                 DebugName = BuildComputeDebugName(dispatch),
+                BufferSubmission = ++_guestBufferSubmission,
                 Textures = new TextureResource[dispatch.Textures.Count],
                 GlobalMemoryBuffers =
                     new GlobalBufferResource[dispatch.GlobalMemoryBuffers.Count],
@@ -2737,7 +2764,9 @@ internal static unsafe class VulkanVideoPresenter
                 for (var index = 0; index < dispatch.GlobalMemoryBuffers.Count; index++)
                 {
                     resources.GlobalMemoryBuffers[index] =
-                        CreateGlobalBufferResource(dispatch.GlobalMemoryBuffers[index]);
+                        CreateGlobalBufferResource(
+                            dispatch.GlobalMemoryBuffers[index],
+                            resources.BufferSubmission);
                 }
 
                 if (traceResources)
@@ -2894,7 +2923,7 @@ internal static unsafe class VulkanVideoPresenter
                         bufferInfoPointer[index] = new DescriptorBufferInfo
                         {
                             Buffer = resources.GlobalMemoryBuffers[index].Buffer,
-                            Offset = 0,
+                            Offset = resources.GlobalMemoryBuffers[index].Offset,
                             Range = resources.GlobalMemoryBuffers[index].Size,
                         };
                     }
@@ -4041,13 +4070,18 @@ internal static unsafe class VulkanVideoPresenter
         }
 
         private GlobalBufferResource CreateGlobalBufferResource(
-            VulkanGuestMemoryBuffer guestBuffer)
+            VulkanGuestMemoryBuffer guestBuffer,
+            ulong submission)
         {
-            var buffer = CreateHostBuffer(
+            var binding = _guestBufferCache.ObtainBuffer(
+                guestBuffer.BaseAddress,
                 guestBuffer.Data,
-                BufferUsageFlags.StorageBufferBit,
-                out var memory);
-            var size = (ulong)Math.Max(guestBuffer.Data.Length, sizeof(uint));
+                GuestBufferUsage.Storage,
+                guestBuffer.Access,
+                submission,
+                allowCaching:
+                    _persistentGuestBufferAllocationsEnabled &&
+                    (guestBuffer.Access & GuestBufferAccess.Write) != 0);
 
             if (ShouldTraceVulkanResources() &&
                 _tracedGlobalBuffers.Add((guestBuffer.BaseAddress, guestBuffer.Data.Length)))
@@ -4058,28 +4092,29 @@ internal static unsafe class VulkanVideoPresenter
             }
             SetDebugName(
                 ObjectType.Buffer,
-                buffer.Handle,
+                binding.Resource.Buffer.Handle,
                 $"SharpEmu global 0x{guestBuffer.BaseAddress:X16} {guestBuffer.Data.Length}b");
 
             return new GlobalBufferResource
             {
-                Buffer = buffer,
-                Memory = memory,
-                Size = size,
+                Binding = binding,
             };
         }
 
         private VertexBufferResource CreateVertexBufferResource(
-            VulkanGuestVertexBuffer guestBuffer)
+            VulkanGuestVertexBuffer guestBuffer,
+            ulong submission)
         {
-            var buffer = CreateHostBuffer(
+            var binding = _guestBufferCache.ObtainBuffer(
+                guestBuffer.BaseAddress,
                 guestBuffer.Data,
-                BufferUsageFlags.VertexBufferBit,
-                out var memory);
-            var size = (ulong)Math.Max(guestBuffer.Data.Length, sizeof(uint));
+                GuestBufferUsage.Vertex,
+                GuestBufferAccess.Read,
+                submission,
+                allowCaching: false);
             SetDebugName(
                 ObjectType.Buffer,
-                buffer.Handle,
+                binding.Resource.Buffer.Handle,
                 $"SharpEmu vertex loc{guestBuffer.Location} " +
                 $"0x{guestBuffer.BaseAddress:X16} {guestBuffer.Data.Length}b");
             if (_tracedVertexBufferCount++ < 64)
@@ -4094,15 +4129,13 @@ internal static unsafe class VulkanVideoPresenter
 
             return new VertexBufferResource
             {
-                Buffer = buffer,
-                Memory = memory,
-                Size = size,
+                Binding = binding,
                 Location = guestBuffer.Location,
                 ComponentCount = guestBuffer.ComponentCount,
                 DataFormat = guestBuffer.DataFormat,
                 NumberFormat = guestBuffer.NumberFormat,
                 Stride = guestBuffer.Stride,
-                OffsetBytes = guestBuffer.OffsetBytes,
+                OffsetBytes = checked(binding.Offset + guestBuffer.OffsetBytes),
             };
         }
 
@@ -4641,6 +4674,88 @@ internal static unsafe class VulkanVideoPresenter
             return buffer;
         }
 
+        private void CreateGuestBufferCache()
+        {
+            _guestBufferCache = new GuestBufferCache(
+                AllocateGuestBuffer,
+                DestroyGuestBuffer,
+                WriteGuestBuffer);
+        }
+
+        private GuestBufferAllocation AllocateGuestBuffer(ulong size)
+        {
+            var buffer = CreateBuffer(
+                size,
+                BufferUsageFlags.StorageBufferBit |
+                BufferUsageFlags.VertexBufferBit |
+                BufferUsageFlags.IndexBufferBit |
+                BufferUsageFlags.TransferSrcBit |
+                BufferUsageFlags.TransferDstBit,
+                MemoryPropertyFlags.HostVisibleBit | MemoryPropertyFlags.HostCoherentBit,
+                out var memory);
+            return new GuestBufferAllocation(buffer, memory);
+        }
+
+        private void DestroyGuestBuffer(GuestBufferResource resource)
+        {
+            if (resource.Buffer.Handle != 0)
+            {
+                _vk.DestroyBuffer(_device, resource.Buffer, null);
+            }
+            if (resource.Memory.Handle != 0)
+            {
+                _vk.FreeMemory(_device, resource.Memory, null);
+            }
+        }
+
+        private void WriteGuestBuffer(
+            GuestBufferResource resource,
+            ulong offset,
+            ReadOnlySpan<byte> data)
+        {
+            if (data.IsEmpty)
+            {
+                return;
+            }
+
+            void* mapped;
+            Check(
+                _vk.MapMemory(_device, resource.Memory, 0, resource.Size, 0, &mapped),
+                "vkMapMemory(guest buffer write)");
+            try
+            {
+                data.CopyTo(new Span<byte>((byte*)mapped + checked((int)offset), data.Length));
+            }
+            finally
+            {
+                _vk.UnmapMemory(_device, resource.Memory);
+            }
+        }
+
+        private void ReadGuestBuffer(
+            GuestBufferResource resource,
+            ulong offset,
+            Span<byte> data)
+        {
+            if (data.IsEmpty)
+            {
+                return;
+            }
+
+            void* mapped;
+            Check(
+                _vk.MapMemory(_device, resource.Memory, 0, resource.Size, 0, &mapped),
+                "vkMapMemory(guest buffer read)");
+            try
+            {
+                new ReadOnlySpan<byte>((byte*)mapped + checked((int)offset), data.Length).CopyTo(data);
+            }
+            finally
+            {
+                _vk.UnmapMemory(_device, resource.Memory);
+            }
+        }
+
         private void CreateStagingBuffer(ulong size)
         {
             _stagingBuffer = CreateBuffer(
@@ -4668,6 +4783,85 @@ internal static unsafe class VulkanVideoPresenter
         }
 
         private const uint MaxComputeZSlicesPerSubmission = 8;
+
+        private void RecordGuestBufferBarriers(
+            TranslatedDrawResources resources,
+            PipelineStageFlags destinationStages)
+        {
+            var bindings = resources.GlobalMemoryBuffers
+                .Where(resource => resource is not null)
+                .Select(resource => resource.Binding)
+                .Concat(resources.VertexBuffers
+                    .Where(resource => resource is not null)
+                    .Select(resource => resource.Binding))
+                .Concat(resources.IndexBuffer is { } indexBuffer ? [indexBuffer] : [])
+                .DistinctBy(binding => (
+                    binding.Resource,
+                    binding.Offset,
+                    binding.Size,
+                    binding.Usage,
+                    binding.Access))
+                .ToArray();
+            if (bindings.Length == 0)
+            {
+                return;
+            }
+
+            var barriers = stackalloc BufferMemoryBarrier[bindings.Length];
+            for (var index = 0; index < bindings.Length; index++)
+            {
+                var binding = bindings[index];
+                var usage = binding.Usage;
+                var access = binding.Access;
+                var destinationAccess = default(AccessFlags);
+                if ((access & GuestBufferAccess.Read) != 0)
+                {
+                    destinationAccess |= AccessFlags.ShaderReadBit;
+                }
+                if ((access & GuestBufferAccess.Write) != 0)
+                {
+                    destinationAccess |= AccessFlags.ShaderWriteBit;
+                }
+                if ((usage & GuestBufferUsage.Vertex) != 0)
+                {
+                    destinationAccess |= AccessFlags.VertexAttributeReadBit;
+                }
+                if ((usage & GuestBufferUsage.Index) != 0)
+                {
+                    destinationAccess |= AccessFlags.IndexReadBit;
+                }
+                if (access == GuestBufferAccess.None)
+                {
+                    destinationAccess |=
+                        AccessFlags.ShaderReadBit |
+                        AccessFlags.ShaderWriteBit;
+                }
+
+                barriers[index] = new BufferMemoryBarrier
+                {
+                    SType = StructureType.BufferMemoryBarrier,
+                    SrcAccessMask = AccessFlags.HostWriteBit,
+                    DstAccessMask = destinationAccess,
+                    SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                    DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                    Buffer = binding.Resource.Buffer,
+                    Offset = binding.Offset,
+                    Size = binding.Size,
+                };
+            }
+
+            _vk.CmdPipelineBarrier(
+                _commandBuffer,
+                PipelineStageFlags.HostBit,
+                destinationStages,
+                0,
+                0,
+                null,
+                (uint)bindings.Length,
+                barriers,
+                0,
+                null);
+        }
 
         private void ExecuteComputeDispatch(VulkanComputeGuestDispatch work)
         {
@@ -4721,6 +4915,7 @@ internal static unsafe class VulkanVideoPresenter
                         RecordTextureUploads(resources, PipelineStageFlags.ComputeShaderBit);
                         RecordStorageImagesForWrite(resources, PipelineStageFlags.ComputeShaderBit);
                     }
+                    RecordGuestBufferBarriers(resources, PipelineStageFlags.ComputeShaderBit);
 
                     _vk.CmdBindPipeline(
                         _commandBuffer,
@@ -4971,7 +5166,6 @@ internal static unsafe class VulkanVideoPresenter
                 BeginDebugLabel(_commandBuffer, resources.DebugName);
                 RecordTextureUploads(resources, PipelineStageFlags.FragmentShaderBit);
                 RecordStorageImagesForWrite(resources, PipelineStageFlags.FragmentShaderBit);
-
                 var toColorAttachments = stackalloc ImageMemoryBarrier[targets.Length];
                 var anyPriorContents = false;
                 for (var index = 0; index < targets.Length; index++)
@@ -6663,6 +6857,36 @@ internal static unsafe class VulkanVideoPresenter
                 address);
         }
 
+        private void TraceGuestBufferContents(TranslatedDrawResources resources)
+        {
+            foreach (var binding in resources.GlobalMemoryBuffers
+                .Where(resource => resource is not null)
+                .Select(resource => resource.Binding)
+                .Where(binding =>
+                    (binding.Access & GuestBufferAccess.Write) != 0 &&
+                    AddressListContains(
+                        "SHARPEMU_TRACE_GUEST_BUFFER_ADDRS",
+                        binding.Resource.GuestAddress + binding.Offset))
+                .DistinctBy(binding => binding.Resource.GuestAddress + binding.Offset))
+            {
+                var address = binding.Resource.GuestAddress + binding.Offset;
+                var count = _tracedGuestBufferWriteCounts.TryGetValue(address, out var previous)
+                    ? previous + 1
+                    : 1;
+                _tracedGuestBufferWriteCounts[address] = count;
+                if (count > 4)
+                {
+                    continue;
+                }
+
+                var bytes = new byte[checked((int)Math.Min(binding.Size, 64UL))];
+                ReadGuestBuffer(binding.Resource, binding.Offset, bytes);
+                Console.Error.WriteLine(
+                    $"[LOADER][TRACE] vk.guest_buffer addr=0x{address:X16} " +
+                    $"write={count} bytes={Convert.ToHexString(bytes)}");
+            }
+        }
+
         private static bool AddressListContains(
             string environmentVariable,
             ulong address)
@@ -6714,6 +6938,12 @@ internal static unsafe class VulkanVideoPresenter
             Framebuffer framebuffer,
             Extent2D extent)
         {
+            RecordGuestBufferBarriers(
+                resources,
+                PipelineStageFlags.VertexInputBit |
+                PipelineStageFlags.VertexShaderBit |
+                PipelineStageFlags.FragmentShaderBit);
+
             var clearValue = default(ClearValue);
             var renderPassInfo = new RenderPassBeginInfo
             {
@@ -6778,12 +7008,12 @@ internal static unsafe class VulkanVideoPresenter
                 new Extent2D(drawScissor.Width, drawScissor.Height));
             _vk.CmdSetScissor(_commandBuffer, 0, 1, &scissor);
 
-            if (resources.IndexBuffer.Handle != 0)
+            if (resources.IndexBuffer is { } indexBuffer)
             {
                 _vk.CmdBindIndexBuffer(
                     _commandBuffer,
-                    resources.IndexBuffer,
-                    0,
+                    indexBuffer.Resource.Buffer,
+                    indexBuffer.Offset,
                     resources.Index32Bit ? IndexType.Uint32 : IndexType.Uint16);
                 _vk.CmdDrawIndexed(
                     _commandBuffer,
@@ -6863,7 +7093,7 @@ internal static unsafe class VulkanVideoPresenter
                     continue;
                 }
 
-                RecycleHostBuffer(globalBuffer.Buffer, globalBuffer.Memory);
+                _guestBufferCache.Release(globalBuffer.Binding);
             }
 
             foreach (var vertexBuffer in resources.VertexBuffers)
@@ -6873,10 +7103,13 @@ internal static unsafe class VulkanVideoPresenter
                     continue;
                 }
 
-                RecycleHostBuffer(vertexBuffer.Buffer, vertexBuffer.Memory);
+                _guestBufferCache.Release(vertexBuffer.Binding);
             }
 
-            RecycleHostBuffer(resources.IndexBuffer, resources.IndexMemory);
+            if (resources.IndexBuffer is { } indexBuffer)
+            {
+                _guestBufferCache.Release(indexBuffer);
+            }
 
             if (!resources.PipelineCached && resources.Pipeline.Handle != 0)
             {
@@ -7364,6 +7597,7 @@ internal static unsafe class VulkanVideoPresenter
             }
             _samplers.Clear();
             _shaderDigests.Clear();
+            _guestBufferCache.Dispose();
             foreach (var allocation in _hostBufferAllocations.Values)
             {
                 _vk.DestroyBuffer(_device, allocation.Buffer, null);

--- a/tests/SharpEmu.Tests.GuestBufferCache/Program.cs
+++ b/tests/SharpEmu.Tests.GuestBufferCache/Program.cs
@@ -1,0 +1,134 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.Libs.VideoOut;
+using Silk.NET.Vulkan;
+using VkBuffer = Silk.NET.Vulkan.Buffer;
+
+var storage = new Dictionary<GuestBufferResource, byte[]>();
+ulong nextHandle = 1;
+var destroyed = 0;
+
+using var cache = new GuestBufferCache(
+    size => new GuestBufferAllocation(
+        new VkBuffer(nextHandle++),
+        new DeviceMemory(nextHandle++)),
+    resource =>
+    {
+        storage.Remove(resource);
+        destroyed++;
+    },
+    (resource, offset, data) =>
+    {
+        if (!storage.TryGetValue(resource, out var bytes))
+        {
+            bytes = new byte[checked((int)resource.Size)];
+            storage.Add(resource, bytes);
+        }
+        data.CopyTo(bytes.AsSpan(checked((int)offset)));
+    },
+    maximumCachedBytes: 32);
+
+var zero = Words(0);
+var first = cache.ObtainBuffer(
+    0x1000,
+    zero,
+    GuestBufferUsage.Storage,
+    GuestBufferAccess.Write,
+    1,
+    allowCaching: true);
+cache.Release(first);
+
+// Stand in for a compute shader changing the cached allocation.
+Words(37).CopyTo(storage[first.Resource], 0);
+var rewritten = cache.ObtainBuffer(
+    0x1000,
+    zero,
+    GuestBufferUsage.Storage,
+    GuestBufferAccess.Write,
+    2,
+    allowCaching: true);
+Assert(ReferenceEquals(first.Resource, rewritten.Resource),
+    "an idle exact allocation was not reused");
+Assert(storage[rewritten.Resource].SequenceEqual(zero),
+    "CPU rewrite with the same bytes did not replace GPU contents");
+
+var renamed = cache.ObtainBuffer(
+    0x1000,
+    Words(9),
+    GuestBufferUsage.Storage,
+    GuestBufferAccess.Write,
+    3,
+    allowCaching: true);
+Assert(!ReferenceEquals(rewritten.Resource, renamed.Resource),
+    "an in-flight allocation was overwritten instead of renamed");
+Assert(storage[renamed.Resource].SequenceEqual(Words(9)),
+    "renamed allocation did not receive current CPU data");
+cache.Release(rewritten);
+cache.Release(renamed);
+
+var readOnly = cache.ObtainBuffer(
+    0x3000,
+    Words(5),
+    GuestBufferUsage.Storage,
+    GuestBufferAccess.Read,
+    4,
+    allowCaching: true);
+Assert(!readOnly.Resource.Cached, "read-only buffer entered the persistent cache");
+cache.Release(readOnly);
+
+var zeroAddress = cache.ObtainBuffer(
+    0,
+    Words(6),
+    GuestBufferUsage.Index,
+    GuestBufferAccess.Read,
+    5,
+    allowCaching: true);
+Assert(!zeroAddress.Resource.Cached, "guest address zero was used as a persistent key");
+cache.Release(zeroAddress);
+
+var baseRange = cache.ObtainBuffer(
+    0x5000,
+    Words(1, 2, 3, 4),
+    GuestBufferUsage.Storage,
+    GuestBufferAccess.Write,
+    6,
+    allowCaching: true);
+cache.Release(baseRange);
+var overlap = cache.ObtainBuffer(
+    0x5008,
+    Words(7, 8, 9, 10),
+    GuestBufferUsage.Storage,
+    GuestBufferAccess.Write,
+    7,
+    allowCaching: true);
+Assert(!ReferenceEquals(baseRange.Resource, overlap.Resource),
+    "overlapping logical ranges were merged into one allocation");
+cache.Release(overlap);
+
+cache.Collect(100);
+Assert(cache.CachedBytes <= 32, "cache exceeded its byte budget after collection");
+Assert(destroyed >= 3, "transient or over-budget allocations were not destroyed");
+
+Console.WriteLine("GuestBufferCache CPU ownership, renaming, fallback, and budget tests passed.");
+
+static byte[] Words(params uint[] values)
+{
+    var bytes = new byte[values.Length * sizeof(uint)];
+    for (var index = 0; index < values.Length; index++)
+    {
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            bytes.AsSpan(index * sizeof(uint)),
+            values[index]);
+    }
+    return bytes;
+}
+
+static void Assert(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(message);
+    }
+}

--- a/tests/SharpEmu.Tests.GuestBufferCache/SharpEmu.Tests.GuestBufferCache.csproj
+++ b/tests/SharpEmu.Tests.GuestBufferCache/SharpEmu.Tests.GuestBufferCache.csproj
@@ -1,0 +1,15 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SharpEmu.Libs\SharpEmu.Libs.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/SharpEmu.Tools.ShaderDump/Program.cs
+++ b/tools/SharpEmu.Tools.ShaderDump/Program.cs
@@ -9,8 +9,8 @@
 // resulting vertex, pixel, and compute SPIR-V blobs to disk. The blobs can then be
 // checked with spirv-val / spirv-dis.
 //
-// Programs that contain buffer_store_dword automatically get a single
-// global-memory binding covering every store, which the emitter exposes as
+// Programs that contain buffer instructions automatically get a single
+// global-memory binding covering every access, which the emitter exposes as
 // guestBuffers[0] (descriptor set 0, binding 0).
 //
 // Each program carries an expectation: ExpectTranslate=true programs must
@@ -136,6 +136,15 @@ const ulong ProgramAddress = 0x100000;
         0xE0700010, 0x80020000, // buffer_store_dword v0, off, s[8:11], 0 offset:16
         0xBF810000,             // s_endpgm
     ]),
+    ("persistent-buffer-double", true, [
+        0xE0380000, 0x80020000, // buffer_load_dwordx4 v[0:3], off, s[8:11], 0
+        0x34000081,             // v_lshlrev_b32 v0, 1, v0
+        0x34020281,             // v_lshlrev_b32 v1, 1, v1
+        0x34040481,             // v_lshlrev_b32 v2, 1, v2
+        0x34060681,             // v_lshlrev_b32 v3, 1, v3
+        0xE0780000, 0x80020000, // buffer_store_dwordx4 v[0:3], off, s[8:11], 0
+        0xBF810000,             // s_endpgm
+    ]),
 ];
 
 var assembly = typeof(CxaGuardExports).Assembly;
@@ -217,33 +226,33 @@ foreach (var (name, expectTranslate, words) in testPrograms)
         continue;
     }
 
-    // Buffer stores need a global-memory binding; the emitter resolves them by
-    // instruction PC, so collect store PCs from the decoded program itself.
+    // Buffer accesses need a global-memory binding; the emitter resolves them by
+    // instruction PC, so collect their PCs from the decoded program itself.
     var programObj = decodeArgs[2]!;
     var instructions = (System.Collections.IEnumerable)programObj
         .GetType().GetProperty("Instructions")!.GetValue(programObj)!;
-    var storePcs = new List<uint>();
+    var bufferPcs = new List<uint>();
     foreach (var instruction in instructions)
     {
         var op = (string)instruction.GetType().GetProperty("Opcode")!.GetValue(instruction)!;
-        if (op.StartsWith("BufferStore", StringComparison.Ordinal))
+        if (op.StartsWith("Buffer", StringComparison.Ordinal))
         {
-            storePcs.Add((uint)instruction.GetType().GetProperty("Pc")!.GetValue(instruction)!);
+            bufferPcs.Add((uint)instruction.GetType().GetProperty("Pc")!.GetValue(instruction)!);
         }
     }
 
     // The binding's scalar base (8 -> s[8:11]) must match the srsrc field of
-    // the hand-assembled buffer_store words, and the 64-byte backing store
-    // must cover every hand-assembled store offset.
-    var globalBindings = Array.CreateInstance(globalBindingType, storePcs.Count > 0 ? 1 : 0);
-    if (storePcs.Count > 0)
+    // the hand-assembled buffer words, and the 64-byte backing store must cover
+    // every hand-assembled access offset.
+    var globalBindings = Array.CreateInstance(globalBindingType, bufferPcs.Count > 0 ? 1 : 0);
+    if (bufferPcs.Count > 0)
     {
         globalBindings.SetValue(
             Activator.CreateInstance(
                 globalBindingType,
                 8u,
                 0UL,
-                (IReadOnlyList<uint>)storePcs,
+                (IReadOnlyList<uint>)bufferPcs,
                 new byte[64]),
             0);
     }


### PR DESCRIPTION
## Summary

This PR adds a **safe, opt-in Vulkan allocation cache** for translated guest storage buffers.

It no longer attempts to infer CPU/GPU ownership from byte equality or preserve GPU-produced contents without readback. CPU memory remains authoritative and the current CPU snapshot is uploaded on every use, matching the pre-PR correctness model.

Allocation reuse is disabled by default and can be tested with:

`SHARPEMU_PERSISTENT_GUEST_BUFFERS=1`

## Why the scope changed

The previous implementation compared incoming bytes with `CpuShadow` and skipped uploads when they matched. That is ambiguous:

1. CPU writes 0
2. GPU writes 37
3. CPU intentionally writes 0 again

Byte equality cannot distinguish step 3 from a stale CPU snapshot, so the cache incorrectly retained 37. Native guest writes also bypass `ICpuMemory.TryWrite`, and GPU-to-CPU readback does not exist yet.

Persistent GPU content therefore cannot be enabled safely until page-based dirty tracking, native write-fault integration, mapping generations, and readback are implemented together.

## What changes

- removes `CpuShadow` and `CpuKnown`;
- removes byte equality as an ownership rule;
- removes aggressive overlap merging and active-binding rebasing;
- removes global GPU waits from buffer updates;
- always uploads the current CPU snapshot before use;
- requires explicit access on `VulkanGuestMemoryBuffer`;
- classifies AGC buffer loads as Read, stores as Write, and atomics as ReadWrite;
- makes index-buffer guest addresses mandatory;
- never uses address 0 as a persistent key;
- keeps vertex, index, read-only, and unknown-access buffers transient;
- enables allocation caching only for confirmed storage writers and only behind the opt-in switch;
- uses resource renaming when an exact allocation is still in flight;
- indexes reusable allocations by exact `(address, size)` instead of scanning/merging ranges;
- bounds the cache by bytes (64 MiB), not object count;
- applies host-to-consumer barriers to the actual binding offset and size.

## Correctness model

This PR caches **Vulkan allocations**, not GPU ownership or GPU-produced data.

```
guest CPU snapshot -> full upload -> Vulkan work
```

A GPU write is valid for that submitted work, but a later submission receives the current CPU snapshot again. This deliberately preserves existing emulator behavior and avoids regressions until a complete coherency contract exists.

## Tests

The cache test now verifies:

1. CPU -> GPU(37) -> CPU rewrites the same 0 -> Vulkan observes 0;
2. an in-flight allocation is renamed instead of globally waiting;
3. read-only buffers remain transient;
4. guest address 0 remains transient;
5. overlapping logical ranges are not merged;
6. cached bytes are reduced to the configured memory budget.

Local validation:

- Release build: 0 warnings, 0 errors;
- SharpEmu.Libs.Tests: 18/18 passed;
- GuestBufferCache regression test: passed;
- ShaderDump: all programs behaved as expected.

## Deliberately deferred

True persistent GPU contents require a separate, cross-layer coherency change:

- page-based CPU-dirty/GPU-dirty tracking;
- hooks in `ICpuMemory.TryWrite`;
- native guest write-fault handling;
- mapping identities/generations;
- per-submission GPU-write completion;
- GPU-to-CPU readback before CPU access;
- resource-specific fences instead of global waits.

Those pieces must land as one coherent contract rather than being approximated through byte comparisons.