### PR TITLE
[Tools] Fix ShaderDump reflection invoke against new optional parameters

### DIFF
--- a/tools/SharpEmu.Tools.ShaderDump/Program.cs
+++ b/tools/SharpEmu.Tools.ShaderDump/Program.cs
@@ -201,8 +201,8 @@ foreach (var (name, expectTranslate, words) in testPrograms)
         null,
         null)!;
 
-    object?[] compileArgs = [state, evaluation, null, null, 0, -1, 0];
-    if ((bool)tryCompile.Invoke(null, compileArgs)!)
+    var compileArgs = PadWithDefaults(tryCompile, [state, evaluation, null, null]);
+    if ((bool)tryCompile.Invoke(null, BindingFlags.OptionalParamBinding, null, compileArgs, null)!)
     {
         var shader = compileArgs[2]!;
         var spirv = (byte[])shader.GetType().GetProperty("Spirv")!.GetValue(shader)!;
@@ -216,8 +216,8 @@ foreach (var (name, expectTranslate, words) in testPrograms)
         Console.WriteLine($"[{name}] emit: FAILED ({compileArgs[3]})");
     }
 
-    object?[] computeArgs = [state, evaluation, 1u, 1u, 1u, null, null];
-    if ((bool)tryCompileCompute.Invoke(null, computeArgs)!)
+    var computeArgs = PadWithDefaults(tryCompileCompute, [state, evaluation, 1u, 1u, 1u, null, null]);
+    if ((bool)tryCompileCompute.Invoke(null, BindingFlags.OptionalParamBinding, null, computeArgs, null)!)
     {
         var shader = computeArgs[5]!;
         var spirv = (byte[])shader.GetType().GetProperty("Spirv")!.GetValue(shader)!;
@@ -236,6 +236,37 @@ Console.WriteLine(failures == 0
     ? "RESULT: all programs behaved as expected"
     : $"RESULT: {failures} unexpected outcome(s)");
 Environment.ExitCode = failures == 0 ? 0 : 1;
+
+// Reflection Invoke does not apply C# default parameter values, so a newly
+// added optional parameter on a translator entry point would otherwise throw
+// TargetParameterCountException. Type.Missing + OptionalParamBinding lets the
+// runtime substitute the declared defaults; only a new *required* parameter
+// should force a tool update.
+static object?[] PadWithDefaults(MethodInfo method, object?[] arguments)
+{
+    var parameters = method.GetParameters();
+    if (arguments.Length > parameters.Length)
+    {
+        throw new InvalidOperationException(
+            $"{method.DeclaringType?.Name}.{method.Name} takes fewer parameters than the tool supplies");
+    }
+
+    var padded = new object?[parameters.Length];
+    arguments.CopyTo(padded, 0);
+    for (var i = arguments.Length; i < padded.Length; i++)
+    {
+        if (!parameters[i].IsOptional)
+        {
+            throw new InvalidOperationException(
+                $"{method.DeclaringType?.Name}.{method.Name} gained a required parameter " +
+                $"'{parameters[i].Name}' — the tool needs updating");
+        }
+
+        padded[i] = Type.Missing;
+    }
+
+    return padded;
+}
 
 internal sealed class FakeMemory : ICpuMemory
 {


### PR DESCRIPTION
Follow-up to #111. `ShaderDump` currently crashes on `main` with `TargetParameterCountException`: `TryCompileVertexShader` gained an optional `scalarRegisterBufferIndex` parameter in #156, and reflection `Invoke` does not apply C# default parameter values, so the tool's 7-argument call no longer matches the 8-parameter method.

Rather than hard-coding the new default (which breaks again on the next added parameter), the compile calls now pad trailing optional parameters with `Type.Missing` under `BindingFlags.OptionalParamBinding`, so the runtime substitutes the declared defaults. If a translator entry point ever gains a new **required** parameter, the tool fails with a named error saying which method and parameter changed, instead of a bare crash.

Verified on `main` + this commit:
- all five programs behave as expected, exit code 0 (`fmac`, `muls`, `sopp-hints`, `exec` decode+emit both stages; `sopp-mode` pins its loud decode failure);
- all eight emitted blobs pass `spirv-val --target-env vulkan1.3`;
- the `exec-cs.spv` blob also re-verified numerically on real hardware via the executor in #127 (RTX 3060, all values bit-exact including the EXEC-masked store suppression).

This is also a live data point for the reflection-vs-`InternalsVisibleTo` question raised in #111 — reflection kept the emulator source untouched, but it means translator signature changes surface only when someone runs the tool. Happy to move the tools to `InternalsVisibleTo` (or the public `TryCreateState`/`TryEvaluate` entry points) in a follow-up if that's the preferred direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
