### PR TITLE
Fix historic SysAbi exports bound to wrong symbol names

### DIFF
--- a/src/SharpEmu.Libs/AvPlayer/AvPlayerExports.cs
+++ b/src/SharpEmu.Libs/AvPlayer/AvPlayerExports.cs
@@ -36,6 +36,17 @@ public static class AvPlayerExports
     }
 
     [SysAbiExport(
+        Nid = "KMcEa+rHsIo",
+        ExportName = "sceAvPlayerAddSource",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAvPlayer")]
+    public static int AvPlayerAddSource(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
         Nid = "JdksQu8pNdQ",
         ExportName = "sceAvPlayerGetVideoDataEx",
         Target = Generation.Gen4 | Generation.Gen5,

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -6947,15 +6947,4 @@ public static class KernelMemoryCompatExports
         sum = left + right;
         return sum >= left;
     }
-
-    [SysAbiExport(
-        Nid = "KMcEa+rHsIo",
-        ExportName = "sceKernelMapMemory",
-        Target = Generation.Gen4 | Generation.Gen5,
-        LibraryName = "libKernel")]
-    public static int KernelMapMemory(CpuContext ctx)
-    {
-        ctx[CpuRegister.Rax] = 0;
-        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
-    }
 }

--- a/src/SharpEmu.Libs/Np/NpWebApi2Exports.cs
+++ b/src/SharpEmu.Libs/Np/NpWebApi2Exports.cs
@@ -33,7 +33,7 @@ public static class NpWebApi2Exports
 
     [SysAbiExport(
         Nid = "WV1GwM32NgY",
-        ExportName = "sceNpWebApi2InitializeForToolkit",
+        ExportName = "sceNpWebApi2PushEventCreateHandle",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libSceNpWebApi2")]
     public static int NpWebApi2InitializeAlt(CpuContext ctx)


### PR DESCRIPTION
Move NID `KMcEa+rHsIo` from a mislabeled `sceKernelMapMemory` libKernel stub to `sceAvPlayerAddSource` in AvPlayer (Aerolib name; behavior unchanged)
Align NID `WV1GwM32NgY` ExportName with `sceNpWebApi2PushEventCreateHandle` (handler unchanged)
