### PR TITLE
[Vulkan] Extract guest work scheduler

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Validate synthetic shaders
         run: dotnet run --project tools/SharpEmu.Tools.ShaderDump/SharpEmu.Tools.ShaderDump.csproj -c Release -- artifacts/shader-dump
 
+      - name: Test guest work scheduler
+        run: dotnet run --project tests/SharpEmu.Tests.GuestWorkScheduler/SharpEmu.Tests.GuestWorkScheduler.csproj -c Release --no-build
+
       - name: Publish win-x64 CLI
         run: dotnet publish src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r win-x64 --self-contained true --no-restore -p:PublishDir="${env:PUBLISH_DIR}"
 

--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -14,5 +14,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj" />
+    <Project Path="tests/SharpEmu.Tests.GuestWorkScheduler/SharpEmu.Tests.GuestWorkScheduler.csproj" />
   </Folder>
 </Solution>

--- a/src/SharpEmu.Libs/SharpEmu.Libs.csproj
+++ b/src/SharpEmu.Libs/SharpEmu.Libs.csproj
@@ -19,6 +19,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <PackageReference Include="Silk.NET.Windowing" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SharpEmu.Tests.GuestWorkScheduler" />
+  </ItemGroup>
+
   <PropertyGroup>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/SharpEmu.Libs/VideoOut/GuestWorkScheduler.cs
+++ b/src/SharpEmu.Libs/VideoOut/GuestWorkScheduler.cs
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Libs.VideoOut;
+
+internal readonly record struct GuestWorkSchedulerSnapshot(
+    int Queued,
+    long EnqueuedSequence,
+    long CompletedSequence)
+{
+    public long Backlog => Math.Max(0, EnqueuedSequence - CompletedSequence);
+}
+
+internal sealed class GuestWorkScheduler
+{
+    private readonly int _capacity;
+    private readonly object _gate = new();
+    private readonly Queue<object> _queue = new();
+    private bool _closed;
+    private long _enqueuedSequence;
+    private long _completedSequence;
+
+    public GuestWorkScheduler(int capacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+        _capacity = capacity;
+    }
+
+    public bool TryEnqueue(object work)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        lock (_gate)
+        {
+            if (_closed || _queue.Count >= _capacity)
+            {
+                return false;
+            }
+
+            _queue.Enqueue(work);
+            _enqueuedSequence++;
+            return true;
+        }
+    }
+
+    public bool TryTake(out object work)
+    {
+        lock (_gate)
+        {
+            return _queue.TryDequeue(out work!);
+        }
+    }
+
+    public void Complete()
+    {
+        lock (_gate)
+        {
+            if (_completedSequence >= _enqueuedSequence)
+            {
+                throw new InvalidOperationException("guest work completion without an enqueue");
+            }
+            _completedSequence++;
+        }
+    }
+
+    public GuestWorkSchedulerSnapshot Snapshot()
+    {
+        lock (_gate)
+        {
+            return new GuestWorkSchedulerSnapshot(
+                _queue.Count,
+                _enqueuedSequence,
+                _completedSequence);
+        }
+    }
+
+    public void Close()
+    {
+        lock (_gate)
+        {
+            _closed = true;
+        }
+    }
+}

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -178,7 +178,7 @@ internal static unsafe class VulkanVideoPresenter
     private const uint GuestFormatR16G16B16A16Sint = 0x2000C;
 
     private static readonly object _gate = new();
-    private static readonly Queue<object> _pendingGuestWork = new();
+    private static readonly GuestWorkScheduler _guestWork = new(MaxPendingGuestWork);
     private static readonly Dictionary<ulong, uint> _availableGuestImages = new();
     private static readonly Dictionary<ulong, uint> _gpuGuestImages = new();
     private static readonly HashSet<(ulong Address, uint Width, uint Height)>
@@ -192,8 +192,6 @@ internal static unsafe class VulkanVideoPresenter
     private const string DebugUtilsExtensionName = "VK_EXT_debug_utils";
     private const uint NvidiaVendorId = 0x10DE;
     private static bool _splashHidden;
-    private static long _enqueuedGuestWorkSequence;
-    private static long _completedGuestWorkSequence;
 
     private static bool ShouldTracePresentedGuestImageContentsForDiagnostics()
     {
@@ -238,7 +236,7 @@ internal static unsafe class VulkanVideoPresenter
                     1,
                     GuestDrawKind.None,
                     TranslatedDraw: null,
-                    RequiredGuestWorkSequence: _enqueuedGuestWorkSequence,
+                    RequiredGuestWorkSequence: _guestWork.Snapshot().EnqueuedSequence,
                     IsSplash: false)
                 : hasSplash
                 ? new Presentation(
@@ -248,7 +246,7 @@ internal static unsafe class VulkanVideoPresenter
                     1,
                     GuestDrawKind.None,
                     TranslatedDraw: null,
-                    RequiredGuestWorkSequence: _enqueuedGuestWorkSequence,
+                    RequiredGuestWorkSequence: _guestWork.Snapshot().EnqueuedSequence,
                     IsSplash: true)
                 : new Presentation(
                     null,
@@ -257,7 +255,7 @@ internal static unsafe class VulkanVideoPresenter
                     0,
                     GuestDrawKind.None,
                     TranslatedDraw: null,
-                    RequiredGuestWorkSequence: _enqueuedGuestWorkSequence,
+                    RequiredGuestWorkSequence: _guestWork.Snapshot().EnqueuedSequence,
                     IsSplash: false);
             _thread = new Thread(Run)
             {
@@ -286,7 +284,7 @@ internal static unsafe class VulkanVideoPresenter
                 sequence,
                 GuestDrawKind.None,
                 TranslatedDraw: null,
-                RequiredGuestWorkSequence: _enqueuedGuestWorkSequence,
+                RequiredGuestWorkSequence: _guestWork.Snapshot().EnqueuedSequence,
                 IsSplash: false);
             System.Threading.Monitor.PulseAll(_gate);
             Console.Error.WriteLine("[LOADER][INFO] Vulkan VideoOut hid splash");
@@ -320,7 +318,7 @@ internal static unsafe class VulkanVideoPresenter
                 sequence,
                 GuestDrawKind.None,
                 TranslatedDraw: null,
-                RequiredGuestWorkSequence: _enqueuedGuestWorkSequence,
+                RequiredGuestWorkSequence: _guestWork.Snapshot().EnqueuedSequence,
                 IsSplash: false);
             System.Threading.Monitor.PulseAll(_gate);
             if (_thread is not null)
@@ -370,7 +368,7 @@ internal static unsafe class VulkanVideoPresenter
                 sequence,
                 drawKind,
                 TranslatedDraw: null,
-                RequiredGuestWorkSequence: _enqueuedGuestWorkSequence,
+                RequiredGuestWorkSequence: _guestWork.Snapshot().EnqueuedSequence,
                 IsSplash: false);
             System.Threading.Monitor.PulseAll(_gate);
             if (_thread is not null)
@@ -441,7 +439,7 @@ internal static unsafe class VulkanVideoPresenter
                     primitiveType,
                     indexBuffer,
                     renderState ?? VulkanGuestRenderState.Default),
-                RequiredGuestWorkSequence: _enqueuedGuestWorkSequence,
+                RequiredGuestWorkSequence: _guestWork.Snapshot().EnqueuedSequence,
                 IsSplash: false);
             System.Threading.Monitor.PulseAll(_gate);
             if (_thread is not null)
@@ -985,6 +983,7 @@ internal static unsafe class VulkanVideoPresenter
         }
         finally
         {
+            _guestWork.Close();
             lock (_gate)
             {
                 _closed = true;
@@ -1000,7 +999,7 @@ internal static unsafe class VulkanVideoPresenter
         {
             if (_latestPresentation is not { } latest ||
                 latest.Sequence == presentedSequence ||
-                latest.RequiredGuestWorkSequence > _completedGuestWorkSequence)
+                latest.RequiredGuestWorkSequence > _guestWork.Snapshot().CompletedSequence)
             {
                 presentation = default;
                 return false;
@@ -1015,34 +1014,26 @@ internal static unsafe class VulkanVideoPresenter
     {
         while (!_closed &&
                _thread is not null &&
-               _pendingGuestWork.Count >= MaxPendingGuestWork)
+               _guestWork.Snapshot().Queued >= MaxPendingGuestWork)
         {
             System.Threading.Monitor.Wait(_gate);
         }
 
-        if (_closed)
+        if (_closed || !_guestWork.TryEnqueue(work))
         {
             return;
         }
-
-        _pendingGuestWork.Enqueue(work);
-        _enqueuedGuestWorkSequence++;
         System.Threading.Monitor.PulseAll(_gate);
     }
 
-    private static bool TryTakeGuestWork(out object work)
-    {
-        lock (_gate)
-        {
-            return _pendingGuestWork.TryDequeue(out work!);
-        }
-    }
+    private static bool TryTakeGuestWork(out object work) =>
+        _guestWork.TryTake(out work);
 
     private static void CompleteGuestWork()
     {
+        _guestWork.Complete();
         lock (_gate)
         {
-            _completedGuestWorkSequence++;
             System.Threading.Monitor.PulseAll(_gate);
         }
     }
@@ -5664,15 +5655,9 @@ internal static unsafe class VulkanVideoPresenter
                     var hotName = hottestThreadId == 0
                         ? "idle"
                         : GetPerformanceThreadName(hottestThreadId);
-                    long guestBacklog;
-                    int queuedGuestWork;
-                    lock (_gate)
-                    {
-                        guestBacklog = Math.Max(
-                            0,
-                            _enqueuedGuestWorkSequence - _completedGuestWorkSequence);
-                        queuedGuestWork = _pendingGuestWork.Count;
-                    }
+                    var guestWork = _guestWork.Snapshot();
+                    var guestBacklog = guestWork.Backlog;
+                    var queuedGuestWork = guestWork.Queued;
 
                     var gpuInFlight = _pendingGuestSubmissions.Count +
                         (_presentationInFlight ? 1 : 0);
@@ -5797,11 +5782,12 @@ internal static unsafe class VulkanVideoPresenter
             var gpuWorkInFlight = _pendingGuestSubmissions.Count > 0 || _presentationInFlight;
             lock (_gate)
             {
+                var guestWork = _guestWork.Snapshot();
                 if (_closed ||
-                    _pendingGuestWork.Count > 0 ||
+                    guestWork.Queued > 0 ||
                     (_latestPresentation is { } latest &&
                      latest.Sequence != _presentedSequence &&
-                     latest.RequiredGuestWorkSequence <= _completedGuestWorkSequence))
+                     latest.RequiredGuestWorkSequence <= guestWork.CompletedSequence))
                 {
                     return;
                 }

--- a/tests/SharpEmu.Tests.GuestWorkScheduler/Program.cs
+++ b/tests/SharpEmu.Tests.GuestWorkScheduler/Program.cs
@@ -1,0 +1,61 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.VideoOut;
+
+AssertThrows<ArgumentOutOfRangeException>(() => new GuestWorkScheduler(0));
+
+var scheduler = new GuestWorkScheduler(2);
+Assert(scheduler.TryEnqueue("first"), "first enqueue failed");
+Assert(scheduler.TryEnqueue("second"), "second enqueue failed");
+Assert(!scheduler.TryEnqueue("overflow"), "scheduler exceeded its capacity");
+
+var pending = scheduler.Snapshot();
+Assert(pending.Queued == 2, "queued work count is incorrect");
+Assert(pending.EnqueuedSequence == 2, "enqueue sequence is incorrect");
+Assert(pending.CompletedSequence == 0, "completion sequence advanced early");
+Assert(pending.Backlog == 2, "backlog is incorrect");
+
+Assert(scheduler.TryTake(out var first) && Equals(first, "first"),
+    "scheduler did not preserve FIFO order");
+scheduler.Complete();
+Assert(scheduler.TryEnqueue("third"), "capacity was not released");
+Assert(scheduler.TryTake(out var second) && Equals(second, "second"),
+    "second work item was reordered");
+scheduler.Complete();
+Assert(scheduler.TryTake(out var third) && Equals(third, "third"),
+    "third work item was not available");
+scheduler.Complete();
+
+var completed = scheduler.Snapshot();
+Assert(completed.Queued == 0, "completed queue is not empty");
+Assert(completed.EnqueuedSequence == 3 && completed.CompletedSequence == 3,
+    "completed sequence does not match enqueued work");
+AssertThrows<InvalidOperationException>(scheduler.Complete);
+
+scheduler.Close();
+Assert(!scheduler.TryEnqueue("closed"), "closed scheduler accepted work");
+
+Console.WriteLine("GuestWorkScheduler capacity, FIFO, sequence, and close tests passed.");
+
+static void Assert(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(message);
+    }
+}
+
+static void AssertThrows<TException>(Action action)
+    where TException : Exception
+{
+    try
+    {
+        action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+    throw new InvalidOperationException($"Expected {typeof(TException).Name}");
+}

--- a/tests/SharpEmu.Tests.GuestWorkScheduler/SharpEmu.Tests.GuestWorkScheduler.csproj
+++ b/tests/SharpEmu.Tests.GuestWorkScheduler/SharpEmu.Tests.GuestWorkScheduler.csproj
@@ -1,0 +1,15 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SharpEmu.Libs\SharpEmu.Libs.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
﻿## Summary

Extract the translated guest-work queue and its sequencing state from `VulkanVideoPresenter` into a focused `GuestWorkScheduler`.

This is intentionally independent from #158: it starts from current `main`, does not use the persistent buffer cache, and can be reviewed or merged in either order.

## Why

`VulkanVideoPresenter` currently owns both Vulkan presentation and the generic mechanics of guest-work scheduling:

- pending work queue
- queue capacity
- enqueue/completion sequence counters
- FIFO dequeue
- backlog snapshots
- shutdown state

That makes the presenter responsible for work that does not require Vulkan and makes later extraction of submissions/fences harder.

## What changed

- adds `GuestWorkScheduler` as the owner of FIFO work, capacity, sequence counters and close state
- adds one atomic snapshot for queue depth, enqueued sequence, completed sequence and backlog
- removes the queue and sequence fields from `VulkanVideoPresenter`
- routes presentation dependencies, render wake checks and the performance HUD through scheduler snapshots
- keeps the existing render-loop waiting policy in the presenter; this PR does not move Vulkan command buffers or fences
- rejects invalid capacity, queue overflow, work after close, and unmatched completion

## Behavior preserved

- maximum 16 queued guest operations
- FIFO dispatch order
- presentations wait for the guest-work sequence captured when they are submitted
- producers receive capacity only after completed work wakes them
- the performance HUD reports the same queue/backlog values
- presenter shutdown stops accepting new work

## Tests

Adds a dependency-free CI test covering:

- invalid capacity
- bounded enqueue
- FIFO ordering
- enqueue and completion sequences
- backlog snapshots
- completion imbalance detection
- closed-scheduler rejection

Local validation:

- `dotnet build SharpEmu.slnx -c Release --no-restore`: 0 warnings, 0 errors
- `SharpEmu.Tests.GuestWorkScheduler`: passed

## Deliberately out of scope

This PR does not move command-buffer acquisition, Vulkan fences, image transitions or deferred resource destruction. The extracted scheduler provides a small boundary for that later work without making this review depend on a full presenter rewrite.
