### PR TITLE
[Vulkan] Introduce persistent guest image cache

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Build solution
         run: dotnet build SharpEmu.slnx -c Release --no-restore
 
+      - name: Test guest image cache
+        run: dotnet run --project tests/SharpEmu.Tests.GuestImageCache/SharpEmu.Tests.GuestImageCache.csproj -c Release --no-build
+
       - name: Publish win-x64 CLI
         run: dotnet publish src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r win-x64 --self-contained true --no-restore -p:PublishDir="${env:PUBLISH_DIR}"
 

--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -12,4 +12,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <Project Path="src/SharpEmu.Libs/SharpEmu.Libs.csproj" />
     <Project Path="src/SharpEmu.Logging/SharpEmu.Logging.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/SharpEmu.Tests.GuestImageCache/SharpEmu.Tests.GuestImageCache.csproj" />
+  </Folder>
 </Solution>

--- a/src/SharpEmu.Libs/SharpEmu.Libs.csproj
+++ b/src/SharpEmu.Libs/SharpEmu.Libs.csproj
@@ -15,6 +15,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <PackageReference Include="Silk.NET.Windowing" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SharpEmu.Tests.GuestImageCache" />
+  </ItemGroup>
+
   <PropertyGroup>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/SharpEmu.Libs/VideoOut/GuestImageCache.cs
+++ b/src/SharpEmu.Libs/VideoOut/GuestImageCache.cs
@@ -1,0 +1,96 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Silk.NET.Vulkan;
+
+namespace SharpEmu.Libs.VideoOut;
+
+internal sealed class GuestImageResource
+{
+    public ulong Address;
+    public ulong GuestSize;
+    public uint Width;
+    public uint Height;
+    public uint MipLevels;
+    public Format Format;
+    public Image Image;
+    public DeviceMemory Memory;
+    public ImageView View;
+    public ImageView[] MipViews = [];
+    public Dictionary<(Format Format, uint MipLevel, uint LevelCount, uint DstSelect), ImageView> FormatViews { get; } = new();
+    public RenderPass RenderPass;
+    public Framebuffer Framebuffer;
+    public bool Initialized;
+    public bool InitialUploadPending;
+    public bool IsCpuBacked;
+    public ulong CpuContentFingerprint;
+}
+
+internal sealed class GuestImageCache : IDisposable
+{
+    private readonly Dictionary<ulong, GuestImageResource> _resources = new();
+    private readonly Action _waitForIdle;
+    private readonly Action<GuestImageResource> _destroy;
+
+    public GuestImageCache(Action waitForIdle, Action<GuestImageResource> destroy)
+    {
+        _waitForIdle = waitForIdle;
+        _destroy = destroy;
+    }
+
+    public bool TryGetValue(ulong address, out GuestImageResource resource) =>
+        _resources.TryGetValue(address, out resource!);
+
+    public bool ContainsKey(ulong address) => _resources.ContainsKey(address);
+
+    public void Add(GuestImageResource resource)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(resource.GuestSize);
+        _resources.Add(resource.Address, resource);
+    }
+
+    public IReadOnlyList<GuestImageResource> InvalidateOverlaps(ulong address, ulong size)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(size);
+        var end = checked(address + size);
+        // ponytail: image counts are small; use an interval index only if profiling justifies it.
+        var overlaps = _resources.Values
+            .Where(resource => RangesOverlap(address, end, resource.Address, resource.GuestSize))
+            .ToArray();
+        if (overlaps.Length == 0)
+        {
+            return overlaps;
+        }
+
+        _waitForIdle();
+        foreach (var resource in overlaps)
+        {
+            _resources.Remove(resource.Address);
+            _destroy(resource);
+        }
+
+        return overlaps;
+    }
+
+    public void Dispose()
+    {
+        if (_resources.Count == 0)
+        {
+            return;
+        }
+
+        _waitForIdle();
+        foreach (var resource in _resources.Values)
+        {
+            _destroy(resource);
+        }
+
+        _resources.Clear();
+    }
+
+    private static bool RangesOverlap(ulong leftStart, ulong leftEnd, ulong rightStart, ulong rightSize)
+    {
+        var rightEnd = checked(rightStart + rightSize);
+        return leftStart < rightEnd && rightStart < leftEnd;
+    }
+}

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -996,7 +996,7 @@ internal static unsafe class VulkanVideoPresenter
         private bool _deviceLost;
         private bool _deviceLostLogged;
         private int _directPresentationCount;
-        private readonly Dictionary<ulong, GuestImageResource> _guestImages = new();
+        private readonly GuestImageCache _guestImages;
         private readonly HashSet<(ulong Address, uint Width, uint Height, Format Format)> _tracedTextureCacheHits = new();
         private static readonly bool _dumpTextures = string.Equals(
             Environment.GetEnvironmentVariable("SHARPEMU_DUMP_TEXTURES"),
@@ -1113,26 +1113,6 @@ internal static unsafe class VulkanVideoPresenter
             public uint OffsetBytes;
         }
 
-        private sealed class GuestImageResource
-        {
-            public ulong Address;
-            public uint Width;
-            public uint Height;
-            public uint MipLevels;
-            public Format Format;
-            public Image Image;
-            public DeviceMemory Memory;
-            public ImageView View;
-            public ImageView[] MipViews = [];
-            public Dictionary<(Format Format, uint MipLevel, uint LevelCount, uint DstSelect), ImageView> FormatViews { get; } = new();
-            public RenderPass RenderPass;
-            public Framebuffer Framebuffer;
-            public bool Initialized;
-            public bool InitialUploadPending;
-            public bool IsCpuBacked;
-            public ulong CpuContentFingerprint;
-        }
-
         private sealed record PendingGuestSubmission(
             Fence Fence,
             CommandBuffer CommandBuffer,
@@ -1142,6 +1122,7 @@ internal static unsafe class VulkanVideoPresenter
 
         public Presenter(uint width, uint height)
         {
+            _guestImages = new GuestImageCache(WaitForGuestImagesIdle, DestroyGuestImage);
             var options = WindowOptions.DefaultVulkan;
             options.Size = new Vector2D<int>((int)DefaultWindowWidth, (int)DefaultWindowHeight);
             options.Title = VideoOutExports.GetWindowTitle();
@@ -3606,6 +3587,7 @@ internal static unsafe class VulkanVideoPresenter
                 var guestImage = new GuestImageResource
                 {
                     Address = texture.Address,
+                    GuestSize = expectedSize,
                     Width = width,
                     Height = height,
                     MipLevels = 1,
@@ -3617,7 +3599,9 @@ internal static unsafe class VulkanVideoPresenter
                     IsCpuBacked = true,
                     CpuContentFingerprint = contentFingerprint,
                 };
-                _guestImages.Add(texture.Address, guestImage);
+                ForgetGuestImageTracking(
+                    _guestImages.InvalidateOverlaps(texture.Address, expectedSize));
+                _guestImages.Add(guestImage);
                 resource.OwnsStorage = false;
                 resource.GuestImage = guestImage;
                 lock (_gate)
@@ -4366,6 +4350,23 @@ internal static unsafe class VulkanVideoPresenter
                 : checked(((ulong)width + 3) / 4 * (((ulong)height + 3) / 4) * blockBytes);
         }
 
+        private static ulong GetTextureByteCount(
+            uint format,
+            uint width,
+            uint height,
+            uint mipLevels)
+        {
+            ulong size = 0;
+            for (uint mipLevel = 0; mipLevel < mipLevels; mipLevel++)
+            {
+                size = checked(size + GetTextureByteCount(format, width, height));
+                width = Math.Max(1, width >> 1);
+                height = Math.Max(1, height >> 1);
+            }
+
+            return size;
+        }
+
         private static Format GetTextureFormat(uint format, uint numberType) =>
             (format, numberType) switch
             {
@@ -4927,15 +4928,15 @@ internal static unsafe class VulkanVideoPresenter
 
                     return existing;
                 }
-
-                DestroyGuestImage(existing);
-                _guestImages.Remove(target.Address);
-                lock (_gate)
-                {
-                    _availableGuestImages.Remove(target.Address);
-                    _gpuGuestImages.Remove(target.Address);
-                }
             }
+
+            var guestSize = GetTextureByteCount(
+                target.Format,
+                target.Width,
+                target.Height,
+                mipLevels);
+            ForgetGuestImageTracking(
+                _guestImages.InvalidateOverlaps(target.Address, guestSize));
 
             var imageInfo = new ImageCreateInfo
             {
@@ -5015,6 +5016,7 @@ internal static unsafe class VulkanVideoPresenter
             var resource = new GuestImageResource
             {
                 Address = target.Address,
+                GuestSize = guestSize,
                 Width = target.Width,
                 Height = target.Height,
                 MipLevels = mipLevels,
@@ -5038,8 +5040,34 @@ internal static unsafe class VulkanVideoPresenter
             }
             SetDebugName(ObjectType.RenderPass, renderPass.Handle, $"{debugName} renderpass");
             SetDebugName(ObjectType.Framebuffer, framebuffer.Handle, $"{debugName} framebuffer");
-            _guestImages.Add(target.Address, resource);
+            _guestImages.Add(resource);
             return resource;
+        }
+
+        private void WaitForGuestImagesIdle()
+        {
+            CompletePendingPresentation(wait: true);
+            while (_pendingGuestSubmissions.Count != 0)
+            {
+                CollectCompletedGuestSubmissions(waitForOldest: true);
+            }
+        }
+
+        private void ForgetGuestImageTracking(IReadOnlyList<GuestImageResource> resources)
+        {
+            if (resources.Count == 0)
+            {
+                return;
+            }
+
+            lock (_gate)
+            {
+                foreach (var resource in resources)
+                {
+                    _availableGuestImages.Remove(resource.Address);
+                    _gpuGuestImages.Remove(resource.Address);
+                }
+            }
         }
 
         private (RenderPass RenderPass, Framebuffer Framebuffer) CreateRenderPassAndFramebuffer(
@@ -7075,11 +7103,7 @@ internal static unsafe class VulkanVideoPresenter
             }
             _hostBufferAllocations.Clear();
             _hostBufferPool.Clear();
-            foreach (var guestImage in _guestImages.Values)
-            {
-                DestroyGuestImage(guestImage);
-            }
-            _guestImages.Clear();
+            _guestImages.Dispose();
             lock (_gate)
             {
                 _availableGuestImages.Clear();

--- a/tests/SharpEmu.Tests.GuestImageCache/Program.cs
+++ b/tests/SharpEmu.Tests.GuestImageCache/Program.cs
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.VideoOut;
+
+var waits = 0;
+var destroyed = new List<GuestImageResource>();
+using var cache = new GuestImageCache(
+    () => waits++,
+    resource => destroyed.Add(resource));
+
+var first = new GuestImageResource { Address = 0x1000, GuestSize = 0x100 };
+cache.Add(first);
+Assert(cache.TryGetValue(0x1000, out var found) && ReferenceEquals(found, first),
+    "exact guest image lookup failed");
+
+Assert(cache.InvalidateOverlaps(0x1100, 0x80).Count == 0,
+    "adjacent ranges were treated as aliases");
+Assert(waits == 0, "non-overlapping invalidation waited for the GPU");
+
+var invalidated = cache.InvalidateOverlaps(0x1080, 0x100);
+Assert(invalidated.Count == 1 && ReferenceEquals(invalidated[0], first),
+    "overlapping alias was not invalidated");
+Assert(waits == 1 && destroyed.SequenceEqual([first]),
+    "overlap did not wait once before destroying the old image");
+
+var second = new GuestImageResource { Address = 0x1080, GuestSize = 0x100 };
+cache.Add(second);
+Assert(cache.ContainsKey(0x1080), "replacement image was not cached");
+
+cache.Dispose();
+Assert(waits == 2 && destroyed.SequenceEqual([first, second]),
+    "cache disposal did not safely destroy the remaining image");
+
+Console.WriteLine("GuestImageCache lookup, alias invalidation, and safe lifetime tests passed.");
+
+static void Assert(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(message);
+    }
+}

--- a/tests/SharpEmu.Tests.GuestImageCache/SharpEmu.Tests.GuestImageCache.csproj
+++ b/tests/SharpEmu.Tests.GuestImageCache/SharpEmu.Tests.GuestImageCache.csproj
@@ -1,0 +1,15 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SharpEmu.Libs\SharpEmu.Libs.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Extract persistent guest images from `VulkanVideoPresenter` into a dedicated `GuestImageCache`.

The cache associates each Vulkan image with its guest-memory byte range, preserves compatible images across work, and invalidates every cached alias whose range overlaps a replacement image.

## Why

The presenter previously indexed images only by their starting address and destroyed an incompatible image immediately. That had two architectural/correctness gaps:

- two different guest addresses could alias overlapping memory without invalidating one another;
- recreating an image could destroy Vulkan objects still referenced by an in-flight presentation or guest submission.

This is a small first step toward a real texture/image cache without combining depth, array/3D image support, or CPU/GPU readback into one review.

## What changed

- move `GuestImageResource` out of the presenter;
- add `GuestSize` and mip-aware guest byte-range calculation;
- add `GuestImageCache` for persistent exact-address lookup and overlap invalidation;
- wait for pending presentation and guest fences before destroying aliased or incompatible resources;
- remove stale availability/GPU ownership bookkeeping for every invalidated alias;
- route CPU-backed textures and render/storage targets through the cache;
- dispose all cached images through the same safe-lifetime path.

## Tests

Added a dependency-free executable test that verifies:

- persistent exact-address lookup;
- adjacent ranges do not alias;
- overlapping ranges invalidate the previous image;
- invalidation waits exactly once before destruction;
- cache disposal safely destroys remaining resources.

CI runs this test after the Release solution build.

Local verification:

- `dotnet build SharpEmu.slnx -c Release --no-restore` — 0 warnings, 0 errors
- `dotnet run --project tests/SharpEmu.Tests.GuestImageCache/SharpEmu.Tests.GuestImageCache.csproj -c Release --no-build` — passed

## Scope

This deliberately does not add depth/stencil, cube/array/3D images, subresource dirty tracking, or GPU-to-CPU image readback. Those can build on this cache in focused follow-up PRs.