### PR TITLE
[Vulkan] Extract guest submission scheduler

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Validate synthetic shaders
         run: dotnet run --project tools/SharpEmu.Tools.ShaderDump/SharpEmu.Tools.ShaderDump.csproj -c Release -- artifacts/shader-dump
 
+      - name: Test guest submission scheduler
+        run: dotnet run --project tests/SharpEmu.Tests.GuestSubmissionScheduler/SharpEmu.Tests.GuestSubmissionScheduler.csproj -c Release --no-build
+
       - name: Publish win-x64 CLI
         run: dotnet publish src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r win-x64 --self-contained true --no-restore -p:PublishDir="${env:PUBLISH_DIR}"
 

--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -14,5 +14,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj" />
+    <Project Path="tests/SharpEmu.Tests.GuestSubmissionScheduler/SharpEmu.Tests.GuestSubmissionScheduler.csproj" />
   </Folder>
 </Solution>

--- a/src/SharpEmu.Libs/SharpEmu.Libs.csproj
+++ b/src/SharpEmu.Libs/SharpEmu.Libs.csproj
@@ -19,6 +19,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <PackageReference Include="Silk.NET.Windowing" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SharpEmu.Tests.GuestSubmissionScheduler" />
+  </ItemGroup>
+
   <PropertyGroup>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/SharpEmu.Libs/VideoOut/GuestSubmissionScheduler.cs
+++ b/src/SharpEmu.Libs/VideoOut/GuestSubmissionScheduler.cs
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Libs.VideoOut;
+
+internal sealed class GuestSubmissionScheduler<TSubmission>
+{
+    private readonly Queue<TSubmission> _pending = new();
+    private readonly int _capacity;
+    private readonly Action<TSubmission> _wait;
+    private readonly Func<TSubmission, bool> _isComplete;
+    private readonly Action<TSubmission> _release;
+
+    public GuestSubmissionScheduler(
+        int capacity,
+        Action<TSubmission> wait,
+        Func<TSubmission, bool> isComplete,
+        Action<TSubmission> release)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+        _capacity = capacity;
+        _wait = wait;
+        _isComplete = isComplete;
+        _release = release;
+    }
+
+    public int Count => _pending.Count;
+
+    public void Track(TSubmission submission) => _pending.Enqueue(submission);
+
+    public void EnsureCapacity()
+    {
+        Collect(waitForOldest: false);
+        if (_pending.Count >= _capacity)
+        {
+            Collect(waitForOldest: true);
+        }
+    }
+
+    public void Collect(bool waitForOldest)
+    {
+        if (waitForOldest && _pending.TryPeek(out var oldest))
+        {
+            _wait(oldest);
+        }
+
+        while (_pending.TryPeek(out var submission) && _isComplete(submission))
+        {
+            _pending.Dequeue();
+            _release(submission);
+        }
+    }
+}

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1159,7 +1159,7 @@ internal static unsafe class VulkanVideoPresenter
         private readonly Dictionary<HostBufferPoolKey, Stack<HostBufferAllocation>>
             _hostBufferPool = new();
         private readonly Dictionary<ulong, HostBufferAllocation> _hostBufferAllocations = new();
-        private readonly Queue<PendingGuestSubmission> _pendingGuestSubmissions = new();
+        private readonly GuestSubmissionScheduler<PendingGuestSubmission> _guestSubmissions;
 
         private readonly record struct GraphicsPipelineKey(
             string VertexShader,
@@ -1284,6 +1284,11 @@ internal static unsafe class VulkanVideoPresenter
 
         public Presenter(uint width, uint height)
         {
+            _guestSubmissions = new GuestSubmissionScheduler<PendingGuestSubmission>(
+                MaxInFlightGuestSubmissions,
+                WaitForGuestSubmission,
+                IsGuestSubmissionComplete,
+                ReleaseGuestSubmission);
             var options = WindowOptions.DefaultVulkan;
             options.Size = new Vector2D<int>((int)DefaultWindowWidth, (int)DefaultWindowHeight);
             options.Title = VideoOutExports.GetWindowTitle();
@@ -2244,7 +2249,7 @@ internal static unsafe class VulkanVideoPresenter
                 throw;
             }
 
-            _pendingGuestSubmissions.Enqueue(
+            _guestSubmissions.Track(
                 new PendingGuestSubmission(
                     fence,
                     commandBuffer,
@@ -2288,16 +2293,12 @@ internal static unsafe class VulkanVideoPresenter
 
         private void EnsureGuestSubmissionCapacity()
         {
-            CollectCompletedGuestSubmissions(waitForOldest: false);
-            if (_pendingGuestSubmissions.Count >= MaxInFlightGuestSubmissions)
-            {
-                CollectCompletedGuestSubmissions(waitForOldest: true);
-            }
+            _guestSubmissions.EnsureCapacity();
         }
 
         private void WaitForAllGuestSubmissions()
         {
-            while (_pendingGuestSubmissions.Count != 0)
+            while (_guestSubmissions.Count != 0)
             {
                 CollectCompletedGuestSubmissions(waitForOldest: true);
             }
@@ -2305,43 +2306,40 @@ internal static unsafe class VulkanVideoPresenter
 
         private void CollectCompletedGuestSubmissions(bool waitForOldest)
         {
-            if (waitForOldest && _pendingGuestSubmissions.TryPeek(out var oldest))
+            _guestSubmissions.Collect(waitForOldest);
+        }
+
+        private void WaitForGuestSubmission(PendingGuestSubmission submission)
+        {
+            var fence = submission.Fence;
+            Check(
+                _vk.WaitForFences(_device, 1, &fence, true, ulong.MaxValue),
+                $"vkWaitForFences(guest: {submission.DebugName})");
+        }
+
+        private bool IsGuestSubmissionComplete(PendingGuestSubmission submission)
+        {
+            var status = _vk.GetFenceStatus(_device, submission.Fence);
+            if (status == Result.NotReady)
             {
-                var fence = oldest.Fence;
-                var result = _vk.WaitForFences(
-                    _device,
-                    1,
-                    &fence,
-                    true,
-                    ulong.MaxValue);
-                Check(result, $"vkWaitForFences(guest: {oldest.DebugName})");
+                return false;
             }
 
-            while (_pendingGuestSubmissions.TryPeek(out var submission))
+            Check(status, $"vkGetFenceStatus(guest: {submission.DebugName})");
+            return true;
+        }
+
+        private void ReleaseGuestSubmission(PendingGuestSubmission submission)
+        {
+            foreach (var image in submission.TraceImages)
             {
-                var status = _vk.GetFenceStatus(_device, submission.Fence);
-                if (status == Result.NotReady)
-                {
-                    break;
-                }
-
-                Check(status, $"vkGetFenceStatus(guest: {submission.DebugName})");
-                _pendingGuestSubmissions.Dequeue();
-
-                foreach (var image in submission.TraceImages)
-                {
-                    TraceGuestImageContents(image);
-                }
-
-                DestroyTranslatedDrawResources(submission.Resources);
-                var commandBuffer = submission.CommandBuffer;
-                _vk.FreeCommandBuffers(
-                    _device,
-                    _commandPool,
-                    1,
-                    &commandBuffer);
-                _vk.DestroyFence(_device, submission.Fence, null);
+                TraceGuestImageContents(image);
             }
+
+            DestroyTranslatedDrawResources(submission.Resources);
+            var commandBuffer = submission.CommandBuffer;
+            _vk.FreeCommandBuffers(_device, _commandPool, 1, &commandBuffer);
+            _vk.DestroyFence(_device, submission.Fence, null);
         }
 
         private IReadOnlyList<GuestImageResource> GetTraceImages(
@@ -5674,7 +5672,7 @@ internal static unsafe class VulkanVideoPresenter
                         queuedGuestWork = _pendingGuestWork.Count;
                     }
 
-                    var gpuInFlight = _pendingGuestSubmissions.Count +
+                    var gpuInFlight = _guestSubmissions.Count +
                         (_presentationInFlight ? 1 : 0);
                     var readCount = Interlocked.Read(
                         ref Agc.Gen5ShaderScalarEvaluator.GlobalMemoryReadCount);
@@ -5794,7 +5792,7 @@ internal static unsafe class VulkanVideoPresenter
 
         private void WaitForRenderWork()
         {
-            var gpuWorkInFlight = _pendingGuestSubmissions.Count > 0 || _presentationInFlight;
+            var gpuWorkInFlight = _guestSubmissions.Count > 0 || _presentationInFlight;
             lock (_gate)
             {
                 if (_closed ||

--- a/tests/SharpEmu.Tests.GuestSubmissionScheduler/Program.cs
+++ b/tests/SharpEmu.Tests.GuestSubmissionScheduler/Program.cs
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.VideoOut;
+
+AssertThrows<ArgumentOutOfRangeException>(() =>
+    new GuestSubmissionScheduler<Submission>(0, _ => { }, _ => true, _ => { }));
+
+var waited = new List<int>();
+var released = new List<int>();
+var scheduler = new GuestSubmissionScheduler<Submission>(
+    2,
+    submission =>
+    {
+        waited.Add(submission.Id);
+        submission.Complete = true;
+    },
+    submission => submission.Complete,
+    submission => released.Add(submission.Id));
+
+var first = new Submission(1);
+var second = new Submission(2);
+scheduler.Track(first);
+scheduler.Track(second);
+scheduler.Collect(waitForOldest: false);
+Assert(released.Count == 0, "in-flight submissions were released early");
+
+second.Complete = true;
+scheduler.Collect(waitForOldest: false);
+Assert(released.Count == 0, "FIFO lifetime ordering was not preserved");
+
+scheduler.EnsureCapacity();
+Assert(waited.SequenceEqual([1]), "capacity did not wait for the oldest submission");
+Assert(released.SequenceEqual([1, 2]), "completed resources were not released in FIFO order");
+Assert(scheduler.Count == 0, "completed submissions remain tracked");
+
+Console.WriteLine("GuestSubmissionScheduler capacity and deferred release tests passed.");
+
+static void Assert(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(message);
+    }
+}
+
+static void AssertThrows<TException>(Action action)
+    where TException : Exception
+{
+    try
+    {
+        action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+
+    throw new InvalidOperationException($"Expected {typeof(TException).Name}");
+}
+
+internal sealed class Submission(int id)
+{
+    public int Id { get; } = id;
+    public bool Complete { get; set; }
+}

--- a/tests/SharpEmu.Tests.GuestSubmissionScheduler/SharpEmu.Tests.GuestSubmissionScheduler.csproj
+++ b/tests/SharpEmu.Tests.GuestSubmissionScheduler/SharpEmu.Tests.GuestSubmissionScheduler.csproj
@@ -1,0 +1,15 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SharpEmu.Libs\SharpEmu.Libs.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Extract in-flight guest submission lifetime management from `VulkanVideoPresenter` into a focused `GuestSubmissionScheduler<TSubmission>`.

## Why

The presenter directly owned a queue of fences, command buffers, transient draw resources, trace images, capacity throttling, fence polling, and deferred destruction. This made submission ordering and resource lifetime difficult to test independently from Vulkan.

This PR separates the policy from Vulkan operations while keeping the current behavior:

- submissions remain FIFO;
- resources remain alive until their fence completes;
- reaching the in-flight limit waits only for the oldest submission;
- all consecutively completed submissions are released together.

The presenter supplies the Vulkan-specific wait, completion check, and release callbacks. The scheduler owns ordering, capacity, and deferred release.

## What changed

- add generic `GuestSubmissionScheduler<TSubmission>`;
- route guest submission tracking and collection through it;
- isolate Vulkan fence wait/status and command-buffer/resource cleanup into callbacks;
- use its count for performance and idle accounting;
- add permanent CI coverage for capacity and deferred lifetime behavior.

## Tests

The dependency-free executable test verifies:

- invalid capacity is rejected;
- in-flight resources are not released early;
- a completed later submission cannot bypass an earlier one;
- capacity waits for the oldest submission;
- completed resources are released in FIFO order.

Local verification:

- `dotnet build SharpEmu.slnx -c Release --no-restore` — 0 warnings, 0 errors
- `dotnet run --project tests/SharpEmu.Tests.GuestSubmissionScheduler/SharpEmu.Tests.GuestSubmissionScheduler.csproj -c Release --no-build` — passed

## Relationship to #172

#172 extracts the CPU-side guest work queue. This PR independently extracts the GPU-side in-flight submission and deferred destruction policy. Neither PR depends on the other, so they can be reviewed and merged in either order.