### PR TITLE
Fix pak size-collision that crashed Quake right after the intro demo

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,11 +12,14 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.18" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.18" />
     <PackageVersion Include="Iced" Version="1.21.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.Windowing" Version="2.23.0" />
     <!-- Transitive of Avalonia.Desktop; pinned to fix GHSA-xrw6-gwf8-vvr9 -->
     <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
   </ItemGroup>
 </Project>

--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -12,4 +12,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <Project Path="src/SharpEmu.Libs/SharpEmu.Libs.csproj" />
     <Project Path="src/SharpEmu.Logging/SharpEmu.Logging.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/src/SharpEmu.Libs/Ampr/PakDirectoryTracker.cs
+++ b/src/SharpEmu.Libs/Ampr/PakDirectoryTracker.cs
@@ -54,20 +54,41 @@ internal static class PakDirectoryTracker
 
         if (state.Directory is { } entries)
         {
+            // Several unrelated archived files can share a byte count (e.g. a head model and a bot
+            // navigation file both 0x3A34 bytes). Directory order alone then picks whichever comes
+            // first, which is wrong when the game reads them out of order. id archives cluster
+            // related assets, and the guest streams them with locality, so disambiguate collisions
+            // by choosing the unconsumed match nearest the running read cursor.
+            DirectoryEntry? best = null;
+            var bestDistance = ulong.MaxValue;
             foreach (var entry in entries)
             {
-                if (!entry.Consumed && entry.FileLen == requestedSize)
+                if (entry.Consumed || entry.FileLen != requestedSize)
                 {
-                    entry.Consumed = true;
-                    if (_trace)
-                    {
-                        Console.Error.WriteLine(
-                            $"[LOADER][TRACE] pak.directory_match: id=0x{fileId:X8} name='{entry.Name}' " +
-                            $"filepos=0x{entry.FilePos:X8} filelen=0x{entry.FileLen:X8}");
-                    }
-
-                    return entry.FilePos;
+                    continue;
                 }
+
+                var distance = entry.FilePos >= state.NextOffset
+                    ? entry.FilePos - state.NextOffset
+                    : state.NextOffset - entry.FilePos;
+                if (distance < bestDistance)
+                {
+                    bestDistance = distance;
+                    best = entry;
+                }
+            }
+
+            if (best is not null)
+            {
+                best.Consumed = true;
+                if (_trace)
+                {
+                    Console.Error.WriteLine(
+                        $"[LOADER][TRACE] pak.directory_match: id=0x{fileId:X8} name='{best.Name}' " +
+                        $"filepos=0x{best.FilePos:X8} filelen=0x{best.FileLen:X8}");
+                }
+
+                return best.FilePos;
             }
         }
 

--- a/src/SharpEmu.Libs/SharpEmu.Libs.csproj
+++ b/src/SharpEmu.Libs/SharpEmu.Libs.csproj
@@ -9,6 +9,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="SharpEmu.Libs.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Silk.NET.Vulkan" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" />

--- a/tests/SharpEmu.Libs.Tests/Ampr/PakDirectoryTrackerTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ampr/PakDirectoryTrackerTests.cs
@@ -1,0 +1,108 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Text;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Ampr;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Ampr;
+
+// PakDirectoryTracker reconstructs the absolute pak offset for a "next sequential chunk" read
+// (offset -1) from the requested byte count. When several archived files share that byte count,
+// picking by directory order alone mis-resolves out-of-order reads: Quake requested progs/h_ogre.mdl
+// (0x3A34 bytes) but the tracker returned bots/navigation/death32c.nav, which shares the size and
+// sits earlier in the directory, so the guest parsed NAV2 data as a brush model and aborted.
+public sealed class PakDirectoryTrackerTests
+{
+    private const int EntrySize = 64;
+    private const int NameLength = 56;
+
+    private readonly record struct PakEntry(string Name, uint FilePos, uint FileLen);
+
+    [Fact]
+    public void ResolveSequentialOffset_SizeCollision_PicksEntryNearestReadCursor()
+    {
+        const uint fileId = 0x5AA5_0001;
+        const uint collidingLen = 0x3A34;
+        var memory = new FakeCpuMemory(0x1_0000_0000, 0x1000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+
+        // "far" collides in size but lives early in the pak; "near" is what the guest actually wants.
+        LoadDirectory(ctx, fileId, memory, 0x1_0000_0000, dirFileOffset: 0x400, new[]
+        {
+            new PakEntry("far.dat", FilePos: 0x1000, FileLen: collidingLen),
+            new PakEntry("near.dat", FilePos: 0x9000, FileLen: collidingLen),
+        });
+
+        // Advance the read cursor next to the "near" entry, mimicking a burst of nearby asset reads.
+        PakDirectoryTracker.OnReadCompleted(ctx, fileId, destination: 0x1_0000_0000, fileOffset: 0x8800, bytesRead: 0x400);
+
+        Assert.Equal(0x9000UL, PakDirectoryTracker.ResolveSequentialOffset(fileId, collidingLen));
+        // Once the near entry is consumed, the same size resolves to the remaining match.
+        Assert.Equal(0x1000UL, PakDirectoryTracker.ResolveSequentialOffset(fileId, collidingLen));
+    }
+
+    [Fact]
+    public void ResolveSequentialOffset_ContiguousSameSizeRun_StaysInOrder()
+    {
+        const uint fileId = 0x5AA5_0002;
+        const uint runLen = 0x608;
+        var memory = new FakeCpuMemory(0x1_0000_0000, 0x1000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+
+        // A contiguous run of equal-size lumps (like Quake's gfx/weapons/ww_*.lmp) must still resolve
+        // in packed order when the guest streams them sequentially.
+        LoadDirectory(ctx, fileId, memory, 0x1_0000_0000, dirFileOffset: 0x400, new[]
+        {
+            new PakEntry("lump_a", FilePos: 0x1000, FileLen: runLen),
+            new PakEntry("lump_b", FilePos: 0x1000 + runLen, FileLen: runLen),
+            new PakEntry("lump_c", FilePos: 0x1000 + (runLen * 2), FileLen: runLen),
+        });
+
+        var first = PakDirectoryTracker.ResolveSequentialOffset(fileId, runLen);
+        PakDirectoryTracker.OnReadCompleted(ctx, fileId, destination: 0x1_0000_0000, fileOffset: first, bytesRead: runLen);
+        var second = PakDirectoryTracker.ResolveSequentialOffset(fileId, runLen);
+        PakDirectoryTracker.OnReadCompleted(ctx, fileId, destination: 0x1_0000_0000, fileOffset: second, bytesRead: runLen);
+        var third = PakDirectoryTracker.ResolveSequentialOffset(fileId, runLen);
+
+        Assert.Equal(0x1000UL, first);
+        Assert.Equal(0x1000UL + runLen, second);
+        Assert.Equal(0x1000UL + (runLen * 2), third);
+    }
+
+    // Feeds the tracker a synthetic PACK header + directory table exactly as the AMPR read path does:
+    // first the 12-byte header (which arms directory parsing), then the directory records themselves.
+    private static void LoadDirectory(
+        CpuContext ctx,
+        uint fileId,
+        FakeCpuMemory memory,
+        ulong destination,
+        ulong dirFileOffset,
+        PakEntry[] entries)
+    {
+        Span<byte> header = stackalloc byte[12];
+        header[0] = (byte)'P';
+        header[1] = (byte)'A';
+        header[2] = (byte)'C';
+        header[3] = (byte)'K';
+        BinaryPrimitives.WriteUInt32LittleEndian(header[4..8], (uint)dirFileOffset);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[8..12], (uint)(entries.Length * EntrySize));
+        memory.TryWrite(destination, header);
+        PakDirectoryTracker.OnReadCompleted(ctx, fileId, destination, fileOffset: 0, bytesRead: 12);
+
+        var table = new byte[entries.Length * EntrySize];
+        for (var i = 0; i < entries.Length; i++)
+        {
+            var record = table.AsSpan(i * EntrySize, EntrySize);
+            var name = Encoding.ASCII.GetBytes(entries[i].Name);
+            name.AsSpan(0, Math.Min(name.Length, NameLength)).CopyTo(record);
+            BinaryPrimitives.WriteUInt32LittleEndian(record.Slice(56, 4), entries[i].FilePos);
+            BinaryPrimitives.WriteUInt32LittleEndian(record.Slice(60, 4), entries[i].FileLen);
+        }
+
+        memory.TryWrite(destination, table);
+        PakDirectoryTracker.OnReadCompleted(ctx, fileId, destination, dirFileOffset, (ulong)table.Length);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/FakeCpuMemory.cs
+++ b/tests/SharpEmu.Libs.Tests/FakeCpuMemory.cs
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+
+namespace SharpEmu.Libs.Tests;
+
+// A single contiguous guest region backed by a byte[]. Enough to hand C strings and small
+// structures to HLE exports under test without a live guest.
+internal sealed class FakeCpuMemory : ICpuMemory
+{
+    private readonly ulong _base;
+    private readonly byte[] _storage;
+
+    public FakeCpuMemory(ulong baseAddress, int size)
+    {
+        _base = baseAddress;
+        _storage = new byte[size];
+    }
+
+    public bool TryRead(ulong virtualAddress, Span<byte> destination)
+    {
+        if (!TryResolve(virtualAddress, destination.Length, out var offset))
+        {
+            return false;
+        }
+
+        _storage.AsSpan(offset, destination.Length).CopyTo(destination);
+        return true;
+    }
+
+    public bool TryWrite(ulong virtualAddress, ReadOnlySpan<byte> source)
+    {
+        if (!TryResolve(virtualAddress, source.Length, out var offset))
+        {
+            return false;
+        }
+
+        source.CopyTo(_storage.AsSpan(offset, source.Length));
+        return true;
+    }
+
+    public ulong WriteCString(ulong virtualAddress, string text)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(text);
+        TryWrite(virtualAddress, bytes);
+        TryWrite(virtualAddress + (ulong)bytes.Length, stackalloc byte[] { 0 });
+        return virtualAddress;
+    }
+
+    private bool TryResolve(ulong virtualAddress, int length, out int offset)
+    {
+        offset = 0;
+        if (virtualAddress < _base)
+        {
+            return false;
+        }
+
+        var relative = virtualAddress - _base;
+        if (relative + (ulong)length > (ulong)_storage.Length)
+        {
+            return false;
+        }
+
+        offset = (int)relative;
+        return true;
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj
+++ b/tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj
@@ -1,0 +1,22 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SharpEmu.Libs\SharpEmu.Libs.csproj" />
+    <ProjectReference Include="..\..\src\SharpEmu.HLE\SharpEmu.HLE.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+</Project>

--- a/tests/SharpEmu.Libs.Tests/packages.lock.json
+++ b/tests/SharpEmu.Libs.Tests/packages.lock.json
@@ -1,0 +1,212 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "gNu2zhnuwjq5vQlU4S7yK/lfaKZDLmtcu+vTjnhfTlMAUYn+Hmgu8IIX0UCwWepYkk+Szx03DHx1bDnc9Fd+9w=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "9.0.9",
+        "contentHash": "fNGvKct2De8ghm0Bpfq0iWthtzIWabgOTi+gJhNOPhNJIowXNEUE2eZNW/zNCzrHVA3PXg2yZ+3cWZndC2IqYA=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Silk.NET.Core": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "D7AT/nnwlB+4RZ84XY8QNGBZMJI5z9l4CSSETIJ1wCfRJzRt/341y3MRZ4HbnFz4r/IGaWOEZr86iE+0/65yyQ==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Microsoft.Extensions.DependencyModel": "9.0.9"
+        }
+      },
+      "Silk.NET.GLFW": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "UIs4sH57xlPUNHQ/1bt9rymPWlGy8IMDCNv86h0iM4TOA1CkIx0XM/n/tA4AReh1zQkNrvkxPEdZ3Blvy1dyXg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Ultz.Native.GLFW": "3.4.0"
+        }
+      },
+      "Silk.NET.Maths": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "r8PdIVzME8EH0qAgbmRPO87I4GfgR2j8TofT7EMuRJDf1QluoQwnVypDoFJjQ2ZBSRsGYk5unYxxogI05Ogsmw=="
+      },
+      "Silk.NET.Windowing.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "ThStSinmY9KQI8DGiF5XEhkLJVnBcgRTBTzL9ijg1wMZAYuckz7ykrNw04fjRm2Gryh6tCNGbvz2XaY0efeFzg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "aYBudKmENmvLRn9p15HbdvlQTnnXskcDfTfbYwSb/4fr263rGLwYuDw/txUEc2jihHJiWCp5+75Y7z5wTJWl7g==",
+        "dependencies": {
+          "Silk.NET.GLFW": "2.23.0",
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "sharpemu.hle": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.Logging": "[1.0.0, )"
+        }
+      },
+      "sharpemu.libs": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.HLE": "[1.0.0, )",
+          "Silk.NET.Vulkan": "[2.23.0, )",
+          "Silk.NET.Vulkan.Extensions.EXT": "[2.23.0, )",
+          "Silk.NET.Vulkan.Extensions.KHR": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "sharpemu.logging": {
+        "type": "Project"
+      },
+      "Silk.NET.Vulkan": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "3/irtlSWXZ3eTi8N6nelI6L34NTB8ZJHpqVMNzZx2aX7Ek9YEQ34NoQW8/Tljrtmkg8KRhHW8hKTEzZaKV8PgA==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0"
+        }
+      },
+      "Silk.NET.Vulkan.Extensions.EXT": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "+Oth189ksRiL6HvGCwIdnsYHawqrbO8y49u1H61z3wsfcHhQZeVDYe/wF5LD7fk3NcdgDvwFD3mLm1QWhdZySw==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Vulkan": "2.23.0"
+        }
+      },
+      "Silk.NET.Vulkan.Extensions.KHR": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "uRaf4j+SmH3DumjSSSUbFg33BnsGZUyXGj93O9NgGKZSJN3OTmNmQDxRew+/KiVLcgH6qzbto8aNGZ++j9GFWg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Vulkan": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "OPNPmt/lRyUKVYrFLQXVxyATqD3MKLc1iY1oKx1/2GppgmZxVZPwN12tekrQ4C7408kgB1L5JD1Wnirqqeb2kg==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I was chasing why Quake (PPSA01880) throws its error dialog and aborts a bit after the intro demo starts, and it turned out to be in the AMPR pak reader rather than where I expected.

When the game streams a file it asks for "the next sequential chunk" and only hands us the byte count - the absolute offset comes across as -1. PakDirectoryTracker maps that byte count back to a real offset by matching it against the pak directory. The catch is that different files can be the exact same size: progs/h_ogre.mdl and bots/navigation/death32c.nav are both 0x3A34 bytes. The tracker was picking the first unconsumed entry of that size in directory order, and death32c.nav sits much earlier in the table and never gets read during the demo. So when the engine asked for h_ogre.mdl it got the nav file's bytes instead, tried to parse "NAV2..." as a brush model, the version check failed and it called abort().

The fix disambiguates size collisions by locality: among the unconsumed entries of the right size, pick the one closest to the current read cursor. id archives keep related assets together and the game streams them with locality, so this lands on the right file - h_ogre is right next to the other ogre models it just read, while death32c is megabytes away.

Added two unit tests, one for the collision case and one to make sure a contiguous run of same-size lumps (the ww_*.lmp weapon icons) still resolves in packed order. That test project didn't exist yet so this brings a small one; it overlaps a bit with #169, whichever lands first the other just rebases.

Tested with a copy of Quake - with this the demo actually plays instead of dying at the error dialog, here it is running:

<img width="1276" height="747" alt="image" src="https://github.com/user-attachments/assets/d448117d-4112-4874-99a5-6a96ba816e5b" />
