### PR TITLE
GUI: Add code -1073741819 (Access Violation) as an emulation error

### DIFF
--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -1499,6 +1499,7 @@ public partial class MainWindow : Window
             2 => "Exit.EbootNotFound",
             3 => "Exit.RuntimeException",
             4 => "Exit.EmulationError",
+            -1073741819 => "Exit.EmulationError",
             _ => "Exit.Unknown",
         };
         var meaning = Localization.Instance.Get(meaningKey);


### PR DESCRIPTION
There's currently games that crash on this access violation code due to emulation errors, so it'd make sense to add this error code as an emulation error (I think).