### PR TITLE
[HLE] Remove steady-state allocations from the hot HLE paths

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -535,8 +535,7 @@ public sealed partial class DirectExecutionBackend
 					out var blockContinuation,
 					out var hasBlockContinuation,
 					out var blockWakeKey,
-					out var blockResumeHandler,
-					out var blockWakeHandler,
+					out var blockWaiter,
 					out var blockDeadlineTimestamp) &&
 				TryYieldGuestThreadToHostStub(argPackPtr, num, num7, importStubEntry.Nid, blockReason))
 			{
@@ -546,8 +545,7 @@ public sealed partial class DirectExecutionBackend
 						GuestThreadExecution.CurrentGuestThreadHandle,
 						blockContinuation,
 						blockWakeKey,
-						blockResumeHandler,
-						blockWakeHandler,
+						blockWaiter,
 						blockDeadlineTimestamp);
 				}
 
@@ -678,8 +676,7 @@ public sealed partial class DirectExecutionBackend
 				out var blockContinuation,
 				out var hasBlockContinuation,
 				out var blockWakeKey,
-				out var blockResumeHandler,
-				out var blockWakeHandler,
+				out var blockWaiter,
 				out var blockDeadlineTimestamp) &&
 			TryYieldGuestThreadToHostStub(argPackPtr, dispatchIndex, returnRip, importStubEntry.Nid, blockReason))
 		{
@@ -689,8 +686,7 @@ public sealed partial class DirectExecutionBackend
 					GuestThreadExecution.CurrentGuestThreadHandle,
 					blockContinuation,
 					blockWakeKey,
-					blockResumeHandler,
-					blockWakeHandler,
+					blockWaiter,
 					blockDeadlineTimestamp);
 			}
 

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -1970,23 +1970,36 @@ public sealed partial class DirectExecutionBackend
 			return false;
 		}
 
-		List<byte> list = new List<byte>(Math.Min(maxLength, 256));
-		Span<byte> destination = stackalloc byte[1];
-		for (int i = 0; i < maxLength; i++)
+		// Reads stay byte-by-byte through TryReadByteCompat (its Marshal.ReadByte
+		// fallback must probe exactly up to the terminator), but the bytes land in a
+		// stack buffer instead of a List<byte> + ToArray per symbol resolution.
+		const int StackBufferLength = 512;
+		byte[]? rented = maxLength > StackBufferLength ? System.Buffers.ArrayPool<byte>.Shared.Rent(maxLength) : null;
+		Span<byte> buffer = rented is null ? stackalloc byte[StackBufferLength] : rented;
+		try
 		{
-			if (!TryReadByteCompat(address + (ulong)i, destination))
+			for (int i = 0; i < maxLength; i++)
 			{
-				return false;
+				if (!TryReadByteCompat(address + (ulong)i, buffer.Slice(i, 1)))
+				{
+					return false;
+				}
+				if (buffer[i] == 0)
+				{
+					value = System.Text.Encoding.ASCII.GetString(buffer[..i]);
+					return true;
+				}
 			}
-			if (destination[0] == 0)
-			{
-				value = System.Text.Encoding.ASCII.GetString(list.ToArray());
-				return true;
-			}
-			list.Add(destination[0]);
+			value = System.Text.Encoding.ASCII.GetString(buffer[..maxLength]);
+			return true;
 		}
-		value = System.Text.Encoding.ASCII.GetString(list.ToArray());
-		return true;
+		finally
+		{
+			if (rented is not null)
+			{
+				System.Buffers.ArrayPool<byte>.Shared.Return(rented);
+			}
+		}
 	}
 
 	private bool TryReadByteCompat(ulong address, Span<byte> destination)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -434,9 +434,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 		public string? BlockWakeKey { get; set; }
 
-		public Func<int>? BlockResumeHandler { get; set; }
-
-		public Func<bool>? BlockWakeHandler { get; set; }
+		// Stays set through the wake transition; Resume() consumes it when the thread pumps.
+		public IGuestThreadBlockWaiter? BlockWaiter { get; set; }
 
 		public long BlockDeadlineTimestamp { get; set; }
 
@@ -2797,14 +2796,13 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					continue;
 				}
 
-				if (thread.BlockWakeHandler is not null && !thread.BlockWakeHandler())
+				if (thread.BlockWaiter is not null && !thread.BlockWaiter.TryWake())
 				{
 					continue;
 				}
 
 				thread.State = GuestThreadRunState.Ready;
 				thread.BlockReason = null;
-				thread.BlockWakeHandler = null;
 				thread.BlockDeadlineTimestamp = 0;
 				_readyGuestThreads.Enqueue(thread);
 				Interlocked.Increment(ref _readyGuestThreadCount);
@@ -2855,8 +2853,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		ulong guestThreadHandle,
 		GuestCpuContinuation continuation,
 		string wakeKey,
-		Func<int>? resumeHandler,
-		Func<bool>? wakeHandler,
+		IGuestThreadBlockWaiter? waiter,
 		long blockDeadlineTimestamp)
 	{
 		if (guestThreadHandle == 0 || continuation.Rip < 65536 || continuation.Rsp == 0)
@@ -2874,8 +2871,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			thread.BlockedContinuation = continuation;
 			thread.HasBlockedContinuation = true;
 			thread.BlockWakeKey = wakeKey;
-			thread.BlockResumeHandler = resumeHandler;
-			thread.BlockWakeHandler = wakeHandler;
+			thread.BlockWaiter = waiter;
 			thread.BlockDeadlineTimestamp = blockDeadlineTimestamp;
 		}
 	}
@@ -2898,7 +2894,6 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 				thread.State = GuestThreadRunState.Ready;
 				thread.BlockReason = null;
-				thread.BlockWakeHandler = null;
 				thread.BlockDeadlineTimestamp = 0;
 				_readyGuestThreads.Enqueue(thread);
 				Interlocked.Increment(ref _readyGuestThreadCount);
@@ -3575,7 +3570,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		{
 			LastError = null;
 			GuestCpuContinuation continuation = default;
-			Func<int>? resumeHandler = null;
+			IGuestThreadBlockWaiter? blockWaiter = null;
 			var resumeContinuation = false;
 			lock (_guestThreadGate)
 			{
@@ -3585,17 +3580,16 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					thread.BlockedContinuation = default;
 					thread.HasBlockedContinuation = false;
 					thread.BlockWakeKey = null;
-					resumeHandler = thread.BlockResumeHandler;
-					thread.BlockResumeHandler = null;
-					thread.BlockWakeHandler = null;
+					blockWaiter = thread.BlockWaiter;
+					thread.BlockWaiter = null;
 					thread.BlockDeadlineTimestamp = 0;
 					resumeContinuation = true;
 				}
 			}
 
-			if (resumeHandler is not null)
+			if (blockWaiter is not null)
 			{
-				continuation = continuation with { Rax = unchecked((ulong)(long)resumeHandler()) };
+				continuation = continuation with { Rax = unchecked((ulong)(long)blockWaiter.Resume()) };
 			}
 
 			if (_logGuestThreads)
@@ -3620,12 +3614,11 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 						thread.State = GuestThreadRunState.Blocked;
 						thread.BlockReason = blockReason;
 						if (thread.HasBlockedContinuation &&
-							thread.BlockWakeHandler is not null &&
-							thread.BlockWakeHandler())
+							thread.BlockWaiter is not null &&
+							thread.BlockWaiter.TryWake())
 						{
 							thread.State = GuestThreadRunState.Ready;
 							thread.BlockReason = null;
-							thread.BlockWakeHandler = null;
 							thread.BlockDeadlineTimestamp = 0;
 							_readyGuestThreads.Enqueue(thread);
 							Interlocked.Increment(ref _readyGuestThreadCount);

--- a/src/SharpEmu.HLE/CpuContext.cs
+++ b/src/SharpEmu.HLE/CpuContext.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Text;
 
@@ -238,23 +239,63 @@ public sealed class CpuContext(ICpuMemory memory, Generation generation)
             return false;
         }
 
-        var bytes = new byte[capacity];
-        for (var index = 0; index < bytes.Length; index++)
+        const int StackBufferLength = 512;
+        const int ReadChunkLength = 128;
+        var rented = capacity > StackBufferLength ? ArrayPool<byte>.Shared.Rent(capacity) : null;
+        Span<byte> bytes = rented is null ? stackalloc byte[StackBufferLength] : rented;
+        try
         {
-            if (!Memory.TryRead(address + (ulong)index, bytes.AsSpan(index, 1)))
+            var length = 0;
+            while (length < capacity)
             {
-                return false;
+                // Bulk-read in bounded chunks rather than the full capacity: the string
+                // may end just before unmapped memory, and overreading past the
+                // terminator by more than a chunk could fault where the old
+                // byte-by-byte loop succeeded.
+                var chunk = Math.Min(ReadChunkLength, capacity - length);
+                var span = bytes.Slice(length, chunk);
+                if (Memory.TryRead(address + (ulong)length, span))
+                {
+                    var terminator = span.IndexOf((byte)0);
+                    if (terminator >= 0)
+                    {
+                        value = Encoding.UTF8.GetString(bytes[..(length + terminator)]);
+                        return true;
+                    }
+
+                    length += chunk;
+                    continue;
+                }
+
+                // The chunk touches an unreadable range; fall back to per-byte reads so a
+                // terminator sitting before the bad byte still yields the string.
+                for (var i = 0; i < chunk; i++)
+                {
+                    if (!Memory.TryRead(address + (ulong)(length + i), bytes.Slice(length + i, 1)))
+                    {
+                        return false;
+                    }
+
+                    if (bytes[length + i] == 0)
+                    {
+                        value = Encoding.UTF8.GetString(bytes[..(length + i)]);
+                        return true;
+                    }
+                }
+
+                length += chunk;
             }
 
-            if (bytes[index] == 0)
+            value = Encoding.UTF8.GetString(bytes[..capacity]);
+            return true;
+        }
+        finally
+        {
+            if (rented is not null)
             {
-                value = Encoding.UTF8.GetString(bytes, 0, index);
-                return true;
+                ArrayPool<byte>.Shared.Return(rented);
             }
         }
-
-        value = Encoding.UTF8.GetString(bytes);
-        return true;
     }
 
     public bool PushUInt64(ulong value)

--- a/src/SharpEmu.HLE/GuestThreadExecution.cs
+++ b/src/SharpEmu.HLE/GuestThreadExecution.cs
@@ -23,6 +23,20 @@ public readonly record struct GuestThreadSnapshot(
     ulong LastReturnRip,
     string? BlockReason);
 
+/// <summary>
+/// Continuation state for a blocked guest thread, replacing the closure pair a blocking
+/// wait used to allocate. TryWake runs under the scheduler's guest-thread gate and
+/// returns true when the waiter has a final result and the thread should be re-readied;
+/// false leaves it parked. Resume runs later on the woken thread outside that gate, and
+/// its return value becomes the guest's RAX for the resumed call.
+/// </summary>
+public interface IGuestThreadBlockWaiter
+{
+    int Resume();
+
+    bool TryWake();
+}
+
 public interface IGuestThreadScheduler
 {
     bool SupportsGuestContextTransfer { get; }
@@ -106,10 +120,7 @@ public static class GuestThreadExecution
     private static string? _pendingBlockWakeKey;
 
     [ThreadStatic]
-    private static Func<int>? _pendingBlockResumeHandler;
-
-    [ThreadStatic]
-    private static Func<bool>? _pendingBlockWakeHandler;
+    private static IGuestThreadBlockWaiter? _pendingBlockWaiter;
 
     [ThreadStatic]
     private static long _pendingBlockDeadlineTimestamp;
@@ -157,8 +168,7 @@ public static class GuestThreadExecution
         _pendingBlockContinuationValid = false;
         _pendingBlockContinuation = default;
         _pendingBlockWakeKey = null;
-        _pendingBlockResumeHandler = null;
-        _pendingBlockWakeHandler = null;
+        _pendingBlockWaiter = null;
         _pendingBlockDeadlineTimestamp = 0;
         _pendingEntryExit = false;
         _pendingEntryExitValue = 0;
@@ -179,8 +189,7 @@ public static class GuestThreadExecution
         _pendingBlockContinuationValid = false;
         _pendingBlockContinuation = default;
         _pendingBlockWakeKey = null;
-        _pendingBlockResumeHandler = null;
-        _pendingBlockWakeHandler = null;
+        _pendingBlockWaiter = null;
         _pendingBlockDeadlineTimestamp = 0;
         _pendingEntryExit = false;
         _pendingEntryExitValue = 0;
@@ -211,8 +220,7 @@ public static class GuestThreadExecution
         CpuContext? context,
         string reason,
         string? wakeKey = null,
-        Func<int>? resumeHandler = null,
-        Func<bool>? wakeHandler = null,
+        IGuestThreadBlockWaiter? waiter = null,
         long blockDeadlineTimestamp = 0)
     {
         if (!IsGuestThread)
@@ -222,8 +230,7 @@ public static class GuestThreadExecution
 
         _pendingBlockReason = string.IsNullOrWhiteSpace(reason) ? "guest_thread_blocked" : reason;
         _pendingBlockWakeKey = string.IsNullOrWhiteSpace(wakeKey) ? _pendingBlockReason : wakeKey;
-        _pendingBlockResumeHandler = resumeHandler;
-        _pendingBlockWakeHandler = wakeHandler;
+        _pendingBlockWaiter = waiter;
         _pendingBlockDeadlineTimestamp = blockDeadlineTimestamp;
         if (context is not null && TryCaptureCurrentBlockContinuation(context, out var continuation))
         {
@@ -255,7 +262,6 @@ public static class GuestThreadExecution
             out hasContinuation,
             out _,
             out _,
-            out _,
             out _);
     }
 
@@ -264,16 +270,14 @@ public static class GuestThreadExecution
         out GuestCpuContinuation continuation,
         out bool hasContinuation,
         out string wakeKey,
-        out Func<int>? resumeHandler,
-        out Func<bool>? wakeHandler)
+        out IGuestThreadBlockWaiter? waiter)
     {
         return TryConsumeCurrentThreadBlock(
             out reason,
             out continuation,
             out hasContinuation,
             out wakeKey,
-            out resumeHandler,
-            out wakeHandler,
+            out waiter,
             out _);
     }
 
@@ -282,8 +286,7 @@ public static class GuestThreadExecution
         out GuestCpuContinuation continuation,
         out bool hasContinuation,
         out string wakeKey,
-        out Func<int>? resumeHandler,
-        out Func<bool>? wakeHandler,
+        out IGuestThreadBlockWaiter? waiter,
         out long blockDeadlineTimestamp)
     {
         reason = _pendingBlockReason ?? string.Empty;
@@ -292,8 +295,7 @@ public static class GuestThreadExecution
             continuation = default;
             hasContinuation = false;
             wakeKey = string.Empty;
-            resumeHandler = null;
-            wakeHandler = null;
+            waiter = null;
             blockDeadlineTimestamp = 0;
             return false;
         }
@@ -301,15 +303,13 @@ public static class GuestThreadExecution
         continuation = _pendingBlockContinuation;
         hasContinuation = _pendingBlockContinuationValid;
         wakeKey = _pendingBlockWakeKey ?? reason;
-        resumeHandler = _pendingBlockResumeHandler;
-        wakeHandler = _pendingBlockWakeHandler;
+        waiter = _pendingBlockWaiter;
         blockDeadlineTimestamp = _pendingBlockDeadlineTimestamp;
         _pendingBlockReason = null;
         _pendingBlockContinuation = default;
         _pendingBlockContinuationValid = false;
         _pendingBlockWakeKey = null;
-        _pendingBlockResumeHandler = null;
-        _pendingBlockWakeHandler = null;
+        _pendingBlockWaiter = null;
         _pendingBlockDeadlineTimestamp = 0;
         return true;
     }

--- a/src/SharpEmu.Libs/Kernel/KernelEventFlagCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventFlagCompatExports.cs
@@ -34,9 +34,43 @@ public static class KernelEventFlagCompatExports
         public object Gate { get; } = new();
     }
 
-    private sealed class EventFlagWaiter
+    private sealed class EventFlagWaiter : IGuestThreadBlockWaiter
     {
+        public required CpuContext Ctx { get; init; }
+        public required EventFlagState State { get; init; }
+        public required ulong Pattern { get; init; }
+        public required uint WaitMode { get; init; }
+        public required ulong ResultAddress { get; init; }
+        public bool Timed { get; init; }
+
+        // Timed-wait completion state; unused when Timed is false.
+        public ulong TimeoutAddress { get; init; }
+        public long DeadlineTimestamp { get; init; }
+
         public OrbisGen2Result? Result { get; set; }
+
+        // Untimed waits stash the prepared result here at wake and return it at resume.
+        private OrbisGen2Result _blockedResult = OrbisGen2Result.ORBIS_GEN2_OK;
+
+        public int Resume() => Timed
+            ? CompleteBlockedTimedWait(Ctx, State, this, Pattern, WaitMode, ResultAddress, TimeoutAddress, DeadlineTimestamp)
+            : (int)_blockedResult;
+
+        public bool TryWake()
+        {
+            if (Timed)
+            {
+                return TryCompleteBlockedTimedWait(Ctx, State, this, Pattern, WaitMode, ResultAddress);
+            }
+
+            if (!TryPrepareBlockedWait(Ctx, State, Pattern, WaitMode, ResultAddress, out var preparedResult))
+            {
+                return false;
+            }
+
+            _blockedResult = preparedResult;
+            return true;
+        }
     }
 
     [SysAbiExport(
@@ -249,27 +283,22 @@ public static class KernelEventFlagCompatExports
 
                 var deadline = GuestThreadExecution.ComputeDeadlineTimestamp(
                     TimeSpan.FromTicks((long)timeoutUsec * 10L));
-                var timedWaiter = new EventFlagWaiter();
+                var timedWaiter = new EventFlagWaiter
+                {
+                    Ctx = ctx,
+                    State = state,
+                    Pattern = pattern,
+                    WaitMode = waitMode,
+                    ResultAddress = resultAddress,
+                    Timed = true,
+                    TimeoutAddress = timeoutAddress,
+                    DeadlineTimestamp = deadline,
+                };
                 if (GuestThreadExecution.RequestCurrentThreadBlock(
                         ctx,
                         "sceKernelWaitEventFlag",
                         GetEventFlagWakeKey(handle),
-                        resumeHandler: () => CompleteBlockedTimedWait(
-                            ctx,
-                            state,
-                            timedWaiter,
-                            pattern,
-                            waitMode,
-                            resultAddress,
-                            timeoutAddress,
-                            deadline),
-                        wakeHandler: () => TryCompleteBlockedTimedWait(
-                            ctx,
-                            state,
-                            timedWaiter,
-                            pattern,
-                            waitMode,
-                            resultAddress),
+                        timedWaiter,
                         blockDeadlineTimestamp: deadline))
                 {
                     state.WaitingThreads++;
@@ -286,27 +315,17 @@ public static class KernelEventFlagCompatExports
             var currentGuestThread = GuestThreadExecution.CurrentGuestThreadHandle;
             var currentFiber = FiberExports.GetCurrentFiberAddressForDiagnostics(ctx);
             var managedThread = Environment.CurrentManagedThreadId;
-            var blockedWaitResult = OrbisGen2Result.ORBIS_GEN2_OK;
             var requestedBlock = GuestThreadExecution.RequestCurrentThreadBlock(
                 ctx,
                 "sceKernelWaitEventFlag",
                 GetEventFlagWakeKey(handle),
-                () => (int)blockedWaitResult,
-                () =>
+                new EventFlagWaiter
                 {
-                    if (!TryPrepareBlockedWait(
-                            ctx,
-                            state,
-                            pattern,
-                            waitMode,
-                            resultAddress,
-                            out var preparedResult))
-                    {
-                        return false;
-                    }
-
-                    blockedWaitResult = preparedResult;
-                    return true;
+                    Ctx = ctx,
+                    State = state,
+                    Pattern = pattern,
+                    WaitMode = waitMode,
+                    ResultAddress = resultAddress,
                 });
             TraceEventFlag($"wait-unsatisfied handle=0x{handle:X16} pattern=0x{pattern:X16} bits=0x{state.Bits:X16} guest_thread=0x{currentGuestThread:X16} fiber=0x{currentFiber:X16} managed={managedThread} block={requestedBlock} ret=0x{returnRip:X16} frames={FormatFrameChain(ctx)}");
             TraceEventFlag($"wait-object handle=0x{handle:X16} name='{state.Name}' {FormatGuestWaitObject(ctx)}");

--- a/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
@@ -36,6 +36,19 @@ public static class KernelEventQueueCompatExports
         short Filter,
         ulong UserData);
 
+    private sealed class EqueueWaiter : IGuestThreadBlockWaiter
+    {
+        public required CpuContext Ctx { get; init; }
+        public required ulong Handle { get; init; }
+        public required ulong EventsAddress { get; init; }
+        public required int EventCapacity { get; init; }
+        public required ulong OutCountAddress { get; init; }
+
+        public int Resume() => ResumeWaitEqueue(Ctx, Handle, EventsAddress, EventCapacity, OutCountAddress);
+
+        public bool TryWake() => HasPendingEvents(Handle);
+    }
+
     [SysAbiExport(
         Nid = "D0OdFMjp46I",
         ExportName = "sceKernelCreateEqueue",
@@ -347,8 +360,14 @@ public static class KernelEventQueueCompatExports
                 ctx,
                 "sceKernelWaitEqueue",
                 GetEventQueueWakeKey(handle),
-                () => ResumeWaitEqueue(ctx, handle, eventsAddress, eventCapacity, outCountAddress),
-                () => HasPendingEvents(handle)))
+                new EqueueWaiter
+                {
+                    Ctx = ctx,
+                    Handle = handle,
+                    EventsAddress = eventsAddress,
+                    EventCapacity = eventCapacity,
+                    OutCountAddress = outCountAddress,
+                }))
         {
             TraceEventQueue(ctx, "wait-block", handle);
             return (int)OrbisGen2Result.ORBIS_GEN2_OK;

--- a/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
+using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using System.Threading;
 
 namespace SharpEmu.Libs.Kernel;
@@ -78,6 +80,8 @@ public static class KernelEventQueueCompatExports
             _pendingEvents.Remove(handle);
             _registeredEvents.Remove(handle);
         }
+
+        _wakeKeys.TryRemove(handle, out _);
 
         TraceEventQueue(ctx, "delete", handle);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
@@ -663,8 +667,12 @@ public static class KernelEventQueueCompatExports
         return null;
     }
 
+    // Wake keys are formatted once per handle: WakeEventQueue runs on every event
+    // enqueue (vblank/flip edges included), so formatting there is steady string churn.
+    private static readonly ConcurrentDictionary<ulong, string> _wakeKeys = new();
+
     private static string GetEventQueueWakeKey(ulong handle) =>
-        $"sceKernelWaitEqueue:{handle:X16}";
+        _wakeKeys.GetOrAdd(handle, static h => $"sceKernelWaitEqueue:{h:X16}");
 
     private static void WakeEventQueue(ulong handle)
     {
@@ -678,7 +686,10 @@ public static class KernelEventQueueCompatExports
             return 0;
         }
 
+        // Engines wait on the vblank/flip equeue every frame, so the delivery buffer
+        // (usually a single event) comes from the pool instead of a per-call array.
         KernelQueuedEvent[] events;
+        int count;
         lock (_eventQueueGate)
         {
             if (!_pendingEvents.TryGetValue(handle, out var queue) || queue.Count == 0)
@@ -686,8 +697,8 @@ public static class KernelEventQueueCompatExports
                 return 0;
             }
 
-            var count = Math.Min(eventCapacity, queue.Count);
-            events = new KernelQueuedEvent[count];
+            count = Math.Min(eventCapacity, queue.Count);
+            events = ArrayPool<KernelQueuedEvent>.Shared.Rent(count);
             for (var i = 0; i < count; i++)
             {
                 events[i] = queue.First!.Value;
@@ -695,15 +706,22 @@ public static class KernelEventQueueCompatExports
             }
         }
 
-        for (var i = 0; i < events.Length; i++)
+        try
         {
-            if (!WriteKernelEvent(ctx, eventsAddress + ((ulong)i * KernelEventSize), events[i]))
+            for (var i = 0; i < count; i++)
             {
-                return i;
+                if (!WriteKernelEvent(ctx, eventsAddress + ((ulong)i * KernelEventSize), events[i]))
+                {
+                    return i;
+                }
             }
         }
+        finally
+        {
+            ArrayPool<KernelQueuedEvent>.Shared.Return(events);
+        }
 
-        return events.Length;
+        return count;
     }
 
     private static bool WriteKernelEvent(CpuContext ctx, ulong address, KernelQueuedEvent queuedEvent)
@@ -718,9 +736,12 @@ public static class KernelEventQueueCompatExports
         return ctx.Memory.TryWrite(address, eventBytes);
     }
 
+    private static readonly bool _logEqueue =
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_EQUEUE"), "1", StringComparison.Ordinal);
+
     private static void TraceEventQueue(CpuContext ctx, string operation, ulong handle)
     {
-        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_EQUEUE"), "1", StringComparison.Ordinal))
+        if (!_logEqueue)
         {
             return;
         }

--- a/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
@@ -19,7 +19,7 @@ public static class KernelEventQueueCompatExports
 
     private static readonly object _eventQueueGate = new();
     private static readonly HashSet<ulong> _eventQueues = new();
-    private static readonly Dictionary<ulong, LinkedList<KernelQueuedEvent>> _pendingEvents = new();
+    private static readonly Dictionary<ulong, KernelEventDeque> _pendingEvents = new();
     private static readonly Dictionary<ulong, Dictionary<(ulong Ident, short Filter), KernelEventRegistration>> _registeredEvents = new();
     private static long _nextEventQueueHandle = 1;
 
@@ -35,6 +35,63 @@ public static class KernelEventQueueCompatExports
         ulong Ident,
         short Filter,
         ulong UserData);
+
+    // Grow-only ring buffer standing in for LinkedList<KernelQueuedEvent>, which
+    // allocated a node per enqueue — steady churn at one enqueue per vblank/flip edge
+    // per registered queue. Mutated only under _eventQueueGate.
+    private sealed class KernelEventDeque
+    {
+        private KernelQueuedEvent[] _items = new KernelQueuedEvent[4];
+        private int _head;
+
+        public int Count { get; private set; }
+
+        public KernelQueuedEvent this[int index]
+        {
+            get => _items[(_head + index) % _items.Length];
+            set => _items[(_head + index) % _items.Length] = value;
+        }
+
+        public void AddLast(in KernelQueuedEvent item)
+        {
+            if (Count == _items.Length)
+            {
+                var grown = new KernelQueuedEvent[_items.Length * 2];
+                for (var i = 0; i < Count; i++)
+                {
+                    grown[i] = this[i];
+                }
+
+                _items = grown;
+                _head = 0;
+            }
+
+            _items[(_head + Count) % _items.Length] = item;
+            Count++;
+        }
+
+        public KernelQueuedEvent RemoveFirst()
+        {
+            var value = _items[_head];
+            _head = (_head + 1) % _items.Length;
+            Count--;
+            return value;
+        }
+
+        public int FindIndex(ulong ident, short filter)
+        {
+            for (var i = 0; i < Count; i++)
+            {
+                var candidate = this[i];
+                if (candidate.Ident == ident && candidate.Filter == filter)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+    }
 
     private sealed class EqueueWaiter : IGuestThreadBlockWaiter
     {
@@ -66,7 +123,7 @@ public static class KernelEventQueueCompatExports
         lock (_eventQueueGate)
         {
             _eventQueues.Add(handle);
-            _pendingEvents[handle] = new LinkedList<KernelQueuedEvent>();
+            _pendingEvents[handle] = new KernelEventDeque();
             _registeredEvents[handle] = new Dictionary<(ulong Ident, short Filter), KernelEventRegistration>();
         }
 
@@ -432,7 +489,7 @@ public static class KernelEventQueueCompatExports
 
             if (!_pendingEvents.TryGetValue(handle, out var queue))
             {
-                queue = new LinkedList<KernelQueuedEvent>();
+                queue = new KernelEventDeque();
                 _pendingEvents[handle] = queue;
             }
 
@@ -503,7 +560,7 @@ public static class KernelEventQueueCompatExports
 
                 if (!_pendingEvents.TryGetValue(handle, out var queue))
                 {
-                    queue = new LinkedList<KernelQueuedEvent>();
+                    queue = new KernelEventDeque();
                     _pendingEvents[handle] = queue;
                 }
 
@@ -550,7 +607,7 @@ public static class KernelEventQueueCompatExports
 
             if (!_pendingEvents.TryGetValue(handle, out var queue))
             {
-                queue = new LinkedList<KernelQueuedEvent>();
+                queue = new KernelEventDeque();
                 _pendingEvents[handle] = queue;
             }
 
@@ -586,15 +643,15 @@ public static class KernelEventQueueCompatExports
 
             if (!_pendingEvents.TryGetValue(handle, out var events))
             {
-                events = new LinkedList<KernelQueuedEvent>();
+                events = new KernelEventDeque();
                 _pendingEvents[handle] = events;
             }
 
             var count = 1UL;
-            var pendingNode = FindPendingEvent(events, ident, filter);
-            if (pendingNode is not null)
+            var pendingIndex = events.FindIndex(ident, filter);
+            if (pendingIndex >= 0)
             {
-                count = Math.Min(((pendingNode.Value.Data >> 12) & 0xFUL) + 1, 0xFUL);
+                count = Math.Min(((events[pendingIndex].Data >> 12) & 0xFUL) + 1, 0xFUL);
             }
 
             var timeBits = unchecked((ulong)Environment.TickCount64) & 0xFFFUL;
@@ -607,9 +664,9 @@ public static class KernelEventQueueCompatExports
                 eventData,
                 userData);
 
-            if (pendingNode is not null)
+            if (pendingIndex >= 0)
             {
-                pendingNode.Value = triggeredEvent;
+                events[pendingIndex] = triggeredEvent;
             }
             else
             {
@@ -654,36 +711,20 @@ public static class KernelEventQueueCompatExports
     }
 
     private static void QueueOrUpdateEvent(
-        LinkedList<KernelQueuedEvent> queue,
+        KernelEventDeque queue,
         KernelQueuedEvent queuedEvent)
     {
-        var pendingNode = FindPendingEvent(queue, queuedEvent.Ident, queuedEvent.Filter);
-        if (pendingNode is null)
+        var pendingIndex = queue.FindIndex(queuedEvent.Ident, queuedEvent.Filter);
+        if (pendingIndex < 0)
         {
             queue.AddLast(queuedEvent);
             return;
         }
 
-        pendingNode.Value = queuedEvent with
+        queue[pendingIndex] = queuedEvent with
         {
-            Fflags = Math.Max(pendingNode.Value.Fflags + 1, queuedEvent.Fflags),
+            Fflags = Math.Max(queue[pendingIndex].Fflags + 1, queuedEvent.Fflags),
         };
-    }
-
-    private static LinkedListNode<KernelQueuedEvent>? FindPendingEvent(
-        LinkedList<KernelQueuedEvent> queue,
-        ulong ident,
-        short filter)
-    {
-        for (var node = queue.First; node is not null; node = node.Next)
-        {
-            if (node.Value.Ident == ident && node.Value.Filter == filter)
-            {
-                return node;
-            }
-        }
-
-        return null;
     }
 
     // Wake keys are formatted once per handle: WakeEventQueue runs on every event
@@ -720,8 +761,7 @@ public static class KernelEventQueueCompatExports
             events = ArrayPool<KernelQueuedEvent>.Shared.Rent(count);
             for (var i = 0; i < count; i++)
             {
-                events[i] = queue.First!.Value;
-                queue.RemoveFirst();
+                events[i] = queue.RemoveFirst();
             }
         }
 

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -1223,7 +1223,11 @@ public static class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_OK;
         }
 
-        var chunk = ArrayPool<byte>.Shared.Rent((int)Math.Min(rawCount, (ulong)MemcpyChunkSize));
+        // Cap iterations at the requested chunk size, not chunk.Length: Rent may hand
+        // back a larger array, and the copy granularity should not depend on pool
+        // bucketing internals.
+        var chunkLength = (int)Math.Min(rawCount, (ulong)MemcpyChunkSize);
+        var chunk = ArrayPool<byte>.Shared.Rent(chunkLength);
         try
         {
             // memmove aliases this export, so overlapping ranges must survive the chunked
@@ -1234,7 +1238,7 @@ public static class KernelMemoryCompatExports
             ulong offset = copyBackward ? rawCount : 0;
             while (remaining > 0)
             {
-                var take = (int)Math.Min((ulong)chunk.Length, remaining);
+                var take = (int)Math.Min((ulong)chunkLength, remaining);
                 if (copyBackward)
                 {
                     offset -= (ulong)take;

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -18,6 +18,10 @@ public static class KernelMemoryCompatExports
     private const int MaxGuestStringLength = 4096;
     private const int WideCharSize = sizeof(ushort);
     private const int MemsetChunkSize = 16 * 1024;
+    private const int MemcpyChunkSize = 256 * 1024;
+
+    // Shared all-zero scratch for chunked zero-fill loops; never written to.
+    private static readonly byte[] _zeroChunk = new byte[MemsetChunkSize];
     private const int TlsModuleBlockSize = 0x10000;
     private const int O_WRONLY = 0x1;
     private const int O_RDWR = 0x2;
@@ -255,11 +259,10 @@ public static class KernelMemoryCompatExports
                 DirectStart: 0);
         }
 
-        var zeroes = new byte[(int)Math.Min(mappedLength, (ulong)MemsetChunkSize)];
         for (ulong offset = 0; offset < mappedLength;)
         {
-            var chunkLength = (int)Math.Min((ulong)zeroes.Length, mappedLength - offset);
-            if (!ctx.Memory.TryWrite(address + offset, zeroes.AsSpan(0, chunkLength)))
+            var chunkLength = (int)Math.Min((ulong)_zeroChunk.Length, mappedLength - offset);
+            if (!ctx.Memory.TryWrite(address + offset, _zeroChunk.AsSpan(0, chunkLength)))
             {
                 return false;
             }
@@ -422,33 +425,50 @@ public static class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
-        var chunk = new byte[MemsetChunkSize];
-        Array.Fill(chunk, value);
-        var remaining = length;
-        var cursor = destination;
-        while (remaining > 0)
+        // Rent may hand back a larger array than requested; only the first chunkLength
+        // bytes are filled, so the loop must cap at chunkLength rather than chunk.Length.
+        var chunkLength = (int)Math.Min(length, (ulong)MemsetChunkSize);
+        var chunk = value == 0 ? _zeroChunk : ArrayPool<byte>.Shared.Rent(chunkLength);
+        if (value != 0)
         {
-            var take = (int)Math.Min((ulong)chunk.Length, remaining);
-            if (!TryWriteCompat(ctx, cursor, chunk.AsSpan(0, take)))
+            chunk.AsSpan(0, chunkLength).Fill(value);
+        }
+
+        try
+        {
+            var remaining = length;
+            var cursor = destination;
+            while (remaining > 0)
             {
-                if (length <= 0x40)
+                var take = (int)Math.Min((ulong)chunkLength, remaining);
+                if (!TryWriteCompat(ctx, cursor, chunk.AsSpan(0, take)))
                 {
-                    var recoveryIndex = Interlocked.Increment(ref _inaccessibleMemsetRecoveryCount);
-                    if (recoveryIndex <= 8)
+                    if (length <= 0x40)
                     {
-                        Console.Error.WriteLine(
-                            $"[LOADER][WARNING] memset inaccessible-dst recovery#{recoveryIndex}: rip=0x{ctx.Rip:X16} dst=0x{destination:X16} len=0x{length:X} val=0x{value:X2}");
+                        var recoveryIndex = Interlocked.Increment(ref _inaccessibleMemsetRecoveryCount);
+                        if (recoveryIndex <= 8)
+                        {
+                            Console.Error.WriteLine(
+                                $"[LOADER][WARNING] memset inaccessible-dst recovery#{recoveryIndex}: rip=0x{ctx.Rip:X16} dst=0x{destination:X16} len=0x{length:X} val=0x{value:X2}");
+                        }
+
+                        ctx[CpuRegister.Rax] = destination;
+                        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
                     }
 
-                    ctx[CpuRegister.Rax] = destination;
-                    return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
                 }
 
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+                cursor += (ulong)take;
+                remaining -= (ulong)take;
             }
-
-            cursor += (ulong)take;
-            remaining -= (ulong)take;
+        }
+        finally
+        {
+            if (value != 0)
+            {
+                ArrayPool<byte>.Shared.Return(chunk);
+            }
         }
 
         ctx[CpuRegister.Rax] = destination;
@@ -1185,11 +1205,10 @@ public static class KernelMemoryCompatExports
         var rawCount = ctx[CpuRegister.Rdx];
 
         // A garbage/absurd count (observed as e.g. 0xA7560035 from the same still-unidentified
-        // upstream bug that also feeds bad lengths to memset) must not reach
-        // GC.AllocateUninitializedArray: attempting a multi-GB allocation from a guest-thread
-        // call context corrupted the CLR outright ("Invalid Program: attempted to call a
-        // UnmanagedCallersOnly method from managed code") instead of throwing a normal
-        // exception. Reject anything above a sane bound before allocating.
+        // upstream bug that also feeds bad lengths to memset) must not turn into a multi-GB
+        // copy attempt from a guest-thread call context, which corrupted the CLR outright
+        // ("Invalid Program: attempted to call a UnmanagedCallersOnly method from managed
+        // code") instead of throwing a normal exception. Reject anything above a sane bound.
         const ulong maxSaneCount = 512UL * 1024 * 1024;
         if (rawCount > maxSaneCount)
         {
@@ -1198,15 +1217,48 @@ public static class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
-        var count = (int)rawCount;
-        var payload = GC.AllocateUninitializedArray<byte>(count);
-        if (count > 0 && (!TryReadCompat(ctx, source, payload) || !TryWriteCompat(ctx, destination, payload)))
+        ctx[CpuRegister.Rax] = destination;
+        if (rawCount == 0)
         {
-            ctx[CpuRegister.Rax] = destination;
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
         }
 
-        ctx[CpuRegister.Rax] = destination;
+        var chunk = ArrayPool<byte>.Shared.Rent((int)Math.Min(rawCount, (ulong)MemcpyChunkSize));
+        try
+        {
+            // memmove aliases this export, so overlapping ranges must survive the chunked
+            // copy: when the destination starts inside the source range, copy high-to-low
+            // so no source byte is overwritten before it has been read.
+            var copyBackward = destination > source && destination - source < rawCount;
+            var remaining = rawCount;
+            ulong offset = copyBackward ? rawCount : 0;
+            while (remaining > 0)
+            {
+                var take = (int)Math.Min((ulong)chunk.Length, remaining);
+                if (copyBackward)
+                {
+                    offset -= (ulong)take;
+                }
+
+                var span = chunk.AsSpan(0, take);
+                if (!TryReadCompat(ctx, source + offset, span) || !TryWriteCompat(ctx, destination + offset, span))
+                {
+                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+                }
+
+                if (!copyBackward)
+                {
+                    offset += (ulong)take;
+                }
+
+                remaining -= (ulong)take;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(chunk);
+        }
+
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -61,10 +61,34 @@ public static class KernelPthreadCompatExports
         public string WakeKey { get; } = "pthread_mutex#" + Interlocked.Increment(ref _nextMutexWakeId).ToString("X");
     }
 
-    private sealed class PthreadMutexWaiter
+    private sealed class PthreadMutexWaiter : IGuestThreadBlockWaiter
     {
         public required ulong ThreadId { get; init; }
+        public required CpuContext Ctx { get; init; }
+        public required ulong MutexAddress { get; init; }
+        public required ulong ResolvedAddress { get; init; }
+        public required PthreadMutexState State { get; init; }
         public int Reserved;
+
+        public int Resume() => CompleteBlockedMutexLock(Ctx, MutexAddress, ResolvedAddress, State, this);
+
+        public bool TryWake() => TryReserveBlockedMutexLock(Ctx, MutexAddress, ResolvedAddress, State, this);
+    }
+
+    private sealed class PthreadCondWaiter : IGuestThreadBlockWaiter
+    {
+        public required CpuContext Ctx { get; init; }
+        public required ulong CondAddress { get; init; }
+        public required ulong MutexAddress { get; init; }
+        public required PthreadCondState State { get; init; }
+        public required ulong ObservedEpoch { get; init; }
+        public required bool Timed { get; init; }
+        public required int ReleasedRecursion { get; init; }
+        public required bool PosixResult { get; init; }
+
+        public int Resume() => ResumePthreadCondWait(Ctx, CondAddress, MutexAddress, State, ObservedEpoch, Timed, ReleasedRecursion, PosixResult);
+
+        public bool TryWake() => State.SignalEpoch != ObservedEpoch;
     }
 
     private sealed class PthreadCondState
@@ -724,7 +748,6 @@ public static class KernelPthreadCompatExports
         if (!acquired)
         {
             TraceContendedMutex(ctx, mutexAddress, resolvedAddress, state, currentThreadId);
-            var waiter = new PthreadMutexWaiter { ThreadId = currentThreadId };
             // Fibers retain the synchronous fallback to preserve switch state.
             var currentFiber = FiberExports.GetCurrentFiberAddressForDiagnostics(ctx);
             var canCooperativelyBlock = _enableMutexLockBlocking || currentFiber == 0;
@@ -736,8 +759,14 @@ public static class KernelPthreadCompatExports
                     ctx,
                     "pthread_mutex_lock",
                     state.WakeKey,
-                    () => CompleteBlockedMutexLock(ctx, mutexAddress, resolvedAddress, state, waiter),
-                    () => TryReserveBlockedMutexLock(ctx, mutexAddress, resolvedAddress, state, waiter)))
+                    new PthreadMutexWaiter
+                    {
+                        ThreadId = currentThreadId,
+                        Ctx = ctx,
+                        MutexAddress = mutexAddress,
+                        ResolvedAddress = resolvedAddress,
+                        State = state,
+                    }))
             {
                 TracePthreadMutex(ctx, "lock-block", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_OK);
                 return (int)OrbisGen2Result.ORBIS_GEN2_OK;
@@ -1363,8 +1392,17 @@ public static class KernelPthreadCompatExports
                     ctx,
                     timed ? "pthread_cond_timedwait" : "pthread_cond_wait",
                     state.WakeKey,
-                    () => ResumePthreadCondWait(ctx, condAddress, mutexAddress, state, observedEpoch, timed, releasedRecursion, posixResult),
-                    () => state.SignalEpoch != observedEpoch,
+                    new PthreadCondWaiter
+                    {
+                        Ctx = ctx,
+                        CondAddress = condAddress,
+                        MutexAddress = mutexAddress,
+                        State = state,
+                        ObservedEpoch = observedEpoch,
+                        Timed = timed,
+                        ReleasedRecursion = releasedRecursion,
+                        PosixResult = posixResult,
+                    },
                     timed ? GuestThreadExecution.ComputeDeadlineTimestamp(GetCondWaitTimeout(timeoutUsec)) : 0))
             {
                 TracePthreadCond(timed ? "wait-block-timed" : "wait-block", condAddress, mutexAddress, state, timed, waitResult);

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
@@ -164,6 +164,17 @@ public static class KernelPthreadExtendedCompatExports
         }
     }
 
+    private sealed class RwlockWaiter : IGuestThreadBlockWaiter
+    {
+        public required PthreadRwlockState Rwlock { get; init; }
+        public required ulong ThreadId { get; init; }
+        public required bool Write { get; init; }
+
+        public int Resume() => (int)OrbisGen2Result.ORBIS_GEN2_OK;
+
+        public bool TryWake() => TryAcquireBlockedRwlock(Rwlock, ThreadId, Write);
+    }
+
     private readonly record struct TlsKeyState(ulong Destructor);
 
     private readonly record struct PthreadAttrState(
@@ -1318,8 +1329,7 @@ public static class KernelPthreadExtendedCompatExports
                             ctx,
                             "pthread_rwlock_wrlock",
                             rwlock.WakeKey,
-                            static () => (int)OrbisGen2Result.ORBIS_GEN2_OK,
-                            () => TryAcquireBlockedRwlock(rwlock, currentThreadId, write: true)))
+                            new RwlockWaiter { Rwlock = rwlock, ThreadId = currentThreadId, Write = true }))
                     {
                         transferredToScheduler = true;
                         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
@@ -1355,8 +1365,7 @@ public static class KernelPthreadExtendedCompatExports
                             ctx,
                             "pthread_rwlock_rdlock",
                             rwlock.WakeKey,
-                            static () => (int)OrbisGen2Result.ORBIS_GEN2_OK,
-                            () => TryAcquireBlockedRwlock(rwlock, currentThreadId, write: false)))
+                            new RwlockWaiter { Rwlock = rwlock, ThreadId = currentThreadId, Write = false }))
                     {
                         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
                     }

--- a/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
@@ -30,14 +30,26 @@ public static class KernelSemaphoreCompatExports
         public object Gate { get; } = new();
     }
 
-    private sealed class SemaphoreWaiter
+    private sealed class SemaphoreWaiter : IGuestThreadBlockWaiter
     {
+        public required KernelSemaphoreState Semaphore { get; init; }
         public required int NeedCount { get; init; }
         public required int CancelEpochAtBlock { get; init; }
         public bool Timed { get; init; }
 
+        // Timed-wait completion state; unused when Timed is false.
+        public CpuContext? Ctx { get; init; }
+        public ulong TimeoutAddress { get; init; }
+        public long DeadlineTimestamp { get; init; }
+
         // Written and read only under the owning semaphore's Gate.
         public int? Result { get; set; }
+
+        public int Resume() => Timed
+            ? CompleteBlockedTimedSemaWait(Ctx!, Semaphore, this, TimeoutAddress, DeadlineTimestamp)
+            : CompleteBlockedSemaWait(Semaphore, this);
+
+        public bool TryWake() => TryConsumeBlockedSemaWait(Semaphore, this);
     }
 
     private static string GetSemaphoreWakeKey(uint handle) => $"kernel_sema:0x{handle:X8}";
@@ -165,16 +177,19 @@ public static class KernelSemaphoreCompatExports
                     var deadline = GuestThreadExecution.ComputeDeadlineTimestamp(TimeSpan.FromTicks((long)timeoutMicros * 10L));
                     var timedWaiter = new SemaphoreWaiter
                     {
+                        Semaphore = semaphore,
                         NeedCount = needCount,
                         CancelEpochAtBlock = semaphore.CancelEpoch,
                         Timed = true,
+                        Ctx = ctx,
+                        TimeoutAddress = timeoutAddress,
+                        DeadlineTimestamp = deadline,
                     };
                     if (GuestThreadExecution.RequestCurrentThreadBlock(
                             ctx,
                             "sceKernelWaitSema",
                             semaphore.WakeKey,
-                            resumeHandler: () => CompleteBlockedTimedSemaWait(ctx, semaphore, timedWaiter, timeoutAddress, deadline),
-                            wakeHandler: () => TryConsumeBlockedSemaWait(semaphore, timedWaiter),
+                            timedWaiter,
                             blockDeadlineTimestamp: deadline))
                     {
                         semaphore.WaitingThreads++;
@@ -200,6 +215,7 @@ public static class KernelSemaphoreCompatExports
             {
                 var waiter = new SemaphoreWaiter
                 {
+                    Semaphore = semaphore,
                     NeedCount = needCount,
                     CancelEpochAtBlock = semaphore.CancelEpoch,
                 };
@@ -207,8 +223,7 @@ public static class KernelSemaphoreCompatExports
                         ctx,
                         "sceKernelWaitSema",
                         semaphore.WakeKey,
-                        resumeHandler: () => CompleteBlockedSemaWait(semaphore, waiter),
-                        wakeHandler: () => TryConsumeBlockedSemaWait(semaphore, waiter)))
+                        waiter))
                 {
                     if (_traceSema)
                     {

--- a/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
@@ -19,6 +19,8 @@ public static class KernelSemaphoreCompatExports
     private sealed class KernelSemaphoreState
     {
         public required string Name { get; init; }
+        // Formatted once at creation; signal/wait/cancel/delete all wake through this key.
+        public required string WakeKey { get; init; }
         public required int InitialCount { get; init; }
         public required int MaxCount { get; init; }
         public int Count { get; set; }
@@ -79,6 +81,7 @@ public static class KernelSemaphoreCompatExports
         var state = new KernelSemaphoreState
         {
             Name = name,
+            WakeKey = GetSemaphoreWakeKey(handle),
             InitialCount = initialCount,
             MaxCount = maxCount,
             Count = initialCount,
@@ -96,7 +99,7 @@ public static class KernelSemaphoreCompatExports
                 state.Deleted = true;
             }
 
-            _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
+            _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(state.WakeKey);
             return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
@@ -169,7 +172,7 @@ public static class KernelSemaphoreCompatExports
                     if (GuestThreadExecution.RequestCurrentThreadBlock(
                             ctx,
                             "sceKernelWaitSema",
-                            GetSemaphoreWakeKey(handle),
+                            semaphore.WakeKey,
                             resumeHandler: () => CompleteBlockedTimedSemaWait(ctx, semaphore, timedWaiter, timeoutAddress, deadline),
                             wakeHandler: () => TryConsumeBlockedSemaWait(semaphore, timedWaiter),
                             blockDeadlineTimestamp: deadline))
@@ -203,7 +206,7 @@ public static class KernelSemaphoreCompatExports
                 if (!GuestThreadExecution.RequestCurrentThreadBlock(
                         ctx,
                         "sceKernelWaitSema",
-                        GetSemaphoreWakeKey(handle),
+                        semaphore.WakeKey,
                         resumeHandler: () => CompleteBlockedSemaWait(semaphore, waiter),
                         wakeHandler: () => TryConsumeBlockedSemaWait(semaphore, waiter)))
                 {
@@ -314,7 +317,7 @@ public static class KernelSemaphoreCompatExports
         // Wake everyone; the wake handler consumes the count per waiter, so a waiter
         // whose needCount exceeds the remaining count stays parked while a smaller
         // waiter can proceed.
-        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
+        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(semaphore.WakeKey);
         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
@@ -358,7 +361,7 @@ public static class KernelSemaphoreCompatExports
             }
         }
 
-        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
+        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(semaphore.WakeKey);
         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
@@ -382,7 +385,7 @@ public static class KernelSemaphoreCompatExports
             semaphore.Deleted = true;
         }
 
-        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
+        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(semaphore.WakeKey);
         if (_traceSema)
         {
             TraceSemaphore($"delete handle=0x{handle:X8} name='{semaphore.Name}'");

--- a/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
@@ -100,7 +100,10 @@ public static class KernelSemaphoreCompatExports
             return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
-        TraceSemaphore($"create handle=0x{handle:X8} name='{name}' attr=0x{attr:X} init={initialCount} max={maxCount}");
+        if (_traceSema)
+        {
+            TraceSemaphore($"create handle=0x{handle:X8} name='{name}' attr=0x{attr:X} init={initialCount} max={maxCount}");
+        }
         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
@@ -131,7 +134,10 @@ public static class KernelSemaphoreCompatExports
             if (semaphore.Count >= needCount)
             {
                 semaphore.Count -= needCount;
-                TraceSemaphore($"wait handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                if (_traceSema)
+                {
+                    TraceSemaphore($"wait handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                }
                 return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
             }
 
@@ -145,7 +151,10 @@ public static class KernelSemaphoreCompatExports
                 if (timeoutMicros == 0)
                 {
                     _ = ctx.TryWriteUInt32(timeoutAddress, 0);
-                    TraceSemaphore($"wait-timeout handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                    if (_traceSema)
+                    {
+                        TraceSemaphore($"wait-timeout handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                    }
                     pollTimedOut = true;
                 }
                 else
@@ -166,14 +175,20 @@ public static class KernelSemaphoreCompatExports
                             blockDeadlineTimestamp: deadline))
                     {
                         semaphore.WaitingThreads++;
-                        TraceSemaphore($"wait-block-timed handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} timeout_us={timeoutMicros} waiters={semaphore.WaitingThreads}");
+                        if (_traceSema)
+                        {
+                            TraceSemaphore($"wait-block-timed handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} timeout_us={timeoutMicros} waiters={semaphore.WaitingThreads}");
+                        }
                         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
                     }
 
                     // Host-owned threads cannot park in the guest scheduler; degrade to the
                     // immediate-timeout poll the callers already tolerate.
                     _ = ctx.TryWriteUInt32(timeoutAddress, 0);
-                    TraceSemaphore($"wait-timeout handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                    if (_traceSema)
+                    {
+                        TraceSemaphore($"wait-timeout handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                    }
                     pollTimedOut = true;
                 }
             }
@@ -192,12 +207,18 @@ public static class KernelSemaphoreCompatExports
                         resumeHandler: () => CompleteBlockedSemaWait(semaphore, waiter),
                         wakeHandler: () => TryConsumeBlockedSemaWait(semaphore, waiter)))
                 {
-                    TraceSemaphore($"wait-would-block handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                    if (_traceSema)
+                    {
+                        TraceSemaphore($"wait-would-block handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                    }
                     return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN);
                 }
 
                 semaphore.WaitingThreads++;
-                TraceSemaphore($"wait-block handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} waiters={semaphore.WaitingThreads}");
+                if (_traceSema)
+                {
+                    TraceSemaphore($"wait-block handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} waiters={semaphore.WaitingThreads}");
+                }
                 return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
             }
         }
@@ -239,12 +260,18 @@ public static class KernelSemaphoreCompatExports
         {
             if (semaphore.Count < needCount)
             {
-                TraceSemaphore($"poll-busy handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                if (_traceSema)
+                {
+                    TraceSemaphore($"poll-busy handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                }
                 return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY);
             }
 
             semaphore.Count -= needCount;
-            TraceSemaphore($"poll handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+            if (_traceSema)
+            {
+                TraceSemaphore($"poll handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+            }
             return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
         }
     }
@@ -277,7 +304,10 @@ public static class KernelSemaphoreCompatExports
             }
 
             semaphore.Count += signalCount;
-            TraceSemaphore($"signal handle=0x{handle:X8} name='{semaphore.Name}' signal={signalCount} count={semaphore.Count} waiters={semaphore.WaitingThreads}");
+            if (_traceSema)
+            {
+                TraceSemaphore($"signal handle=0x{handle:X8} name='{semaphore.Name}' signal={signalCount} count={semaphore.Count} waiters={semaphore.WaitingThreads}");
+            }
         }
 
         // Wake after releasing the gate (lock order: scheduler gate -> semaphore gate).
@@ -322,7 +352,10 @@ public static class KernelSemaphoreCompatExports
             // exactly once in its wake handler. Zeroing here as well would double-count
             // and silently absorb the increment of a waiter that parks between this
             // gate release and the wake-all below.
-            TraceSemaphore($"cancel handle=0x{handle:X8} name='{semaphore.Name}' set={setCount} count={semaphore.Count}");
+            if (_traceSema)
+            {
+                TraceSemaphore($"cancel handle=0x{handle:X8} name='{semaphore.Name}' set={setCount} count={semaphore.Count}");
+            }
         }
 
         _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
@@ -350,7 +383,10 @@ public static class KernelSemaphoreCompatExports
         }
 
         _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
-        TraceSemaphore($"delete handle=0x{handle:X8} name='{semaphore.Name}'");
+        if (_traceSema)
+        {
+            TraceSemaphore($"delete handle=0x{handle:X8} name='{semaphore.Name}'");
+        }
         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
@@ -376,7 +412,10 @@ public static class KernelSemaphoreCompatExports
         {
             waiter.Result = (int)OrbisGen2Result.ORBIS_GEN2_ERROR_DELETED;
             semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
-            TraceSemaphore($"wake-deleted name='{semaphore.Name}' need={waiter.NeedCount}");
+            if (_traceSema)
+            {
+                TraceSemaphore($"wake-deleted name='{semaphore.Name}' need={waiter.NeedCount}");
+            }
             return true;
         }
 
@@ -384,7 +423,10 @@ public static class KernelSemaphoreCompatExports
         {
             waiter.Result = (int)OrbisGen2Result.ORBIS_GEN2_ERROR_CANCELED;
             semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
-            TraceSemaphore($"wake-canceled name='{semaphore.Name}' need={waiter.NeedCount}");
+            if (_traceSema)
+            {
+                TraceSemaphore($"wake-canceled name='{semaphore.Name}' need={waiter.NeedCount}");
+            }
             return true;
         }
 
@@ -393,7 +435,10 @@ public static class KernelSemaphoreCompatExports
             semaphore.Count -= waiter.NeedCount;
             waiter.Result = (int)OrbisGen2Result.ORBIS_GEN2_OK;
             semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
-            TraceSemaphore($"wake-consume name='{semaphore.Name}' need={waiter.NeedCount} count={semaphore.Count} waiters={semaphore.WaitingThreads}");
+            if (_traceSema)
+            {
+                TraceSemaphore($"wake-consume name='{semaphore.Name}' need={waiter.NeedCount} count={semaphore.Count} waiters={semaphore.WaitingThreads}");
+            }
             return true;
         }
 
@@ -434,7 +479,10 @@ public static class KernelSemaphoreCompatExports
             {
                 waiter.Result = (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT;
                 semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
-                TraceSemaphore($"wake-timeout name='{semaphore.Name}' need={waiter.NeedCount} count={semaphore.Count} waiters={semaphore.WaitingThreads}");
+                if (_traceSema)
+                {
+                    TraceSemaphore($"wake-timeout name='{semaphore.Name}' need={waiter.NeedCount} count={semaphore.Count} waiters={semaphore.WaitingThreads}");
+                }
             }
 
             result = waiter.Result!.Value;
@@ -456,11 +504,13 @@ public static class KernelSemaphoreCompatExports
         return result;
     }
 
+    // Call sites must check this before building the interpolated message; the trace
+    // strings would otherwise be allocated on every semaphore op even with tracing off.
+    private static readonly bool _traceSema =
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_SEMA"), "1", StringComparison.Ordinal);
+
     private static void TraceSemaphore(string message)
     {
-        if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_SEMA"), "1", StringComparison.Ordinal))
-        {
-            Console.Error.WriteLine($"[LOADER][TRACE] sema.{message}");
-        }
+        Console.Error.WriteLine($"[LOADER][TRACE] sema.{message}");
     }
 }

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -5,6 +5,7 @@ using SharpEmu.HLE;
 using SharpEmu.Libs.Audio;
 using SharpEmu.Libs.Kernel;
 using SharpEmu.Logging;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -180,6 +181,10 @@ public static class VideoOutExports
         }
     }
 
+    // Only ever touched by the vblank pump thread; reused across edges so the 60 Hz
+    // pump does not allocate a fresh snapshot per edge.
+    private static readonly List<VideoOutPortState> _vblankPumpPorts = new();
+
     private static void PumpVblanks()
     {
         lock (_vblankEdgeGate)
@@ -188,7 +193,7 @@ public static class VideoOutExports
             Monitor.PulseAll(_vblankEdgeGate);
         }
 
-        VideoOutPortState[] ports;
+        _vblankPumpPorts.Clear();
         lock (_stateGate)
         {
             if (_ports.Count == 0)
@@ -198,10 +203,16 @@ public static class VideoOutExports
 
             // Signalling reaches WakeBlockedThreads -> Pump(), which serialises on one global
             // flag. Waking an unwatched queue would hold it 60x/sec and starve guest threads.
-            ports = _ports.Values.Where(static port => port.VblankEvents.Count != 0).ToArray();
+            foreach (var port in _ports.Values)
+            {
+                if (port.VblankEvents.Count != 0)
+                {
+                    _vblankPumpPorts.Add(port);
+                }
+            }
         }
 
-        foreach (var port in ports)
+        foreach (var port in _vblankPumpPorts)
         {
             SignalVblank(port);
         }
@@ -1064,33 +1075,47 @@ public static class VideoOutExports
 
     private static void SignalVblank(VideoOutPortState port)
     {
-        List<FlipEventRegistration> vblankEvents;
+        // Snapshot the registrations into a pooled rental so the triggers can run outside
+        // _stateGate without copying the list into a fresh allocation on every edge.
+        // A per-port reusable buffer would race: the pump thread and a guest thread's
+        // first-edge signal (AddVblankEvent) can signal the same port concurrently.
+        FlipEventRegistration[] vblankEvents;
+        int vblankEventCount;
         ulong eventHint;
         lock (_stateGate)
         {
             port.VblankCount++;
             eventHint = SceVideoOutInternalEventVblank |
                 ((port.VblankCount & 0x0000_FFFF_FFFF_FFFFUL) << 16);
-            vblankEvents = new List<FlipEventRegistration>(port.VblankEvents);
+            vblankEventCount = port.VblankEvents.Count;
+            vblankEvents = ArrayPool<FlipEventRegistration>.Shared.Rent(Math.Max(vblankEventCount, 1));
+            port.VblankEvents.CopyTo(vblankEvents);
         }
 
         var signalCount = Interlocked.Increment(ref _vblankSignalCount);
 
-        foreach (var vblankEvent in vblankEvents)
+        try
         {
-            _ = KernelEventQueueCompatExports.TriggerDisplayEvent(
-                vblankEvent.Equeue,
-                SceVideoOutInternalEventVblank,
-                OrbisKernelEventFilterVideoOut,
-                eventHint,
-                vblankEvent.UserData);
+            for (var i = 0; i < vblankEventCount; i++)
+            {
+                _ = KernelEventQueueCompatExports.TriggerDisplayEvent(
+                    vblankEvents[i].Equeue,
+                    SceVideoOutInternalEventVblank,
+                    OrbisKernelEventFilterVideoOut,
+                    eventHint,
+                    vblankEvents[i].UserData);
+            }
+        }
+        finally
+        {
+            ArrayPool<FlipEventRegistration>.Shared.Return(vblankEvents);
         }
 
         if (_logVideoOutSync && (signalCount <= 8 || signalCount % 60 == 0))
         {
             Console.Error.WriteLine(
                 $"[LOADER][SYNC] vblank#{signalCount} handle={port.Handle} count={port.VblankCount} " +
-                $"queues={vblankEvents.Count} hint=0x{eventHint:X16}");
+                $"queues={vblankEventCount} hint=0x{eventHint:X16}");
         }
     }
 
@@ -1112,8 +1137,11 @@ public static class VideoOutExports
             return OrbisVideoOutErrorInvalidIndex;
         }
 
+        // Pooled snapshot for the same reason as SignalVblank: triggers run outside
+        // _stateGate, and SubmitFlip is per-frame so a fresh List copy is steady churn.
         ulong eventHint;
-        List<FlipEventRegistration> flipEvents;
+        FlipEventRegistration[] flipEvents;
+        int flipEventCount;
         lock (_stateGate)
         {
             if (bufferIndex != -1 && port.BufferSlots[bufferIndex].GroupIndex < 0)
@@ -1125,7 +1153,9 @@ public static class VideoOutExports
             port.FlipCount++;
             eventHint = SceVideoOutInternalEventFlip |
                 ((unchecked((ulong)flipArg) & 0x0000_FFFF_FFFF_FFFFUL) << 16);
-            flipEvents = new List<FlipEventRegistration>(port.FlipEvents);
+            flipEventCount = port.FlipEvents.Count;
+            flipEvents = ArrayPool<FlipEventRegistration>.Shared.Rent(Math.Max(flipEventCount, 1));
+            port.FlipEvents.CopyTo(flipEvents);
         }
 
         var guestImageSubmitted = false;
@@ -1147,14 +1177,21 @@ public static class VideoOutExports
             _ = TryDumpFrame(ctx, port, bufferIndex, flipMode, flipArg);
         }
 
-        foreach (var flipEvent in flipEvents)
+        try
         {
-            _ = KernelEventQueueCompatExports.TriggerDisplayEvent(
-                flipEvent.Equeue,
-                SceVideoOutInternalEventFlip,
-                OrbisKernelEventFilterVideoOut,
-                eventHint,
-                flipEvent.UserData);
+            for (var i = 0; i < flipEventCount; i++)
+            {
+                _ = KernelEventQueueCompatExports.TriggerDisplayEvent(
+                    flipEvents[i].Equeue,
+                    SceVideoOutInternalEventFlip,
+                    OrbisKernelEventFilterVideoOut,
+                    eventHint,
+                    flipEvents[i].UserData);
+            }
+        }
+        finally
+        {
+            ArrayPool<FlipEventRegistration>.Shared.Return(flipEvents);
         }
 
         var flipCount = Interlocked.Increment(ref _flipSubmitCount);
@@ -1163,12 +1200,12 @@ public static class VideoOutExports
             Console.Error.WriteLine(
                 $"[LOADER][SYNC] flip#{flipCount} handle={handle} buffer={bufferIndex} " +
                 $"addr=0x{guestImageAddress:X16} submitted={guestImageSubmitted} " +
-                $"flipQueues={flipEvents.Count}");
+                $"flipQueues={flipEventCount}");
         }
 
         if (_logVideoOut)
         {
-            TraceVideoOut($"videoout.submit_flip handle={handle} index={bufferIndex} mode={flipMode} arg={flipArg} events={flipEvents.Count}");
+            TraceVideoOut($"videoout.submit_flip handle={handle} index={bufferIndex} mode={flipMode} arg={flipArg} events={flipEventCount}");
         }
         ReportFrameRate(presented: false);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -221,6 +221,12 @@ public static class VideoOutExports
         Environment.GetEnvironmentVariable("SHARPEMU_LOG_VIDEOOUT_SYNC"),
         "1",
         StringComparison.Ordinal);
+    // Call sites must check this before building the interpolated message; the trace
+    // strings would otherwise be allocated on the per-frame flip path even with tracing off.
+    private static readonly bool _logVideoOut = string.Equals(
+        Environment.GetEnvironmentVariable("SHARPEMU_LOG_VIDEOOUT"),
+        "1",
+        StringComparison.Ordinal);
     private static readonly bool _dumpVideoOut = string.Equals(
         Environment.GetEnvironmentVariable("SHARPEMU_DUMP_VIDEOOUT"),
         "1",
@@ -558,7 +564,10 @@ public static class VideoOutExports
         // Some engines wait on this queue before issuing their first flip. Provide a first
         // edge now; later calls to WaitVblank advance the same notification sequence.
         SignalVblank(port);
-        TraceVideoOut($"videoout.add_vblank_event eq=0x{equeue:X16} handle={handle} udata=0x{userData:X16}");
+        if (_logVideoOut)
+        {
+            TraceVideoOut($"videoout.add_vblank_event eq=0x{equeue:X16} handle={handle} udata=0x{userData:X16}");
+        }
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -595,7 +604,10 @@ public static class VideoOutExports
             }
         }
 
-        TraceVideoOut($"videoout.add_flip_event eq=0x{equeue:X16} handle={handle} udata=0x{userData:X16}");
+        if (_logVideoOut)
+        {
+            TraceVideoOut($"videoout.add_flip_event eq=0x{equeue:X16} handle={handle} udata=0x{userData:X16}");
+        }
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -656,7 +668,10 @@ public static class VideoOutExports
         KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x18, unchecked((ulong)flipArg));
         KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x20, currentBuffer);
 
-        TraceVideoOut($"videoout.get_flip_status handle={handle} count={count} currentBuffer={currentBuffer}");
+        if (_logVideoOut)
+        {
+            TraceVideoOut($"videoout.get_flip_status handle={handle} count={count} currentBuffer={currentBuffer}");
+        }
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -1151,7 +1166,10 @@ public static class VideoOutExports
                 $"flipQueues={flipEvents.Count}");
         }
 
-        TraceVideoOut($"videoout.submit_flip handle={handle} index={bufferIndex} mode={flipMode} arg={flipArg} events={flipEvents.Count}");
+        if (_logVideoOut)
+        {
+            TraceVideoOut($"videoout.submit_flip handle={handle} index={bufferIndex} mode={flipMode} arg={flipArg} events={flipEvents.Count}");
+        }
         ReportFrameRate(presented: false);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
@@ -1233,8 +1251,11 @@ public static class VideoOutExports
                 slot.AddressRight = 0;
             }
 
-            TraceVideoOut(
-                $"videoout.register_buffers handle={port.Handle} group={groupIndex} start={startIndex} count={addresses.Length} fmt=0x{attribute.PixelFormat:X} tile={attribute.TilingMode} {attribute.Width}x{attribute.Height} pitch={attribute.PitchInPixel}");
+            if (_logVideoOut)
+            {
+                TraceVideoOut(
+                    $"videoout.register_buffers handle={port.Handle} group={groupIndex} start={startIndex} count={addresses.Length} fmt=0x{attribute.PixelFormat:X} tile={attribute.TilingMode} {attribute.Width}x{attribute.Height} pitch={attribute.PitchInPixel}");
+            }
             VulkanVideoPresenter.EnsureStarted(attribute.Width, attribute.Height);
 
             var guestFormat = MapPixelFormatToGuestTextureFormat(attribute.PixelFormat);
@@ -1400,7 +1421,10 @@ public static class VideoOutExports
         var basePath = GetFrameDumpBasePath(frameIndex, port.Handle, bufferIndex);
         WriteBmp(basePath + ".bmp", attribute.Width, attribute.Height, rgb);
         WriteFrameMetadata(basePath + ".txt", slot.AddressLeft, attribute, bufferIndex, flipMode, flipArg, "bmp-linear-read", fingerprint);
-        TraceVideoOut($"videoout.dump_frame path={basePath}.bmp addr=0x{slot.AddressLeft:X16} {attribute.Width}x{attribute.Height} fmt=0x{attribute.PixelFormat:X} fingerprint=0x{fingerprint:X16}");
+        if (_logVideoOut)
+        {
+            TraceVideoOut($"videoout.dump_frame path={basePath}.bmp addr=0x{slot.AddressLeft:X16} {attribute.Width}x{attribute.Height} fmt=0x{attribute.PixelFormat:X} fingerprint=0x{fingerprint:X16}");
+        }
         return true;
     }
 
@@ -1439,7 +1463,10 @@ public static class VideoOutExports
         var basePath = GetFrameDumpBasePath(frameIndex, handle, bufferIndex);
         File.WriteAllBytes(basePath + ".raw", bytes);
         WriteFrameMetadata(basePath + ".txt", address, attribute, bufferIndex, flipMode, flipArg, reason, fingerprint);
-        TraceVideoOut($"videoout.dump_frame path={basePath}.raw addr=0x{address:X16} bytes={byteCount} reason={reason} fingerprint=0x{fingerprint:X16}");
+        if (_logVideoOut)
+        {
+            TraceVideoOut($"videoout.dump_frame path={basePath}.raw addr=0x{address:X16} bytes={byteCount} reason={reason} fingerprint=0x{fingerprint:X16}");
+        }
         return true;
     }
 
@@ -1666,11 +1693,6 @@ public static class VideoOutExports
 
     private static void TraceVideoOut(string message)
     {
-        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_VIDEOOUT"), "1", StringComparison.Ordinal))
-        {
-            return;
-        }
-
         Console.Error.WriteLine($"[LOADER][TRACE] {message}");
     }
 }

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -1079,7 +1079,7 @@ public static class VideoOutExports
         // _stateGate without copying the list into a fresh allocation on every edge.
         // A per-port reusable buffer would race: the pump thread and a guest thread's
         // first-edge signal (AddVblankEvent) can signal the same port concurrently.
-        FlipEventRegistration[] vblankEvents;
+        FlipEventRegistration[]? vblankEvents = null;
         int vblankEventCount;
         ulong eventHint;
         lock (_stateGate)
@@ -1088,27 +1088,33 @@ public static class VideoOutExports
             eventHint = SceVideoOutInternalEventVblank |
                 ((port.VblankCount & 0x0000_FFFF_FFFF_FFFFUL) << 16);
             vblankEventCount = port.VblankEvents.Count;
-            vblankEvents = ArrayPool<FlipEventRegistration>.Shared.Rent(Math.Max(vblankEventCount, 1));
-            port.VblankEvents.CopyTo(vblankEvents);
+            if (vblankEventCount != 0)
+            {
+                vblankEvents = ArrayPool<FlipEventRegistration>.Shared.Rent(vblankEventCount);
+                port.VblankEvents.CopyTo(vblankEvents);
+            }
         }
 
         var signalCount = Interlocked.Increment(ref _vblankSignalCount);
 
-        try
+        if (vblankEvents is not null)
         {
-            for (var i = 0; i < vblankEventCount; i++)
+            try
             {
-                _ = KernelEventQueueCompatExports.TriggerDisplayEvent(
-                    vblankEvents[i].Equeue,
-                    SceVideoOutInternalEventVblank,
-                    OrbisKernelEventFilterVideoOut,
-                    eventHint,
-                    vblankEvents[i].UserData);
+                for (var i = 0; i < vblankEventCount; i++)
+                {
+                    _ = KernelEventQueueCompatExports.TriggerDisplayEvent(
+                        vblankEvents[i].Equeue,
+                        SceVideoOutInternalEventVblank,
+                        OrbisKernelEventFilterVideoOut,
+                        eventHint,
+                        vblankEvents[i].UserData);
+                }
             }
-        }
-        finally
-        {
-            ArrayPool<FlipEventRegistration>.Shared.Return(vblankEvents);
+            finally
+            {
+                ArrayPool<FlipEventRegistration>.Shared.Return(vblankEvents);
+            }
         }
 
         if (_logVideoOutSync && (signalCount <= 8 || signalCount % 60 == 0))
@@ -1140,7 +1146,7 @@ public static class VideoOutExports
         // Pooled snapshot for the same reason as SignalVblank: triggers run outside
         // _stateGate, and SubmitFlip is per-frame so a fresh List copy is steady churn.
         ulong eventHint;
-        FlipEventRegistration[] flipEvents;
+        FlipEventRegistration[]? flipEvents = null;
         int flipEventCount;
         lock (_stateGate)
         {
@@ -1154,8 +1160,11 @@ public static class VideoOutExports
             eventHint = SceVideoOutInternalEventFlip |
                 ((unchecked((ulong)flipArg) & 0x0000_FFFF_FFFF_FFFFUL) << 16);
             flipEventCount = port.FlipEvents.Count;
-            flipEvents = ArrayPool<FlipEventRegistration>.Shared.Rent(Math.Max(flipEventCount, 1));
-            port.FlipEvents.CopyTo(flipEvents);
+            if (flipEventCount != 0)
+            {
+                flipEvents = ArrayPool<FlipEventRegistration>.Shared.Rent(flipEventCount);
+                port.FlipEvents.CopyTo(flipEvents);
+            }
         }
 
         var guestImageSubmitted = false;
@@ -1177,21 +1186,24 @@ public static class VideoOutExports
             _ = TryDumpFrame(ctx, port, bufferIndex, flipMode, flipArg);
         }
 
-        try
+        if (flipEvents is not null)
         {
-            for (var i = 0; i < flipEventCount; i++)
+            try
             {
-                _ = KernelEventQueueCompatExports.TriggerDisplayEvent(
-                    flipEvents[i].Equeue,
-                    SceVideoOutInternalEventFlip,
-                    OrbisKernelEventFilterVideoOut,
-                    eventHint,
-                    flipEvents[i].UserData);
+                for (var i = 0; i < flipEventCount; i++)
+                {
+                    _ = KernelEventQueueCompatExports.TriggerDisplayEvent(
+                        flipEvents[i].Equeue,
+                        SceVideoOutInternalEventFlip,
+                        OrbisKernelEventFilterVideoOut,
+                        eventHint,
+                        flipEvents[i].UserData);
+                }
             }
-        }
-        finally
-        {
-            ArrayPool<FlipEventRegistration>.Shared.Return(flipEvents);
+            finally
+            {
+                ArrayPool<FlipEventRegistration>.Shared.Return(flipEvents);
+            }
         }
 
         var flipCount = Interlocked.Increment(ref _flipSubmitCount);


### PR DESCRIPTION
## What

Removes the steady-state managed allocations from the hottest HLE paths, so running a game no longer generates constant GC pressure. GC pauses are critical for us because a collection that lands mid-frame stalls every HLE dispatch behind it, which the guest observes as a frame hitch. This PR does not change any HLE semantics; it changes *how* the same work is done.

Five single-topic commits:

1. **`memcpy`/`memset` bounce buffers** — `memcpy`/`memmove` no longer allocate a buffer sized to the whole copy (large copies previously landed on the LOH and forced Gen2 collections); they loop through a single pooled 256 KB rental, copying high-to-low when the ranges overlap so `memmove` semantics survive the chunking. `memset` uses a shared zero chunk for the dominant zero-fill case and a pooled prefix-fill otherwise — a 4-byte memset used to allocate and fill a fresh 16 KB array.
2. **Per-frame VideoOut/equeue plumbing** — the 60 Hz vblank pump no longer LINQs a fresh port array per edge; flip/vblank registration snapshots come from the pool instead of a `List` copy per frame; `sceKernelWaitEqueue` delivery uses a pooled buffer; wake-key strings are formatted once per handle instead of on every signal/enqueue.
3. **Guest C-string reads** — `TryReadNullTerminatedUtf8` reads through a stack buffer in bounded bulk chunks (with a per-byte fallback at unreadable edges, so strings ending just before unmapped memory resolve exactly as before) instead of `new byte[capacity]` plus one memory-read call per byte. Only the final `string` is allocated.
4. **Blocking waits** — every wait that actually parked a guest thread allocated two capturing lambdas for the scheduler's resume/wake callbacks. The scheduler now carries a single `IGuestThreadBlockWaiter` object (`Resume()`/`TryWake()`, same contracts as the old delegates), and the existing waiter objects absorbed the captured state as fields. A blocking wait now allocates exactly one object.
5. **Event queue nodes** — pending-event queues are backed by a grow-only ring deque instead of `LinkedList`, which allocated a node per vblank/flip enqueue.

## Behavior notes

- **`memcpy` fault semantics changed**: the old code read the entire source before writing anything, so a faulting `memcpy` left the destination untouched. The chunked copy commits earlier 256 KB chunks before reporting the fault. The return code is unchanged; the difference is only observable to a guest that continues past a `memcpy` memory fault and re-reads the region.
- The `SHARPEMU_LOG_SEMA` / `SHARPEMU_LOG_VIDEOOUT` / `SHARPEMU_LOG_EQUEUE` flags are now read once at startup into cached bools (same pattern as the existing `_logVideoOutSync` / `_dumpVideoOut` flags). Trace output with the flags set is byte-identical.

## How verified

- Builds clean (0 warnings). No package or public-API changes outside the internal scheduler seam.
- The diff was put through an adversarial multi-angle review (removed-behavior audit, cross-file caller trace, line-by-line). It confirmed all `RequestCurrentThreadBlock` callers migrated, the waiter lifecycle matches the old handler lifecycle (the `State != Blocked` guard covers the wake transition), the ring deque preserves FIFO + coalescing semantics, and pooled buffers are always sliced to the requested count. The one semantic change it surfaced is the `memcpy` fault note above.
- Micro-benchmarks below isolate each before/after pattern.
- **Still needs real-game validation on Windows** — this branch was developed on macOS (build-only). Most valuable runs: Dreaming Sarah (the title that surfaced the perf sensitivity), anything load-heavy (large `memcpy` traffic), and one run each with the three `SHARPEMU_LOG_*` flags set to confirm trace output is unchanged.

## Measuring in-game with dotnet-monitor

To capture the real effect while a game runs (rather than the micro-benchmarks below), grab GC counters from a `main` build and from this branch over the same gameplay section:

```sh
dotnet tool install -g dotnet-monitor
dotnet-monitor collect --no-auth
```

Launch the game, then find the emulator PID. **On Windows target the mitigated child process, not the launcher** — the CLI relaunches itself, and the game (and all the GC activity) lives in the child:

```sh
curl http://localhost:52323/processes
```

Capture 60 seconds of runtime counters during a comparable section (same area/scene on both builds):

```sh
curl "http://localhost:52323/livemetrics?pid=<PID>&durationSeconds=60" -o before.metrics.json
```

Repeat on this branch as `after.metrics.json` and compare the `System.Runtime` counters — the ones this PR moves are **Allocation Rate** (`alloc-rate`), **% Time in GC**, **Gen 0/1/2 GC Count**, and **LOH Size**. An optional `curl "http://localhost:52323/gcdump?pid=<PID>" -o heap.gcdump` gives a heap snapshot openable in Visual Studio / PerfView if anything looks off.

## Benchmarks

BenchmarkDotNet (ShortRun, `MemoryDiagnoser`) comparing the removed pattern against the new one, with guest memory stubbed by an interface-dispatched flat array so the numbers isolate the pattern change. Captured on an Apple M5 Max / .NET 10.0.9 arm64 — absolute times will differ on the Windows x64 target, but the ratios and the allocation columns are what matter. `Allocated` is per operation.

| Pattern | Before | After | Allocated before → after |
| --- | ---: | ---: | ---: |
| `memcpy` 256 B | 14.4 ns | 10.7 ns | 280 B → **0** |
| `memcpy` 4 KB | 155.7 ns | 69.0 ns | 4.1 KB → **0** |
| `memcpy` 64 KB | 2.17 µs | 1.25 µs | 64 KB → **0** |
| `memcpy` 1 MB | 49.7 µs | 31.7 µs | 1 MB + Gen0/1/2 → **0, no GC** |
| `memcpy` 8 MB | 724 µs | 255 µs | 8 MB + 154 Gen2/1k ops → **0, no GC** |
| `memset` 16 B (zero) | 434 ns | 1.5 ns | 16 KB → **0** |
| `memset` 4 KB (non-zero) | 469 ns | 65.8 ns | 16 KB → **0** |
| trace call, tracing off | 120 ns | ~0 ns | 152 B → **0** |
| wake-key per signal | 13.9 ns | ~0 ns | 72 B → **0** |
| blocking-wait setup | 14.5 ns | 2.7 ns | 192 B → **40 B** (the waiter itself) |
| equeue enqueue + drain cycle | 9.0 ns | 6.2 ns | 128 B → **0** |
| flip/vblank snapshot | 6.2 ns | 5.3 ns | 88 B → **0** |
| guest C-string read (cap 128) | 30.8 ns | 19.6 ns | 224 B → **72 B** (the string itself) |

Note the 8 MB `memcpy` row: the old path forced 154 Gen2 collections per 1000 operations — that is the frame-hitch mechanism this PR removes, and a micro-benchmark *understates* it because steady-state LOH fragmentation doesn't accumulate in a benchmark loop.

<details>
<summary>Full BenchmarkDotNet output</summary>

```
BenchmarkDotNet v0.15.8, macOS Tahoe 26.5.1 (25F80) [Darwin 25.5.0]
Apple M5 Max, 1 CPU, 18 logical and 18 physical cores
.NET SDK 10.0.301
  [Host]   : .NET 10.0.9 (10.0.9, 10.0.926.27113), Arm64 RyuJIT armv8.0-a
  ShortRun : .NET 10.0.9 (10.0.9, 10.0.926.27113), Arm64 RyuJIT armv8.0-a

Job=ShortRun  IterationCount=3  LaunchCount=1  WarmupCount=3
```

| Type | Method | CopySize | FillLength | Value | Mean | Ratio | Gen0 | Gen1 | Gen2 | Allocated |
|--- |--- |--- |--- |--- |---: |---: |---: |---: |---: |---: |
| EventQueueCycle | Before_LinkedListCycle | - | - | - | 9.0457 ns | 1.000 | 0.0153 | - | - | 128 B |
| EventQueueCycle | After_RingDequeCycle | - | - | - | 6.1782 ns | 0.683 | - | - | - | - |
| GuestString | Before_PerByteWithArray | - | - | - | 30.8473 ns | 1.000 | 0.0268 | - | - | 224 B |
| GuestString | After_ChunkedStackBuffer | - | - | - | 19.6220 ns | 0.636 | 0.0086 | - | - | 72 B |
| FlipSnapshot | Before_ListCopy | - | - | - | 6.2463 ns | 1.000 | 0.0105 | - | - | 88 B |
| FlipSnapshot | After_PooledSnapshot | - | - | - | 5.2631 ns | 0.843 | - | - | - | - |
| TraceGuard | Before_EagerInterpolation | - | - | - | 120.0158 ns | 1.000 | 0.0181 | - | - | 152 B |
| TraceGuard | After_CachedBoolGuard | - | - | - | 0.0124 ns | 0.000 | - | - | - | - |
| Waiter | Before_WaiterPlusTwoClosures | - | - | - | 14.5389 ns | 1.000 | 0.0229 | 0.0000 | - | 192 B |
| Waiter | After_SingleWaiterObject | - | - | - | 2.6901 ns | 0.185 | 0.0048 | - | - | 40 B |
| WakeKey | Before_FormatPerCall | - | - | - | 13.8698 ns | 1.000 | 0.0086 | - | - | 72 B |
| WakeKey | After_CachedOnState | - | - | - | 0.1056 ns | 0.008 | - | - | - | - |
| Memcpy | Before_FullBounceBuffer | 256 | - | - | 14.3782 ns | 1.00 | 0.0335 | - | - | 280 B |
| Memcpy | After_PooledChunks | 256 | - | - | 10.7216 ns | 0.75 | - | - | - | - |
| Memcpy | Before_FullBounceBuffer | 4096 | - | - | 155.7226 ns | 1.00 | 0.4909 | - | - | 4120 B |
| Memcpy | After_PooledChunks | 4096 | - | - | 68.9776 ns | 0.44 | - | - | - | - |
| Memcpy | Before_FullBounceBuffer | 65536 | - | - | 2,169.7342 ns | 1.00 | 7.8087 | - | - | 65560 B |
| Memcpy | After_PooledChunks | 65536 | - | - | 1,252.1187 ns | 0.58 | - | - | - | - |
| Memcpy | Before_FullBounceBuffer | 1048576 | - | - | 49,677.8065 ns | 1.00 | 61.6455 | 61.6455 | 61.6455 | 1048637 B |
| Memcpy | After_PooledChunks | 1048576 | - | - | 31,732.1243 ns | 0.64 | - | - | - | - |
| Memcpy | Before_FullBounceBuffer | 8388608 | - | - | 724,026.5160 ns | 1.00 | 154.2969 | 154.2969 | 154.2969 | 8388734 B |
| Memcpy | After_PooledChunks | 8388608 | - | - | 255,249.4572 ns | 0.35 | - | - | - | - |
| Memset | Before_FreshFilledChunk | - | 16 | 0 | 434.2092 ns | 1.000 | 1.9569 | - | - | 16408 B |
| Memset | After_SharedOrPooledChunk | - | 16 | 0 | 1.4966 ns | 0.003 | - | - | - | - |
| Memset | Before_FreshFilledChunk | - | 16 | 204 | 438.8787 ns | 1.00 | 1.9569 | - | - | 16408 B |
| Memset | After_SharedOrPooledChunk | - | 16 | 204 | 5.3436 ns | 0.01 | - | - | - | - |
| Memset | Before_FreshFilledChunk | - | 4096 | 0 | 480.1341 ns | 1.00 | 1.9569 | - | - | 16408 B |
| Memset | After_SharedOrPooledChunk | - | 4096 | 0 | 36.0691 ns | 0.08 | - | - | - | - |
| Memset | Before_FreshFilledChunk | - | 4096 | 204 | 469.1476 ns | 1.00 | 1.9569 | - | - | 16408 B |
| Memset | After_SharedOrPooledChunk | - | 4096 | 204 | 65.8435 ns | 0.14 | - | - | - | - |
| Memset | Before_FreshFilledChunk | - | 262144 | 0 | 3,074.7834 ns | 1.00 | 1.9569 | - | - | 16408 B |
| Memset | After_SharedOrPooledChunk | - | 262144 | 0 | 2,713.0673 ns | 0.88 | - | - | - | - |
| Memset | Before_FreshFilledChunk | - | 262144 | 204 | 3,074.5744 ns | 1.00 | 1.9569 | - | - | 16408 B |
| Memset | After_SharedOrPooledChunk | - | 262144 | 204 | 2,722.9358 ns | 0.89 | - | - | - | - |

</details>
