### PR TITLE
Fix large-title boot blockers across kernel, AGC, AJM, and VideoOut

### DIFF
--- a/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
+++ b/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
@@ -26,10 +26,6 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
     private const ulong StackSize = 0x0020_0000UL;
     private static readonly ulong TlsBaseAddress = OperatingSystem.IsWindows() ? 0x7FFE_0000_0000UL : 0x6FFE_0000_0000UL;
     private const ulong TlsSize = 0x0001_0000UL;
-    // The static TLS blocks live at negative offsets from the TCB (FreeBSD
-    // amd64 variant II). Keep every host in sync with GuestTlsTemplate's
-    // startup reservation; PS5 modules routinely reach beyond one host page.
-    private const ulong TlsPrefixSize = GuestTlsTemplate.StartupStaticTlsReservation;
     private static readonly ulong BootstrapStubBaseAddress = OperatingSystem.IsWindows() ? 0x7FFD_F000_0000UL : 0x6FFD_F000_0000UL;
     private static readonly ulong BootstrapPayloadBaseAddress = OperatingSystem.IsWindows() ? 0x7FFD_E000_0000UL : 0x6FFD_E000_0000UL;
     private static readonly ulong DynlibFallbackStubBaseAddress = OperatingSystem.IsWindows() ? 0x7FFD_D000_0000UL : 0x6FFD_D000_0000UL;
@@ -347,15 +343,16 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
     private ulong TryMapTlsRegion()
     {
         const ulong tlsStride = 0x0100_0000UL;
+        var tlsPrefixSize = GuestTlsTemplate.StartupStaticTlsReservation;
         for (var i = 0; i < 32; i++)
         {
             var candidateBase = TlsBaseAddress - ((ulong)i * tlsStride);
-            var mappedBase = candidateBase - TlsPrefixSize;
+            var mappedBase = candidateBase - tlsPrefixSize;
             try
             {
                 _virtualMemory.Map(
                     mappedBase,
-                    TlsSize + TlsPrefixSize,
+                    checked(TlsSize + tlsPrefixSize),
                     fileOffset: 0,
                     fileData: ReadOnlySpan<byte>.Empty,
                     ProgramHeaderFlags.Read | ProgramHeaderFlags.Write);

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -68,12 +68,118 @@ public sealed partial class DirectExecutionBackend
 
 	private unsafe static int RawVectoredHandlerManaged(void* exceptionInfo)
 	{
+		if (TryEmulateGuestInsertq(exceptionInfo))
+		{
+			return -1;
+		}
+
 		return TryRecoverUnresolvedSentinel(exceptionInfo);
 	}
 
 	private unsafe static int RawUnhandledFilterManaged(void* exceptionInfo)
 	{
+		if (TryEmulateGuestInsertq(exceptionInfo))
+		{
+			return -1;
+		}
+
 		return TryRecoverUnresolvedSentinel(exceptionInfo);
+	}
+
+	private unsafe static bool TryEmulateGuestInsertq(void* exceptionInfo)
+	{
+		const uint IllegalInstruction = 0xC000001D;
+		const int Xmm0ContextOffset = 0x1A0;
+
+		if (_activeExecutionBackend is null || exceptionInfo == null)
+		{
+			return false;
+		}
+
+		var pointers = (EXCEPTION_POINTERS*)exceptionInfo;
+		if (pointers->ExceptionRecord == null ||
+			pointers->ExceptionRecord->ExceptionCode != IllegalInstruction ||
+			pointers->ContextRecord == null)
+		{
+			return false;
+		}
+
+		var contextRecord = pointers->ContextRecord;
+		var rip = ReadCtxU64(contextRecord, 248);
+		var instruction = (byte*)rip;
+		if (instruction[0] != 0xF2)
+		{
+			return false;
+		}
+
+		var offset = 1;
+		byte rex = 0;
+		if ((instruction[offset] & 0xF0) == 0x40)
+		{
+			rex = instruction[offset++];
+		}
+
+		if (instruction[offset++] != 0x0F)
+		{
+			return false;
+		}
+
+		var opcode = instruction[offset++];
+		if (opcode is not (0x78 or 0x79))
+		{
+			return false;
+		}
+
+		var modRm = instruction[offset++];
+		if ((modRm & 0xC0) != 0xC0)
+		{
+			return false;
+		}
+
+		var destinationRegister = ((modRm >> 3) & 7) | ((rex & 4) != 0 ? 8 : 0);
+		var sourceRegister = (modRm & 7) | ((rex & 1) != 0 ? 8 : 0);
+		var destinationOffset = Xmm0ContextOffset + (destinationRegister * 16);
+		var sourceOffset = Xmm0ContextOffset + (sourceRegister * 16);
+		var destinationLow = ReadCtxU64(contextRecord, destinationOffset);
+		var sourceLow = ReadCtxU64(contextRecord, sourceOffset);
+
+		int fieldLength;
+		int bitIndex;
+		if (opcode == 0x78)
+		{
+			fieldLength = instruction[offset++] & 0x3F;
+			bitIndex = instruction[offset++] & 0x3F;
+		}
+		else
+		{
+			var sourceHigh = ReadCtxU64(contextRecord, sourceOffset + sizeof(ulong));
+			fieldLength = (int)(sourceHigh & 0x3F);
+			bitIndex = (int)((sourceHigh >> 8) & 0x3F);
+		}
+
+		fieldLength = fieldLength == 0 ? 64 : fieldLength;
+		if (bitIndex + fieldLength > 64)
+		{
+			return false;
+		}
+
+		var sourceMask = fieldLength == 64
+			? ulong.MaxValue
+			: (1UL << fieldLength) - 1;
+		var destinationMask = sourceMask << bitIndex;
+		var result = (destinationLow & ~destinationMask) |
+			((sourceLow & sourceMask) << bitIndex);
+		WriteCtxU64(contextRecord, destinationOffset, result);
+		WriteCtxU64(contextRecord, 248, rip + (ulong)offset);
+
+		var count = Interlocked.Increment(ref _insertqEmulationCount);
+		if (count <= 8)
+		{
+			Console.Error.WriteLine(
+				$"[LOADER][INFO] Emulated SSE4a INSERTQ#{count} at 0x{rip:X16}: " +
+				$"xmm{destinationRegister},xmm{sourceRegister} length={fieldLength} index={bitIndex}");
+		}
+		return true;
 	}
 
 	private unsafe static int TryRecoverUnresolvedSentinel(void* exceptionInfo)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -170,6 +170,7 @@ public sealed partial class DirectExecutionBackend
 		var result = (destinationLow & ~destinationMask) |
 			((sourceLow & sourceMask) << bitIndex);
 		WriteCtxU64(contextRecord, destinationOffset, result);
+		WriteCtxU64(contextRecord, destinationOffset + sizeof(ulong), 0);
 		WriteCtxU64(contextRecord, 248, rip + (ulong)offset);
 
 		var count = Interlocked.Increment(ref _insertqEmulationCount);

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -670,6 +670,15 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	private int _gateOwnerManagedThreadId;
 	private long _gateAcquireTimestamp;
 
+	// Serializes stack/TLS region reservation for new guest threads. The search in
+	// TryMapGuestThreadRegion is a check-then-map (IsGuestThreadRegionFree followed by
+	// IVirtualMemory.Map), and Map neither rejects nor is atomic against an overlapping
+	// concurrent reservation. Without this gate two threads created at the same time
+	// (e.g. an engine spawning its worker pool) can pick the same free slot; the loser's
+	// Map re-zeroes the winner's live stack, corrupting it. Held only around the region
+	// selection, never across guest execution.
+	private readonly object _guestThreadRegionGate = new object();
+
 	private GateHolder LockGate(string site)
 	{
 		Monitor.Enter(_guestThreadGate);
@@ -3480,13 +3489,19 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			}
 			else
 			{
-				if (!TryMapGuestThreadRegion(
+				bool mapped;
+				lock (_guestThreadRegionGate)
+				{
+					mapped = TryMapGuestThreadRegion(
 						virtualMemory,
 						GuestThreadStackBaseAddress,
 						GuestThreadStackSize,
 						ProgramHeaderFlags.Read | ProgramHeaderFlags.Write,
 						out callbackStackBase,
-						out error))
+						out error);
+				}
+
+				if (!mapped)
 				{
 					return false;
 				}
@@ -3889,20 +3904,30 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				if (external.ExceptionStackBase == 0)
 				{
 					string? mapError = null;
-					if (!TryGetVirtualMemory(external.Context, out var virtualMemory) ||
-						!TryMapGuestThreadRegion(
+					if (!TryGetVirtualMemory(external.Context, out var virtualMemory))
+					{
+						error = "external guest context has no virtual memory";
+						return false;
+					}
+
+					bool mapped;
+					lock (_guestThreadRegionGate)
+					{
+						mapped = TryMapGuestThreadRegion(
 							virtualMemory,
 							GuestThreadStackBaseAddress,
 							GuestThreadStackSize,
 							ProgramHeaderFlags.Read | ProgramHeaderFlags.Write,
 							out var stackBase,
-							out mapError))
-					{
-						error = mapError ?? "external guest context has no virtual memory";
-						return false;
+							out mapError);
+						external.ExceptionStackBase = stackBase;
 					}
 
-					external.ExceptionStackBase = stackBase;
+					if (!mapped)
+					{
+						error = mapError ?? "failed to reserve external guest exception stack";
+						return false;
+					}
 				}
 
 				if (_pendingGuestExceptions.ContainsKey(threadHandle))
@@ -3949,20 +3974,30 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			if (target.ExceptionStackBase == 0)
 			{
 				string? mapError = null;
-				if (!TryGetVirtualMemory(target.Context, out var virtualMemory) ||
-					!TryMapGuestThreadRegion(
+				if (!TryGetVirtualMemory(target.Context, out var virtualMemory))
+				{
+					error = "guest thread context has no virtual memory";
+					return false;
+				}
+
+				bool mapped;
+				lock (_guestThreadRegionGate)
+				{
+					mapped = TryMapGuestThreadRegion(
 						virtualMemory,
 						GuestThreadStackBaseAddress,
 						GuestThreadStackSize,
 						ProgramHeaderFlags.Read | ProgramHeaderFlags.Write,
 						out var mappedExceptionStack,
-						out mapError))
-				{
-					error = mapError ?? "guest thread context has no virtual memory";
-					return false;
+						out mapError);
+					target.ExceptionStackBase = mappedExceptionStack;
 				}
 
-				target.ExceptionStackBase = mappedExceptionStack;
+				if (!mapped)
+				{
+					error = mapError ?? "failed to reserve guest exception stack";
+					return false;
+				}
 			}
 			exceptionStackBase = target.ExceptionStackBase;
 
@@ -4426,13 +4461,20 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			error = "creator context memory is not backed by IVirtualMemory";
 			return false;
 		}
-		if (!TryMapGuestThreadRegion(virtualMemory, GuestThreadStackBaseAddress, GuestThreadStackSize, ProgramHeaderFlags.Read | ProgramHeaderFlags.Write, out var stackBase, out error))
+		// Reserve the stack and TLS regions under a single lock so concurrent thread
+		// creations cannot select overlapping slots (see _guestThreadRegionGate).
+		ulong stackBase;
+		ulong tlsBase;
+		lock (_guestThreadRegionGate)
 		{
-			return false;
-		}
-		if (!TryMapGuestThreadTlsRegion(virtualMemory, out var tlsBase, out error))
-		{
-			return false;
+			if (!TryMapGuestThreadRegion(virtualMemory, GuestThreadStackBaseAddress, GuestThreadStackSize, ProgramHeaderFlags.Read | ProgramHeaderFlags.Write, out stackBase, out error))
+			{
+				return false;
+			}
+			if (!TryMapGuestThreadTlsRegion(virtualMemory, out tlsBase, out error))
+			{
+				return false;
+			}
 		}
 
 		var trackedMemory = new TrackedCpuMemory(virtualMemory);

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -176,6 +176,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private const uint PAGE_EXECUTE_READ = 32u;
 
+	private const uint MEM_IMAGE = 0x0100_0000u;
+
 	private const int TlsHandlerRegionSize = 16384;
 
 	private const ulong TlsModuleAllocStart = 140726751354880uL;
@@ -197,6 +199,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	private uint _hostRspSlotTlsIndex = uint.MaxValue;
 
 	private nint _tlsGetValueAddress;
+
+	private nint _virtualQueryAddress;
 
 	private nint _queryPerformanceCounterAddress;
 
@@ -994,6 +998,11 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			if (_tlsGetValueAddress == 0)
 			{
 				throw new InvalidOperationException("Failed to resolve kernel32!TlsGetValue");
+			}
+			_virtualQueryAddress = kernel32 != 0 ? GetProcAddress(kernel32, "VirtualQuery") : 0;
+			if (_virtualQueryAddress == 0)
+			{
+				throw new InvalidOperationException("Failed to resolve kernel32!VirtualQuery");
 			}
 			_queryPerformanceCounterAddress = kernel32 != 0 ? GetProcAddress(kernel32, "QueryPerformanceCounter") : 0;
 			if (_queryPerformanceCounterAddress == 0)
@@ -2261,7 +2270,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private unsafe nint CreateExceptionHandlerTrampoline(nint managedHandler)
 	{
-		const uint stubSize = 256u;
+		const uint stubSize = 512u;
 		void* ptr = VirtualAlloc(null, stubSize, 12288u, 64u);
 		if (ptr == null)
 		{
@@ -2274,6 +2283,41 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x55); // push r13
 		EmitByte(code, ref offset, 0x49); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xE4); // mov r12, rsp
 		EmitByte(code, ref offset, 0x49); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xCD); // mov r13, rcx
+
+		// A hardware AV in coreclr or another loaded PE image may be the first step
+		// in constructing a managed exception. Re-entering managed diagnostics from
+		// that transition corrupts the CLR's thread mode. Guest ELF mappings are
+		// MEM_PRIVATE, so identify MEM_IMAGE faults natively and leave them to the
+		// owning runtime/driver VEH without crossing the managed boundary.
+		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x58); // sub rsp, 0x58
+		EmitByte(code, ref offset, 0x49); EmitByte(code, ref offset, 0x8B); EmitByte(code, ref offset, 0x45); EmitByte(code, ref offset, 0x00); // mov rax, [r13]
+		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x8B); EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x10); // mov rcx, [rax+0x10]
+		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x8D); EmitByte(code, ref offset, 0x54); EmitByte(code, ref offset, 0x24); EmitByte(code, ref offset, 0x20); // lea rdx, [rsp+0x20]
+		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0xB8); EmitUInt32(code, ref offset, (uint)sizeof(MEMORY_BASIC_INFORMATION64)); // mov r8d, sizeof(MBI)
+		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xB8); // mov rax, VirtualQuery
+		*(nint*)(code + offset) = _virtualQueryAddress;
+		offset += sizeof(nint);
+		EmitByte(code, ref offset, 0xFF); EmitByte(code, ref offset, 0xD0); // call rax
+		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x85); EmitByte(code, ref offset, 0xC0); // test rax, rax
+		EmitByte(code, ref offset, 0x74); // je continueFilter
+		int queryFailedJump = offset;
+		EmitByte(code, ref offset, 0x00);
+		EmitByte(code, ref offset, 0x81); EmitByte(code, ref offset, 0x7C); EmitByte(code, ref offset, 0x24); EmitByte(code, ref offset, 0x48); // cmp dword ptr [rsp+0x48], MEM_IMAGE
+		EmitUInt32(code, ref offset, MEM_IMAGE);
+		EmitByte(code, ref offset, 0x75); // jne continueFilter
+		int notImageJump = offset;
+		EmitByte(code, ref offset, 0x00);
+		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xC4); EmitByte(code, ref offset, 0x58); // add rsp, 0x58
+		EmitByte(code, ref offset, 0x31); EmitByte(code, ref offset, 0xC0); // xor eax, eax
+		EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xE4); // mov rsp, r12
+		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5D); // pop r13
+		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5C); // pop r12
+		EmitByte(code, ref offset, 0xC3); // ret
+		int continueFilterOffset = offset;
+		code[queryFailedJump] = checked((byte)(continueFilterOffset - (queryFailedJump + 1)));
+		code[notImageJump] = checked((byte)(continueFilterOffset - (notImageJump + 1)));
+		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xC4); EmitByte(code, ref offset, 0x58); // add rsp, 0x58
+
 		EmitByte(code, ref offset, 0x65); EmitByte(code, ref offset, 0x48); // mov rax, gs:[8]
 		EmitByte(code, ref offset, 0x8B); EmitByte(code, ref offset, 0x04); EmitByte(code, ref offset, 0x25);
 		EmitUInt32(code, ref offset, 8u);

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -815,6 +815,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private static int _nestedVehTraceCount;
 
+	private static int _insertqEmulationCount;
+
 	private const uint MEM_COMMIT = 4096u;
 
 	private const uint MEM_RESERVE = 8192u;

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -12,6 +12,7 @@ using SharpEmu.Core.Cpu;
 using SharpEmu.Core.Loader;
 using SharpEmu.Core.Memory;
 using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
 
 namespace SharpEmu.Core.Cpu.Native;
 
@@ -2400,15 +2401,57 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private unsafe void PatchTlsPatterns()
 	{
-        // Large Gen5 executables can keep valid code well past the first 32 MiB.
-        // Astro Bot, for example, has an FS:[0] TLS load near +0x70A0000.
-        const ulong MaxScanBytes = 134217728uL;
-		ulong num = _entryPoint;
-		ulong num2 = num + MaxScanBytes;
-		int num3 = 0;
-		int num4 = 0;
-		int num9 = 0;
+		// Prefer exact registered module ranges: large executables and LLE-loaded
+		// modules can keep TLS accesses far outside a fixed entry-point window.
+		const ulong FallbackScanBytes = 134217728uL;
+		int patchedLoads = 0;
+		int patchedStores = 0;
+		int patchedCanaries = 0;
 		int sse4aPatchCount = 0;
+		bool scannedAnyModule = false;
+		foreach (int moduleHandle in KernelModuleRegistry.GetModuleHandles(includeSystemModules: true))
+		{
+			if (!KernelModuleRegistry.TryGetModuleByHandle(moduleHandle, out var module) ||
+				module.BaseAddress == 0 ||
+				module.EndAddress <= module.BaseAddress)
+			{
+				continue;
+			}
+
+			scannedAnyModule = true;
+			PatchTlsPatternsInRange(
+				module.BaseAddress,
+				module.EndAddress,
+				ref patchedLoads,
+				ref patchedStores,
+				ref patchedCanaries,
+				ref sse4aPatchCount);
+		}
+
+		if (!scannedAnyModule)
+		{
+			PatchTlsPatternsInRange(
+				_entryPoint,
+				_entryPoint + FallbackScanBytes,
+				ref patchedLoads,
+				ref patchedStores,
+				ref patchedCanaries,
+				ref sse4aPatchCount);
+		}
+
+		Console.Error.WriteLine(
+			$"[LOADER][INFO] Patched {patchedLoads} TLS loads, {patchedStores} TLS stores, " +
+			$"{patchedCanaries} stack-canary accesses, {sse4aPatchCount} SSE4a EXTRQ blends");
+	}
+
+	private unsafe void PatchTlsPatternsInRange(
+		ulong num,
+		ulong num2,
+		ref int num3,
+		ref int num9,
+		ref int num4,
+		ref int sse4aPatchCount)
+	{
 		while (num < num2)
 		{
 			if (VirtualQuery((void*)num, out var lpBuffer, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) == 0 || lpBuffer.RegionSize == 0)
@@ -2453,7 +2496,6 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			}
 			num = num6 > num ? num6 : num + 4096uL;
 		}
-		Console.Error.WriteLine($"[LOADER][INFO] Patched {num3} TLS loads, {num9} TLS stores, {num4} stack-canary accesses, {sse4aPatchCount} SSE4a EXTRQ blends");
 	}
 
 	private unsafe bool TryPatchSse4aExtrqBlend(nint address, byte* source)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -153,10 +153,6 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private const ulong GuestThreadTlsSize = 0x0001_0000UL;
 
-	// Matches CpuDispatcher.TlsPrefixSize: static TLS blocks sit below the
-	// thread pointer and PS5 modules can reach beyond one host page.
-	private const ulong GuestThreadTlsPrefixSize = GuestTlsTemplate.StartupStaticTlsReservation;
-
 	private const ulong GuestThreadRegionStride = 0x0100_0000UL;
 
 	// Unity titles routinely create more than 64 workers once native plugins,
@@ -4574,11 +4570,12 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		out ulong tlsBase,
 		out string? error)
 	{
+		var tlsPrefixSize = GuestTlsTemplate.StartupStaticTlsReservation;
 		for (int i = 0; i < GuestThreadRegionSlots; i++)
 		{
 			var candidateBase = GuestThreadTlsBaseAddress - ((ulong)i * GuestThreadRegionStride);
-			var mappedBase = candidateBase - GuestThreadTlsPrefixSize;
-			var mappedSize = GuestThreadTlsSize + GuestThreadTlsPrefixSize;
+			var mappedBase = candidateBase - tlsPrefixSize;
+			var mappedSize = checked(GuestThreadTlsSize + tlsPrefixSize);
 			if (!IsGuestThreadRegionFree(virtualMemory, mappedBase, mappedSize))
 			{
 				continue;

--- a/src/SharpEmu.HLE/GuestTlsTemplate.cs
+++ b/src/SharpEmu.HLE/GuestTlsTemplate.cs
@@ -14,10 +14,11 @@ namespace SharpEmu.HLE;
 /// </summary>
 public static class GuestTlsTemplate
 {
-    // Must match CpuDispatcher/DirectExecutionBackend's mapped prefix. PS5
-    // modules can require more than one host page of Variant II static TLS;
-    // Dreaming Sarah's startup image, for example, reaches 0x1870 bytes.
-    public const ulong StartupStaticTlsReservation = 0x10000UL;
+    // Keep a useful baseline for ordinary titles, but grow the actual mapped
+    // prefix from the registered startup layout. Large executables such as
+    // GTA V require more than 64 KiB of Variant II static TLS.
+    public const ulong MinimumStartupStaticTlsReservation = 0x10000UL;
+    private const ulong GuestPageSize = 0x1000UL;
     private static readonly object _gate = new();
     private static readonly SortedDictionary<ulong, ModuleTemplate> _modules = new();
     private static readonly Dictionary<ulong, ThreadDtv> _threadDtvs = new();
@@ -102,6 +103,23 @@ public static class GuestTlsTemplate
         get { lock (_gate) { return _staticTlsSize; } }
     }
 
+    /// <summary>
+    /// Page-aligned prefix that new thread mappings must reserve below the
+    /// thread pointer for all modules registered before execution starts.
+    /// </summary>
+    public static ulong StartupStaticTlsReservation
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return Math.Max(
+                    MinimumStartupStaticTlsReservation,
+                    AlignUp(_staticTlsSize, GuestPageSize));
+            }
+        }
+    }
+
     /// <summary>Largest PT_TLS alignment required by the registered modules.</summary>
     public static ulong MaximumAlignment
     {
@@ -171,11 +189,10 @@ public static class GuestTlsTemplate
                 memorySize,
                 normalizedAlignment,
                 alignmentBias);
-            if (staticOffset > StartupStaticTlsReservation)
+            if (staticOffset > int.MaxValue)
             {
-                throw new InvalidOperationException(
-                    $"Static TLS requires 0x{staticOffset:X} bytes, but startup maps only " +
-                    $"0x{StartupStaticTlsReservation:X} bytes below the thread pointer.");
+                throw new InvalidDataException(
+                    $"Aggregate static TLS span 0x{staticOffset:X} exceeds the supported process limit.");
             }
             _modules.Add(moduleId, new ModuleTemplate
             {

--- a/src/SharpEmu.HLE/OrbisGen2Result.cs
+++ b/src/SharpEmu.HLE/OrbisGen2Result.cs
@@ -41,11 +41,15 @@ public enum OrbisGen2Result : int
     ORBIS_GEN2_ERROR_DEADLOCK = unchecked((int)0x8002000B),
 
     /// <summary>
-    /// Indicates that the waited-on object was deleted while the caller was
-    /// blocked on it. Matches the SCE kernel EACCES code that waiters of a
-    /// deleted semaphore observe.
+    /// Indicates that the caller may not access the requested resource.
+    /// Matches the SCE kernel EACCES code, which waiters of a deleted
+    /// semaphore observe and which direct memory queries report for
+    /// unallocated areas (titles rely on it to end enumeration loops).
     /// </summary>
-    ORBIS_GEN2_ERROR_DELETED = unchecked((int)0x8002000D),
+    ORBIS_GEN2_ERROR_ACCESS_DENIED = unchecked((int)0x8002000D),
+
+    /// <summary>Compatibility name for the EACCES result used by deleted wait objects.</summary>
+    ORBIS_GEN2_ERROR_DELETED = ORBIS_GEN2_ERROR_ACCESS_DENIED,
 
     /// <summary>
     /// Indicates that the target resource is busy.

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -142,6 +142,7 @@ public static partial class AgcExports
     private const uint Gen5TextureFormatR16G16B16A16Float = 12;
     private const uint Gen5TextureType1D = 8;
     private const uint Gen5TextureType2D = 9;
+    private const uint Gen5TextureType3D = 10;
     private const ulong MaxPresentedTextureBytes = 128UL * 1024UL * 1024UL;
     private const ulong VideoOutPixelFormatA8R8G8B8Srgb = 0x80000000;
     private const ulong VideoOutPixelFormatA8B8G8R8Srgb = 0x80002200;
@@ -7690,11 +7691,14 @@ public static partial class AgcExports
     {
         texture = default!;
         if ((descriptor.Type != Gen5TextureType1D &&
-             descriptor.Type != Gen5TextureType2D) ||
+             descriptor.Type != Gen5TextureType2D &&
+             descriptor.Type != Gen5TextureType3D) ||
             descriptor.Width == 0 ||
             descriptor.Height == 0 ||
+            descriptor.Depth == 0 ||
             descriptor.Width > 8192 ||
-            descriptor.Height > 8192)
+            descriptor.Height > 8192 ||
+            descriptor.Depth > 2048)
         {
             TraceTextureFallback(descriptor, "invalid-descriptor");
             texture = CreateFallbackGuestDrawTexture(isStorage, descriptor.Format, descriptor.NumberType);
@@ -7710,7 +7714,7 @@ public static partial class AgcExports
         var sourceByteCount = GetTextureByteCount(
             descriptor.Format,
             sourceWidth,
-            descriptor.Height);
+            descriptor.Height) * descriptor.Depth;
         if (sourceByteCount == 0 ||
             sourceByteCount > MaxPresentedTextureBytes ||
             sourceByteCount > int.MaxValue)
@@ -7770,7 +7774,9 @@ public static partial class AgcExports
                 Pitch: sourceWidth,
                 TileMode: descriptor.TileMode,
                 DstSelect: descriptor.DstSelect,
-                Sampler: ToGuestSampler(samplerDescriptor));
+                Sampler: ToGuestSampler(samplerDescriptor),
+                Depth: descriptor.Depth,
+                Type: descriptor.Type);
             return true;
         }
 
@@ -7843,7 +7849,9 @@ public static partial class AgcExports
                 Pitch: sourceWidth,
                 TileMode: descriptor.TileMode,
                 DstSelect: descriptor.DstSelect,
-                Sampler: ToGuestSampler(samplerDescriptor));
+                Sampler: ToGuestSampler(samplerDescriptor),
+                Depth: descriptor.Depth,
+                Type: descriptor.Type);
             return true;
         }
 
@@ -7869,7 +7877,9 @@ public static partial class AgcExports
                     descriptor.DstSelect,
                     descriptor.TileMode,
                     sourceWidth,
-                    sampler)))
+                    sampler,
+                    descriptor.Depth,
+                    descriptor.Type)))
         {
             texture = new GuestDrawTexture(
                 descriptor.Address,
@@ -7947,7 +7957,9 @@ public static partial class AgcExports
             Pitch: sourceWidth,
             TileMode: descriptor.TileMode,
             DstSelect: descriptor.DstSelect,
-            Sampler: ToGuestSampler(samplerDescriptor));
+            Sampler: ToGuestSampler(samplerDescriptor),
+            Depth: descriptor.Depth,
+            Type: descriptor.Type);
         return true;
     }
 
@@ -9904,6 +9916,7 @@ public static partial class AgcExports
             Address: 0,
             Width: 1,
             Height: 1,
+            Depth: 1,
             Format: format,
             NumberType: numberType,
             TileMode: tileMode,
@@ -10870,7 +10883,7 @@ public static partial class AgcExports
             : string.Join(',', values.Select(static value => $"{value:X8}"));
 
     private static string FormatTextureDescriptor(TextureDescriptor descriptor) =>
-        $"addr=0x{descriptor.Address:X16} {descriptor.Width}x{descriptor.Height} " +
+        $"addr=0x{descriptor.Address:X16} {descriptor.Width}x{descriptor.Height}x{descriptor.Depth} " +
         $"fmt={descriptor.Format} num={descriptor.NumberType} tile={descriptor.TileMode} " +
         $"type={descriptor.Type} depth={descriptor.Depth} base_array={descriptor.BaseArray} " +
         $"levels={descriptor.BaseLevel}-{descriptor.LastLevel}/max{descriptor.MaxMip} " +

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -933,6 +933,32 @@ public static partial class AgcExports
     }
 
     [SysAbiExport(
+        Nid = "t7PlZ9nt5Lc",
+        ExportName = "sceAgcCbNopGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int CbNopGetSize(CpuContext ctx)
+    {
+        // Byte size of the packet sceAgcCbNop emits for the same dword
+        // count: the packet occupies exactly that many dwords.
+        var dwordCount = (uint)ctx[CpuRegister.Rdi];
+        ctx[CpuRegister.Rax] = (ulong)dwordCount * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "hL7C0IRpWZI",
+        ExportName = "sceAgcCbQueueEndOfPipeActionGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int CbQueueEndOfPipeActionGetSize(CpuContext ctx)
+    {
+        // End-of-pipe actions are release-mem style packets (8 dwords).
+        ctx[CpuRegister.Rax] = 8 * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
         Nid = "k3GhuSNmBLU",
         ExportName = "sceAgcCbDispatch",
         Target = Generation.Gen5,
@@ -1127,6 +1153,18 @@ public static partial class AgcExports
         }
 
         return ReturnPointer(ctx, commandAddress);
+    }
+
+    [SysAbiExport(
+        Nid = "ewobAQeMo5k",
+        ExportName = "sceAgcAcbAcquireMemGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int AcbAcquireMemGetSize(CpuContext ctx)
+    {
+        // Byte size of the packet sceAgcAcbAcquireMem emits (8 dwords).
+        ctx[CpuRegister.Rax] = 8 * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     [SysAbiExport(
@@ -1701,6 +1739,42 @@ public static partial class AgcExports
             $"agc.dcb_acquire_mem buf=0x{commandBufferAddress:X16} cmd=0x{commandAddress:X16} " +
             $"engine={engine} cbdb=0x{cbDbOp:X8} gcr=0x{gcrControl:X8} base=0x{baseAddress:X16} size=0x{sizeBytes:X16}");
         return ReturnPointer(ctx, commandAddress);
+    }
+
+    [SysAbiExport(
+        Nid = "-vnlTPPXPrw",
+        ExportName = "sceAgcDcbAcquireMemGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbAcquireMemGetSize(CpuContext ctx)
+    {
+        // Byte size of the packet sceAgcDcbAcquireMem emits (8 dwords).
+        ctx[CpuRegister.Rax] = 8 * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "QIXCsbipds0",
+        ExportName = "sceAgcDcbRewindGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbRewindGetSize(CpuContext ctx)
+    {
+        // Rewind packets are 2 dwords (header + valid flag).
+        ctx[CpuRegister.Rax] = 2 * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "VEGu4dixjUg",
+        ExportName = "sceAgcDcbJumpGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbJumpGetSize(CpuContext ctx)
+    {
+        // Jump packets are indirect-buffer chains (4 dwords).
+        ctx[CpuRegister.Rax] = 4 * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     [SysAbiExport(
@@ -2634,6 +2708,37 @@ public static partial class AgcExports
 
         TraceAgc($"agc.driver_delete_eq_event eq=0x{equeue:X16} id=0x{eventId:X16}");
         return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "XlNp7jzGiPo",
+        ExportName = "sceAgcDriverSetTFRing",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgcDriver")]
+    public static int DriverSetTFRing(CpuContext ctx)
+    {
+        // The tessellation-factor ring only matters to the real hardware
+        // scheduler; accept and record the registration so titles that
+        // treat a non-zero result as fatal keep booting.
+        var ringAddress = ctx[CpuRegister.Rdi];
+        var ringSizeBytes = (uint)ctx[CpuRegister.Rsi];
+        TraceAgc($"agc.driver_set_tf_ring addr=0x{ringAddress:X16} size=0x{ringSizeBytes:X}");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "MM4IZSEYytQ",
+        ExportName = "sceAgcDriverSetHsOffchipParam",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgcDriver")]
+    public static int DriverSetHsOffchipParam(CpuContext ctx)
+    {
+        // Hull-shader off-chip LDS configuration only matters to the real
+        // hardware scheduler; accept it so the title's fatal-on-error
+        // bootstrap check passes.
+        var param = (uint)ctx[CpuRegister.Rdi];
+        TraceAgc($"agc.driver_set_hs_offchip_param param=0x{param:X8}");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
     [SysAbiExport(

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -1386,6 +1386,36 @@ public static partial class AgcExports
     }
 
     [SysAbiExport(
+        Nid = "w4-d0n60hdo",
+        ExportName = "sceAgcDcbSetUcRegisterDirect",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbSetUcRegisterDirect(CpuContext ctx)
+    {
+        var commandBufferAddress = ctx[CpuRegister.Rdi];
+        var packedRegister = ctx[CpuRegister.Rsi];
+        var value = (uint)packedRegister;
+        var offset = (uint)(packedRegister >> 32);
+        if (commandBufferAddress == 0 || offset > ushort.MaxValue)
+        {
+            return ReturnPointer(ctx, 0);
+        }
+
+        if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 3, out var commandAddress) ||
+            !ctx.TryWriteUInt32(commandAddress, Pm4(3, ItSetUconfigReg, 0)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, offset) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, value))
+        {
+            return ReturnPointer(ctx, 0);
+        }
+
+        TraceAgc(
+            $"agc.dcb_set_uc_direct buf=0x{commandBufferAddress:X16} cmd=0x{commandAddress:X16} " +
+            $"offset=0x{offset:X4} value=0x{value:X8}");
+        return ReturnPointer(ctx, commandAddress);
+    }
+
+    [SysAbiExport(
         Nid = "ZvwO9euwYzc",
         ExportName = "sceAgcDcbSetCxRegistersIndirect",
         Target = Generation.Gen5,

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -3100,9 +3100,13 @@ public static partial class AgcExports
         SubmittedDcbState state,
         ulong commandAddress,
         uint dwordCount,
-        bool tracePackets)
+        bool tracePackets,
+        uint nestingDepth = 0)
     {
-        if (commandAddress == 0 || dwordCount == 0 || dwordCount > 1_000_000)
+        if (commandAddress == 0 ||
+            dwordCount == 0 ||
+            dwordCount > 1_000_000 ||
+            nestingDepth > 16)
         {
             return false;
         }
@@ -3127,7 +3131,8 @@ public static partial class AgcExports
                 state,
                 commandAddress,
                 dwordCount,
-                tracePackets);
+                tracePackets,
+                nestingDepth);
         }
         finally
         {
@@ -3143,7 +3148,8 @@ public static partial class AgcExports
         SubmittedDcbState state,
         ulong commandAddress,
         uint dwordCount,
-        bool tracePackets)
+        bool tracePackets,
+        uint nestingDepth)
     {
         var offset = 0u;
         while (offset < dwordCount)
@@ -3241,6 +3247,32 @@ public static partial class AgcExports
             }
 
             ApplySubmittedRegisters(ctx, state, currentAddress, length, op, register);
+
+            if (op == ItIndirectBuffer &&
+                length >= 4 &&
+                ctx.TryReadUInt32(currentAddress + 4, out var indirectAddressLo) &&
+                ctx.TryReadUInt32(currentAddress + 8, out var indirectAddressHi) &&
+                ctx.TryReadUInt32(currentAddress + 12, out var indirectControl))
+            {
+                var indirectAddress =
+                    indirectAddressLo | ((ulong)(indirectAddressHi & 0xFFFF) << 32);
+                var indirectDwords = indirectControl & 0xF_FFFF;
+                if (tracePackets)
+                {
+                    TraceAgcShader(
+                        $"agc.dcb.indirect depth={nestingDepth + 1} " +
+                        $"addr=0x{indirectAddress:X16} dwords={indirectDwords}");
+                }
+
+                ParseSubmittedDcb(
+                    ctx,
+                    gpuState,
+                    state,
+                    indirectAddress,
+                    indirectDwords,
+                    tracePackets,
+                    nestingDepth + 1);
+            }
 
             if (op == ItSetBase &&
                 length >= 4 &&
@@ -10566,6 +10598,74 @@ public static partial class AgcExports
         return (int)result;
     }
 
+    private static bool TryReadDcbJumpArguments(
+        CpuContext ctx,
+        out ulong targetAddress,
+        out uint targetDwords,
+        out string argumentForm)
+    {
+        if (IsReadableDcbSegment(
+                ctx,
+                ctx[CpuRegister.Rsi],
+                ctx[CpuRegister.Rdx],
+                out targetAddress,
+                out targetDwords))
+        {
+            argumentForm = "compact";
+            return true;
+        }
+
+        if (IsReadableDcbSegment(
+                ctx,
+                ctx[CpuRegister.Rcx],
+                ctx[CpuRegister.R8],
+                out targetAddress,
+                out targetDwords))
+        {
+            argumentForm = "extended";
+            return true;
+        }
+
+        var stackAddress = ctx[CpuRegister.Rsp];
+        if (ctx.TryReadUInt64(stackAddress + sizeof(ulong), out var stackDwords) &&
+            IsReadableDcbSegment(
+                ctx,
+                ctx[CpuRegister.R9],
+                stackDwords,
+                out targetAddress,
+                out targetDwords))
+        {
+            argumentForm = "extended-stack";
+            return true;
+        }
+
+        targetAddress = 0;
+        targetDwords = 0;
+        argumentForm = string.Empty;
+        return false;
+    }
+
+    private static bool IsReadableDcbSegment(
+        CpuContext ctx,
+        ulong address,
+        ulong dwordCount,
+        out ulong targetAddress,
+        out uint targetDwords)
+    {
+        targetAddress = 0;
+        targetDwords = 0;
+        if (address == 0 || dwordCount == 0 || dwordCount > 0xF_FFFF ||
+            !ctx.TryReadUInt32(address, out _) ||
+            !ctx.TryReadUInt32(address + ((dwordCount - 1) * sizeof(uint)), out _))
+        {
+            return false;
+        }
+
+        targetAddress = address;
+        targetDwords = (uint)dwordCount;
+        return true;
+    }
+
     private static uint Pm4(uint lengthDwords, uint op, uint register) =>
         0xC0000000u |
         ((((ushort)lengthDwords - 2u) & 0x3FFFu) << 16) |
@@ -10998,24 +11098,30 @@ public static partial class AgcExports
         LibraryName = "libSceAgc")]
     public static int DcbJump(CpuContext ctx)
     {
-        var dcb = ctx[CpuRegister.Rdi];
-        var target = ctx[CpuRegister.Rsi];
-        var sizeDwords = (uint)ctx[CpuRegister.Rdx];
-        if (dcb == 0)
+        var commandBufferAddress = ctx[CpuRegister.Rdi];
+        if (commandBufferAddress == 0 ||
+            !TryReadDcbJumpArguments(
+                ctx,
+                out var targetAddress,
+                out var targetDwords,
+                out var argumentForm))
         {
             return ReturnPointer(ctx, 0);
         }
 
-        if (!TryAllocateCommandDwords(ctx, dcb, 4, out var cmd) ||
-            !ctx.TryWriteUInt32(cmd, Pm4(4, ItIndirectBuffer, RZero)) ||
-            !ctx.TryWriteUInt32(cmd + 4, (uint)(target & 0xFFFF_FFFFUL)) ||
-            !ctx.TryWriteUInt32(cmd + 8, (uint)((target >> 32) & 0xFFFFUL)) ||
-            !ctx.TryWriteUInt32(cmd + 12, sizeDwords & 0xFFFFF))
+        if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 4, out var commandAddress) ||
+            !ctx.TryWriteUInt32(commandAddress, Pm4(4, ItIndirectBuffer, RZero)) ||
+            !ctx.TryWriteUInt32(commandAddress + 4, (uint)targetAddress) ||
+            !ctx.TryWriteUInt32(commandAddress + 8, (uint)((targetAddress >> 32) & 0xFFFF)) ||
+            !ctx.TryWriteUInt32(commandAddress + 12, targetDwords & 0xF_FFFF))
         {
             return ReturnPointer(ctx, 0);
         }
 
-        return ReturnPointer(ctx, cmd);
+        TraceAgcShader(
+            $"agc.dcb_jump buf=0x{commandBufferAddress:X16} cmd=0x{commandAddress:X16} " +
+            $"target=0x{targetAddress:X16} dwords={targetDwords} args={argumentForm}");
+        return ReturnPointer(ctx, commandAddress);
     }
 
     [SysAbiExport(

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -78,6 +78,8 @@ public static partial class AgcExports
     private const uint SpiShaderPgmHiLs = 0x149;
     private const uint SpiShaderPgmLoGs = 0x8A;
     private const uint SpiShaderPgmHiGs = 0x8B;
+    private const uint SpiShaderPgmLoHs = 0x10A;
+    private const uint SpiShaderPgmHiHs = 0x10B;
     private const uint SpiPsInputEna = 0x1B3;
     private const uint SpiPsInputAddr = 0x1B4;
     private const uint ComputePgmLo = 0x20C;
@@ -10138,6 +10140,7 @@ public static partial class AgcExports
             1 => SpiShaderPgmLoPs,
             2 or 6 => SpiShaderPgmLoEs,
             4 => SpiShaderPgmLoGs,
+            5 => SpiShaderPgmLoHs,
             7 => SpiShaderPgmLoLs,
             _ => 0u,
         };
@@ -10147,6 +10150,7 @@ public static partial class AgcExports
             1 => SpiShaderPgmHiPs,
             2 or 6 => SpiShaderPgmHiEs,
             4 => SpiShaderPgmHiGs,
+            5 => SpiShaderPgmHiHs,
             7 => SpiShaderPgmHiLs,
             _ => 0u,
         };

--- a/src/SharpEmu.Libs/Audio/AjmExports.cs
+++ b/src/SharpEmu.Libs/Audio/AjmExports.cs
@@ -10,8 +10,26 @@ namespace SharpEmu.Libs.Audio;
 
 public static class AjmExports
 {
-    private static readonly ConcurrentDictionary<uint, byte> Contexts = new();
+    private const int OrbisAjmErrorInvalidContext = unchecked((int)0x80930002);
+    private const int OrbisAjmErrorInvalidParameter = unchecked((int)0x80930005);
+    private const int OrbisAjmErrorOutOfResources = unchecked((int)0x80930007);
+    private const int OrbisAjmErrorCodecAlreadyRegistered = unchecked((int)0x80930009);
+    private const int OrbisAjmErrorCodecNotRegistered = unchecked((int)0x8093000A);
+    private const int OrbisAjmErrorWrongRevisionFlag = unchecked((int)0x8093000B);
+    private const uint MaxCodecType = 23;
+    private const int MaxInstanceIndex = 0x2FFF;
+    private static readonly ConcurrentDictionary<uint, AjmContextState> Contexts = new();
     private static int _nextContextId;
+
+    private sealed class AjmContextState
+    {
+        public object Gate { get; } = new();
+
+        public HashSet<uint> RegisteredCodecs { get; } = new();
+
+        public int NextInstanceIndex { get; set; }
+    }
+
     public static int AjmInitialize(CpuContext ctx)
     {
         var reserved = ctx[CpuRegister.Rdi];
@@ -29,7 +47,7 @@ public static class AjmExports
             return unchecked((int)0x806A0001);
         }
 
-        Contexts[contextId] = 0;
+        Contexts[contextId] = new AjmContextState();
         if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_AJM"), "1", StringComparison.Ordinal))
         {
             Console.Error.WriteLine(
@@ -62,9 +80,22 @@ public static class AjmExports
         var contextId = unchecked((uint)ctx[CpuRegister.Rdi]);
         var codecType = unchecked((uint)ctx[CpuRegister.Rsi]);
         var reserved = ctx[CpuRegister.Rdx];
-        if (reserved != 0 || !Contexts.ContainsKey(contextId))
+        if (codecType >= MaxCodecType || reserved != 0)
         {
-            return unchecked((int)0x806A0001);
+            return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
+        }
+
+        if (!Contexts.TryGetValue(contextId, out var state))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidContext);
+        }
+
+        lock (state.Gate)
+        {
+            if (!state.RegisteredCodecs.Add(codecType))
+            {
+                return ctx.SetReturn(OrbisAjmErrorCodecAlreadyRegistered);
+            }
         }
 
         if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_AJM"), "1", StringComparison.Ordinal))
@@ -75,6 +106,55 @@ public static class AjmExports
 
         ctx[CpuRegister.Rax] = 0;
         return 0;
+    }
+
+    [SysAbiExport(
+        Nid = "AxoDrINp4J8",
+        ExportName = "sceAjmInstanceCreate",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAjm")]
+    public static int AjmInstanceCreate(CpuContext ctx)
+    {
+        var contextId = unchecked((uint)ctx[CpuRegister.Rdi]);
+        var codecType = unchecked((uint)ctx[CpuRegister.Rsi]);
+        var flags = ctx[CpuRegister.Rdx];
+        var outputAddress = ctx[CpuRegister.Rcx];
+        if (codecType >= MaxCodecType || outputAddress == 0)
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
+        }
+
+        if ((flags & 0x7) == 0)
+        {
+            return ctx.SetReturn(OrbisAjmErrorWrongRevisionFlag);
+        }
+
+        if (!Contexts.TryGetValue(contextId, out var state))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidContext);
+        }
+
+        uint instanceId;
+        lock (state.Gate)
+        {
+            if (!state.RegisteredCodecs.Contains(codecType))
+            {
+                return ctx.SetReturn(OrbisAjmErrorCodecNotRegistered);
+            }
+
+            if (state.NextInstanceIndex >= MaxInstanceIndex)
+            {
+                return ctx.SetReturn(OrbisAjmErrorOutOfResources);
+            }
+
+            instanceId = (codecType << 14) | unchecked((uint)++state.NextInstanceIndex);
+        }
+
+        Span<byte> value = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(value, instanceId);
+        return ctx.Memory.TryWrite(outputAddress, value)
+            ? ctx.SetReturn(0)
+            : ctx.SetReturn(OrbisAjmErrorInvalidParameter);
     }
 
     [SysAbiExport(

--- a/src/SharpEmu.Libs/Audio/AjmExports.cs
+++ b/src/SharpEmu.Libs/Audio/AjmExports.cs
@@ -4,6 +4,7 @@
 using SharpEmu.HLE;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace SharpEmu.Libs.Audio;
@@ -11,15 +12,24 @@ namespace SharpEmu.Libs.Audio;
 public static class AjmExports
 {
     private const int OrbisAjmErrorInvalidContext = unchecked((int)0x80930002);
+    private const int OrbisAjmErrorInvalidInstance = unchecked((int)0x80930003);
+    private const int OrbisAjmErrorInvalidBatch = unchecked((int)0x80930004);
     private const int OrbisAjmErrorInvalidParameter = unchecked((int)0x80930005);
+    private const int OrbisAjmErrorOutOfMemory = unchecked((int)0x80930006);
     private const int OrbisAjmErrorOutOfResources = unchecked((int)0x80930007);
     private const int OrbisAjmErrorCodecAlreadyRegistered = unchecked((int)0x80930009);
     private const int OrbisAjmErrorCodecNotRegistered = unchecked((int)0x8093000A);
     private const int OrbisAjmErrorWrongRevisionFlag = unchecked((int)0x8093000B);
+    private const int OrbisAjmErrorMalformedBatch = unchecked((int)0x80930011);
+    private const int OrbisAjmErrorBufferTooBig = unchecked((int)0x80930015);
+    private const int OrbisAjmErrorInvalidAddress = unchecked((int)0x80930016);
     private const uint MaxCodecType = 23;
     private const int MaxInstanceIndex = 0x2FFF;
+    private const ulong MaxJobBufferSize = 64UL * 1024UL * 1024UL;
     private static readonly ConcurrentDictionary<uint, AjmContextState> Contexts = new();
+    private static readonly ConditionalWeakTable<ICpuMemory, AjmMemoryState> MemoryStates = new();
     private static int _nextContextId;
+    private static long _batchTraceCount;
 
     private sealed class AjmContextState
     {
@@ -27,8 +37,41 @@ public static class AjmExports
 
         public HashSet<uint> RegisteredCodecs { get; } = new();
 
+        public Dictionary<uint, AjmInstanceState> Instances { get; } = new();
+
+        public HashSet<uint> CompletedBatches { get; } = new();
+
         public int NextInstanceIndex { get; set; }
+
+        public uint NextBatchId { get; set; }
     }
+
+    private sealed class AjmInstanceState(ulong flags)
+    {
+        public ulong Flags { get; } = flags;
+
+        public ulong TotalDecodedSamples { get; set; }
+    }
+
+    private sealed class AjmMemoryState
+    {
+        public object Gate { get; } = new();
+
+        public Dictionary<ulong, AjmBatchBuilder> Builders { get; } = new();
+    }
+
+    private sealed class AjmBatchBuilder
+    {
+        public List<AjmDecodeJob> DecodeJobs { get; } = new();
+    }
+
+    private readonly record struct AjmDecodeJob(
+        uint InstanceId,
+        ulong InputAddress,
+        ulong InputSize,
+        ulong OutputAddress,
+        ulong OutputSize,
+        ulong SidebandAddress);
 
     public static int AjmInitialize(CpuContext ctx)
     {
@@ -148,6 +191,7 @@ public static class AjmExports
             }
 
             instanceId = (codecType << 14) | unchecked((uint)++state.NextInstanceIndex);
+            state.Instances[instanceId] = new AjmInstanceState(flags);
         }
 
         Span<byte> value = stackalloc byte[sizeof(uint)];
@@ -171,14 +215,319 @@ public static class AjmExports
     [SysAbiExport(
         Nid = "MmpF1XsQiHw",
         ExportName = "sceAjmBatchInitialize",
-        Target = Generation.Gen4 | Generation.Gen5,
+        Target = Generation.Gen5,
         LibraryName = "libSceAjm")]
     public static int AjmBatchInitialize(CpuContext ctx)
     {
-        // The caller owns and initializes the batch storage. This API resets
-        // its submission cursor on hardware; FMOD does not consume a return
-        // value or an additional output object here.
-        ctx[CpuRegister.Rax] = 0;
-        return 0;
+        var initializationAddress = ctx[CpuRegister.Rdi];
+        var initializationSize = ctx[CpuRegister.Rsi];
+        var batchAddress = ctx[CpuRegister.Rdx];
+        if (batchAddress == 0 || initializationSize > MaxJobBufferSize)
+        {
+            return ctx.SetReturn(
+                initializationSize > MaxJobBufferSize
+                    ? OrbisAjmErrorBufferTooBig
+                    : OrbisAjmErrorInvalidParameter);
+        }
+
+        if (!IsReadableRange(ctx, initializationAddress, initializationSize))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidAddress);
+        }
+
+        var memoryState = MemoryStates.GetValue(ctx.Memory, static _ => new AjmMemoryState());
+        lock (memoryState.Gate)
+        {
+            memoryState.Builders[batchAddress] = new AjmBatchBuilder();
+        }
+
+        TraceBatch($"initialize batch=0x{batchAddress:X16} init=0x{initializationAddress:X16}+0x{initializationSize:X}");
+        return ctx.SetReturn(0);
+    }
+
+    [SysAbiExport(
+        Nid = "39WxhR-ePew",
+        ExportName = "sceAjmBatchJobDecode",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAjm")]
+    public static int AjmBatchJobDecode(CpuContext ctx)
+    {
+        var batchAddress = ctx[CpuRegister.Rdi];
+        var instanceId = unchecked((uint)ctx[CpuRegister.Rsi]);
+        var inputAddress = ctx[CpuRegister.Rdx];
+        var inputSize = ctx[CpuRegister.Rcx];
+        var outputAddress = ctx[CpuRegister.R8];
+        var outputSize = ctx[CpuRegister.R9];
+        var rsp = ctx[CpuRegister.Rsp];
+        if (!ctx.TryReadUInt64(rsp + sizeof(ulong), out var sidebandAddress))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidAddress);
+        }
+
+        if (batchAddress == 0 || instanceId == 0 || sidebandAddress == 0)
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
+        }
+
+        if (inputSize > MaxJobBufferSize || outputSize > MaxJobBufferSize)
+        {
+            return ctx.SetReturn(OrbisAjmErrorBufferTooBig);
+        }
+
+        if (!IsReadableRange(ctx, inputAddress, inputSize) ||
+            (outputSize != 0 && outputAddress == 0))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidAddress);
+        }
+
+        var memoryState = MemoryStates.GetValue(ctx.Memory, static _ => new AjmMemoryState());
+        lock (memoryState.Gate)
+        {
+            if (!memoryState.Builders.TryGetValue(batchAddress, out var builder))
+            {
+                return ctx.SetReturn(OrbisAjmErrorInvalidBatch);
+            }
+
+            builder.DecodeJobs.Add(new AjmDecodeJob(
+                instanceId,
+                inputAddress,
+                inputSize,
+                outputAddress,
+                outputSize,
+                sidebandAddress));
+        }
+
+        TraceBatch(
+            $"decode batch=0x{batchAddress:X16} instance={instanceId} " +
+            $"input=0x{inputAddress:X16}+0x{inputSize:X} output=0x{outputAddress:X16}+0x{outputSize:X}");
+        return ctx.SetReturn(0);
+    }
+
+    [SysAbiExport(
+        Nid = "5tOfnaClcqM",
+        ExportName = "sceAjmBatchStart",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAjm")]
+    public static int AjmBatchStart(CpuContext ctx)
+    {
+        var contextId = unchecked((uint)ctx[CpuRegister.Rdi]);
+        var batchAddress = ctx[CpuRegister.Rsi];
+        var batchSize = ctx[CpuRegister.Rdx];
+        var priority = unchecked((int)ctx[CpuRegister.Rcx]);
+        var outBatchIdAddress = ctx[CpuRegister.R8];
+        if (batchAddress == 0 || outBatchIdAddress == 0)
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
+        }
+
+        if (batchSize == 0 || (batchSize & 7) != 0)
+        {
+            return ctx.SetReturn(OrbisAjmErrorMalformedBatch);
+        }
+
+        if (!Contexts.TryGetValue(contextId, out var context))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidContext);
+        }
+
+        List<AjmDecodeJob> jobs;
+        var memoryState = MemoryStates.GetValue(ctx.Memory, static _ => new AjmMemoryState());
+        lock (memoryState.Gate)
+        {
+            if (!memoryState.Builders.TryGetValue(batchAddress, out var builder))
+            {
+                return ctx.SetReturn(OrbisAjmErrorInvalidBatch);
+            }
+
+            jobs = new List<AjmDecodeJob>(builder.DecodeJobs);
+        }
+
+        Dictionary<uint, AjmInstanceState> instances;
+        lock (context.Gate)
+        {
+            instances = new Dictionary<uint, AjmInstanceState>(jobs.Count);
+            foreach (var job in jobs)
+            {
+                if (!context.Instances.TryGetValue(job.InstanceId, out var instance))
+                {
+                    return ctx.SetReturn(OrbisAjmErrorInvalidInstance);
+                }
+
+                instances[job.InstanceId] = instance;
+            }
+        }
+
+        lock (memoryState.Gate)
+        {
+            memoryState.Builders.Remove(batchAddress);
+        }
+
+        foreach (var job in jobs)
+        {
+            if (!TryCompleteDecode(ctx, job, instances[job.InstanceId]))
+            {
+                return ctx.SetReturn(OrbisAjmErrorInvalidAddress);
+            }
+        }
+
+        uint batchId;
+        lock (context.Gate)
+        {
+            batchId = ++context.NextBatchId;
+            if (batchId == 0)
+            {
+                batchId = ++context.NextBatchId;
+            }
+
+            if (!context.CompletedBatches.Add(batchId))
+            {
+                return ctx.SetReturn(OrbisAjmErrorOutOfMemory);
+            }
+        }
+
+        Span<byte> value = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(value, batchId);
+        if (!ctx.Memory.TryWrite(outBatchIdAddress, value))
+        {
+            lock (context.Gate)
+            {
+                context.CompletedBatches.Remove(batchId);
+            }
+
+            return ctx.SetReturn(OrbisAjmErrorInvalidAddress);
+        }
+
+        TraceBatch(
+            $"start context={contextId} batch={batchId} address=0x{batchAddress:X16} " +
+            $"size=0x{batchSize:X} priority={priority} jobs={jobs.Count}");
+        return ctx.SetReturn(0);
+    }
+
+    [SysAbiExport(
+        Nid = "-qLsfDAywIY",
+        ExportName = "sceAjmBatchWait",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAjm")]
+    public static int AjmBatchWait(CpuContext ctx)
+    {
+        var contextId = unchecked((uint)ctx[CpuRegister.Rdi]);
+        var batchId = unchecked((uint)ctx[CpuRegister.Rsi]);
+        var batchErrorAddress = ctx[CpuRegister.Rcx];
+        if (!Contexts.TryGetValue(contextId, out var context))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidContext);
+        }
+
+        lock (context.Gate)
+        {
+            if (!context.CompletedBatches.Remove(batchId))
+            {
+                return ctx.SetReturn(OrbisAjmErrorInvalidBatch);
+            }
+        }
+
+        if (batchErrorAddress != 0 && !TryZeroMemory(ctx, batchErrorAddress, 32))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidAddress);
+        }
+
+        TraceBatch($"wait context={contextId} batch={batchId}");
+        return ctx.SetReturn(0);
+    }
+
+    private static bool TryCompleteDecode(CpuContext ctx, AjmDecodeJob job, AjmInstanceState instance)
+    {
+        if (!TryZeroMemory(ctx, job.OutputAddress, job.OutputSize) ||
+            !TryZeroMemory(ctx, job.SidebandAddress, 32))
+        {
+            return false;
+        }
+
+        var inputConsumed = checked((int)job.InputSize);
+        var outputWritten = checked((int)job.OutputSize);
+        ulong totalDecodedSamples;
+        lock (instance)
+        {
+            instance.TotalDecodedSamples += CalculateDecodedSamples(job.OutputSize, instance.Flags);
+            totalDecodedSamples = instance.TotalDecodedSamples;
+        }
+
+        return ctx.TryWriteInt32(job.SidebandAddress, 0) &&
+            ctx.TryWriteInt32(job.SidebandAddress + 4, 0) &&
+            ctx.TryWriteInt32(job.SidebandAddress + 8, inputConsumed) &&
+            ctx.TryWriteInt32(job.SidebandAddress + 12, outputWritten) &&
+            ctx.TryWriteUInt64(job.SidebandAddress + 16, totalDecodedSamples);
+    }
+
+    private static ulong CalculateDecodedSamples(ulong outputSize, ulong instanceFlags)
+    {
+        var channels = (instanceFlags >> 3) & 0xF;
+        if (channels == 0)
+        {
+            channels = 1;
+        }
+
+        var encoding = (instanceFlags >> 7) & 0x7;
+        var bytesPerSample = encoding == 0 ? 2UL : 4UL;
+        return outputSize / (channels * bytesPerSample);
+    }
+
+    private static bool IsReadableRange(CpuContext ctx, ulong address, ulong size)
+    {
+        if (size == 0)
+        {
+            return true;
+        }
+
+        if (address == 0 || address > ulong.MaxValue - (size - 1))
+        {
+            return false;
+        }
+
+        return ctx.TryReadByte(address, out _) && ctx.TryReadByte(address + size - 1, out _);
+    }
+
+    private static bool TryZeroMemory(CpuContext ctx, ulong address, ulong size)
+    {
+        if (size == 0)
+        {
+            return true;
+        }
+
+        if (address == 0 || size > MaxJobBufferSize || address > ulong.MaxValue - (size - 1))
+        {
+            return false;
+        }
+
+        Span<byte> zeros = stackalloc byte[4096];
+        var remaining = size;
+        var current = address;
+        while (remaining != 0)
+        {
+            var chunkSize = (int)Math.Min((ulong)zeros.Length, remaining);
+            if (!ctx.Memory.TryWrite(current, zeros[..chunkSize]))
+            {
+                return false;
+            }
+
+            current += unchecked((ulong)chunkSize);
+            remaining -= unchecked((ulong)chunkSize);
+        }
+
+        return true;
+    }
+
+    private static void TraceBatch(string message)
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_AJM"), "1", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var count = Interlocked.Increment(ref _batchTraceCount);
+        if (count <= 16 || count % 1000 == 0)
+        {
+            Console.Error.WriteLine($"[LOADER][TRACE] ajm.{message}");
+        }
     }
 }

--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -17,6 +17,7 @@ public static class AudioOut2Exports
     private const int AudioOut2ContextParamSize = 0x40;
     private const int AudioOut2ContextMemorySize = 0x10000;
     private const int AudioOut2ContextMemoryAlignment = 0x10000;
+    private const uint SpeakerArrayMemorySize = 0x10000;
     private static long _nextContextHandle = 1;
     private static long _nextUserHandle = 1;
     private static int _nextPortId;
@@ -182,6 +183,36 @@ public static class AudioOut2Exports
     {
         Contexts.TryRemove(ctx[CpuRegister.Rdi], out _);
         return SetReturn(ctx, 0);
+    }
+
+    [SysAbiExport(
+        Nid = "G1YOKDJYX2Y",
+        ExportName = "sceAudioOut2GetSpeakerArrayMemorySize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2GetSpeakerArrayMemorySize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = SpeakerArrayMemorySize;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "+k91hoTuoA8",
+        ExportName = "sceAudioOut2SpeakerArrayCreate",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2SpeakerArrayCreate(CpuContext ctx)
+    {
+        var outHandleAddress = ctx[CpuRegister.Rdi];
+        if (outHandleAddress == 0)
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        var handle = (ulong)Interlocked.Increment(ref _nextContextHandle);
+        return TryWriteUInt64(ctx, outHandleAddress, handle)
+            ? SetReturn(ctx, 0)
+            : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
     }
 
     [SysAbiExport(

--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -16,7 +16,6 @@ public static class AudioOut2Exports
     // following the 0x40-byte parameter block.
     private const int AudioOut2ContextParamSize = 0x40;
     private const int AudioOut2ContextMemorySize = 0x10000;
-    private const int AudioOut2ContextMemoryAlignment = 0x10000;
     private const uint SpeakerArrayMemorySize = 0x10000;
     private static long _nextContextHandle = 1;
     private static long _nextUserHandle = 1;
@@ -113,20 +112,16 @@ public static class AudioOut2Exports
     public static int AudioOut2ContextQueryMemory(CpuContext ctx)
     {
         var paramAddress = ctx[CpuRegister.Rdi];
-        var memoryInfoAddress = ctx[CpuRegister.Rsi];
-        if (paramAddress == 0 || memoryInfoAddress == 0)
+        var outMemorySizeAddress = ctx[CpuRegister.Rsi];
+        if (paramAddress == 0 || outMemorySizeAddress == 0)
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        Span<byte> memoryInfo = stackalloc byte[0x20];
-        memoryInfo.Clear();
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x00..], AudioOut2ContextMemorySize);
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x08..], AudioOut2ContextMemoryAlignment);
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x10..], AudioOut2ContextMemorySize);
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x18..], AudioOut2ContextMemoryAlignment);
-
-        return ctx.Memory.TryWrite(memoryInfoAddress, memoryInfo)
+        // The second argument is a pointer to one uint64_t, not a larger memory-info
+        // structure. Writing past these eight bytes corrupts callers that keep the
+        // output in a stack slot (including GTA V's saved stack canary).
+        return ctx.TryWriteUInt64(outMemorySizeAddress, AudioOut2ContextMemorySize)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
     }
@@ -271,11 +266,26 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2ContextGetQueueLevel(CpuContext ctx)
     {
-        // The advance path paces synchronously, so the queue is always drained.
-        var levelAddress = ctx[CpuRegister.Rsi];
-        if (levelAddress != 0)
+        var handle = ctx[CpuRegister.Rdi];
+        var outQueueLevelAddress = ctx[CpuRegister.Rsi];
+        var outQueueAvailableAddress = ctx[CpuRegister.Rdx];
+        if (handle == 0)
         {
-            _ = TryWriteUInt64(ctx, levelAddress, 0);
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        // Both outputs are uint32_t values. GTA V places the level output four
+        // bytes before its stack canary, so an eight-byte write corrupts it.
+        if (outQueueLevelAddress != 0 && !ctx.TryWriteUInt32(outQueueLevelAddress, 0))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        // Nothing is queued to real hardware: report an empty queue with room
+        // available so submitters keep flowing.
+        if (outQueueAvailableAddress != 0 && !ctx.TryWriteUInt32(outQueueAvailableAddress, 4))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
         return SetReturn(ctx, 0);

--- a/src/SharpEmu.Libs/Gpu/GuestGpuTypes.cs
+++ b/src/SharpEmu.Libs/Gpu/GuestGpuTypes.cs
@@ -27,7 +27,9 @@ internal sealed record GuestDrawTexture(
     uint Pitch = 0,
     uint TileMode = 0,
     uint DstSelect = 0xFAC,
-    GuestSampler Sampler = default);
+    GuestSampler Sampler = default,
+    uint Depth = 1,
+    uint Type = 9);
 
 /// <summary>Raw guest sampler descriptor dwords, copied verbatim from guest memory.</summary>
 internal readonly record struct GuestSampler(
@@ -146,7 +148,9 @@ internal sealed record GuestRenderTarget(
     uint Height,
     uint Format,
     uint NumberType,
-    uint MipLevels = 1);
+    uint MipLevels = 1,
+    uint Depth = 1,
+    uint Type = 9);
 
 /// <summary>Guest DB surface bound alongside a color render target.</summary>
 internal sealed record GuestDepthTarget(

--- a/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
@@ -85,6 +85,10 @@ public static partial class KernelMemoryCompatExports
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
+        catch (ObjectDisposedException)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
 
         if (read > 0 && !ctx.Memory.TryWrite(bufferAddress, buffer.AsSpan(0, read)))
         {

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -2052,75 +2052,7 @@ public static partial class KernelMemoryCompatExports
         ExportName = "_pread",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libKernel")]
-    public static int KernelPreadUnderscore(CpuContext ctx)
-    {
-        var fd = unchecked((int)ctx[CpuRegister.Rdi]);
-        var bufferAddress = ctx[CpuRegister.Rsi];
-        var requested = (int)Math.Min(ctx[CpuRegister.Rdx], int.MaxValue);
-        var offset = unchecked((long)ctx[CpuRegister.Rcx]);
-        if (requested < 0 || offset < 0 || (requested > 0 && bufferAddress == 0))
-        {
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
-        }
-
-        if (requested == 0)
-        {
-            ctx[CpuRegister.Rax] = 0;
-            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
-        }
-
-        FileStream? stream;
-        lock (_fdGate)
-        {
-            _openFiles.TryGetValue(fd, out stream);
-        }
-
-        if (stream is null)
-        {
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
-        }
-
-        var buffer = GC.AllocateUninitializedArray<byte>(requested);
-        int read;
-        try
-        {
-            // Positional read that leaves the descriptor's file position
-            // untouched, matching pread semantics.
-            read = RandomAccess.Read(stream.SafeFileHandle, buffer.AsSpan(0, requested), offset);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
-        {
-            LogIoTrace("pread", stream.Name, $"fd={fd} req={requested} offset={offset} error={ex.GetType().Name}");
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
-        }
-
-        if (read > 0 && !ctx.Memory.TryWrite(bufferAddress, buffer.AsSpan(0, read)))
-        {
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
-        }
-
-        LogIoTrace(
-            "pread",
-            stream.Name,
-            $"fd={fd} req={requested} offset={offset} read={read} preview='{PreviewIoBytes(buffer, read, 64)}' hex={PreviewIoHex(buffer, read, 32)}");
-
-        ctx[CpuRegister.Rax] = unchecked((ulong)read);
-        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
-    }
-
-    [SysAbiExport(
-        Nid = "ezv-RSBNKqI",
-        ExportName = "pread",
-        Target = Generation.Gen4 | Generation.Gen5,
-        LibraryName = "libKernel")]
-    public static int PosixPread(CpuContext ctx) => KernelPreadUnderscore(ctx);
-
-    [SysAbiExport(
-        Nid = "+r3rMFwItV4",
-        ExportName = "sceKernelPread",
-        Target = Generation.Gen4 | Generation.Gen5,
-        LibraryName = "libKernel")]
-    public static int KernelPread(CpuContext ctx) => KernelPreadUnderscore(ctx);
+    public static int KernelPreadUnderscore(CpuContext ctx) => KernelPreadCore(ctx);
 
     [SysAbiExport(
         Nid = "Oy6IpwgtYOk",

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -51,6 +51,7 @@ public static partial class KernelMemoryCompatExports
     private const int SeekCur = 1;
     private const int SeekEnd = 2;
     private const ulong DirectMemorySizeBytes = 16384UL * 1024 * 1024;
+    private const int DirectMemoryQueryFindNext = 0x1;
     private const ulong UnsetMainDirectMemoryPoolBase = ulong.MaxValue;
     private const ulong FlexibleMemorySizeBytes = 448UL * 1024 * 1024;
     private const int OrbisVirtualQueryInfoSize = 72;
@@ -2047,6 +2048,81 @@ public static partial class KernelMemoryCompatExports
     public static int KernelRead(CpuContext ctx) => KernelReadUnderscore(ctx);
 
     [SysAbiExport(
+        Nid = "OYL2VFX66hU",
+        ExportName = "_pread",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelPreadUnderscore(CpuContext ctx)
+    {
+        var fd = unchecked((int)ctx[CpuRegister.Rdi]);
+        var bufferAddress = ctx[CpuRegister.Rsi];
+        var requested = (int)Math.Min(ctx[CpuRegister.Rdx], int.MaxValue);
+        var offset = unchecked((long)ctx[CpuRegister.Rcx]);
+        if (requested < 0 || offset < 0 || (requested > 0 && bufferAddress == 0))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (requested == 0)
+        {
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        FileStream? stream;
+        lock (_fdGate)
+        {
+            _openFiles.TryGetValue(fd, out stream);
+        }
+
+        if (stream is null)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+        }
+
+        var buffer = GC.AllocateUninitializedArray<byte>(requested);
+        int read;
+        try
+        {
+            // Positional read that leaves the descriptor's file position
+            // untouched, matching pread semantics.
+            read = RandomAccess.Read(stream.SafeFileHandle, buffer.AsSpan(0, requested), offset);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            LogIoTrace("pread", stream.Name, $"fd={fd} req={requested} offset={offset} error={ex.GetType().Name}");
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (read > 0 && !ctx.Memory.TryWrite(bufferAddress, buffer.AsSpan(0, read)))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        LogIoTrace(
+            "pread",
+            stream.Name,
+            $"fd={fd} req={requested} offset={offset} read={read} preview='{PreviewIoBytes(buffer, read, 64)}' hex={PreviewIoHex(buffer, read, 32)}");
+
+        ctx[CpuRegister.Rax] = unchecked((ulong)read);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "ezv-RSBNKqI",
+        ExportName = "pread",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixPread(CpuContext ctx) => KernelPreadUnderscore(ctx);
+
+    [SysAbiExport(
+        Nid = "+r3rMFwItV4",
+        ExportName = "sceKernelPread",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelPread(CpuContext ctx) => KernelPreadUnderscore(ctx);
+
+    [SysAbiExport(
         Nid = "Oy6IpwgtYOk",
         ExportName = "lseek",
         Target = Generation.Gen4 | Generation.Gen5,
@@ -3258,7 +3334,7 @@ public static partial class KernelMemoryCompatExports
     public static int KernelDirectMemoryQuery(CpuContext ctx)
     {
         var offset = ctx[CpuRegister.Rdi];
-        _ = ctx[CpuRegister.Rsi]; // flags
+        var flags = unchecked((int)ctx[CpuRegister.Rsi]);
         var infoAddress = ctx[CpuRegister.Rdx];
         var infoSize = ctx[CpuRegister.Rcx];
         if (infoAddress == 0 || infoSize < 24)
@@ -3266,27 +3342,49 @@ public static partial class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
+        var findNext = (flags & DirectMemoryQueryFindNext) != 0;
+        var found = false;
+        DirectAllocation match = default;
         lock (_memoryGate)
         {
             foreach (var block in _directAllocations.Values)
             {
-                if (offset < block.Start || offset >= block.Start + block.Length)
+                if (offset >= block.Start + block.Length)
                 {
                     continue;
                 }
 
-                if (!ctx.TryWriteUInt64(infoAddress, block.Start) ||
-                    !ctx.TryWriteUInt64(infoAddress + sizeof(ulong), block.Start + block.Length) ||
-                    !TryWriteInt32(ctx, infoAddress + (sizeof(ulong) * 2), block.MemoryType))
+                // Blocks above the queried offset only count in FIND_NEXT
+                // mode; otherwise the offset must fall inside the block.
+                if (offset < block.Start && !findNext)
                 {
-                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+                    continue;
                 }
 
-                return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                if (!found || block.Start < match.Start)
+                {
+                    match = block;
+                    found = true;
+                }
             }
         }
 
-        return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+        if (!found)
+        {
+            // The kernel reports unallocated areas with the EACCES code;
+            // titles use it as the stop condition when walking direct
+            // memory with FIND_NEXT.
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_ACCESS_DENIED;
+        }
+
+        if (!ctx.TryWriteUInt64(infoAddress, match.Start) ||
+            !ctx.TryWriteUInt64(infoAddress + sizeof(ulong), match.Start + match.Length) ||
+            !TryWriteInt32(ctx, infoAddress + (sizeof(ulong) * 2), match.MemoryType))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     [SysAbiExport(

--- a/src/SharpEmu.Libs/Remoteplay/RemoteplayExports.cs
+++ b/src/SharpEmu.Libs/Remoteplay/RemoteplayExports.cs
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+
+namespace SharpEmu.Libs.Remoteplay;
+
+public static class RemoteplayExports
+{
+    private const int RemoteplayConnectionStatusDisconnected = 0;
+
+    [SysAbiExport(
+        Nid = "k1SwgkMSOM8",
+        ExportName = "sceRemoteplayInitialize",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceRemoteplay")]
+    public static int RemoteplayInitialize(CpuContext ctx) => ctx.SetReturn(0);
+
+    [SysAbiExport(
+        Nid = "g3PNjYKWqnQ",
+        ExportName = "sceRemoteplayGetConnectionStatus",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceRemoteplay")]
+    public static int RemoteplayGetConnectionStatus(CpuContext ctx)
+    {
+        var statusAddress = ctx[CpuRegister.Rsi];
+        if (statusAddress == 0)
+        {
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        // No remote play session ever exists under emulation.
+        return ctx.TryWriteInt32(statusAddress, RemoteplayConnectionStatusDisconnected)
+            ? ctx.SetReturn(0)
+            : ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+    }
+}

--- a/src/SharpEmu.Libs/SystemService/SystemServiceExports.cs
+++ b/src/SharpEmu.Libs/SystemService/SystemServiceExports.cs
@@ -156,4 +156,11 @@ public static class SystemServiceExports
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libSceSystemService")]
     public static int SystemServiceReportAbnormalTermination(CpuContext ctx) => ctx.SetReturn(0);
+
+    [SysAbiExport(
+        Nid = "8Lo6Zv94aho",
+        ExportName = "sceSystemServiceDisableNoticeScreenSkipFlagAutoSet",
+        Target = Generation.Gen5,
+        LibraryName = "libSceSystemService")]
+    public static int SystemServiceDisableNoticeScreenSkipFlagAutoSet(CpuContext ctx) => ctx.SetReturn(0);
 }

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1431,6 +1431,17 @@ internal static unsafe class VulkanVideoPresenter
     {
         var format = (dataFormat, numberType) switch
         {
+            (1, 1) => Format.R8SNorm,
+            (1, 4) => Format.R8Uint,
+            (1, 5) => Format.R8Sint,
+            (2, 0) => Format.R16Unorm,
+            (2, 1) => Format.R16SNorm,
+            (2, 4) => Format.R16Uint,
+            (2, 5) => Format.R16Sint,
+            (2, 7) => Format.R16Sfloat,
+            (3, 1) => Format.R8G8SNorm,
+            (3, 4) => Format.R8G8Uint,
+            (3, 5) => Format.R8G8Sint,
             (4, 4) => Format.R32Uint,
             (4, 5) => Format.R32Sint,
             (4, 7) => Format.R32Sfloat,
@@ -1438,15 +1449,21 @@ internal static unsafe class VulkanVideoPresenter
             (5, 5) => Format.R16G16Sint,
             (5, 7) => Format.R16G16Sfloat,
             (6, 7) or (7, 7) => Format.B10G11R11UfloatPack32,
+            (8, 4) => Format.A2B10G10R10UintPack32,
+            (8, _) => Format.A2B10G10R10UnormPack32,
             (9, _) => Format.A2R10G10B10UnormPack32,
             (10, 4) => Format.R8G8B8A8Uint,
             (10, 5) => Format.R8G8B8A8Sint,
             (10, 9) => Format.R8G8B8A8Srgb,
             (10, _) => Format.R8G8B8A8Unorm,
+            (11, 4) => Format.R32G32Uint,
+            (11, 5) => Format.R32G32Sint,
             (11, 7) => Format.R32G32Sfloat,
             (12, 4) => Format.R16G16B16A16Uint,
             (12, 5) => Format.R16G16B16A16Sint,
             (12, 7) => Format.R16G16B16A16Sfloat,
+            (14, 4) => Format.R32G32B32A32Uint,
+            (14, 5) => Format.R32G32B32A32Sint,
             (13, 7) or (14, 7) => Format.R32G32B32A32Sfloat,
             (20, 0) => Format.R32Uint,
             (29, 0) or (4, 0) => Format.R32Sfloat,
@@ -1471,10 +1488,13 @@ internal static unsafe class VulkanVideoPresenter
 
         var outputKind = format switch
         {
-            Format.R8Uint or Format.R32Uint or Format.R16G16Uint or
-                Format.R8G8B8A8Uint or Format.R16G16B16A16Uint => Gen5PixelOutputKind.Uint,
-            Format.R32Sint or Format.R16G16Sint or Format.R8G8B8A8Sint or
-                Format.R16G16B16A16Sint => Gen5PixelOutputKind.Sint,
+            Format.R8Uint or Format.R16Uint or Format.R8G8Uint or Format.R32Uint or
+                Format.R16G16Uint or Format.A2B10G10R10UintPack32 or Format.R8G8B8A8Uint or
+                Format.R32G32Uint or Format.R16G16B16A16Uint or
+                Format.R32G32B32A32Uint => Gen5PixelOutputKind.Uint,
+            Format.R8Sint or Format.R16Sint or Format.R8G8Sint or Format.R32Sint or
+                Format.R16G16Sint or Format.R8G8B8A8Sint or Format.R32G32Sint or
+                Format.R16G16B16A16Sint or Format.R32G32B32A32Sint => Gen5PixelOutputKind.Sint,
             _ => Gen5PixelOutputKind.Float,
         };
         result = new VulkanRenderTargetFormat(format, outputKind);
@@ -8383,6 +8403,19 @@ internal static unsafe class VulkanVideoPresenter
         private static Format GetRenderTargetFormat(uint format, uint numberType) =>
             (format, numberType) switch
             {
+                (1, 0) => Format.R8Unorm,
+                (1, 1) => Format.R8SNorm,
+                (1, 4) => Format.R8Uint,
+                (1, 5) => Format.R8Sint,
+                (2, 0) => Format.R16Unorm,
+                (2, 1) => Format.R16SNorm,
+                (2, 4) => Format.R16Uint,
+                (2, 5) => Format.R16Sint,
+                (2, 7) => Format.R16Sfloat,
+                (3, 0) => Format.R8G8Unorm,
+                (3, 1) => Format.R8G8SNorm,
+                (3, 4) => Format.R8G8Uint,
+                (3, 5) => Format.R8G8Sint,
                 (4, 4) => Format.R32Uint,
                 (4, 5) => Format.R32Sint,
                 (4, 7) => Format.R32Sfloat,
@@ -8391,16 +8424,22 @@ internal static unsafe class VulkanVideoPresenter
                 (5, 7) => Format.R16G16Sfloat,
                 (6, 7) => Format.B10G11R11UfloatPack32,
                 (7, 7) => Format.B10G11R11UfloatPack32,
+                (8, 4) => Format.A2B10G10R10UintPack32,
+                (8, _) => Format.A2B10G10R10UnormPack32,
                 (9, _) => Format.A2B10G10R10UnormPack32,
                 (10, 9) => Format.R8G8B8A8Srgb,
                 (10, 4) => Format.R8G8B8A8Uint,
                 (10, 5) => Format.R8G8B8A8Sint,
                 (10, _) => Format.R8G8B8A8Unorm,
+                (11, 4) => Format.R32G32Uint,
+                (11, 5) => Format.R32G32Sint,
                 (11, 7) => Format.R32G32Sfloat,
                 (12, 4) => Format.R16G16B16A16Uint,
                 (12, 5) => Format.R16G16B16A16Sint,
                 (12, 7) => Format.R16G16B16A16Sfloat,
                 (13, 7) => Format.R32G32B32A32Sfloat,
+                (14, 4) => Format.R32G32B32A32Uint,
+                (14, 5) => Format.R32G32B32A32Sint,
                 (14, 7) => Format.R32G32B32A32Sfloat,
                 (_, 0) => GetTextureFormat(format, numberType),
                 (_, 9) => GetTextureFormat(format, numberType),

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1252,7 +1252,9 @@ internal static unsafe class VulkanVideoPresenter
         uint DstSelect,
         uint TileMode,
         uint Pitch,
-        GuestSampler Sampler);
+        GuestSampler Sampler,
+        uint Depth,
+        uint Type);
 
     // Guest memory handle for render-thread self-healing: when a draw whose
     // texel copy was skipped misses the texture cache (eviction, cache
@@ -2327,6 +2329,8 @@ internal static unsafe class VulkanVideoPresenter
             ulong Address,
             uint Width,
             uint Height,
+            uint Depth,
+            uint Type,
             uint MipLevels,
             uint GuestFormat,
             Format Format);
@@ -2488,6 +2492,7 @@ internal static unsafe class VulkanVideoPresenter
             public ImageView View;
             public uint Width;
             public uint Height;
+            public uint Depth = 1;
             public uint RowLength;
             public uint DstSelect;
             public bool NeedsUpload;
@@ -2581,6 +2586,8 @@ internal static unsafe class VulkanVideoPresenter
             public long FlipVersion;
             public uint Width;
             public uint Height;
+            public uint Depth = 1;
+            public uint Type = 9;
             public uint MipLevels;
             public uint GuestFormat;
             public Format Format;
@@ -2857,11 +2864,11 @@ internal static unsafe class VulkanVideoPresenter
         }
 
         private static string GuestImageDebugName(GuestRenderTarget target, Format format) =>
-            $"SharpEmu guest 0x{target.Address:X16} {target.Width}x{target.Height} " +
+            $"SharpEmu guest 0x{target.Address:X16} {target.Width}x{target.Height}x{target.Depth} " +
             $"fmt{target.Format}/{format}";
 
         private static string TextureDebugName(GuestDrawTexture texture, Format format) =>
-            $"SharpEmu texture 0x{texture.Address:X16} {texture.Width}x{texture.Height} " +
+            $"SharpEmu texture 0x{texture.Address:X16} {texture.Width}x{texture.Height}x{texture.Depth} " +
             $"fmt{texture.Format}/{format}";
 
         private void CreateInstance()
@@ -4624,7 +4631,7 @@ internal static unsafe class VulkanVideoPresenter
             var rowLength = texture.TileMode == 0
                 ? Math.Max(texture.Pitch, width)
                 : width;
-            var byteCount = GetTextureByteCount(texture.Format, rowLength, height);
+            var byteCount = GetTextureByteCount(texture.Format, rowLength, height) * texture.Depth;
             if (byteCount == 0 || byteCount > int.MaxValue)
             {
                 return null;
@@ -6181,7 +6188,7 @@ internal static unsafe class VulkanVideoPresenter
             var rowLength = texture.TileMode == 0
                 ? Math.Max(texture.Pitch, texture.Width)
                 : texture.Width;
-            var expectedSize = GetTextureByteCount(texture.Format, rowLength, texture.Height);
+            var expectedSize = GetTextureByteCount(texture.Format, rowLength, texture.Height) * texture.Depth;
             if (expectedSize == 0 || expectedSize > int.MaxValue)
             {
                 return false;
@@ -6216,6 +6223,7 @@ internal static unsafe class VulkanVideoPresenter
                 View = view,
                 Width = guestImage.Width,
                 Height = guestImage.Height,
+                Depth = guestImage.Depth,
                 RowLength = rowLength,
                 DstSelect = texture.DstSelect,
                 NeedsUpload = true,
@@ -6418,7 +6426,9 @@ internal static unsafe class VulkanVideoPresenter
                 texture.DstSelect,
                 texture.TileMode,
                 texture.Pitch,
-                texture.Sampler);
+                texture.Sampler,
+                texture.Depth,
+                texture.Type);
             if (_textureCache.TryGetValue(key, out var cached))
             {
                 return cached;
@@ -6544,12 +6554,16 @@ internal static unsafe class VulkanVideoPresenter
             GuestImageResource guestImage)
         {
             if (guestImage.Width == texture.Width &&
-                guestImage.Height == texture.Height)
+                guestImage.Height == texture.Height &&
+                guestImage.Depth == texture.Depth &&
+                guestImage.Type == texture.Type)
             {
                 return true;
             }
 
-            if (texture.TileMode == 0 ||
+            if (texture.Type != 9 ||
+                guestImage.Type != 9 ||
+                texture.TileMode == 0 ||
                 texture.Width == 0 ||
                 texture.Height == 0)
             {
@@ -6597,7 +6611,7 @@ internal static unsafe class VulkanVideoPresenter
                 var expectedSize = GetTextureByteCount(
                     texture.Format,
                     texture.Width,
-                    texture.Height);
+                    texture.Height) * texture.Depth;
                 if ((ulong)texture.RgbaPixels.Length == expectedSize &&
                     texture.RgbaPixels.AsSpan().IndexOfAnyExcept((byte)0) >= 0)
                 {
@@ -6648,13 +6662,15 @@ internal static unsafe class VulkanVideoPresenter
         {
             var width = Math.Max(texture.Width, 1);
             var height = Math.Max(texture.Height, 1);
+            var depth = Math.Max(texture.Depth, 1);
+            var is3D = texture.Type == 10;
             var vkFormat = GetTextureFormat(texture.Format, texture.NumberType);
             var imageInfo = new ImageCreateInfo
             {
                 SType = StructureType.ImageCreateInfo,
-                ImageType = ImageType.Type2D,
+                ImageType = is3D ? ImageType.Type3D : ImageType.Type2D,
                 Format = vkFormat,
-                Extent = new Extent3D(width, height, 1),
+                Extent = new Extent3D(width, height, is3D ? depth : 1),
                 MipLevels = 1,
                 ArrayLayers = 1,
                 Samples = SampleCountFlags.Count1Bit,
@@ -6690,7 +6706,7 @@ internal static unsafe class VulkanVideoPresenter
             {
                 SType = StructureType.ImageViewCreateInfo,
                 Image = image,
-                ViewType = ImageViewType.Type2D,
+                ViewType = is3D ? ImageViewType.Type3D : ImageViewType.Type2D,
                 Format = vkFormat,
                 Components = new ComponentMapping(
                     ComponentSwizzle.Identity,
@@ -6710,6 +6726,8 @@ internal static unsafe class VulkanVideoPresenter
                 Address = 0,
                 Width = width,
                 Height = height,
+                Depth = depth,
+                Type = texture.Type,
                 MipLevels = 1,
                 GuestFormat = GetGuestTextureFormat(texture.Format, texture.NumberType),
                 Format = vkFormat,
@@ -6726,6 +6744,7 @@ internal static unsafe class VulkanVideoPresenter
                 View = view,
                 Width = width,
                 Height = height,
+                Depth = depth,
                 RowLength = width,
                 DstSelect = texture.DstSelect,
                 OwnsStorage = true,
@@ -6750,7 +6769,9 @@ internal static unsafe class VulkanVideoPresenter
                     texture.Height,
                     texture.Format,
                     texture.NumberType,
-                    texture.ResourceMipLevels),
+                    texture.ResourceMipLevels,
+                    texture.Depth,
+                    texture.Type),
                 format);
             var selectedMipLevel = GetStorageMipLevel(texture);
             if (selectedMipLevel >= guestImage.MipLevels)
@@ -6784,18 +6805,20 @@ internal static unsafe class VulkanVideoPresenter
         {
             var width = Math.Max(texture.Width, 1);
             var height = Math.Max(texture.Height, 1);
+            var depth = Math.Max(texture.Depth, 1);
+            var is3D = texture.Type == 10;
             var rowLength = texture.TileMode == 0
                 ? Math.Max(texture.Pitch, width)
                 : width;
             var vkFormat = GetTextureFormat(texture.Format, texture.NumberType);
 
-            var expectedSize = GetTextureByteCount(texture.Format, rowLength, height);
+            var expectedSize = GetTextureByteCount(texture.Format, rowLength, height) * depth;
             if (_tracedTextureUploads.Add((texture.Address, width, height, vkFormat)))
             {
                 Console.Error.WriteLine(
                     $"[LOADER][TRACE] vk.texture addr=0x{texture.Address:X16} " +
                     $"fmt={texture.Format} num={texture.NumberType} vk={vkFormat} " +
-                    $"size={width}x{height} row={rowLength} tile={texture.TileMode} " +
+                    $"size={width}x{height}x{depth} row={rowLength} tile={texture.TileMode} " +
                     $"dst=0x{texture.DstSelect:X3} " +
                     $"bytes={texture.RgbaPixels.Length} expected={expectedSize}");
             }
@@ -6810,8 +6833,11 @@ internal static unsafe class VulkanVideoPresenter
                     $"[LOADER][TRACE] vk.texture_force_white addr=0x{texture.Address:X16} " +
                     $"size={width}x{height} bytes={pixels.Length}");
             }
-            DumpTextureUpload(texture, pixels, rowLength, width, height);
-            TraceTextureUploadContents(texture, pixels, rowLength, width, height, vkFormat);
+            if (!is3D)
+            {
+                DumpTextureUpload(texture, pixels, rowLength, width, height);
+                TraceTextureUploadContents(texture, pixels, rowLength, width, height, vkFormat);
+            }
             var uploadPixels = texture.Format == 13
                 ? ExpandRgb32Pixels(pixels)
                 : pixels;
@@ -6821,27 +6847,26 @@ internal static unsafe class VulkanVideoPresenter
                 uploadPixels,
                 $"{TextureDebugName(texture, vkFormat)} staging");
 
-            var supportsAttachmentUsage = !IsBlockCompressedFormat(vkFormat);
+            var supportsAttachmentUsage = !is3D && !IsBlockCompressedFormat(vkFormat);
+            var supportsStorageUsage = !IsBlockCompressedFormat(vkFormat);
             var imageInfo = new ImageCreateInfo
             {
                 SType = StructureType.ImageCreateInfo,
                 Flags = supportsAttachmentUsage
                     ? ImageCreateFlags.CreateMutableFormatBit | ImageCreateFlags.CreateExtendedUsageBit
                     : 0,
-                ImageType = ImageType.Type2D,
+                ImageType = is3D ? ImageType.Type3D : ImageType.Type2D,
                 Format = vkFormat,
-                Extent = new Extent3D(width, height, 1),
+                Extent = new Extent3D(width, height, is3D ? depth : 1),
                 MipLevels = 1,
                 ArrayLayers = 1,
                 Samples = SampleCountFlags.Count1Bit,
                 Tiling = ImageTiling.Optimal,
-                Usage = supportsAttachmentUsage
-                    ? ImageUsageFlags.TransferDstBit |
-                      ImageUsageFlags.SampledBit |
-                      ImageUsageFlags.ColorAttachmentBit |
-                      ImageUsageFlags.StorageBit |
-                      ImageUsageFlags.TransferSrcBit
-                    : ImageUsageFlags.TransferDstBit | ImageUsageFlags.SampledBit,
+                Usage = ImageUsageFlags.TransferDstBit |
+                    ImageUsageFlags.SampledBit |
+                    ImageUsageFlags.TransferSrcBit |
+                    (supportsAttachmentUsage ? ImageUsageFlags.ColorAttachmentBit : 0) |
+                    (supportsStorageUsage ? ImageUsageFlags.StorageBit : 0),
                 SharingMode = SharingMode.Exclusive,
                 InitialLayout = ImageLayout.Undefined,
             };
@@ -6862,7 +6887,7 @@ internal static unsafe class VulkanVideoPresenter
             {
                 SType = StructureType.ImageViewCreateInfo,
                 Image = image,
-                ViewType = ImageViewType.Type2D,
+                ViewType = is3D ? ImageViewType.Type3D : ImageViewType.Type2D,
                 Format = vkFormat,
                 Components = ToVkComponentMapping(texture.DstSelect),
                 SubresourceRange = ColorSubresourceRange(),
@@ -6881,6 +6906,7 @@ internal static unsafe class VulkanVideoPresenter
                 View = view,
                 Width = width,
                 Height = height,
+                Depth = depth,
                 RowLength = rowLength,
                 DstSelect = texture.DstSelect,
                 NeedsUpload = true,
@@ -6899,6 +6925,8 @@ internal static unsafe class VulkanVideoPresenter
                     Address = texture.Address,
                     Width = width,
                     Height = height,
+                    Depth = depth,
+                    Type = texture.Type,
                     MipLevels = 1,
                     GuestFormat = guestFormat,
                     Format = vkFormat,
@@ -10000,7 +10028,7 @@ internal static unsafe class VulkanVideoPresenter
                         0,
                         1),
                     ImageOffset = default,
-                    ImageExtent = new Extent3D(target.Width, target.Height, 1),
+                    ImageExtent = new Extent3D(target.Width, target.Height, target.Depth),
                 };
                 _vk.CmdCopyBufferToImage(
                     commandBuffer,
@@ -10063,12 +10091,16 @@ internal static unsafe class VulkanVideoPresenter
             GuestRenderTarget target,
             Format format)
         {
-            var mipLevels = ClampMipLevels(target.Width, target.Height, target.MipLevels);
+            var is3D = target.Type == 10;
+            var depth = is3D ? Math.Max(target.Depth, 1) : 1u;
+            var mipLevels = ClampMipLevels(target.Width, target.Height, depth, target.MipLevels);
             var guestFormat = GetGuestTextureFormat(target.Format, target.NumberType);
             var requestedKey = new GuestImageVariantKey(
                 target.Address,
                 target.Width,
                 target.Height,
+                depth,
+                target.Type,
                 mipLevels,
                 guestFormat,
                 format);
@@ -10076,13 +10108,15 @@ internal static unsafe class VulkanVideoPresenter
             {
                 if (existing.Width == target.Width &&
                     existing.Height == target.Height &&
+                    existing.Depth == depth &&
+                    existing.Type == target.Type &&
                     existing.MipLevels == mipLevels &&
                     existing.GuestFormat == guestFormat &&
                     existing.Format == format)
                 {
                     existing.IsCpuBacked = false;
                     existing.CpuContentFingerprint = 0;
-                    if (existing.RenderPass.Handle == 0)
+                    if (!is3D && existing.RenderPass.Handle == 0)
                     {
                         var attachmentView = existing.MipViews.Length > 0
                             ? existing.MipViews[0]
@@ -10121,6 +10155,8 @@ internal static unsafe class VulkanVideoPresenter
                         existing.Address,
                         existing.Width,
                         existing.Height,
+                        existing.Depth,
+                        existing.Type,
                         existing.MipLevels,
                     existing.GuestFormat,
                     existing.Format),
@@ -10179,19 +10215,18 @@ internal static unsafe class VulkanVideoPresenter
                 Flags =
                     ImageCreateFlags.CreateMutableFormatBit |
                     ImageCreateFlags.CreateExtendedUsageBit,
-                ImageType = ImageType.Type2D,
+                ImageType = is3D ? ImageType.Type3D : ImageType.Type2D,
                 Format = format,
-                Extent = new Extent3D(target.Width, target.Height, 1),
+                Extent = new Extent3D(target.Width, target.Height, depth),
                 MipLevels = mipLevels,
                 ArrayLayers = 1,
                 Samples = SampleCountFlags.Count1Bit,
                 Tiling = ImageTiling.Optimal,
-                Usage =
-                    ImageUsageFlags.ColorAttachmentBit |
-                    ImageUsageFlags.SampledBit |
+                Usage = ImageUsageFlags.SampledBit |
                     ImageUsageFlags.StorageBit |
                     ImageUsageFlags.TransferSrcBit |
-                    ImageUsageFlags.TransferDstBit,
+                    ImageUsageFlags.TransferDstBit |
+                    (is3D ? 0 : ImageUsageFlags.ColorAttachmentBit),
                 SharingMode = SharingMode.Exclusive,
                 InitialLayout = ImageLayout.Undefined,
             };
@@ -10214,7 +10249,7 @@ internal static unsafe class VulkanVideoPresenter
             {
                 SType = StructureType.ImageViewCreateInfo,
                 Image = image,
-                ViewType = ImageViewType.Type2D,
+                ViewType = is3D ? ImageViewType.Type3D : ImageViewType.Type2D,
                 Format = format,
                 Components = new ComponentMapping(
                     ComponentSwizzle.Identity,
@@ -10242,18 +10277,25 @@ internal static unsafe class VulkanVideoPresenter
                 mipViews[mipLevel] = mipView;
             }
 
-            var (renderPass, initialRenderPass, framebuffer) =
-                CreateRenderPassAndFramebuffer(
+            RenderPass renderPass = default;
+            RenderPass initialRenderPass = default;
+            Framebuffer framebuffer = default;
+            if (!is3D)
+            {
+                (renderPass, initialRenderPass, framebuffer) = CreateRenderPassAndFramebuffer(
                     format,
                     mipViews[0],
                     target.Width,
                     target.Height);
+            }
 
             var resource = new GuestImageResource
             {
                 Address = target.Address,
                 Width = target.Width,
                 Height = target.Height,
+                Depth = depth,
+                Type = target.Type,
                 MipLevels = mipLevels,
                 GuestFormat = guestFormat,
                 Format = format,
@@ -10275,23 +10317,32 @@ internal static unsafe class VulkanVideoPresenter
                     mipViews[mipLevel].Handle,
                     $"{debugName} mip{mipLevel}");
             }
-            SetDebugName(ObjectType.RenderPass, renderPass.Handle, $"{debugName} renderpass");
-            SetDebugName(ObjectType.RenderPass, initialRenderPass.Handle, $"{debugName} initial-renderpass");
-            SetDebugName(ObjectType.Framebuffer, framebuffer.Handle, $"{debugName} framebuffer");
+            if (renderPass.Handle != 0)
+            {
+                SetDebugName(ObjectType.RenderPass, renderPass.Handle, $"{debugName} renderpass");
+            }
+            if (initialRenderPass.Handle != 0)
+            {
+                SetDebugName(ObjectType.RenderPass, initialRenderPass.Handle, $"{debugName} initial-renderpass");
+            }
+            if (framebuffer.Handle != 0)
+            {
+                SetDebugName(ObjectType.Framebuffer, framebuffer.Handle, $"{debugName} framebuffer");
+            }
             _guestImages.Add(target.Address, resource);
             lock (_gate)
             {
                 _guestImageExtents[target.Address] = (
                     target.Width,
                     target.Height,
-                    GetTextureByteCount(target.Format, target.Width, target.Height));
+                    GetTextureByteCount(target.Format, target.Width, target.Height) * depth);
             }
 
             if (target.Width <= 1920 && target.Height <= 1080)
             {
                 SharpEmu.HLE.GuestImageWriteTracker.Track(
                     target.Address,
-                    (ulong)target.Width * target.Height * GetTextureBytesPerPixel(target.Format),
+                    (ulong)target.Width * target.Height * depth * GetTextureBytesPerPixel(target.Format),
                     CurrentGuestWorkSequenceForDiagnostics,
                     "vulkan.render-target");
             }
@@ -10768,9 +10819,13 @@ internal static unsafe class VulkanVideoPresenter
             return renderPass;
         }
 
-        private static uint ClampMipLevels(uint width, uint height, uint requestedMipLevels)
+        private static uint ClampMipLevels(
+            uint width,
+            uint height,
+            uint depth,
+            uint requestedMipLevels)
         {
-            var largestDimension = Math.Max(width, height);
+            var largestDimension = Math.Max(Math.Max(width, height), depth);
             uint maximumMipLevels = 1;
             while (largestDimension > 1)
             {
@@ -10955,7 +11010,9 @@ internal static unsafe class VulkanVideoPresenter
             {
                 SType = StructureType.ImageViewCreateInfo,
                 Image = resource.Image,
-                ViewType = ImageViewType.Type2D,
+                ViewType = resource.Type == 10
+                    ? ImageViewType.Type3D
+                    : ImageViewType.Type2D,
                 Format = format,
                 Components = ToVkComponentMapping(dstSelect),
                 SubresourceRange = ColorSubresourceRange(mipLevel, levelCount),
@@ -11573,7 +11630,7 @@ internal static unsafe class VulkanVideoPresenter
                 return;
             }
 
-            var byteCount = checked((ulong)image.Width * image.Height * bytesPerPixel);
+            var byteCount = checked((ulong)image.Width * image.Height * image.Depth * bytesPerPixel);
             var buffer = CreateBuffer(
                 byteCount,
                 BufferUsageFlags.TransferDstBit,
@@ -11625,7 +11682,7 @@ internal static unsafe class VulkanVideoPresenter
                         AspectMask = ImageAspectFlags.ColorBit,
                         LayerCount = 1,
                     },
-                    ImageExtent = new Extent3D(image.Width, image.Height, 1),
+                    ImageExtent = new Extent3D(image.Width, image.Height, image.Depth),
                 };
                 _vk.CmdCopyImageToBuffer(
                     _commandBuffer,
@@ -11955,7 +12012,10 @@ internal static unsafe class VulkanVideoPresenter
                         AspectMask = ImageAspectFlags.ColorBit,
                         LayerCount = 1,
                     },
-                    ImageExtent = new Extent3D(texture.Width, texture.Height, 1),
+                    ImageExtent = new Extent3D(
+                        texture.Width,
+                        texture.Height,
+                        texture.Depth),
                 };
                 _vk.CmdCopyBufferToImage(
                     _commandBuffer,

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -6194,7 +6194,7 @@ internal static unsafe class VulkanVideoPresenter
 
             if (
                 !IsCompatibleGuestImageAlias(texture, source) ||
-                (!source.Initialized && !source.InitialUploadPending) ||
+                !source.Initialized ||
                 IsBlockCompressedFormat(source.Format) ||
                 IsBlockCompressedFormat(format))
             {

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -11446,7 +11446,7 @@ internal static unsafe class VulkanVideoPresenter
                 if (traceAddressedPresentation ||
                     ShouldTracePresentedGuestImageContentsForDiagnostics() &&
                     (_directPresentationCount is 1 or 30 or 120 ||
-                     _directPresentationCount % 600 == 0))
+                     _directPresentationCount % 300 == 0))
                 {
                     Console.Error.WriteLine(
                         $"[LOADER][TRACE] vk.present_sample frame={_directPresentationCount} " +

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -2356,6 +2356,7 @@ internal static unsafe class VulkanVideoPresenter
         private readonly HashSet<(ulong Address, uint Width, uint Height, Format Format)> _tracedTextureCacheHits = new();
         private readonly HashSet<(ulong Address, uint Width, uint Height, uint DstSelect)> _tracedDepthTextureAliases = new();
         private readonly HashSet<(ulong Address, uint Width, uint Height)> _tracedDepthExtentFallbacks = new();
+        private readonly HashSet<(ulong Address, Format Source, Format Destination)> _tracedTextureRawAliases = new();
         private readonly HashSet<(ulong Address, uint Width, uint Height, Format Format)> _tracedTextureUploads = new();
         private readonly HashSet<(ulong Address, uint Width, uint Height, uint Format)> _dumpedTextures = new();
         private readonly HashSet<(ulong Address, uint Width, uint Height, uint Format)> _tracedTextureUploadContents = new();
@@ -2496,6 +2497,7 @@ internal static unsafe class VulkanVideoPresenter
             public uint RowLength;
             public uint DstSelect;
             public bool NeedsUpload;
+            public bool NeedsAliasCopy;
             public bool OwnsStorage;
             public bool IsStorage;
             public bool Cached;
@@ -2512,6 +2514,9 @@ internal static unsafe class VulkanVideoPresenter
             // this TextureResource and retires with the draw fence.
             public GuestImageResource? FeedbackSource;
             public GuestDepthResource? DepthFeedbackSource;
+            public VkBuffer AliasBuffer;
+            public DeviceMemory AliasMemory;
+            public GuestImageResource? AliasSource;
         }
 
         private sealed class GlobalBufferResource
@@ -4142,6 +4147,7 @@ internal static unsafe class VulkanVideoPresenter
                 Check(
                     _vk.QueueSubmit(_queue, 1, &submitInfo, fence),
                     "vkQueueSubmit(guest)");
+                MarkStorageImagesPending(referencedResources ?? resources);
             }
             catch
             {
@@ -6166,7 +6172,85 @@ internal static unsafe class VulkanVideoPresenter
                 }
             }
 
+            if (TryCreateGpuAliasTextureResource(texture, vkFormat, out var aliasResource))
+            {
+                return aliasResource;
+            }
+
             return GetOrCreateCachedTextureResource(texture);
+        }
+
+        private bool TryCreateGpuAliasTextureResource(
+            GuestDrawTexture texture,
+            Format format,
+            out TextureResource resource)
+        {
+            resource = default!;
+            if (texture.Address == 0 ||
+                !_guestImages.TryGetValue(texture.Address, out var source))
+            {
+                return false;
+            }
+
+            if (
+                !IsCompatibleGuestImageAlias(texture, source) ||
+                (!source.Initialized && !source.InitialUploadPending) ||
+                IsBlockCompressedFormat(source.Format) ||
+                IsBlockCompressedFormat(format))
+            {
+                return false;
+            }
+
+            var sourceBytesPerPixel = GetReadbackBytesPerPixel(source.Format);
+            var destinationBytesPerPixel = GetReadbackBytesPerPixel(format);
+            if (sourceBytesPerPixel == 0 || destinationBytesPerPixel == 0)
+            {
+                return false;
+            }
+
+            var texelCount = checked(
+                (ulong)source.Width * source.Height * source.Depth);
+            var sourceBytes = checked(texelCount * sourceBytesPerPixel);
+            var destinationBytes = checked(
+                (ulong)texture.Width * texture.Height * texture.Depth *
+                destinationBytesPerPixel);
+            if (destinationBytes > sourceBytes)
+            {
+                return false;
+            }
+
+            resource = CreateTextureResource(texture);
+            if (resource.StagingBuffer.Handle != 0)
+            {
+                _vk.DestroyBuffer(_device, resource.StagingBuffer, null);
+                resource.StagingBuffer = default;
+            }
+
+            if (resource.StagingMemory.Handle != 0)
+            {
+                _vk.FreeMemory(_device, resource.StagingMemory, null);
+                resource.StagingMemory = default;
+            }
+
+            resource.NeedsUpload = false;
+            resource.NeedsAliasCopy = true;
+            resource.UpdatesCpuContent = false;
+            resource.AliasSource = source;
+            resource.AliasBuffer = CreateBuffer(
+                sourceBytes,
+                BufferUsageFlags.TransferDstBit | BufferUsageFlags.TransferSrcBit,
+                MemoryPropertyFlags.DeviceLocalBit,
+                out resource.AliasMemory);
+            if (_tracedTextureRawAliases.Add((texture.Address, source.Format, format)))
+            {
+                TraceVulkanShader(
+                    $"vk.texture_raw_alias addr=0x{texture.Address:X16} " +
+                    $"source={source.Format}:{source.Width}x{source.Height}x{source.Depth} " +
+                    $"destination={format}:{texture.Width}x{texture.Height}x{texture.Depth} " +
+                    $"bytes={destinationBytes}/{sourceBytes}");
+            }
+
+            return true;
         }
 
         private bool TryCreateCpuTextureRefreshResource(
@@ -11894,6 +11978,7 @@ internal static unsafe class VulkanVideoPresenter
                 Format.R32Sint or
                 Format.R32Sfloat or
                 Format.B10G11R11UfloatPack32 or
+                Format.R16G16Unorm or
                 Format.R16G16Uint or
                 Format.R16G16Sint or
                 Format.R16G16Sfloat or
@@ -11972,6 +12057,12 @@ internal static unsafe class VulkanVideoPresenter
                 if (texture.GuestDepth is { } depth)
                 {
                     RecordGuestDepthForSampling(depth, shaderStage);
+                }
+
+                if (texture.NeedsAliasCopy)
+                {
+                    RecordTextureAliasCopy(texture, shaderStage);
+                    continue;
                 }
 
                 if (!texture.NeedsUpload)
@@ -12471,6 +12562,133 @@ internal static unsafe class VulkanVideoPresenter
             }
         }
 
+        private void RecordTextureAliasCopy(
+            TextureResource texture,
+            PipelineStageFlags shaderStage)
+        {
+            var source = texture.AliasSource ??
+                throw new InvalidOperationException("Texture alias has no source image.");
+            var sourceToTransfer = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                SrcAccessMask = AccessFlags.ShaderReadBit,
+                DstAccessMask = AccessFlags.TransferReadBit,
+                OldLayout = ImageLayout.ShaderReadOnlyOptimal,
+                NewLayout = ImageLayout.TransferSrcOptimal,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = source.Image,
+                SubresourceRange = ColorSubresourceRange(),
+            };
+            var destinationToTransfer = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                DstAccessMask = AccessFlags.TransferWriteBit,
+                OldLayout = ImageLayout.Undefined,
+                NewLayout = ImageLayout.TransferDstOptimal,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = texture.Image,
+                SubresourceRange = ColorSubresourceRange(),
+            };
+            var imageBarriers = stackalloc ImageMemoryBarrier[2]
+            {
+                sourceToTransfer,
+                destinationToTransfer,
+            };
+            _vk.CmdPipelineBarrier(
+                _commandBuffer,
+                PipelineStageFlags.AllCommandsBit,
+                PipelineStageFlags.TransferBit,
+                0,
+                0,
+                null,
+                0,
+                null,
+                2,
+                imageBarriers);
+
+            var sourceRegion = new BufferImageCopy
+            {
+                ImageSubresource = new ImageSubresourceLayers
+                {
+                    AspectMask = ImageAspectFlags.ColorBit,
+                    LayerCount = 1,
+                },
+                ImageExtent = new Extent3D(source.Width, source.Height, source.Depth),
+            };
+            _vk.CmdCopyImageToBuffer(
+                _commandBuffer,
+                source.Image,
+                ImageLayout.TransferSrcOptimal,
+                texture.AliasBuffer,
+                1,
+                &sourceRegion);
+
+            var bufferBarrier = new BufferMemoryBarrier
+            {
+                SType = StructureType.BufferMemoryBarrier,
+                SrcAccessMask = AccessFlags.TransferWriteBit,
+                DstAccessMask = AccessFlags.TransferReadBit,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Buffer = texture.AliasBuffer,
+                Size = Vk.WholeSize,
+            };
+            _vk.CmdPipelineBarrier(
+                _commandBuffer,
+                PipelineStageFlags.TransferBit,
+                PipelineStageFlags.TransferBit,
+                0,
+                0,
+                null,
+                1,
+                &bufferBarrier,
+                0,
+                null);
+
+            var destinationRegion = new BufferImageCopy
+            {
+                ImageSubresource = new ImageSubresourceLayers
+                {
+                    AspectMask = ImageAspectFlags.ColorBit,
+                    LayerCount = 1,
+                },
+                ImageExtent = new Extent3D(texture.Width, texture.Height, texture.Depth),
+            };
+            _vk.CmdCopyBufferToImage(
+                _commandBuffer,
+                texture.AliasBuffer,
+                texture.Image,
+                ImageLayout.TransferDstOptimal,
+                1,
+                &destinationRegion);
+
+            var sourceToRead = sourceToTransfer;
+            sourceToRead.SrcAccessMask = AccessFlags.TransferReadBit;
+            sourceToRead.DstAccessMask = AccessFlags.ShaderReadBit;
+            sourceToRead.OldLayout = ImageLayout.TransferSrcOptimal;
+            sourceToRead.NewLayout = ImageLayout.ShaderReadOnlyOptimal;
+            var destinationToRead = destinationToTransfer;
+            destinationToRead.SrcAccessMask = AccessFlags.TransferWriteBit;
+            destinationToRead.DstAccessMask = AccessFlags.ShaderReadBit;
+            destinationToRead.OldLayout = ImageLayout.TransferDstOptimal;
+            destinationToRead.NewLayout = ImageLayout.ShaderReadOnlyOptimal;
+            imageBarriers[0] = sourceToRead;
+            imageBarriers[1] = destinationToRead;
+            _vk.CmdPipelineBarrier(
+                _commandBuffer,
+                PipelineStageFlags.TransferBit,
+                shaderStage,
+                0,
+                0,
+                null,
+                0,
+                null,
+                2,
+                imageBarriers);
+        }
+
         private void RecordStorageImagesForWrite(
             TranslatedDrawResources resources,
             PipelineStageFlags shaderStage)
@@ -12603,6 +12821,21 @@ internal static unsafe class VulkanVideoPresenter
             foreach (var image in traceImages)
             {
                 TraceGuestImageContents(image);
+            }
+        }
+
+        private static void MarkStorageImagesPending(
+            IReadOnlyList<TranslatedDrawResources> resourceSets)
+        {
+            foreach (var resources in resourceSets)
+            {
+                foreach (var texture in resources.Textures)
+                {
+                    if (texture.IsStorage && texture.GuestImage is { } guestImage)
+                    {
+                        guestImage.InitialUploadPending = true;
+                    }
+                }
             }
         }
 
@@ -13121,6 +13354,16 @@ internal static unsafe class VulkanVideoPresenter
                 if (texture.StagingMemory.Handle != 0)
                 {
                     _vk.FreeMemory(_device, texture.StagingMemory, null);
+                }
+
+                if (texture.AliasBuffer.Handle != 0)
+                {
+                    _vk.DestroyBuffer(_device, texture.AliasBuffer, null);
+                }
+
+                if (texture.AliasMemory.Handle != 0)
+                {
+                    _vk.FreeMemory(_device, texture.AliasMemory, null);
                 }
 
                 if (texture.NeedsUpload &&

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -2342,6 +2342,12 @@ internal static unsafe class VulkanVideoPresenter
             _guestImageVariants = new();
         private readonly Dictionary<long, GuestImageResource> _guestImageVersions = new();
         private readonly HashSet<long> _capturedGuestFlipVersions = [];
+        // Resource retirement removes versions from _capturedGuestFlipVersions,
+        // but later wait-safe markers still need to know that their capture ran.
+        // Keep only the newest completed version for each display buffer so this
+        // execution-order proof remains bounded independently of image lifetime.
+        private readonly Dictionary<(int Handle, int BufferIndex), long>
+            _lastCompletedGuestFlipVersions = new();
         private readonly record struct GuestDepthKey(
             ulong Address,
             ulong ReadAddress,
@@ -4494,6 +4500,8 @@ internal static unsafe class VulkanVideoPresenter
                 snapshot.Initialized = true;
                 _guestImageVersions.Add(work.Version, snapshot);
                 _capturedGuestFlipVersions.Add(work.Version);
+                _lastCompletedGuestFlipVersions[
+                    (work.VideoOutHandle, work.DisplayBufferIndex)] = work.Version;
 
                 lock (_gate)
                 {
@@ -4541,7 +4549,10 @@ internal static unsafe class VulkanVideoPresenter
         private void ExecuteOrderedGuestFlipWait(VulkanOrderedGuestFlipWait work)
         {
             var captured = work.Version != 0 &&
-                _capturedGuestFlipVersions.Contains(work.Version);
+                _lastCompletedGuestFlipVersions.TryGetValue(
+                    (work.VideoOutHandle, work.DisplayBufferIndex),
+                    out var completedVersion) &&
+                completedVersion >= work.Version;
             TraceVulkanShader(
                 $"vk.flip_wait_safe version={work.Version} " +
                 $"queue={_activeGuestQueue.Name} submission={_activeGuestQueue.SubmissionId} " +
@@ -13963,6 +13974,7 @@ internal static unsafe class VulkanVideoPresenter
             }
             _guestImageVersions.Clear();
             _capturedGuestFlipVersions.Clear();
+            _lastCompletedGuestFlipVersions.Clear();
             while (_deferredGuestImageVersionDestroys.TryDequeue(out var deferredVersion))
             {
                 DestroyGuestImage(deferredVersion.Image);

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -300,7 +300,8 @@ public static partial class Gen5SpirvTranslator
             uint ComponentType,
             uint VectorType,
             ImageComponentKind ComponentKind,
-            bool IsStorage);
+            bool IsStorage,
+            uint CoordinateComponents);
 
         private readonly record struct SpirvVertexInput(
             uint Variable,
@@ -965,6 +966,8 @@ public static partial class Gen5SpirvTranslator
                     Gen5ShaderTranslator.IsStorageImageOperation(binding.Opcode);
                 var (format, componentKind) =
                     DecodeImageFormat(binding.ResourceDescriptor);
+                var coordinateComponents = GetImageCoordinateComponents(
+                    binding.ResourceDescriptor);
                 var componentType = componentKind switch
                 {
                     ImageComponentKind.Sint => _intType,
@@ -986,7 +989,9 @@ public static partial class Gen5SpirvTranslator
 
                 var imageType = _module.TypeImage(
                     componentType,
-                    SpirvImageDim.Dim2D,
+                    coordinateComponents == 3
+                        ? SpirvImageDim.Dim3D
+                        : SpirvImageDim.Dim2D,
                     depth: false,
                     arrayed: false,
                     multisampled: false,
@@ -1015,7 +1020,8 @@ public static partial class Gen5SpirvTranslator
                         componentType,
                         _module.TypeVector(componentType, 4),
                         componentKind,
-                        isStorage));
+                        isStorage,
+                        coordinateComponents));
                 _interfaces.Add(variable);
             }
         }
@@ -1026,6 +1032,12 @@ public static partial class Gen5SpirvTranslator
                 not SpirvImageFormat.Rgba32f and
                 not SpirvImageFormat.Rgba32i and
                 not SpirvImageFormat.Rgba32ui;
+
+        private static uint GetImageCoordinateComponents(
+            IReadOnlyList<uint> descriptor) =>
+            descriptor.Count >= 4 && ((descriptor[3] >> 28) & 0xFu) == 10
+                ? 3u
+                : 2u;
 
         private static (SpirvImageFormat Format, ImageComponentKind Kind)
             DecodeImageFormat(IReadOnlyList<uint> descriptor)
@@ -3108,7 +3120,7 @@ public static partial class Gen5SpirvTranslator
                     resource.IsStorage
                         ? SpirvOp.ImageQuerySize
                         : SpirvOp.ImageQuerySizeLod,
-                    _module.TypeVector(_intType, 2),
+                    _module.TypeVector(_intType, resource.CoordinateComponents),
                     resource.IsStorage
                         ? [queryImage]
                         : [queryImage, UInt(0)]);
@@ -3121,7 +3133,7 @@ public static partial class Gen5SpirvTranslator
                     }
 
                     uint value;
-                    if (component < 2)
+                    if (component < resource.CoordinateComponents)
                     {
                         var signedValue = _module.AddInstruction(
                             SpirvOp.CompositeExtract,
@@ -3149,7 +3161,10 @@ public static partial class Gen5SpirvTranslator
                     return false;
                 }
 
-                var coordinates = BuildIntegerCoordinates(image, 0);
+                var coordinates = BuildIntegerCoordinates(
+                    image,
+                    0,
+                    resource.CoordinateComponents);
                 var components = new uint[4];
                 uint sourceIndex = 0;
                 for (var component = 0; component < components.Length; component++)
@@ -3185,11 +3200,12 @@ public static partial class Gen5SpirvTranslator
                     components);
                 var imageSize = _module.AddInstruction(
                     SpirvOp.ImageQuerySize,
-                    _module.TypeVector(_intType, 2),
+                    _module.TypeVector(_intType, resource.CoordinateComponents),
                     imageObject);
                 EmitBoundsCheckedImageWrite(
                     coordinates,
                     imageSize,
+                    resource.CoordinateComponents,
                     imageObject,
                     texel);
 
@@ -3211,12 +3227,13 @@ public static partial class Gen5SpirvTranslator
                 {
                     var imageSize = _module.AddInstruction(
                         SpirvOp.ImageQuerySize,
-                        _module.TypeVector(_intType, 2),
+                        _module.TypeVector(_intType, resource.CoordinateComponents),
                         imageObject);
                     var coordinates = BuildClampedIntegerCoordinates(
                         image,
                         0,
-                        imageSize);
+                        imageSize,
+                        resource.CoordinateComponents);
                     sampled = _module.AddInstruction(
                         SpirvOp.ImageRead,
                         resource.VectorType,
@@ -3232,13 +3249,14 @@ public static partial class Gen5SpirvTranslator
                         imageObject);
                     var imageSize = _module.AddInstruction(
                         SpirvOp.ImageQuerySizeLod,
-                        _module.TypeVector(_intType, 2),
+                        _module.TypeVector(_intType, resource.CoordinateComponents),
                         fetchedImage,
                         UInt(mipLevel));
                     var coordinates = BuildClampedIntegerCoordinates(
                         image,
                         0,
-                        imageSize);
+                        imageSize,
+                        resource.CoordinateComponents);
                     sampled = _module.AddInstruction(
                         SpirvOp.ImageFetch,
                         resource.VectorType,
@@ -3275,7 +3293,10 @@ public static partial class Gen5SpirvTranslator
                 if (hasOffset)
                 {
                     addressCursor = AlignFullImageAddress(image, addressCursor);
-                    offset = BuildImageOffset(image, addressCursor);
+                    offset = BuildImageOffset(
+                        image,
+                        addressCursor,
+                        resource.CoordinateComponents);
                     addressCursor += ImageFullAddressSlots(image);
                 }
 
@@ -3299,22 +3320,33 @@ public static partial class Gen5SpirvTranslator
                 }
 
                 var gradientX = hasGradients
-                    ? BuildFloatCoordinates(image, addressCursor)
+                    ? BuildFloatCoordinates(
+                        image,
+                        addressCursor,
+                        resource.CoordinateComponents)
                     : 0u;
                 var gradientY = hasGradients
-                    ? BuildFloatCoordinates(image, addressCursor + 2)
+                    ? BuildFloatCoordinates(
+                        image,
+                        addressCursor + (int)resource.CoordinateComponents,
+                        resource.CoordinateComponents)
                     : 0u;
                 if (hasGradients)
                 {
-                    addressCursor += 4;
+                    addressCursor += checked((int)(2 * resource.CoordinateComponents));
                 }
 
-                var coordinates = BuildFloatCoordinates(image, addressCursor);
+                var coordinates = BuildFloatCoordinates(
+                    image,
+                    addressCursor,
+                    resource.CoordinateComponents);
                 var explicitLod = hasGradients || hasZeroLod || hasLod;
                 var lod = hasZeroLod
                     ? Float(0)
                     : hasLod
-                        ? LoadImageFloatAddress(image, addressCursor + 2)
+                        ? LoadImageFloatAddress(
+                            image,
+                            addressCursor + (int)resource.CoordinateComponents)
                         : lodOrBias;
                 if (hasOffset)
                 {
@@ -3376,6 +3408,12 @@ public static partial class Gen5SpirvTranslator
                          "ImageGather4",
                          StringComparison.Ordinal))
             {
+                if (resource.CoordinateComponents != 2)
+                {
+                    error = "3D image gather is unsupported";
+                    return false;
+                }
+
                 var hasOffset =
                     instruction.Opcode.EndsWith("O", StringComparison.Ordinal);
                 var hasCompare =
@@ -3384,7 +3422,7 @@ public static partial class Gen5SpirvTranslator
                 var offset = 0u;
                 if (hasOffset)
                 {
-                    offset = BuildImageOffset(image, addressCursor);
+                    offset = BuildImageOffset(image, addressCursor, 2);
                     addressCursor += ImageFullAddressSlots(image);
                 }
 
@@ -3399,7 +3437,7 @@ public static partial class Gen5SpirvTranslator
                     addressCursor += ImageFullAddressSlots(image);
                 }
 
-                var coordinates = BuildFloatCoordinates(image, addressCursor);
+                var coordinates = BuildFloatCoordinates(image, addressCursor, 2);
                 var operands = new List<uint>
                 {
                     imageObject,
@@ -3592,15 +3630,21 @@ public static partial class Gen5SpirvTranslator
                 });
         }
 
-        private uint BuildFloatCoordinates(Gen5ImageControl image, int start)
+        private uint BuildFloatCoordinates(
+            Gen5ImageControl image,
+            int start,
+            uint componentCount)
         {
-            var x = LoadImageFloatAddress(image, start);
-            var y = LoadImageFloatAddress(image, start + 1);
+            var coordinates = new uint[componentCount];
+            for (var component = 0; component < coordinates.Length; component++)
+            {
+                coordinates[component] = LoadImageFloatAddress(image, start + component);
+            }
+
             return _module.AddInstruction(
                 SpirvOp.CompositeConstruct,
-                _vec2Type,
-                x,
-                y);
+                _module.TypeVector(_floatType, componentCount),
+                coordinates);
         }
 
         private static int ImageAddressRegister(
@@ -3705,47 +3749,49 @@ public static partial class Gen5SpirvTranslator
                 ShiftLeftLogical(BitwiseAnd(high, UInt(0xFFFF)), UInt(16)));
         }
 
-        private uint BuildIntegerCoordinates(Gen5ImageControl image, int start)
+        private uint BuildIntegerCoordinates(
+            Gen5ImageControl image,
+            int start,
+            uint componentCount)
         {
-            var ivec2 = _module.TypeVector(_intType, 2);
-            var x = Bitcast(_intType, LoadImageIntegerAddress(image, start));
-            var y = Bitcast(_intType, LoadImageIntegerAddress(image, start + 1));
+            var coordinates = new uint[componentCount];
+            for (var component = 0; component < coordinates.Length; component++)
+            {
+                coordinates[component] = Bitcast(
+                    _intType,
+                    LoadImageIntegerAddress(image, start + component));
+            }
+
             return _module.AddInstruction(
                 SpirvOp.CompositeConstruct,
-                ivec2,
-                x,
-                y);
+                _module.TypeVector(_intType, componentCount),
+                coordinates);
         }
 
         private uint BuildClampedIntegerCoordinates(
             Gen5ImageControl image,
             int start,
-            uint imageSize)
+            uint imageSize,
+            uint componentCount)
         {
-            var ivec2 = _module.TypeVector(_intType, 2);
-            var x = ClampSignedCoordinate(
-                Bitcast(
-                    _intType,
-                    LoadImageIntegerAddress(image, start)),
-                _module.AddInstruction(
-                    SpirvOp.CompositeExtract,
-                    _intType,
-                    imageSize,
-                    0));
-            var y = ClampSignedCoordinate(
-                Bitcast(
-                    _intType,
-                    LoadImageIntegerAddress(image, start + 1)),
-                _module.AddInstruction(
-                    SpirvOp.CompositeExtract,
-                    _intType,
-                    imageSize,
-                    1));
+            var coordinates = new uint[componentCount];
+            for (var component = 0; component < coordinates.Length; component++)
+            {
+                coordinates[component] = ClampSignedCoordinate(
+                    Bitcast(
+                        _intType,
+                        LoadImageIntegerAddress(image, start + component)),
+                    _module.AddInstruction(
+                        SpirvOp.CompositeExtract,
+                        _intType,
+                        imageSize,
+                        (uint)component));
+            }
+
             return _module.AddInstruction(
                 SpirvOp.CompositeConstruct,
-                ivec2,
-                x,
-                y);
+                _module.TypeVector(_intType, componentCount),
+                coordinates);
         }
 
         private uint ClampSignedCoordinate(uint value, uint extent)
@@ -3783,65 +3829,46 @@ public static partial class Gen5SpirvTranslator
         private void EmitBoundsCheckedImageWrite(
             uint coordinates,
             uint imageSize,
+            uint componentCount,
             uint imageObject,
             uint texel)
         {
-            var x = _module.AddInstruction(
-                SpirvOp.CompositeExtract,
-                _intType,
-                coordinates,
-                0);
-            var y = _module.AddInstruction(
-                SpirvOp.CompositeExtract,
-                _intType,
-                coordinates,
-                1);
-            var width = _module.AddInstruction(
-                SpirvOp.CompositeExtract,
-                _intType,
-                imageSize,
-                0);
-            var height = _module.AddInstruction(
-                SpirvOp.CompositeExtract,
-                _intType,
-                imageSize,
-                1);
             var zero = _module.Constant(_intType, 0);
-            var xNonNegative = _module.AddInstruction(
-                SpirvOp.SGreaterThanEqual,
-                _boolType,
-                x,
-                zero);
-            var yNonNegative = _module.AddInstruction(
-                SpirvOp.SGreaterThanEqual,
-                _boolType,
-                y,
-                zero);
-            var xInRange = _module.AddInstruction(
-                SpirvOp.SLessThan,
-                _boolType,
-                x,
-                width);
-            var yInRange = _module.AddInstruction(
-                SpirvOp.SLessThan,
-                _boolType,
-                y,
-                height);
-            var lowerInRange = _module.AddInstruction(
-                SpirvOp.LogicalAnd,
-                _boolType,
-                xNonNegative,
-                yNonNegative);
-            var upperInRange = _module.AddInstruction(
-                SpirvOp.LogicalAnd,
-                _boolType,
-                xInRange,
-                yInRange);
-            var inRange = _module.AddInstruction(
-                SpirvOp.LogicalAnd,
-                _boolType,
-                lowerInRange,
-                upperInRange);
+            var inRange = _module.ConstantBool(true);
+            for (uint component = 0; component < componentCount; component++)
+            {
+                var coordinate = _module.AddInstruction(
+                    SpirvOp.CompositeExtract,
+                    _intType,
+                    coordinates,
+                    component);
+                var extent = _module.AddInstruction(
+                    SpirvOp.CompositeExtract,
+                    _intType,
+                    imageSize,
+                    component);
+                var nonNegative = _module.AddInstruction(
+                    SpirvOp.SGreaterThanEqual,
+                    _boolType,
+                    coordinate,
+                    zero);
+                var belowExtent = _module.AddInstruction(
+                    SpirvOp.SLessThan,
+                    _boolType,
+                    coordinate,
+                    extent);
+                var componentInRange = _module.AddInstruction(
+                    SpirvOp.LogicalAnd,
+                    _boolType,
+                    nonNegative,
+                    belowExtent);
+                inRange = _module.AddInstruction(
+                    SpirvOp.LogicalAnd,
+                    _boolType,
+                    inRange,
+                    componentInRange);
+            }
+
             inRange = _module.AddInstruction(
                 SpirvOp.LogicalAnd,
                 _boolType,
@@ -3865,30 +3892,30 @@ public static partial class Gen5SpirvTranslator
             _module.AddLabel(mergeLabel);
         }
 
-        private uint BuildImageOffset(Gen5ImageControl image, int component)
+        private uint BuildImageOffset(
+            Gen5ImageControl image,
+            int component,
+            uint componentCount)
         {
-            var ivec2 = _module.TypeVector(_intType, 2);
             var packed = Bitcast(
                 _intType,
                 LoadV(image.GetAddressRegister(
                     ImageAddressRegister(image, component))));
-            var x = _module.AddInstruction(
-                SpirvOp.BitFieldSExtract,
-                _intType,
-                packed,
-                UInt(0),
-                UInt(6));
-            var y = _module.AddInstruction(
-                SpirvOp.BitFieldSExtract,
-                _intType,
-                packed,
-                UInt(8),
-                UInt(6));
+            var offsets = new uint[componentCount];
+            for (var index = 0; index < offsets.Length; index++)
+            {
+                offsets[index] = _module.AddInstruction(
+                    SpirvOp.BitFieldSExtract,
+                    _intType,
+                    packed,
+                    UInt((uint)(index * 8)),
+                    UInt(6));
+            }
+
             return _module.AddInstruction(
                 SpirvOp.CompositeConstruct,
-                ivec2,
-                x,
-                y);
+                _module.TypeVector(_intType, componentCount),
+                offsets);
         }
 
         private uint ApplyDynamicSampleOffset(
@@ -3898,7 +3925,12 @@ public static partial class Gen5SpirvTranslator
             uint texelOffset,
             uint lod)
         {
-            var ivec2 = _module.TypeVector(_intType, 2);
+            var coordinateType = _module.TypeVector(
+                _intType,
+                resource.CoordinateComponents);
+            var floatCoordinateType = _module.TypeVector(
+                _floatType,
+                resource.CoordinateComponents);
             var image = _module.AddInstruction(
                 SpirvOp.Image,
                 resource.ImageType,
@@ -3920,25 +3952,25 @@ public static partial class Gen5SpirvTranslator
                 signedLod);
             var size = _module.AddInstruction(
                 SpirvOp.ImageQuerySizeLod,
-                ivec2,
+                coordinateType,
                 image,
                 clampedLod);
             var sizeFloat = _module.AddInstruction(
                 SpirvOp.ConvertSToF,
-                _vec2Type,
+                floatCoordinateType,
                 size);
             var offsetFloat = _module.AddInstruction(
                 SpirvOp.ConvertSToF,
-                _vec2Type,
+                floatCoordinateType,
                 texelOffset);
             var normalizedOffset = _module.AddInstruction(
                 SpirvOp.FDiv,
-                _vec2Type,
+                floatCoordinateType,
                 offsetFloat,
                 sizeFloat);
             return _module.AddInstruction(
                 SpirvOp.FAdd,
-                _vec2Type,
+                floatCoordinateType,
                 coordinates,
                 normalizedOffset);
         }

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -2114,6 +2114,25 @@ public static partial class Gen5SpirvTranslator
             var byteAddress = IAdd(
                 LoadV(control.VectorAddress),
                 UInt(unchecked((uint)control.OffsetBytes)));
+            if (control.UsesFlatAddress)
+            {
+                var evaluationBinding = bindingIndex - _globalBufferBase;
+                if ((uint)evaluationBinding >=
+                    (uint)_evaluation.GlobalMemoryBindings.Count)
+                {
+                    error = "missing flat-memory binding";
+                    return false;
+                }
+
+                byteAddress = _module.AddInstruction(
+                    SpirvOp.ISub,
+                    _uintType,
+                    byteAddress,
+                    LoadS(
+                        _evaluation.GlobalMemoryBindings[evaluationBinding]
+                            .ScalarAddress));
+            }
+
             byteAddress = ApplyGuestBufferByteBias(bindingIndex, byteAddress);
             var dwordAddress = ShiftRightLogical(byteAddress, UInt(2));
 

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
@@ -191,6 +191,7 @@ public sealed record Gen5GlobalMemoryControl(
     uint VectorData,
     uint ScalarAddress,
     int OffsetBytes,
+    bool UsesFlatAddress,
     bool Glc,
     bool Slc) : Gen5InstructionControl;
 

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -346,24 +346,38 @@ public static class Gen5ShaderScalarEvaluator
                     continue;
                 }
 
-                if (globalMemory.ScalarAddress >= ScalarRegisterCount - 1)
+                var scalarAddress = globalMemory.ScalarAddress;
+                if (globalMemory.UsesFlatAddress &&
+                    !TryResolveFlatAddressBase(
+                        state.Program,
+                        instruction.Pc,
+                        globalMemory.VectorAddress,
+                        out scalarAddress))
+                {
+                    error =
+                        $"flat-address-base-unresolved pc=0x{instruction.Pc:X} " +
+                        $"v{globalMemory.VectorAddress}:v{globalMemory.VectorAddress + 1}";
+                    return false;
+                }
+
+                if (scalarAddress >= ScalarRegisterCount - 1)
                 {
                     error =
                         $"global-address-register-range pc=0x{instruction.Pc:X} " +
-                        $"s{globalMemory.ScalarAddress}";
+                        $"s{scalarAddress}";
                     return false;
                 }
 
                 var baseAddress =
-                    scalarRegisters[globalMemory.ScalarAddress] |
-                    ((ulong)scalarRegisters[globalMemory.ScalarAddress + 1] << 32);
+                    scalarRegisters[scalarAddress] |
+                    ((ulong)scalarRegisters[scalarAddress + 1] << 32);
                 if (baseAddress == 0)
                 {
                     error = $"global-address-null pc=0x{instruction.Pc:X}";
                     return false;
                 }
 
-                var key = (globalMemory.ScalarAddress, baseAddress);
+                var key = (scalarAddress, baseAddress);
                 var writable = instruction.Opcode.StartsWith(
                         "GlobalStore",
                         StringComparison.Ordinal) ||
@@ -390,7 +404,7 @@ public static class Gen5ShaderScalarEvaluator
                     }
 
                     var binding = new Gen5GlobalMemoryBinding(
-                        globalMemory.ScalarAddress,
+                        scalarAddress,
                         baseAddress,
                         new List<uint> { instruction.Pc },
                         data,
@@ -959,6 +973,79 @@ public static class Gen5ShaderScalarEvaluator
         mipLevel = image.A16 ? raw & 0xFFFF : raw;
         return true;
     }
+
+    private static bool TryResolveFlatAddressBase(
+        Gen5ShaderProgram program,
+        uint pc,
+        uint vectorAddress,
+        out uint scalarAddress)
+    {
+        Gen5ShaderInstruction? lowProducer = null;
+        Gen5ShaderInstruction? highProducer = null;
+        for (var index = program.Instructions.Count - 1; index >= 0; index--)
+        {
+            var candidate = program.Instructions[index];
+            if (candidate.Pc >= pc)
+            {
+                continue;
+            }
+
+            foreach (var destination in candidate.Destinations)
+            {
+                if (destination.Kind != Gen5OperandKind.VectorRegister)
+                {
+                    continue;
+                }
+
+                if (destination.Value == vectorAddress && lowProducer is null)
+                {
+                    lowProducer = candidate;
+                }
+                else if (destination.Value == vectorAddress + 1 && highProducer is null)
+                {
+                    highProducer = candidate;
+                }
+            }
+
+            if (lowProducer is not null && highProducer is not null)
+            {
+                break;
+            }
+        }
+
+        if (lowProducer is null ||
+            highProducer is null ||
+            !IsAddressAdd(lowProducer.Opcode) ||
+            !IsAddressAdd(highProducer.Opcode))
+        {
+            scalarAddress = 0;
+            return false;
+        }
+
+        foreach (var lowSource in lowProducer.Sources)
+        {
+            if (lowSource.Kind != Gen5OperandKind.ScalarRegister)
+            {
+                continue;
+            }
+
+            var highScalar = lowSource.Value + 1;
+            if (highProducer.Sources.Any(
+                    source =>
+                        source.Kind == Gen5OperandKind.ScalarRegister &&
+                        source.Value == highScalar))
+            {
+                scalarAddress = lowSource.Value;
+                return true;
+            }
+        }
+
+        scalarAddress = 0;
+        return false;
+    }
+
+    private static bool IsAddressAdd(string opcode) =>
+        opcode is "VAddI32" or "VAddcU32" or "VAddCoU32";
 
     private static bool TryResolveConstantOperand(Gen5Operand operand, out uint value)
     {

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -1045,7 +1045,7 @@ public static class Gen5ShaderScalarEvaluator
     }
 
     private static bool IsAddressAdd(string opcode) =>
-        opcode is "VAddI32" or "VAddcU32" or "VAddCoU32";
+        opcode is "VAddI32" or "VAddcU32" or "VAddCoU32" or "VAddCoCiU32";
 
     private static bool TryResolveConstantOperand(Gen5Operand operand, out uint value)
     {

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
@@ -1291,8 +1291,14 @@ public static class Gen5ShaderTranslator
         var opcode = (word >> 18) & 0x7F;
         sizeDwords = 2;
         error = string.Empty;
-        name = segment == 0x2
-            ? opcode switch
+        name = segment switch
+        {
+            0x0 => opcode switch
+            {
+                0x08 => "FlatLoadUbyte",
+                _ => string.Empty,
+            },
+            0x2 => opcode switch
             {
                 0x08 => "GlobalLoadUbyte",
                 0x09 => "GlobalLoadSbyte",
@@ -1319,8 +1325,9 @@ public static class Gen5ShaderTranslator
                 0x32 => "GlobalAtomicAdd",
                 0x38 => "GlobalAtomicUMax",
                 _ => string.Empty,
-            }
-            : string.Empty;
+            },
+            _ => string.Empty,
+        };
 
         return FinishDecode(
             name,
@@ -1884,6 +1891,7 @@ public static class Gen5ShaderTranslator
                     "GlobalStoreDword" or
                     "GlobalAtomicAdd" or
                     "GlobalAtomicUMax" => 1u,
+                    "FlatLoadUbyte" => 1u,
                     "GlobalLoadDword" => 1u,
                     "GlobalLoadDwordx2" => 2u,
                     "GlobalLoadDwordx3" => 3u,
@@ -1893,23 +1901,33 @@ public static class Gen5ShaderTranslator
                     "GlobalStoreDwordx4" => 4u,
                     _ => 0u,
                 };
-                sources =
-                [
-                    Gen5Operand.Vector(vectorAddress),
-                    Gen5Operand.Scalar(scalarAddress),
-                ];
-                destinations = opcode.StartsWith("GlobalLoad", StringComparison.Ordinal)
-                    ? Enumerable
-                        .Range((int)vectorData, checked((int)dwordCount))
-                        .Select(index => Gen5Operand.Vector((uint)index))
-                        .ToArray()
-                    : [];
+                var usesFlatAddress = ((word >> 14) & 0x3) == 0;
+                sources = usesFlatAddress
+                    ?
+                    [
+                        Gen5Operand.Vector(vectorAddress),
+                        Gen5Operand.Vector(vectorAddress + 1),
+                    ]
+                    :
+                    [
+                        Gen5Operand.Vector(vectorAddress),
+                        Gen5Operand.Scalar(scalarAddress),
+                    ];
+                destinations =
+                    opcode.StartsWith("GlobalLoad", StringComparison.Ordinal) ||
+                    opcode.StartsWith("FlatLoad", StringComparison.Ordinal)
+                        ? Enumerable
+                            .Range((int)vectorData, checked((int)dwordCount))
+                            .Select(index => Gen5Operand.Vector((uint)index))
+                            .ToArray()
+                        : [];
                 control = new Gen5GlobalMemoryControl(
                     dwordCount,
                     vectorAddress,
                     vectorData,
                     scalarAddress,
                     SignExtend(word & 0x1FFF, 13),
+                    usesFlatAddress,
                     ((word >> 16) & 1) != 0,
                     ((word >> 17) & 1) != 0);
                 break;

--- a/tests/SharpEmu.Libs.Tests/Audio/AudioOut2ExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Audio/AudioOut2ExportsTests.cs
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Audio;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Audio;
+
+public sealed class AudioOut2ExportsTests
+{
+    private const ulong Base = 0x1_0000_0000;
+    private const ulong ParamAddress = Base + 0x100;
+    private const ulong OutMemorySizeAddress = Base + 0x200;
+    private const ulong OutQueueLevelAddress = Base + 0x300;
+    private const ulong OutQueueAvailableAddress = Base + 0x400;
+
+    private readonly FakeCpuMemory _memory = new(Base, 0x1000);
+    private readonly CpuContext _ctx;
+
+    public AudioOut2ExportsTests()
+    {
+        _ctx = new CpuContext(_memory, Generation.Gen5);
+    }
+
+    [Fact]
+    public void ContextQueryMemory_WritesOnlyEightByteSizeOutput()
+    {
+        Span<byte> canary = stackalloc byte[24];
+        canary.Fill(0xA5);
+        Assert.True(_memory.TryWrite(OutMemorySizeAddress + 8, canary));
+
+        _ctx[CpuRegister.Rdi] = ParamAddress;
+        _ctx[CpuRegister.Rsi] = OutMemorySizeAddress;
+
+        Assert.Equal(0, AudioOut2Exports.AudioOut2ContextQueryMemory(_ctx));
+        Assert.True(_ctx.TryReadUInt64(OutMemorySizeAddress, out var memorySize));
+        Assert.Equal(0x10000UL, memorySize);
+
+        Span<byte> canaryAfterCall = stackalloc byte[24];
+        Assert.True(_memory.TryRead(OutMemorySizeAddress + 8, canaryAfterCall));
+        Assert.True(canary.SequenceEqual(canaryAfterCall));
+    }
+
+    [Fact]
+    public void ContextGetQueueLevel_WritesTwoFourByteOutputsWithoutTouchingCanary()
+    {
+        const ulong canary = 0xC0DE_C0DE_CAFE_BA00;
+        Assert.True(_ctx.TryWriteUInt64(OutQueueLevelAddress + 4, canary));
+
+        _ctx[CpuRegister.Rdi] = 1;
+        _ctx[CpuRegister.Rsi] = OutQueueLevelAddress;
+        _ctx[CpuRegister.Rdx] = OutQueueAvailableAddress;
+
+        Assert.Equal(0, AudioOut2Exports.AudioOut2ContextGetQueueLevel(_ctx));
+        Assert.True(_ctx.TryReadUInt32(OutQueueLevelAddress, out var queueLevel));
+        Assert.True(_ctx.TryReadUInt32(OutQueueAvailableAddress, out var queueAvailable));
+        Assert.True(_ctx.TryReadUInt64(OutQueueLevelAddress + 4, out var canaryAfterCall));
+        Assert.Equal(0U, queueLevel);
+        Assert.Equal(4U, queueAvailable);
+        Assert.Equal(canary, canaryAfterCall);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Tls/GuestTlsTemplateTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Tls/GuestTlsTemplateTests.cs
@@ -29,4 +29,29 @@ public sealed class GuestTlsTemplateTests
             GuestTlsTemplate.Reset();
         }
     }
+
+    [Fact]
+    public void StartupReservationExpandsForGtaVStaticTlsSpan()
+    {
+        try
+        {
+            GuestTlsTemplate.Reset();
+
+            var staticOffset = GuestTlsTemplate.RegisterModule(
+                moduleId: 1,
+                initImage: new byte[0x20],
+                memorySize: 0x13550,
+                alignment: 0x10);
+
+            Assert.Equal(0x13550UL, staticOffset);
+            Assert.Equal(0x14000UL, GuestTlsTemplate.StartupStaticTlsReservation);
+            Assert.True(
+                GuestTlsTemplate.StartupStaticTlsReservation >
+                GuestTlsTemplate.MinimumStartupStaticTlsReservation);
+        }
+        finally
+        {
+            GuestTlsTemplate.Reset();
+        }
+    }
 }


### PR DESCRIPTION
Fixes direct-memory queries, static TLS initialization, guest stack reservations, positional reads, and host fault handling. Adds missing AGC packets and exports, Gen5 shader image/buffer operations, additional VideoOut formats and image aliases, plus initial AJM decoding and AudioOut2 plumbing.

GTA V now reaches 1280×720 VideoOut initialization and continues through its frame/audio loop instead of stalling during early boot. Validated with a clean Release build and passing tests.