### PR TITLE
[Gpu] Backend-neutral shader compiler and guest-GPU renderer seam

### DIFF
--- a/.github/workflows/pr-build-links.yml
+++ b/.github/workflows/pr-build-links.yml
@@ -1,0 +1,105 @@
+# Copyright (C) 2026 SharpEmu Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Posts (and keeps updated) a single PR comment linking the per-platform build
+# artifacts once "Build and Release" finishes.
+#
+# This is a workflow_run workflow on purpose: PRs from forks run "Build and
+# Release" with a read-only GITHUB_TOKEN and cannot comment. workflow_run runs
+# afterwards in the base-repo context with a read-write token and does not check
+# out untrusted fork code, so it can comment safely. Because of that, GitHub only
+# triggers it from the copy on the default branch — it does nothing until merged
+# to main.
+name: PR Build Links
+
+on:
+  workflow_run:
+    workflows: ["Build and Release"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post artifact links
+    runs-on: ubuntu-latest
+    # Only for successful PR builds — artifacts exist only when the build passed.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Post or update the artifact-links comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const { owner, repo } = context.repo;
+
+            // Fork PRs leave workflow_run.pull_requests empty, so fall back to
+            // resolving the PR from the build's head commit.
+            let prNumber;
+            if (run.pull_requests && run.pull_requests.length > 0) {
+              prNumber = run.pull_requests[0].number;
+            } else {
+              const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner, repo, commit_sha: run.head_sha,
+              });
+              const open = prs.data.find(pr => pr.state === 'open');
+              if (!open) {
+                core.info('No open PR for this build; nothing to comment.');
+                return;
+              }
+              prNumber = open.number;
+            }
+
+            // Collect the per-platform artifacts the build produced.
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              { owner, repo, run_id: run.id, per_page: 100 },
+            );
+            const platforms = [
+              { key: 'win-x64', label: 'Windows (win-x64)' },
+              { key: 'linux-x64', label: 'Linux (linux-x64)' },
+              { key: 'osx-x64', label: 'macOS (osx-x64)' },
+            ];
+            const rows = [];
+            for (const platform of platforms) {
+              const artifact = artifacts.find(a => a.name.includes(platform.key));
+              if (!artifact) {
+                continue;
+              }
+              const url = `https://github.com/${owner}/${repo}/actions/runs/${run.id}/artifacts/${artifact.id}`;
+              rows.push(`| ${platform.label} | [\`${artifact.name}\`](${url}) |`);
+            }
+            if (rows.length === 0) {
+              core.info('No platform artifacts on this run; nothing to comment.');
+              return;
+            }
+
+            const marker = '<!-- pr-build-links -->';
+            const body = [
+              marker,
+              `### 📦 Build artifacts — \`${run.head_sha.substring(0, 7)}\``,
+              '',
+              '| Platform | Download |',
+              '| --- | --- |',
+              ...rows,
+              '',
+              `From [build run #${run.run_number}](${run.html_url}). ` +
+                'Downloads require a GitHub login and expire after 90 days.',
+            ].join('\n');
+
+            // Upsert one comment so repeated builds refresh it in place.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            }

--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -12,6 +12,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <Project Path="src/SharpEmu.Libs/SharpEmu.Libs.csproj" />
     <Project Path="src/SharpEmu.Logging/SharpEmu.Logging.csproj" />
     <Project Path="src/SharpEmu.ShaderCompiler/SharpEmu.ShaderCompiler.csproj" />
+    <Project Path="src/SharpEmu.ShaderCompiler.Vulkan/SharpEmu.ShaderCompiler.Vulkan.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj" />

--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -11,6 +11,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <Project Path="src/SharpEmu.HLE/SharpEmu.HLE.csproj" />
     <Project Path="src/SharpEmu.Libs/SharpEmu.Libs.csproj" />
     <Project Path="src/SharpEmu.Logging/SharpEmu.Logging.csproj" />
+    <Project Path="src/SharpEmu.ShaderCompiler/SharpEmu.ShaderCompiler.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj" />

--- a/src/SharpEmu.CLI/packages.lock.json
+++ b/src/SharpEmu.CLI/packages.lock.json
@@ -226,6 +226,7 @@
         "dependencies": {
           "SharpEmu.HLE": "[1.0.0, )",
           "SharpEmu.ShaderCompiler": "[1.0.0, )",
+          "SharpEmu.ShaderCompiler.Vulkan": "[1.0.0, )",
           "Silk.NET.Vulkan": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.EXT": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.KHR": "[2.23.0, )",
@@ -239,6 +240,12 @@
         "type": "Project",
         "dependencies": {
           "SharpEmu.HLE": "[1.0.0, )"
+        }
+      },
+      "sharpemu.shadercompiler.vulkan": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.ShaderCompiler": "[1.0.0, )"
         }
       },
       "Avalonia": {

--- a/src/SharpEmu.CLI/packages.lock.json
+++ b/src/SharpEmu.CLI/packages.lock.json
@@ -135,23 +135,6 @@
           "Ultz.Native.GLFW": "3.4.0"
         }
       },
-      "Silk.NET.Input.Common": {
-        "type": "Transitive",
-        "resolved": "2.23.0",
-        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
-        "dependencies": {
-          "Silk.NET.Windowing.Common": "2.23.0"
-        }
-      },
-      "Silk.NET.Input.Glfw": {
-        "type": "Transitive",
-        "resolved": "2.23.0",
-        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
-        "dependencies": {
-          "Silk.NET.Input.Common": "2.23.0",
-          "Silk.NET.Windowing.Glfw": "2.23.0"
-        }
-      },
       "Silk.NET.Maths": {
         "type": "Transitive",
         "resolved": "2.23.0",
@@ -242,7 +225,7 @@
         "type": "Project",
         "dependencies": {
           "SharpEmu.HLE": "[1.0.0, )",
-          "Silk.NET.Input": "[2.23.0, )",
+          "SharpEmu.ShaderCompiler": "[1.0.0, )",
           "Silk.NET.Vulkan": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.EXT": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.KHR": "[2.23.0, )",
@@ -251,6 +234,12 @@
       },
       "sharpemu.logging": {
         "type": "Project"
+      },
+      "sharpemu.shadercompiler": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.HLE": "[1.0.0, )"
+        }
       },
       "Avalonia": {
         "type": "CentralTransitive",
@@ -299,16 +288,6 @@
         "requested": "[1.21.0, )",
         "resolved": "1.21.0",
         "contentHash": "dv5+81Q1TBQvVMSOOOmRcjJmvWcX3BZPZsIq31+RLc5cNft0IHAyNlkdb7ZarOWG913PyBoFDsDXoCIlKmLclg=="
-      },
-      "Silk.NET.Input": {
-        "type": "CentralTransitive",
-        "requested": "[2.23.0, )",
-        "resolved": "2.23.0",
-        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
-        "dependencies": {
-          "Silk.NET.Input.Common": "2.23.0",
-          "Silk.NET.Input.Glfw": "2.23.0"
-        }
       },
       "Silk.NET.Vulkan": {
         "type": "CentralTransitive",
@@ -410,59 +389,6 @@
       }
     },
     "net10.0/osx-arm64": {
-      "Avalonia.Angle.Windows.Natives": {
-        "type": "Transitive",
-        "resolved": "2.1.25547.20250602",
-        "contentHash": "ZL0VLc4s9rvNNFt19Pxm5UNAkmKNylugAwJPX9ulXZ6JWs/l6XZihPWWTyezaoNOVyEPU8YbURtW7XMAtqXH5A=="
-      },
-      "Avalonia.Native": {
-        "type": "Transitive",
-        "resolved": "11.3.18",
-        "contentHash": "8g53DROFW6wVJAnTsE1Iu5bdZO5r0oqxbdbMQODs1QDYCK2IU/y/x/vQVKCYOvqxl4tXkzU9tExv8XqSGPWthQ==",
-        "dependencies": {
-          "Avalonia": "11.3.18"
-        }
-      },
-      "HarfBuzzSharp.NativeAssets.Linux": {
-        "type": "Transitive",
-        "resolved": "8.3.1.1",
-        "contentHash": "3EZ1mpIiKWRLL5hUYA82ZHteeDIVaEA/Z0rA/wU6tjx6crcAkJnBPwDXZugBSfo8+J3EznvRJf49uMsqYfKrHg=="
-      },
-      "HarfBuzzSharp.NativeAssets.macOS": {
-        "type": "Transitive",
-        "resolved": "8.3.1.1",
-        "contentHash": "jbtCsgftcaFLCA13tVKo5iWdElJScrulLTKJre36O4YQTIlwDtPPqhRZNk+Y0vv4D1gxbscasGRucUDfS44ofQ=="
-      },
-      "HarfBuzzSharp.NativeAssets.Win32": {
-        "type": "Transitive",
-        "resolved": "8.3.1.1",
-        "contentHash": "UsJtQsfAJoFDZrXc4hCUfRPMqccfKZ0iumJ/upcUjz/cmsTgVFGNEL5yaJWmkqsuFYdMWbj/En5/kS4PFl9hBA=="
-      },
-      "SkiaSharp.NativeAssets.Linux": {
-        "type": "Transitive",
-        "resolved": "2.88.9",
-        "contentHash": "cWSaJKVPWAaT/WIn9c8T5uT/l4ETwHxNJTkEOtNKjphNo8AW6TF9O32aRkxqw3l8GUdUo66Bu7EiqtFh/XG0Zg==",
-        "dependencies": {
-          "SkiaSharp": "2.88.9"
-        }
-      },
-      "SkiaSharp.NativeAssets.macOS": {
-        "type": "Transitive",
-        "resolved": "2.88.9",
-        "contentHash": "Nv5spmKc4505Ep7oUoJ5vp3KweFpeNqxpyGDWyeEPTX2uR6S6syXIm3gj75dM0YJz7NPvcix48mR5laqs8dPuA=="
-      },
-      "SkiaSharp.NativeAssets.Win32": {
-        "type": "Transitive",
-        "resolved": "2.88.9",
-        "contentHash": "wb2kYgU7iy84nQLYZwMeJXixvK++GoIuECjU4ECaUKNuflyRlJKyiRhN1MAHswvlvzuvkrjRWlK0Za6+kYQK7w=="
-      },
-      "Ultz.Native.GLFW": {
-        "type": "Transitive",
-        "resolved": "3.4.0",
-        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
-      }
-    },
-    "net10.0/osx-x64": {
       "Avalonia.Angle.Windows.Natives": {
         "type": "Transitive",
         "resolved": "2.1.25547.20250602",

--- a/src/SharpEmu.CLI/packages.lock.json
+++ b/src/SharpEmu.CLI/packages.lock.json
@@ -135,6 +135,23 @@
           "Ultz.Native.GLFW": "3.4.0"
         }
       },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
       "Silk.NET.Maths": {
         "type": "Transitive",
         "resolved": "2.23.0",
@@ -199,9 +216,9 @@
         "type": "Project",
         "dependencies": {
           "Iced": "[1.21.0, )",
-          "SharpEmu.HLE": "[1.0.0, )",
-          "SharpEmu.Libs": "[1.0.0, )",
-          "SharpEmu.Logging": "[1.0.0, )"
+          "SharpEmu.HLE": "[0.0.1, )",
+          "SharpEmu.Libs": "[0.0.1, )",
+          "SharpEmu.Logging": "[0.0.1, )"
         }
       },
       "sharpemu.gui": {
@@ -211,22 +228,23 @@
           "Avalonia.Desktop": "[11.3.18, )",
           "Avalonia.Fonts.Inter": "[11.3.18, )",
           "Avalonia.Themes.Fluent": "[11.3.18, )",
-          "SharpEmu.Logging": "[1.0.0, )",
+          "SharpEmu.Logging": "[0.0.1, )",
           "Tmds.DBus.Protocol": "[0.21.3, )"
         }
       },
       "sharpemu.hle": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.Logging": "[1.0.0, )"
+          "SharpEmu.Logging": "[0.0.1, )"
         }
       },
       "sharpemu.libs": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.HLE": "[1.0.0, )",
-          "SharpEmu.ShaderCompiler": "[1.0.0, )",
-          "SharpEmu.ShaderCompiler.Vulkan": "[1.0.0, )",
+          "SharpEmu.HLE": "[0.0.1, )",
+          "SharpEmu.ShaderCompiler": "[0.0.1, )",
+          "SharpEmu.ShaderCompiler.Vulkan": "[0.0.1, )",
+          "Silk.NET.Input": "[2.23.0, )",
           "Silk.NET.Vulkan": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.EXT": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.KHR": "[2.23.0, )",
@@ -239,13 +257,13 @@
       "sharpemu.shadercompiler": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.HLE": "[1.0.0, )"
+          "SharpEmu.HLE": "[0.0.1, )"
         }
       },
       "sharpemu.shadercompiler.vulkan": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.ShaderCompiler": "[1.0.0, )"
+          "SharpEmu.ShaderCompiler": "[0.0.1, )"
         }
       },
       "Avalonia": {
@@ -295,6 +313,16 @@
         "requested": "[1.21.0, )",
         "resolved": "1.21.0",
         "contentHash": "dv5+81Q1TBQvVMSOOOmRcjJmvWcX3BZPZsIq31+RLc5cNft0IHAyNlkdb7ZarOWG913PyBoFDsDXoCIlKmLclg=="
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
+        }
       },
       "Silk.NET.Vulkan": {
         "type": "CentralTransitive",
@@ -396,6 +424,59 @@
       }
     },
     "net10.0/osx-arm64": {
+      "Avalonia.Angle.Windows.Natives": {
+        "type": "Transitive",
+        "resolved": "2.1.25547.20250602",
+        "contentHash": "ZL0VLc4s9rvNNFt19Pxm5UNAkmKNylugAwJPX9ulXZ6JWs/l6XZihPWWTyezaoNOVyEPU8YbURtW7XMAtqXH5A=="
+      },
+      "Avalonia.Native": {
+        "type": "Transitive",
+        "resolved": "11.3.18",
+        "contentHash": "8g53DROFW6wVJAnTsE1Iu5bdZO5r0oqxbdbMQODs1QDYCK2IU/y/x/vQVKCYOvqxl4tXkzU9tExv8XqSGPWthQ==",
+        "dependencies": {
+          "Avalonia": "11.3.18"
+        }
+      },
+      "HarfBuzzSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "3EZ1mpIiKWRLL5hUYA82ZHteeDIVaEA/Z0rA/wU6tjx6crcAkJnBPwDXZugBSfo8+J3EznvRJf49uMsqYfKrHg=="
+      },
+      "HarfBuzzSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "jbtCsgftcaFLCA13tVKo5iWdElJScrulLTKJre36O4YQTIlwDtPPqhRZNk+Y0vv4D1gxbscasGRucUDfS44ofQ=="
+      },
+      "HarfBuzzSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "UsJtQsfAJoFDZrXc4hCUfRPMqccfKZ0iumJ/upcUjz/cmsTgVFGNEL5yaJWmkqsuFYdMWbj/En5/kS4PFl9hBA=="
+      },
+      "SkiaSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "2.88.9",
+        "contentHash": "cWSaJKVPWAaT/WIn9c8T5uT/l4ETwHxNJTkEOtNKjphNo8AW6TF9O32aRkxqw3l8GUdUo66Bu7EiqtFh/XG0Zg==",
+        "dependencies": {
+          "SkiaSharp": "2.88.9"
+        }
+      },
+      "SkiaSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "2.88.9",
+        "contentHash": "Nv5spmKc4505Ep7oUoJ5vp3KweFpeNqxpyGDWyeEPTX2uR6S6syXIm3gj75dM0YJz7NPvcix48mR5laqs8dPuA=="
+      },
+      "SkiaSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "2.88.9",
+        "contentHash": "wb2kYgU7iy84nQLYZwMeJXixvK++GoIuECjU4ECaUKNuflyRlJKyiRhN1MAHswvlvzuvkrjRWlK0Za6+kYQK7w=="
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      }
+    },
+    "net10.0/osx-x64": {
       "Avalonia.Angle.Windows.Natives": {
         "type": "Transitive",
         "resolved": "2.1.25547.20250602",

--- a/src/SharpEmu.Core/packages.lock.json
+++ b/src/SharpEmu.Core/packages.lock.json
@@ -36,6 +36,23 @@
           "Ultz.Native.GLFW": "3.4.0"
         }
       },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
       "Silk.NET.Maths": {
         "type": "Transitive",
         "resolved": "2.23.0",
@@ -67,15 +84,16 @@
       "sharpemu.hle": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.Logging": "[1.0.0, )"
+          "SharpEmu.Logging": "[0.0.1, )"
         }
       },
       "sharpemu.libs": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.HLE": "[1.0.0, )",
-          "SharpEmu.ShaderCompiler": "[1.0.0, )",
-          "SharpEmu.ShaderCompiler.Vulkan": "[1.0.0, )",
+          "SharpEmu.HLE": "[0.0.1, )",
+          "SharpEmu.ShaderCompiler": "[0.0.1, )",
+          "SharpEmu.ShaderCompiler.Vulkan": "[0.0.1, )",
+          "Silk.NET.Input": "[2.23.0, )",
           "Silk.NET.Vulkan": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.EXT": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.KHR": "[2.23.0, )",
@@ -88,13 +106,23 @@
       "sharpemu.shadercompiler": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.HLE": "[1.0.0, )"
+          "SharpEmu.HLE": "[0.0.1, )"
         }
       },
       "sharpemu.shadercompiler.vulkan": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.ShaderCompiler": "[1.0.0, )"
+          "SharpEmu.ShaderCompiler": "[0.0.1, )"
+        }
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
         }
       },
       "Silk.NET.Vulkan": {

--- a/src/SharpEmu.Core/packages.lock.json
+++ b/src/SharpEmu.Core/packages.lock.json
@@ -36,23 +36,6 @@
           "Ultz.Native.GLFW": "3.4.0"
         }
       },
-      "Silk.NET.Input.Common": {
-        "type": "Transitive",
-        "resolved": "2.23.0",
-        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
-        "dependencies": {
-          "Silk.NET.Windowing.Common": "2.23.0"
-        }
-      },
-      "Silk.NET.Input.Glfw": {
-        "type": "Transitive",
-        "resolved": "2.23.0",
-        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
-        "dependencies": {
-          "Silk.NET.Input.Common": "2.23.0",
-          "Silk.NET.Windowing.Glfw": "2.23.0"
-        }
-      },
       "Silk.NET.Maths": {
         "type": "Transitive",
         "resolved": "2.23.0",
@@ -91,7 +74,7 @@
         "type": "Project",
         "dependencies": {
           "SharpEmu.HLE": "[1.0.0, )",
-          "Silk.NET.Input": "[2.23.0, )",
+          "SharpEmu.ShaderCompiler": "[1.0.0, )",
           "Silk.NET.Vulkan": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.EXT": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.KHR": "[2.23.0, )",
@@ -101,14 +84,10 @@
       "sharpemu.logging": {
         "type": "Project"
       },
-      "Silk.NET.Input": {
-        "type": "CentralTransitive",
-        "requested": "[2.23.0, )",
-        "resolved": "2.23.0",
-        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
+      "sharpemu.shadercompiler": {
+        "type": "Project",
         "dependencies": {
-          "Silk.NET.Input.Common": "2.23.0",
-          "Silk.NET.Input.Glfw": "2.23.0"
+          "SharpEmu.HLE": "[1.0.0, )"
         }
       },
       "Silk.NET.Vulkan": {

--- a/src/SharpEmu.Core/packages.lock.json
+++ b/src/SharpEmu.Core/packages.lock.json
@@ -75,6 +75,7 @@
         "dependencies": {
           "SharpEmu.HLE": "[1.0.0, )",
           "SharpEmu.ShaderCompiler": "[1.0.0, )",
+          "SharpEmu.ShaderCompiler.Vulkan": "[1.0.0, )",
           "Silk.NET.Vulkan": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.EXT": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.KHR": "[2.23.0, )",
@@ -88,6 +89,12 @@
         "type": "Project",
         "dependencies": {
           "SharpEmu.HLE": "[1.0.0, )"
+        }
+      },
+      "sharpemu.shadercompiler.vulkan": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.ShaderCompiler": "[1.0.0, )"
         }
       },
       "Silk.NET.Vulkan": {

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
 using SharpEmu.Libs.Kernel;
 using SharpEmu.Libs.VideoOut;
 using System.Buffers.Binary;

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -3,6 +3,7 @@
 
 using SharpEmu.HLE;
 using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
 using SharpEmu.Libs.Kernel;
 using SharpEmu.Libs.VideoOut;
 using System.Buffers.Binary;

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -3606,12 +3606,15 @@ public static class AgcExports
 
         if (compiled.Vertex is null || compiled.Pixel is null)
         {
-            var pixelOutputs = renderTargets
-                .Select((target, location) => new Gen5PixelOutputBinding(
-                    target.Slot,
+            var pixelOutputs = new Gen5PixelOutputBinding[renderTargets.Length];
+            for (var location = 0; location < renderTargets.Length; location++)
+            {
+                pixelOutputs[location] = new Gen5PixelOutputBinding(
+                    renderTargets[location].Slot,
                     (uint)location,
-                    renderTargetOutputKinds[location]))
-                .ToArray();
+                    renderTargetOutputKinds[location]);
+            }
+
             if (!GuestGpu.Current.TryCompilePixelShader(
                     pixelState,
                     pixelEvaluation,
@@ -3685,6 +3688,17 @@ public static class AgcExports
         IReadOnlyList<Gen5VertexInputBinding> vertexInputs =
             exportEvaluation.VertexInputs ?? [];
         state.UcRegisters.TryGetValue(VgtPrimitiveType, out var primitiveType);
+        var guestTargets = new GuestRenderTarget[renderTargets.Length];
+        for (var index = 0; index < renderTargets.Length; index++)
+        {
+            guestTargets[index] = new GuestRenderTarget(
+                renderTargets[index].Address,
+                renderTargets[index].Width,
+                renderTargets[index].Height,
+                renderTargets[index].Format,
+                renderTargets[index].NumberType);
+        }
+
         draw = new TranslatedGuestDraw(
             exportShaderAddress,
             pixelShaderAddress,
@@ -3699,13 +3713,7 @@ public static class AgcExports
             globalMemoryBindings,
             vertexInputs,
             renderTargets,
-            renderTargets.Select(target =>
-                new GuestRenderTarget(
-                    target.Address,
-                    target.Width,
-                    target.Height,
-                    target.Format,
-                    target.NumberType)).ToArray(),
+            guestTargets,
             ApplyTransparentPremultipliedFillClear(
                 CreateRenderState(state.CxRegisters, renderTargets, pixelState),
                 textures,

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -3693,7 +3693,7 @@ public static class AgcExports
             attributeCount,
             vertexCount,
             state.InstanceCount,
-            indexed ? CreateVulkanIndexBuffer(ctx, state, vertexCount) : null,
+            indexed ? CreateGuestIndexBuffer(ctx, state, vertexCount) : null,
             textures,
             globalMemoryBindings,
             vertexInputs,
@@ -3758,7 +3758,7 @@ public static class AgcExports
             ColorFunc: 0,
         };
 
-    private static GuestIndexBuffer? CreateVulkanIndexBuffer(
+    private static GuestIndexBuffer? CreateGuestIndexBuffer(
         CpuContext ctx,
         SubmittedDcbState state,
         uint indexCount)

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
+using SharpEmu.Libs.Gpu;
 using SharpEmu.ShaderCompiler;
 using SharpEmu.ShaderCompiler.Vulkan;
 using SharpEmu.Libs.Kernel;
@@ -341,12 +342,12 @@ public static class AgcExports
         uint AttributeCount,
         uint VertexCount,
         uint InstanceCount,
-        VulkanGuestIndexBuffer? IndexBuffer,
+        GuestIndexBuffer? IndexBuffer,
         IReadOnlyList<TranslatedImageBinding> Textures,
         IReadOnlyList<Gen5GlobalMemoryBinding> GlobalMemoryBindings,
         IReadOnlyList<Gen5VertexInputBinding> VertexInputs,
         IReadOnlyList<RenderTargetDescriptor> RenderTargets,
-        VulkanGuestRenderState RenderState);
+        GuestRenderState RenderState);
 
     private sealed record TranslatedImageBinding(
         TextureDescriptor Descriptor,
@@ -2944,7 +2945,7 @@ public static class AgcExports
                         handle,
                         displayBufferIndex,
                         out var cachedDisplayBuffer) &&
-                    VulkanVideoPresenter.TrySubmitGuestImage(
+                    GuestGpu.Current.TrySubmitGuestImage(
                         cachedDisplayBuffer.Address,
                         cachedDisplayBuffer.Width,
                         cachedDisplayBuffer.Height,
@@ -2968,10 +2969,10 @@ public static class AgcExports
                         displayBufferIndex,
                         translatedDisplayBuffer,
                         "draw-fallback");
-                    var textures = CreateVulkanGuestDrawTextures(ctx, translatedDraw.Textures, out var fallbackTextureCount);
+                    var textures = CreateGuestDrawTextures(ctx, translatedDraw.Textures, out var fallbackTextureCount);
                     var globalMemoryBuffers =
-                        CreateVulkanGuestMemoryBuffers(translatedDraw.GlobalMemoryBindings);
-                    VulkanVideoPresenter.SubmitTranslatedDraw(
+                        CreateGuestMemoryBuffers(translatedDraw.GlobalMemoryBindings);
+                    GuestGpu.Current.SubmitTranslatedDraw(
                         translatedDraw.PixelSpirv,
                         textures,
                         globalMemoryBuffers,
@@ -3015,7 +3016,7 @@ public static class AgcExports
                              displayBufferIndex,
                              out var displayBuffer))
                 {
-                    VulkanVideoPresenter.SubmitGuestDraw(
+                    GuestGpu.Current.SubmitGuestDraw(
                         state.GuestDrawKind,
                         displayBuffer.Width,
                         displayBuffer.Height);
@@ -3411,23 +3412,23 @@ public static class AgcExports
             var firstTarget = translatedDraw.RenderTargets.FirstOrDefault();
             if (firstTarget.Address != 0)
             {
-                var textures = CreateVulkanGuestDrawTextures(
+                var textures = CreateGuestDrawTextures(
                     ctx,
                     translatedDraw.Textures,
                     out _);
                 var globalMemoryBuffers =
-                    CreateVulkanGuestMemoryBuffers(translatedDraw.GlobalMemoryBindings);
+                    CreateGuestMemoryBuffers(translatedDraw.GlobalMemoryBindings);
                 var vertexBuffers =
-                    CreateVulkanGuestVertexBuffers(translatedDraw.VertexInputs);
+                    CreateGuestVertexBuffers(translatedDraw.VertexInputs);
                 TraceRectListVertices(translatedDraw, vertexBuffers);
                 TraceGrassDrawVertices(translatedDraw, textures, vertexBuffers);
-                VulkanVideoPresenter.SubmitOffscreenTranslatedDraw(
+                GuestGpu.Current.SubmitOffscreenTranslatedDraw(
                     translatedDraw.PixelSpirv,
                     textures,
                     globalMemoryBuffers,
                     translatedDraw.AttributeCount,
                     translatedDraw.RenderTargets.Select(target =>
-                        new VulkanGuestRenderTarget(
+                        new GuestRenderTarget(
                             target.Address,
                             target.Width,
                             target.Height,
@@ -3447,13 +3448,13 @@ public static class AgcExports
                     .FirstOrDefault(binding => binding.IsStorage);
                 if (storageTarget is not null)
                 {
-                    var textures = CreateVulkanGuestDrawTextures(
+                    var textures = CreateGuestDrawTextures(
                         ctx,
                         translatedDraw.Textures,
                         out _);
                     var globalMemoryBuffers =
-                        CreateVulkanGuestMemoryBuffers(translatedDraw.GlobalMemoryBindings);
-                    VulkanVideoPresenter.SubmitStorageTranslatedDraw(
+                        CreateGuestMemoryBuffers(translatedDraw.GlobalMemoryBindings);
+                    GuestGpu.Current.SubmitStorageTranslatedDraw(
                         translatedDraw.PixelSpirv,
                         textures,
                         globalMemoryBuffers,
@@ -3563,14 +3564,14 @@ public static class AgcExports
             .Where(target => HasPixelColorExport(pixelState, target.Slot))
             .OrderBy(target => target.Slot)
             .ToArray();
-        var renderTargetFormats = new VulkanRenderTargetFormat[renderTargets.Length];
+        var renderTargetOutputKinds = new Gen5PixelOutputKind[renderTargets.Length];
         for (var index = 0; index < renderTargets.Length; index++)
         {
             var target = renderTargets[index];
-            if (!VulkanVideoPresenter.TryDecodeRenderTargetFormat(
+            if (!GuestGpu.Current.TryGetRenderTargetOutputKind(
                     target.Format,
                     target.NumberType,
-                    out renderTargetFormats[index]))
+                    out renderTargetOutputKinds[index]))
             {
                 error =
                     $"unsupported color target format={target.Format} number_type={target.NumberType}";
@@ -3582,7 +3583,7 @@ public static class AgcExports
             .Select((target, location) => new Gen5PixelOutputBinding(
                 target.Slot,
                 (uint)location,
-                renderTargetFormats[location].OutputKind))
+                renderTargetOutputKinds[location]))
             .ToArray();
         var outputLayout = string.Join(
             ';',
@@ -3719,8 +3720,8 @@ public static class AgcExports
     /// Treat precisely that draw shape as an overwrite only when every MRT
     /// attachment uses the same premultiplied blend pattern.
     /// </summary>
-    private static VulkanGuestRenderState ApplyTransparentPremultipliedFillClear(
-        VulkanGuestRenderState renderState,
+    private static GuestRenderState ApplyTransparentPremultipliedFillClear(
+        GuestRenderState renderState,
         IReadOnlyList<TranslatedImageBinding> textures,
         IReadOnlyList<Gen5VertexInputBinding> vertexInputs,
         IReadOnlyList<uint> pixelUserData)
@@ -3750,7 +3751,7 @@ public static class AgcExports
         };
     }
 
-    private static bool IsTransparentPremultipliedFillBlend(VulkanGuestBlendState blend) =>
+    private static bool IsTransparentPremultipliedFillBlend(GuestBlendState blend) =>
         blend is
         {
             Enable: true,
@@ -3759,7 +3760,7 @@ public static class AgcExports
             ColorFunc: 0,
         };
 
-    private static VulkanGuestIndexBuffer? CreateVulkanIndexBuffer(
+    private static GuestIndexBuffer? CreateVulkanIndexBuffer(
         CpuContext ctx,
         SubmittedDcbState state,
         uint indexCount)
@@ -3777,7 +3778,7 @@ public static class AgcExports
         var address = state.IndexBufferAddress + byteOffset;
         return (ctx.Memory.TryRead(address, data) ||
                 KernelMemoryCompatExports.TryReadTrackedLibcHeap(address, data))
-            ? new VulkanGuestIndexBuffer(data, is32Bit)
+            ? new GuestIndexBuffer(data, is32Bit)
             : null;
     }
 
@@ -3945,19 +3946,19 @@ public static class AgcExports
         return targets;
     }
 
-    private static VulkanGuestRenderState CreateRenderState(
+    private static GuestRenderState CreateRenderState(
         IReadOnlyDictionary<uint, uint> registers,
         IReadOnlyList<RenderTargetDescriptor> targets,
         Gen5ShaderState pixelState)
     {
         if (targets.Count == 0)
         {
-            return VulkanGuestRenderState.Default;
+            return GuestRenderState.Default;
         }
 
         var target = targets[0];
         var scissor = DecodeScissor(registers, target.Width, target.Height);
-        return new VulkanGuestRenderState(
+        return new GuestRenderState(
             targets.Select(target =>
             {
                 var blend = DecodeBlendState(registers, target.Slot);
@@ -3970,7 +3971,7 @@ public static class AgcExports
             DecodeViewport(registers, target.Width, target.Height, scissor));
     }
 
-    private static VulkanGuestBlendState DecodeBlendState(
+    private static GuestBlendState DecodeBlendState(
         IReadOnlyDictionary<uint, uint> registers,
         uint slot)
     {
@@ -3981,7 +3982,7 @@ public static class AgcExports
         }
 
         registers.TryGetValue(CbBlend0Control + slot, out var control);
-        return new VulkanGuestBlendState(
+        return new GuestBlendState(
             ((control >> 30) & 1u) != 0,
             control & 0x1Fu,
             (control >> 8) & 0x1Fu,
@@ -3993,14 +3994,14 @@ public static class AgcExports
             writeMask);
     }
 
-    private static VulkanGuestRect? DecodeScissor(
+    private static GuestRect? DecodeScissor(
         IReadOnlyDictionary<uint, uint> registers,
         uint targetWidth,
         uint targetHeight)
     {
         if (targetWidth == 0 || targetHeight == 0)
         {
-            return new VulkanGuestRect(0, 0, 0, 0);
+            return new GuestRect(0, 0, 0, 0);
         }
 
         var left = 0;
@@ -4065,22 +4066,22 @@ public static class AgcExports
             return null;
         }
 
-        return new VulkanGuestRect(
+        return new GuestRect(
             left,
             top,
             checked((uint)(right - left)),
             checked((uint)(bottom - top)));
     }
 
-    private static VulkanGuestViewport? DecodeViewport(
+    private static GuestViewport? DecodeViewport(
         IReadOnlyDictionary<uint, uint> registers,
         uint targetWidth,
         uint targetHeight,
-        VulkanGuestRect? scissor)
+        GuestRect? scissor)
     {
         if (targetWidth == 0 || targetHeight == 0)
         {
-            return new VulkanGuestViewport(0, 0, 0, 0, 0, 1);
+            return new GuestViewport(0, 0, 0, 0, 0, 1);
         }
 
         var minDepth = 0f;
@@ -4106,7 +4107,7 @@ public static class AgcExports
             xScale > 0f &&
             yScale != 0f)
         {
-            return new VulkanGuestViewport(
+            return new GuestViewport(
                 xOffset - xScale,
                 yOffset - yScale,
                 xScale * 2f,
@@ -4119,10 +4120,10 @@ public static class AgcExports
         {
             return minDepth == 0f && maxDepth == 1f
                 ? null
-                : new VulkanGuestViewport(0, 0, targetWidth, targetHeight, minDepth, maxDepth);
+                : new GuestViewport(0, 0, targetWidth, targetHeight, minDepth, maxDepth);
         }
 
-        return new VulkanGuestViewport(
+        return new GuestViewport(
             rect.X,
             rect.Y,
             rect.Width,
@@ -4309,16 +4310,16 @@ public static class AgcExports
             $"buffers=[{buffers}] vertex=[{vertexInputs}] indices=[{indices}]");
     }
 
-    private static IReadOnlyList<VulkanGuestDrawTexture> CreateVulkanGuestDrawTextures(
+    private static IReadOnlyList<GuestDrawTexture> CreateGuestDrawTextures(
         CpuContext ctx,
         IReadOnlyList<TranslatedImageBinding> bindings,
         out int fallbackTextureCount)
     {
-        var textures = new List<VulkanGuestDrawTexture>(bindings.Count);
+        var textures = new List<GuestDrawTexture>(bindings.Count);
         fallbackTextureCount = 0;
         foreach (var binding in bindings)
         {
-            if (TryCreateVulkanGuestDrawTexture(
+            if (TryCreateGuestDrawTexture(
                     ctx,
                     binding.Descriptor,
                     binding.IsStorage,
@@ -4337,13 +4338,13 @@ public static class AgcExports
         return textures;
     }
 
-    private static IReadOnlyList<VulkanGuestMemoryBuffer> CreateVulkanGuestMemoryBuffers(
+    private static IReadOnlyList<GuestMemoryBuffer> CreateGuestMemoryBuffers(
         IReadOnlyList<Gen5GlobalMemoryBinding> bindings)
     {
-        var buffers = new VulkanGuestMemoryBuffer[bindings.Count];
+        var buffers = new GuestMemoryBuffer[bindings.Count];
         for (var index = 0; index < bindings.Count; index++)
         {
-            buffers[index] = new VulkanGuestMemoryBuffer(
+            buffers[index] = new GuestMemoryBuffer(
                 bindings[index].BaseAddress,
                 bindings[index].Data);
         }
@@ -4351,14 +4352,14 @@ public static class AgcExports
         return buffers;
     }
 
-    private static IReadOnlyList<VulkanGuestVertexBuffer> CreateVulkanGuestVertexBuffers(
+    private static IReadOnlyList<GuestVertexBuffer> CreateGuestVertexBuffers(
         IReadOnlyList<Gen5VertexInputBinding> bindings)
     {
-        var buffers = new VulkanGuestVertexBuffer[bindings.Count];
+        var buffers = new GuestVertexBuffer[bindings.Count];
         for (var index = 0; index < bindings.Count; index++)
         {
             var binding = bindings[index];
-            buffers[index] = new VulkanGuestVertexBuffer(
+            buffers[index] = new GuestVertexBuffer(
                 binding.Location,
                 binding.ComponentCount,
                 binding.DataFormat,
@@ -4372,13 +4373,13 @@ public static class AgcExports
         return buffers;
     }
 
-    private static bool TryCreateVulkanGuestDrawTexture(
+    private static bool TryCreateGuestDrawTexture(
         CpuContext ctx,
         TextureDescriptor descriptor,
         bool isStorage,
         uint mipLevel,
         IReadOnlyList<uint> samplerDescriptor,
-        out VulkanGuestDrawTexture texture)
+        out GuestDrawTexture texture)
     {
         texture = default!;
         if (descriptor.Type != Gen5TextureType2D ||
@@ -4414,12 +4415,12 @@ public static class AgcExports
 
         if (!isStorage &&
             descriptor.Address != 0 &&
-            VulkanVideoPresenter.IsGpuGuestImageAvailable(
+            GuestGpu.Current.IsGpuGuestImageAvailable(
                 descriptor.Address,
                 descriptor.Format,
                 descriptor.NumberType))
         {
-            texture = new VulkanGuestDrawTexture(
+            texture = new GuestDrawTexture(
                 descriptor.Address,
                 descriptor.Width,
                 descriptor.Height,
@@ -4433,7 +4434,7 @@ public static class AgcExports
                 Pitch: sourceWidth,
                 TileMode: descriptor.TileMode,
                 DstSelect: descriptor.DstSelect,
-                Sampler: ToVulkanSampler(samplerDescriptor));
+                Sampler: ToGuestSampler(samplerDescriptor));
             return true;
         }
 
@@ -4453,7 +4454,7 @@ public static class AgcExports
                 }
             }
 
-            texture = new VulkanGuestDrawTexture(
+            texture = new GuestDrawTexture(
                 descriptor.Address,
                 descriptor.Width,
                 descriptor.Height,
@@ -4467,7 +4468,7 @@ public static class AgcExports
                 Pitch: sourceWidth,
                 TileMode: descriptor.TileMode,
                 DstSelect: descriptor.DstSelect,
-                Sampler: ToVulkanSampler(samplerDescriptor));
+                Sampler: ToGuestSampler(samplerDescriptor));
             return true;
         }
 
@@ -4508,7 +4509,7 @@ public static class AgcExports
         DumpTextureSourceIfRequested(descriptor, sourceWidth, source);
 
         var rgba = source;
-        texture = new VulkanGuestDrawTexture(
+        texture = new GuestDrawTexture(
             descriptor.Address,
             descriptor.Width,
             descriptor.Height,
@@ -4522,7 +4523,7 @@ public static class AgcExports
             Pitch: sourceWidth,
             TileMode: descriptor.TileMode,
             DstSelect: descriptor.DstSelect,
-            Sampler: ToVulkanSampler(samplerDescriptor));
+            Sampler: ToGuestSampler(samplerDescriptor));
         return true;
     }
 
@@ -4555,8 +4556,8 @@ public static class AgcExports
 
     private static void TraceGrassDrawVertices(
         TranslatedGuestDraw draw,
-        IReadOnlyList<VulkanGuestDrawTexture> textures,
-        IReadOnlyList<VulkanGuestVertexBuffer> vertexBuffers)
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestVertexBuffer> vertexBuffers)
     {
         if (_grassTraceCount >= 6 ||
             !textures.Any(texture => texture.Width == 288 && texture.Height == 160) ||
@@ -4595,7 +4596,7 @@ public static class AgcExports
 
     private static void TraceRectListVertices(
         TranslatedGuestDraw draw,
-        IReadOnlyList<VulkanGuestVertexBuffer> vertexBuffers)
+        IReadOnlyList<GuestVertexBuffer> vertexBuffers)
     {
         if (draw.PrimitiveType != 0x11 ||
             draw.IndexBuffer is not null ||
@@ -4678,7 +4679,7 @@ public static class AgcExports
         }
     }
 
-    private static VulkanGuestDrawTexture CreateFallbackGuestDrawTexture(
+    private static GuestDrawTexture CreateFallbackGuestDrawTexture(
         bool isStorage,
         uint format,
         uint numberType)
@@ -4726,9 +4727,9 @@ public static class AgcExports
             $"size={descriptor.Width}x{descriptor.Height} bytes={source.Length} hash=0x{hash:X16}");
     }
 
-    private static VulkanGuestSampler ToVulkanSampler(IReadOnlyList<uint> descriptor) =>
+    private static GuestSampler ToGuestSampler(IReadOnlyList<uint> descriptor) =>
         descriptor.Count >= 4
-            ? new VulkanGuestSampler(
+            ? new GuestSampler(
                 descriptor[0],
                 descriptor[1],
                 descriptor[2],
@@ -4958,13 +4959,13 @@ public static class AgcExports
                     _computeSpirvCache.TryAdd(shaderKey, computeSpirv);
                 }
 
-                var textures = CreateVulkanGuestDrawTextures(
+                var textures = CreateGuestDrawTextures(
                     ctx,
                     translatedBindings,
                     out _);
                 var globalMemoryBuffers =
-                    CreateVulkanGuestMemoryBuffers(evaluation.GlobalMemoryBindings);
-                VulkanVideoPresenter.SubmitComputeDispatch(
+                    CreateGuestMemoryBuffers(evaluation.GlobalMemoryBindings);
+                GuestGpu.Current.SubmitComputeDispatch(
                     shaderAddress,
                     computeSpirv,
                     textures,
@@ -5137,7 +5138,7 @@ public static class AgcExports
                     }
                 }
                 else if (source is { } cachedSourceTexture &&
-                    VulkanVideoPresenter.TrySubmitGuestImageBlit(
+                    GuestGpu.Current.TrySubmitGuestImageBlit(
                         cachedSourceTexture.Address,
                         cachedSourceTexture.Width,
                         cachedSourceTexture.Height,

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Collections.Concurrent;
 using SharpEmu.HLE;
 using SharpEmu.Libs.Gpu;
 using SharpEmu.ShaderCompiler;
@@ -159,10 +160,12 @@ public static class AgcExports
     private static readonly HashSet<ulong> _tracedComputeShaders = new();
     private static readonly Dictionary<(ulong Address, uint Width, uint Height), ulong> _tracedTextureHashes = [];
     private static readonly HashSet<uint> _tracedSubmittedDrawOpcodes = new();
-    private static readonly Dictionary<
-        (ulong Es, ulong EsState, ulong Ps, ulong PsState, string OutputLayout, uint Attributes),
+    // Concurrent so the per-draw/per-dispatch hit path is lock-free (and no longer
+    // shares _submitTraceGate with tracing).
+    private static readonly ConcurrentDictionary<
+        (ulong Es, ulong EsState, ulong Ps, ulong PsState, ulong OutputLayout, uint OutputCount, uint Attributes),
         (IGuestCompiledShader Vertex, IGuestCompiledShader Pixel)> _graphicsShaderCache = new();
-    private static readonly Dictionary<
+    private static readonly ConcurrentDictionary<
         (ulong Cs, ulong State, uint LocalX, uint LocalY, uint LocalZ),
         IGuestCompiledShader> _computeShaderCache = new();
     private static readonly Dictionary<ulong, ulong> _shaderHeadersByCode = new();
@@ -345,6 +348,9 @@ public static class AgcExports
         IReadOnlyList<Gen5GlobalMemoryBinding> GlobalMemoryBindings,
         IReadOnlyList<Gen5VertexInputBinding> VertexInputs,
         IReadOnlyList<RenderTargetDescriptor> RenderTargets,
+        // The seam-shaped view of RenderTargets, built once here so the per-frame
+        // submit path does not rebuild it for every draw of a cached translation.
+        IReadOnlyList<GuestRenderTarget> GuestTargets,
         GuestRenderState RenderState);
 
     private sealed record TranslatedImageBinding(
@@ -3425,13 +3431,7 @@ public static class AgcExports
                     textures,
                     globalMemoryBuffers,
                     translatedDraw.AttributeCount,
-                    translatedDraw.RenderTargets.Select(target =>
-                        new GuestRenderTarget(
-                            target.Address,
-                            target.Width,
-                            target.Height,
-                            target.Format,
-                            target.NumberType)).ToArray(),
+                    translatedDraw.GuestTargets,
                         translatedDraw.VertexShader,
                         translatedDraw.VertexCount,
                         translatedDraw.InstanceCount,
@@ -3577,16 +3577,17 @@ public static class AgcExports
             }
         }
 
-        var pixelOutputs = renderTargets
-            .Select((target, location) => new Gen5PixelOutputBinding(
-                target.Slot,
-                (uint)location,
-                renderTargetOutputKinds[location]))
-            .ToArray();
-        var outputLayout = string.Join(
-            ';',
-            pixelOutputs.Select(output =>
-                $"{output.GuestSlot}:{output.HostLocation}:{(int)output.Kind}"));
+        // Exact packed encoding of the output layout — guest slot (6 bits, CB targets are
+        // 0-7) plus output kind (2 bits) per target, host locations being the sequential
+        // byte positions. Replaces a per-draw LINQ + string build that allocated on every
+        // draw, cache hit or not; the target count disambiguates trailing zero bytes.
+        var outputLayout = 0UL;
+        for (var index = 0; index < renderTargets.Length; index++)
+        {
+            outputLayout |= (ulong)(((renderTargets[index].Slot & 0x3Fu) << 2) |
+                (uint)renderTargetOutputKinds[index]) << (index * 8);
+        }
+
         var attributeCount = GetInterpolatedAttributeCount(pixelState);
         var exportStateFingerprint = ComputeShaderStructureFingerprint(exportEvaluation);
         var pixelStateFingerprint = ComputeShaderStructureFingerprint(pixelEvaluation);
@@ -3596,18 +3597,21 @@ public static class AgcExports
             pixelShaderAddress,
             pixelStateFingerprint,
             outputLayout,
+            (uint)renderTargets.Length,
             attributeCount);
         var totalGlobalBuffers =
             pixelEvaluation.GlobalMemoryBindings.Count +
             exportEvaluation.GlobalMemoryBindings.Count;
-        (IGuestCompiledShader Vertex, IGuestCompiledShader Pixel) compiled;
-        lock (_submitTraceGate)
-        {
-            _graphicsShaderCache.TryGetValue(shaderKey, out compiled);
-        }
+        _graphicsShaderCache.TryGetValue(shaderKey, out var compiled);
 
         if (compiled.Vertex is null || compiled.Pixel is null)
         {
+            var pixelOutputs = renderTargets
+                .Select((target, location) => new Gen5PixelOutputBinding(
+                    target.Slot,
+                    (uint)location,
+                    renderTargetOutputKinds[location]))
+                .ToArray();
             if (!GuestGpu.Current.TryCompilePixelShader(
                     pixelState,
                     pixelEvaluation,
@@ -3644,10 +3648,7 @@ public static class AgcExports
                 pixelStateFingerprint,
                 compiled.Pixel,
                 pixelState.Program);
-            lock (_submitTraceGate)
-            {
-                _graphicsShaderCache.TryAdd(shaderKey, compiled);
-            }
+            _graphicsShaderCache.TryAdd(shaderKey, compiled);
         }
 
         var imageBindings = pixelEvaluation.ImageBindings
@@ -3698,6 +3699,13 @@ public static class AgcExports
             globalMemoryBindings,
             vertexInputs,
             renderTargets,
+            renderTargets.Select(target =>
+                new GuestRenderTarget(
+                    target.Address,
+                    target.Width,
+                    target.Height,
+                    target.Format,
+                    target.NumberType)).ToArray(),
             ApplyTransparentPremultipliedFillClear(
                 CreateRenderState(state.CxRegisters, renderTargets, pixelState),
                 textures,
@@ -4925,11 +4933,7 @@ public static class AgcExports
                 localSizeX,
                 localSizeY,
                 localSizeZ);
-            IGuestCompiledShader? computeShader;
-            lock (_submitTraceGate)
-            {
-                _computeShaderCache.TryGetValue(shaderKey, out computeShader);
-            }
+            _computeShaderCache.TryGetValue(shaderKey, out var computeShader);
 
             if (computeShader is null &&
                 GuestGpu.Current.TryCompileComputeShader(
@@ -4951,10 +4955,7 @@ public static class AgcExports
 
             if (computeShader is not null)
             {
-                lock (_submitTraceGate)
-                {
-                    _computeShaderCache.TryAdd(shaderKey, computeShader);
-                }
+                _computeShaderCache.TryAdd(shaderKey, computeShader);
 
                 var textures = CreateGuestDrawTextures(
                     ctx,

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -8,7 +8,6 @@ using SharpEmu.ShaderCompiler;
 using SharpEmu.Libs.Kernel;
 using SharpEmu.Libs.VideoOut;
 using System.Buffers.Binary;
-using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 
 namespace SharpEmu.Libs.Agc;

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -3632,17 +3632,17 @@ public static class AgcExports
             }
 
             compiled = (vertexShader!, pixelShader!);
-            DumpSpirv(
+            DumpCompiledShader(
                 "vs",
                 exportShaderAddress,
                 exportStateFingerprint,
-                compiled.Vertex.Payload,
+                compiled.Vertex,
                 exportState.Program);
-            DumpSpirv(
+            DumpCompiledShader(
                 "ps",
                 pixelShaderAddress,
                 pixelStateFingerprint,
-                compiled.Pixel.Payload,
+                compiled.Pixel,
                 pixelState.Program);
             lock (_submitTraceGate)
             {
@@ -4941,11 +4941,11 @@ public static class AgcExports
                     out computeShader,
                     out computeError))
             {
-                DumpSpirv(
+                DumpCompiledShader(
                     "cs",
                     shaderAddress,
                     shaderKey.Item2,
-                    computeShader!.Payload,
+                    computeShader!,
                     shaderState.Program);
             }
 
@@ -6388,14 +6388,14 @@ public static class AgcExports
         $"type={descriptor.Type} levels={descriptor.BaseLevel}-{descriptor.LastLevel} " +
         $"pitch={descriptor.Pitch} dst=0x{descriptor.DstSelect:X3}";
 
-    private static void DumpSpirv(
+    private static void DumpCompiledShader(
         string stage,
         ulong shaderAddress,
         ulong stateFingerprint,
-        byte[] spirv,
+        IGuestCompiledShader shader,
         Gen5ShaderProgram program)
     {
-        if (spirv.Length == 0 ||
+        if (shader.Payload.Length == 0 ||
             !string.Equals(
                 Environment.GetEnvironmentVariable("SHARPEMU_DUMP_SPIRV"),
                 "1",
@@ -6407,7 +6407,9 @@ public static class AgcExports
         var directory = Path.Combine(AppContext.BaseDirectory, "shader-dumps");
         Directory.CreateDirectory(directory);
         var name = $"{shaderAddress:X16}-{stateFingerprint:X16}.{stage}";
-        File.WriteAllBytes(Path.Combine(directory, $"{name}.spv"), spirv);
+        File.WriteAllBytes(
+            Path.Combine(directory, $"{name}.{shader.PayloadFileExtension}"),
+            shader.Payload);
 
         var lines = new List<string>(program.Instructions.Count + 2)
         {

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -4,7 +4,6 @@
 using SharpEmu.HLE;
 using SharpEmu.Libs.Gpu;
 using SharpEmu.ShaderCompiler;
-using SharpEmu.ShaderCompiler.Vulkan;
 using SharpEmu.Libs.Kernel;
 using SharpEmu.Libs.VideoOut;
 using System.Buffers.Binary;
@@ -160,13 +159,12 @@ public static class AgcExports
     private static readonly HashSet<ulong> _tracedComputeShaders = new();
     private static readonly Dictionary<(ulong Address, uint Width, uint Height), ulong> _tracedTextureHashes = [];
     private static readonly HashSet<uint> _tracedSubmittedDrawOpcodes = new();
-    private static readonly Dictionary<(ulong Ps, ulong State, Gen5PixelOutputKind Output), byte[]> _pixelSpirvCache = new();
     private static readonly Dictionary<
         (ulong Es, ulong EsState, ulong Ps, ulong PsState, string OutputLayout, uint Attributes),
-        (byte[] Vertex, byte[] Pixel)> _graphicsSpirvCache = new();
+        (IGuestCompiledShader Vertex, IGuestCompiledShader Pixel)> _graphicsShaderCache = new();
     private static readonly Dictionary<
         (ulong Cs, ulong State, uint LocalX, uint LocalY, uint LocalZ),
-        byte[]> _computeSpirvCache = new();
+        IGuestCompiledShader> _computeShaderCache = new();
     private static readonly Dictionary<ulong, ulong> _shaderHeadersByCode = new();
     private static readonly bool _traceAgc = string.Equals(
         Environment.GetEnvironmentVariable("SHARPEMU_LOG_AGC"),
@@ -337,8 +335,8 @@ public static class AgcExports
         ulong ExportShaderAddress,
         ulong PixelShaderAddress,
         uint PrimitiveType,
-        byte[] VertexSpirv,
-        byte[] PixelSpirv,
+        IGuestCompiledShader VertexShader,
+        IGuestCompiledShader PixelShader,
         uint AttributeCount,
         uint VertexCount,
         uint InstanceCount,
@@ -2973,7 +2971,7 @@ public static class AgcExports
                     var globalMemoryBuffers =
                         CreateGuestMemoryBuffers(translatedDraw.GlobalMemoryBindings);
                     GuestGpu.Current.SubmitTranslatedDraw(
-                        translatedDraw.PixelSpirv,
+                        translatedDraw.PixelShader,
                         textures,
                         globalMemoryBuffers,
                         translatedDisplayBuffer.Width,
@@ -2981,7 +2979,7 @@ public static class AgcExports
                         translatedDraw.AttributeCount);
                     TraceAgcShader(
                         $"agc.shader_present ps=0x{translatedDraw.PixelShaderAddress:X16} " +
-                        $"spirv={translatedDraw.PixelSpirv.Length} textures={textures.Count} " +
+                        $"spirv={translatedDraw.PixelShader.Payload.Length} textures={textures.Count} " +
                         $"global_buffers={globalMemoryBuffers.Count} " +
                         $"fallback={fallbackTextureCount} {translatedDisplayBuffer.Width}x{translatedDisplayBuffer.Height}");
 
@@ -3423,7 +3421,7 @@ public static class AgcExports
                 TraceRectListVertices(translatedDraw, vertexBuffers);
                 TraceGrassDrawVertices(translatedDraw, textures, vertexBuffers);
                 GuestGpu.Current.SubmitOffscreenTranslatedDraw(
-                    translatedDraw.PixelSpirv,
+                    translatedDraw.PixelShader,
                     textures,
                     globalMemoryBuffers,
                     translatedDraw.AttributeCount,
@@ -3434,7 +3432,7 @@ public static class AgcExports
                             target.Height,
                             target.Format,
                             target.NumberType)).ToArray(),
-                        translatedDraw.VertexSpirv,
+                        translatedDraw.VertexShader,
                         translatedDraw.VertexCount,
                         translatedDraw.InstanceCount,
                         translatedDraw.PrimitiveType,
@@ -3455,7 +3453,7 @@ public static class AgcExports
                     var globalMemoryBuffers =
                         CreateGuestMemoryBuffers(translatedDraw.GlobalMemoryBindings);
                     GuestGpu.Current.SubmitStorageTranslatedDraw(
-                        translatedDraw.PixelSpirv,
+                        translatedDraw.PixelShader,
                         textures,
                         globalMemoryBuffers,
                         translatedDraw.AttributeCount,
@@ -3602,15 +3600,15 @@ public static class AgcExports
         var totalGlobalBuffers =
             pixelEvaluation.GlobalMemoryBindings.Count +
             exportEvaluation.GlobalMemoryBindings.Count;
-        (byte[] Vertex, byte[] Pixel) compiled;
+        (IGuestCompiledShader Vertex, IGuestCompiledShader Pixel) compiled;
         lock (_submitTraceGate)
         {
-            _graphicsSpirvCache.TryGetValue(shaderKey, out compiled);
+            _graphicsShaderCache.TryGetValue(shaderKey, out compiled);
         }
 
         if (compiled.Vertex is null || compiled.Pixel is null)
         {
-            if (!Gen5SpirvTranslator.TryCompilePixelShader(
+            if (!GuestGpu.Current.TryCompilePixelShader(
                     pixelState,
                     pixelEvaluation,
                     pixelOutputs,
@@ -3620,7 +3618,7 @@ public static class AgcExports
                     totalGlobalBufferCount: totalGlobalBuffers + 2,
                     imageBindingBase: 0,
                     scalarRegisterBufferIndex: totalGlobalBuffers) ||
-                !Gen5SpirvTranslator.TryCompileVertexShader(
+                !GuestGpu.Current.TryCompileVertexShader(
                     exportState,
                     exportEvaluation,
                     out var vertexShader,
@@ -3633,22 +3631,22 @@ public static class AgcExports
                 return false;
             }
 
-            compiled = (vertexShader.Spirv, pixelShader.Spirv);
+            compiled = (vertexShader!, pixelShader!);
             DumpSpirv(
                 "vs",
                 exportShaderAddress,
                 exportStateFingerprint,
-                compiled.Vertex,
+                compiled.Vertex.Payload,
                 exportState.Program);
             DumpSpirv(
                 "ps",
                 pixelShaderAddress,
                 pixelStateFingerprint,
-                compiled.Pixel,
+                compiled.Pixel.Payload,
                 pixelState.Program);
             lock (_submitTraceGate)
             {
-                _graphicsSpirvCache.TryAdd(shaderKey, compiled);
+                _graphicsShaderCache.TryAdd(shaderKey, compiled);
             }
         }
 
@@ -4300,7 +4298,7 @@ public static class AgcExports
         var blend = draw.RenderState.Blend;
         TraceAgcShader(
             $"agc.shader_draw es=0x{draw.ExportShaderAddress:X16} " +
-            $"ps=0x{draw.PixelShaderAddress:X16} spirv={draw.PixelSpirv.Length} " +
+            $"ps=0x{draw.PixelShaderAddress:X16} spirv={draw.PixelShader.Payload.Length} " +
             $"primitive=0x{draw.PrimitiveType:X} " +
             $"blend={(blend.Enable ? 1 : 0)}:{blend.ColorSrcFactor}/{blend.ColorDstFactor}/{blend.ColorFunc} " +
             $"write_mask=0x{blend.WriteMask:X} scissor={scissor} viewport={viewport} " +
@@ -4927,36 +4925,35 @@ public static class AgcExports
                 localSizeX,
                 localSizeY,
                 localSizeZ);
-            byte[] computeSpirv;
+            IGuestCompiledShader? computeShader;
             lock (_submitTraceGate)
             {
-                _computeSpirvCache.TryGetValue(shaderKey, out computeSpirv!);
+                _computeShaderCache.TryGetValue(shaderKey, out computeShader);
             }
 
-            if (computeSpirv is null &&
-                Gen5SpirvTranslator.TryCompileComputeShader(
+            if (computeShader is null &&
+                GuestGpu.Current.TryCompileComputeShader(
                     shaderState,
                     evaluation,
                     localSizeX,
                     localSizeY,
                     localSizeZ,
-                    out var compiledCompute,
+                    out computeShader,
                     out computeError))
             {
-                computeSpirv = compiledCompute.Spirv;
                 DumpSpirv(
                     "cs",
                     shaderAddress,
                     shaderKey.Item2,
-                    computeSpirv,
+                    computeShader!.Payload,
                     shaderState.Program);
             }
 
-            if (computeSpirv is not null)
+            if (computeShader is not null)
             {
                 lock (_submitTraceGate)
                 {
-                    _computeSpirvCache.TryAdd(shaderKey, computeSpirv);
+                    _computeShaderCache.TryAdd(shaderKey, computeShader);
                 }
 
                 var textures = CreateGuestDrawTextures(
@@ -4967,7 +4964,7 @@ public static class AgcExports
                     CreateGuestMemoryBuffers(evaluation.GlobalMemoryBindings);
                 GuestGpu.Current.SubmitComputeDispatch(
                     shaderAddress,
-                    computeSpirv,
+                    computeShader,
                     textures,
                     globalMemoryBuffers,
                     dispatch.GroupCountX,
@@ -5492,7 +5489,7 @@ public static class AgcExports
                                 $"pcs={string.Join(',', binding.InstructionPcs.Select(pc => $"0x{pc:X}"))}");
                         }
 
-                        if (Gen5SpirvTranslator.TryCompilePixelShader(
+                        if (GuestGpu.Current.TryCompilePixelShader(
                                  pixelState,
                                  evaluation,
                                  [new(0, 0, Gen5PixelOutputKind.Float)],
@@ -5501,7 +5498,7 @@ public static class AgcExports
                         {
                             TraceAgcShader(
                                 $"agc.shader_spirv ps=0x{pixelShaderAddress:X16} " +
-                                $"bytes={compiledPixel.Spirv.Length} bindings={evaluation.ImageBindings.Count} " +
+                                $"bytes={compiledPixel!.Payload.Length} bindings={evaluation.ImageBindings.Count} " +
                                 $"global_buffers={evaluation.GlobalMemoryBindings.Count}");
                         }
                         else

--- a/src/SharpEmu.Libs/Agc/AgcShaderCompilerHooks.cs
+++ b/src/SharpEmu.Libs/Agc/AgcShaderCompilerHooks.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using SharpEmu.Libs.Kernel;
 using SharpEmu.ShaderCompiler;
@@ -15,6 +16,12 @@ namespace SharpEmu.Libs.Agc;
 internal static class AgcShaderCompilerHooks
 {
     [ModuleInitializer]
+    [SuppressMessage(
+        "Usage",
+        "CA2255:The 'ModuleInitializer' attribute should not be used in libraries",
+        Justification = "This is the rule's intended advanced scenario: the hook must be " +
+            "installed before any code path can reach the evaluator, and every such path " +
+            "enters through this assembly.")]
     internal static void Install()
     {
         Gen5ShaderScalarEvaluator.FallbackMemoryReader =

--- a/src/SharpEmu.Libs/Agc/AgcShaderCompilerHooks.cs
+++ b/src/SharpEmu.Libs/Agc/AgcShaderCompilerHooks.cs
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Runtime.CompilerServices;
+using SharpEmu.Libs.Kernel;
+using SharpEmu.ShaderCompiler;
+
+namespace SharpEmu.Libs.Agc;
+
+/// <summary>
+/// Wires the backend-neutral shader compiler to this assembly's HLE services. The
+/// module initializer runs before any Libs code can invoke the evaluator, so the hook
+/// is always installed first.
+/// </summary>
+internal static class AgcShaderCompilerHooks
+{
+    [ModuleInitializer]
+    internal static void Install()
+    {
+        Gen5ShaderScalarEvaluator.FallbackMemoryReader =
+            KernelMemoryCompatExports.TryReadTrackedLibcHeap;
+    }
+}

--- a/src/SharpEmu.Libs/Agc/Gen5SpirvShader.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5SpirvShader.cs
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.ShaderCompiler;
+
+namespace SharpEmu.Libs.Agc;
+
+// SPIR-V-specific shader artifact types. These stay beside the SPIR-V emitter (not in
+// the backend-neutral SharpEmu.ShaderCompiler project): each codegen owns its own
+// compiled-shader shape.
+internal enum Gen5SpirvStage
+{
+    Vertex,
+    Pixel,
+    Compute,
+}
+
+internal sealed record Gen5SpirvShader(
+    byte[] Spirv,
+    IReadOnlyList<Gen5GlobalMemoryBinding> GlobalMemoryBindings,
+    IReadOnlyList<Gen5ImageBinding> ImageBindings,
+    uint AttributeCount,
+    IReadOnlyList<Gen5VertexInputBinding> VertexInputs);

--- a/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.Alu.cs
@@ -1,6 +1,8 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using SharpEmu.ShaderCompiler;
+
 namespace SharpEmu.Libs.Agc;
 
 internal static partial class Gen5SpirvTranslator
@@ -2491,47 +2493,7 @@ internal static partial class Gen5SpirvTranslator
                 resultSignChanged);
         }
 
-        private static bool TryDecodeInlineConstant(uint encoded, out uint value)
-        {
-            if (encoded == 125)
-            {
-                value = 0;
-                return true;
-            }
-
-            if (encoded is >= 128 and <= 192)
-            {
-                value = encoded - 128;
-                return true;
-            }
-
-            if (encoded is >= 193 and <= 208)
-            {
-                value = unchecked((uint)-(int)(encoded - 192));
-                return true;
-            }
-
-            var floatingPoint = encoded switch
-            {
-                240 => 0.5f,
-                241 => -0.5f,
-                242 => 1.0f,
-                243 => -1.0f,
-                244 => 2.0f,
-                245 => -2.0f,
-                246 => 4.0f,
-                247 => -4.0f,
-                248 => 1.0f / (2.0f * MathF.PI),
-                _ => float.NaN,
-            };
-            if (float.IsNaN(floatingPoint))
-            {
-                value = 0;
-                return false;
-            }
-
-            value = BitConverter.SingleToUInt32Bits(floatingPoint);
-            return true;
-        }
+        private static bool TryDecodeInlineConstant(uint encoded, out uint value) =>
+            Gen5InlineConstants.TryDecode(encoded, out value);
     }
 }

--- a/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.Libs/Agc/Gen5SpirvTranslator.cs
@@ -1,6 +1,8 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using SharpEmu.ShaderCompiler;
+
 namespace SharpEmu.Libs.Agc;
 
 internal static partial class Gen5SpirvTranslator

--- a/src/SharpEmu.Libs/Gpu/GuestGpu.cs
+++ b/src/SharpEmu.Libs/Gpu/GuestGpu.cs
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.Gpu.Vulkan;
+
+namespace SharpEmu.Libs.Gpu;
+
+/// <summary>
+/// Process-wide access point for the guest-GPU backend, mirroring HostPlatform for the
+/// host seam: static HLE export classes resolve the renderer through <see cref="Current"/>.
+/// Vulkan is the only backend today; Metal/DX12 slot in here.
+/// </summary>
+internal static class GuestGpu
+{
+    private static readonly Lazy<IGuestGpuBackend> Instance = new(static () => new VulkanGuestGpuBackend());
+
+    public static IGuestGpuBackend Current => Instance.Value;
+}

--- a/src/SharpEmu.Libs/Gpu/GuestGpuTypes.cs
+++ b/src/SharpEmu.Libs/Gpu/GuestGpuTypes.cs
@@ -1,0 +1,116 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Libs.Gpu;
+
+// The types that cross the guest-GPU backend seam. Every field is either a neutral
+// primitive (dimensions, counts, host pixel bytes) or a raw guest/AGC value (guest
+// addresses, guest format and number-type codes, guest register bitfields). Host
+// graphics-API values must never appear here: each backend owns the guest -> native
+// translation for its API.
+
+/// <summary>A guest texture referenced by a draw or dispatch. Format/NumberType/
+/// TileMode/DstSelect are raw guest descriptor codes.</summary>
+internal sealed record GuestDrawTexture(
+    ulong Address,
+    uint Width,
+    uint Height,
+    uint Format,
+    uint NumberType,
+    byte[] RgbaPixels,
+    bool IsFallback,
+    bool IsStorage,
+    uint MipLevels = 1,
+    uint MipLevel = 0,
+    uint Pitch = 0,
+    uint TileMode = 0,
+    uint DstSelect = 0xFAC,
+    GuestSampler Sampler = default);
+
+/// <summary>Raw guest sampler descriptor dwords, copied verbatim from guest memory.</summary>
+internal readonly record struct GuestSampler(
+    uint Word0,
+    uint Word1,
+    uint Word2,
+    uint Word3);
+
+internal sealed record GuestMemoryBuffer(
+    ulong BaseAddress,
+    byte[] Data);
+
+/// <summary>DataFormat/NumberFormat are raw guest vertex-attribute codes.</summary>
+internal sealed record GuestVertexBuffer(
+    uint Location,
+    uint ComponentCount,
+    uint DataFormat,
+    uint NumberFormat,
+    ulong BaseAddress,
+    uint Stride,
+    uint OffsetBytes,
+    byte[] Data);
+
+internal sealed record GuestIndexBuffer(
+    byte[] Data,
+    bool Is32Bit);
+
+internal readonly record struct GuestRect(
+    int X,
+    int Y,
+    uint Width,
+    uint Height);
+
+internal readonly record struct GuestViewport(
+    float X,
+    float Y,
+    float Width,
+    float Height,
+    float MinDepth,
+    float MaxDepth);
+
+/// <summary>Factors/funcs are raw guest CB_BLEND*_CONTROL register bitfields; the
+/// defaults (1/0) are the guest ONE/ZERO codes.</summary>
+internal readonly record struct GuestBlendState(
+    bool Enable,
+    uint ColorSrcFactor,
+    uint ColorDstFactor,
+    uint ColorFunc,
+    uint AlphaSrcFactor,
+    uint AlphaDstFactor,
+    uint AlphaFunc,
+    bool SeparateAlphaBlend,
+    uint WriteMask)
+{
+    public static GuestBlendState Default { get; } = new(
+        Enable: false,
+        ColorSrcFactor: 1,
+        ColorDstFactor: 0,
+        ColorFunc: 0,
+        AlphaSrcFactor: 1,
+        AlphaDstFactor: 0,
+        AlphaFunc: 0,
+        SeparateAlphaBlend: false,
+        WriteMask: 0xFu);
+}
+
+internal sealed record GuestRenderState(
+    IReadOnlyList<GuestBlendState> Blends,
+    GuestRect? Scissor,
+    GuestViewport? Viewport)
+{
+    public static GuestRenderState Default { get; } = new(
+        [GuestBlendState.Default],
+        Scissor: null,
+        Viewport: null);
+
+    public GuestBlendState Blend =>
+        Blends.Count == 0 ? GuestBlendState.Default : Blends[0];
+}
+
+/// <summary>Format/NumberType are raw guest render-target register codes.</summary>
+internal sealed record GuestRenderTarget(
+    ulong Address,
+    uint Width,
+    uint Height,
+    uint Format,
+    uint NumberType,
+    uint MipLevels = 1);

--- a/src/SharpEmu.Libs/Gpu/IGuestCompiledShader.cs
+++ b/src/SharpEmu.Libs/Gpu/IGuestCompiledShader.cs
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Libs.Gpu;
+
+/// <summary>
+/// A guest shader compiled by a backend, opaque to the export layers: only the backend
+/// that produced it can submit it. <see cref="Payload"/> is the backend-defined compiled
+/// bytes (SPIR-V words for Vulkan; MSL/DXIL for future backends), exposed solely for
+/// diagnostics dumps and size traces — callers must never interpret it.
+/// </summary>
+internal interface IGuestCompiledShader
+{
+    byte[] Payload { get; }
+}

--- a/src/SharpEmu.Libs/Gpu/IGuestCompiledShader.cs
+++ b/src/SharpEmu.Libs/Gpu/IGuestCompiledShader.cs
@@ -12,4 +12,8 @@ namespace SharpEmu.Libs.Gpu;
 internal interface IGuestCompiledShader
 {
     byte[] Payload { get; }
+
+    /// <summary>File extension for diagnostics dumps of <see cref="Payload"/> ("spv",
+    /// "msl", ...), so dumps stay honestly labeled whatever the backend.</summary>
+    string PayloadFileExtension { get; }
 }

--- a/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
@@ -12,13 +12,48 @@ namespace SharpEmu.Libs.Gpu;
 /// value (formats, blend enums, barrier or pass concepts) may cross this interface,
 /// and submission is coarse-grained — synchronization is a backend-internal concern.
 ///
-/// Interim exception, resolved when shader compilation moves behind the backend: the
-/// shader parameters are SPIR-V blobs, which presumes the Vulkan codegen.
+/// Shader compilation also lives behind the seam: the backend owns its codegen and
+/// returns opaque <see cref="IGuestCompiledShader"/> handles that only it can submit.
 /// </summary>
 internal interface IGuestGpuBackend
 {
     /// <summary>Starts the presenter (window + device) once; safe to call repeatedly.</summary>
     void EnsureStarted(uint width, uint height);
+
+    // Shader compilation. The optional base/index parameters describe how a multi-stage
+    // draw lays both stages' resources into one flat per-role slot space (buffers,
+    // images, scalar-spill slots); each backend maps those slots to its own API binding
+    // model. -1 keeps the emitter's single-stage defaults.
+
+    bool TryCompileVertexShader(
+        Gen5ShaderState state,
+        Gen5ShaderEvaluation evaluation,
+        out IGuestCompiledShader? shader,
+        out string error,
+        int globalBufferBase = 0,
+        int totalGlobalBufferCount = -1,
+        int imageBindingBase = 0,
+        int scalarRegisterBufferIndex = -1);
+
+    bool TryCompilePixelShader(
+        Gen5ShaderState state,
+        Gen5ShaderEvaluation evaluation,
+        IReadOnlyList<Gen5PixelOutputBinding> outputs,
+        out IGuestCompiledShader? shader,
+        out string error,
+        int globalBufferBase = 0,
+        int totalGlobalBufferCount = -1,
+        int imageBindingBase = 0,
+        int scalarRegisterBufferIndex = -1);
+
+    bool TryCompileComputeShader(
+        Gen5ShaderState state,
+        Gen5ShaderEvaluation evaluation,
+        uint localSizeX,
+        uint localSizeY,
+        uint localSizeZ,
+        out IGuestCompiledShader? shader,
+        out string error);
 
     void HideSplashScreen();
 
@@ -29,13 +64,13 @@ internal interface IGuestGpuBackend
     void SubmitGuestDraw(GuestDrawKind drawKind, uint width, uint height);
 
     void SubmitTranslatedDraw(
-        byte[] pixelSpirv,
+        IGuestCompiledShader pixelShader,
         IReadOnlyList<GuestDrawTexture> textures,
         IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint width,
         uint height,
         uint attributeCount,
-        byte[]? vertexSpirv = null,
+        IGuestCompiledShader? vertexShader = null,
         uint vertexCount = 3,
         uint instanceCount = 1,
         uint primitiveType = 4,
@@ -44,12 +79,12 @@ internal interface IGuestGpuBackend
         GuestRenderState? renderState = null);
 
     void SubmitOffscreenTranslatedDraw(
-        byte[] pixelSpirv,
+        IGuestCompiledShader pixelShader,
         IReadOnlyList<GuestDrawTexture> textures,
         IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint attributeCount,
         IReadOnlyList<GuestRenderTarget> targets,
-        byte[]? vertexSpirv = null,
+        IGuestCompiledShader? vertexShader = null,
         uint vertexCount = 3,
         uint instanceCount = 1,
         uint primitiveType = 4,
@@ -58,7 +93,7 @@ internal interface IGuestGpuBackend
         GuestRenderState? renderState = null);
 
     void SubmitStorageTranslatedDraw(
-        byte[] pixelSpirv,
+        IGuestCompiledShader pixelShader,
         IReadOnlyList<GuestDrawTexture> textures,
         IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint attributeCount,
@@ -67,7 +102,7 @@ internal interface IGuestGpuBackend
 
     void SubmitComputeDispatch(
         ulong shaderAddress,
-        byte[] computeSpirv,
+        IGuestCompiledShader computeShader,
         IReadOnlyList<GuestDrawTexture> textures,
         IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint groupCountX,

--- a/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.ShaderCompiler;
+
+namespace SharpEmu.Libs.Gpu;
+
+/// <summary>
+/// The guest-GPU backend seam: everything the AGC/VideoOut export layers need from a
+/// host renderer, expressed in guest-domain terms so Vulkan, Metal, and DX12 backends
+/// can each translate to their native API. Two rules keep it that way: no host-API
+/// value (formats, blend enums, barrier or pass concepts) may cross this interface,
+/// and submission is coarse-grained — synchronization is a backend-internal concern.
+///
+/// Interim exception, resolved when shader compilation moves behind the backend: the
+/// shader parameters are SPIR-V blobs, which presumes the Vulkan codegen.
+/// </summary>
+internal interface IGuestGpuBackend
+{
+    /// <summary>Starts the presenter (window + device) once; safe to call repeatedly.</summary>
+    void EnsureStarted(uint width, uint height);
+
+    void HideSplashScreen();
+
+    /// <summary>Presents one CPU-produced BGRA frame.</summary>
+    void Submit(byte[] bgraFrame, uint width, uint height);
+
+    /// <summary>Presents a recognized fixed-function guest draw (see GuestDrawKind).</summary>
+    void SubmitGuestDraw(GuestDrawKind drawKind, uint width, uint height);
+
+    void SubmitTranslatedDraw(
+        byte[] pixelSpirv,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
+        uint width,
+        uint height,
+        uint attributeCount,
+        byte[]? vertexSpirv = null,
+        uint vertexCount = 3,
+        uint instanceCount = 1,
+        uint primitiveType = 4,
+        GuestIndexBuffer? indexBuffer = null,
+        IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
+        GuestRenderState? renderState = null);
+
+    void SubmitOffscreenTranslatedDraw(
+        byte[] pixelSpirv,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
+        uint attributeCount,
+        IReadOnlyList<GuestRenderTarget> targets,
+        byte[]? vertexSpirv = null,
+        uint vertexCount = 3,
+        uint instanceCount = 1,
+        uint primitiveType = 4,
+        GuestIndexBuffer? indexBuffer = null,
+        IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
+        GuestRenderState? renderState = null);
+
+    void SubmitStorageTranslatedDraw(
+        byte[] pixelSpirv,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
+        uint attributeCount,
+        uint width,
+        uint height);
+
+    void SubmitComputeDispatch(
+        ulong shaderAddress,
+        byte[] computeSpirv,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
+        uint groupCountX,
+        uint groupCountY,
+        uint groupCountZ);
+
+    bool TrySubmitGuestImage(
+        ulong address,
+        uint width,
+        uint height,
+        uint pitchInPixel);
+
+    /// <summary>Registers a display buffer with its guest texture format tag.</summary>
+    void RegisterKnownDisplayBuffer(ulong address, uint guestFormat);
+
+    /// <summary>Format/numberType are raw guest texture descriptor codes.</summary>
+    bool IsGpuGuestImageAvailable(ulong address, uint format, uint numberType);
+
+    bool TrySubmitGuestImageBlit(
+        ulong sourceAddress,
+        uint sourceWidth,
+        uint sourceHeight,
+        uint sourceFormat,
+        ulong destinationAddress,
+        uint destinationWidth,
+        uint destinationHeight,
+        uint destinationFormat);
+
+    /// <summary>
+    /// Whether the backend supports the guest render-target format, and how its pixel
+    /// outputs are typed. Deliberately does not expose the backend's native format —
+    /// the guest codes cross the seam and each backend maps them internally.
+    /// </summary>
+    bool TryGetRenderTargetOutputKind(uint dataFormat, uint numberType, out Gen5PixelOutputKind outputKind);
+}

--- a/src/SharpEmu.Libs/Gpu/Vulkan/VulkanCompiledGuestShader.cs
+++ b/src/SharpEmu.Libs/Gpu/Vulkan/VulkanCompiledGuestShader.cs
@@ -1,0 +1,10 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Libs.Gpu.Vulkan;
+
+/// <summary>The Vulkan backend's compiled shader: raw SPIR-V words.</summary>
+internal sealed record VulkanCompiledGuestShader(byte[] Spirv) : IGuestCompiledShader
+{
+    public byte[] Payload => Spirv;
+}

--- a/src/SharpEmu.Libs/Gpu/Vulkan/VulkanCompiledGuestShader.cs
+++ b/src/SharpEmu.Libs/Gpu/Vulkan/VulkanCompiledGuestShader.cs
@@ -7,4 +7,6 @@ namespace SharpEmu.Libs.Gpu.Vulkan;
 internal sealed record VulkanCompiledGuestShader(byte[] Spirv) : IGuestCompiledShader
 {
     public byte[] Payload => Spirv;
+
+    public string PayloadFileExtension => "spv";
 }

--- a/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
@@ -3,16 +3,102 @@
 
 using SharpEmu.Libs.VideoOut;
 using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
 
 namespace SharpEmu.Libs.Gpu.Vulkan;
 
 /// <summary>
-/// Vulkan backend for the guest-GPU seam. A thin adapter over the existing
-/// VulkanVideoPresenter statics so the seam extraction stays mechanical; folding the
-/// presenter into an instance type is follow-up work, not a seam concern.
+/// Vulkan backend for the guest-GPU seam: SPIR-V codegen via
+/// SharpEmu.ShaderCompiler.Vulkan, rendering via a thin adapter over the existing
+/// VulkanVideoPresenter statics (folding the presenter into an instance type is
+/// follow-up work, not a seam concern).
 /// </summary>
 internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
 {
+    public bool TryCompileVertexShader(
+        Gen5ShaderState state,
+        Gen5ShaderEvaluation evaluation,
+        out IGuestCompiledShader? shader,
+        out string error,
+        int globalBufferBase = 0,
+        int totalGlobalBufferCount = -1,
+        int imageBindingBase = 0,
+        int scalarRegisterBufferIndex = -1)
+    {
+        shader = null;
+        if (!Gen5SpirvTranslator.TryCompileVertexShader(
+                state,
+                evaluation,
+                out var compiled,
+                out error,
+                globalBufferBase,
+                totalGlobalBufferCount,
+                imageBindingBase,
+                scalarRegisterBufferIndex))
+        {
+            return false;
+        }
+
+        shader = new VulkanCompiledGuestShader(compiled.Spirv);
+        return true;
+    }
+
+    public bool TryCompilePixelShader(
+        Gen5ShaderState state,
+        Gen5ShaderEvaluation evaluation,
+        IReadOnlyList<Gen5PixelOutputBinding> outputs,
+        out IGuestCompiledShader? shader,
+        out string error,
+        int globalBufferBase = 0,
+        int totalGlobalBufferCount = -1,
+        int imageBindingBase = 0,
+        int scalarRegisterBufferIndex = -1)
+    {
+        shader = null;
+        if (!Gen5SpirvTranslator.TryCompilePixelShader(
+                state,
+                evaluation,
+                outputs,
+                out var compiled,
+                out error,
+                globalBufferBase,
+                totalGlobalBufferCount,
+                imageBindingBase,
+                scalarRegisterBufferIndex))
+        {
+            return false;
+        }
+
+        shader = new VulkanCompiledGuestShader(compiled.Spirv);
+        return true;
+    }
+
+    public bool TryCompileComputeShader(
+        Gen5ShaderState state,
+        Gen5ShaderEvaluation evaluation,
+        uint localSizeX,
+        uint localSizeY,
+        uint localSizeZ,
+        out IGuestCompiledShader? shader,
+        out string error)
+    {
+        shader = null;
+        if (!Gen5SpirvTranslator.TryCompileComputeShader(
+                state,
+                evaluation,
+                localSizeX,
+                localSizeY,
+                localSizeZ,
+                out var compiled,
+                out error))
+        {
+            return false;
+        }
+
+        shader = new VulkanCompiledGuestShader(compiled.Spirv);
+        return true;
+    }
+
     public void EnsureStarted(uint width, uint height) =>
         VulkanVideoPresenter.EnsureStarted(width, height);
 
@@ -26,13 +112,13 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         VulkanVideoPresenter.SubmitGuestDraw(drawKind, width, height);
 
     public void SubmitTranslatedDraw(
-        byte[] pixelSpirv,
+        IGuestCompiledShader pixelShader,
         IReadOnlyList<GuestDrawTexture> textures,
         IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint width,
         uint height,
         uint attributeCount,
-        byte[]? vertexSpirv = null,
+        IGuestCompiledShader? vertexShader = null,
         uint vertexCount = 3,
         uint instanceCount = 1,
         uint primitiveType = 4,
@@ -40,13 +126,13 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null) =>
         VulkanVideoPresenter.SubmitTranslatedDraw(
-            pixelSpirv,
+            Spirv(pixelShader),
             textures,
             globalMemoryBuffers,
             width,
             height,
             attributeCount,
-            vertexSpirv,
+            vertexShader is null ? null : Spirv(vertexShader),
             vertexCount,
             instanceCount,
             primitiveType,
@@ -55,12 +141,12 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
             renderState);
 
     public void SubmitOffscreenTranslatedDraw(
-        byte[] pixelSpirv,
+        IGuestCompiledShader pixelShader,
         IReadOnlyList<GuestDrawTexture> textures,
         IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint attributeCount,
         IReadOnlyList<GuestRenderTarget> targets,
-        byte[]? vertexSpirv = null,
+        IGuestCompiledShader? vertexShader = null,
         uint vertexCount = 3,
         uint instanceCount = 1,
         uint primitiveType = 4,
@@ -68,12 +154,12 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null) =>
         VulkanVideoPresenter.SubmitOffscreenTranslatedDraw(
-            pixelSpirv,
+            Spirv(pixelShader),
             textures,
             globalMemoryBuffers,
             attributeCount,
             targets,
-            vertexSpirv,
+            vertexShader is null ? null : Spirv(vertexShader),
             vertexCount,
             instanceCount,
             primitiveType,
@@ -82,14 +168,14 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
             renderState);
 
     public void SubmitStorageTranslatedDraw(
-        byte[] pixelSpirv,
+        IGuestCompiledShader pixelShader,
         IReadOnlyList<GuestDrawTexture> textures,
         IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint attributeCount,
         uint width,
         uint height) =>
         VulkanVideoPresenter.SubmitStorageTranslatedDraw(
-            pixelSpirv,
+            Spirv(pixelShader),
             textures,
             globalMemoryBuffers,
             attributeCount,
@@ -98,7 +184,7 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
 
     public void SubmitComputeDispatch(
         ulong shaderAddress,
-        byte[] computeSpirv,
+        IGuestCompiledShader computeShader,
         IReadOnlyList<GuestDrawTexture> textures,
         IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint groupCountX,
@@ -106,7 +192,7 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         uint groupCountZ) =>
         VulkanVideoPresenter.SubmitComputeDispatch(
             shaderAddress,
-            computeSpirv,
+            Spirv(computeShader),
             textures,
             globalMemoryBuffers,
             groupCountX,
@@ -156,4 +242,10 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         outputKind = default;
         return false;
     }
+
+    private static byte[] Spirv(IGuestCompiledShader shader) =>
+        shader is VulkanCompiledGuestShader vulkanShader
+            ? vulkanShader.Spirv
+            : throw new InvalidOperationException(
+                $"shader handle of type {shader.GetType().Name} was not compiled by the Vulkan backend");
 }

--- a/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.VideoOut;
+using SharpEmu.ShaderCompiler;
+
+namespace SharpEmu.Libs.Gpu.Vulkan;
+
+/// <summary>
+/// Vulkan backend for the guest-GPU seam. A thin adapter over the existing
+/// VulkanVideoPresenter statics so the seam extraction stays mechanical; folding the
+/// presenter into an instance type is follow-up work, not a seam concern.
+/// </summary>
+internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
+{
+    public void EnsureStarted(uint width, uint height) =>
+        VulkanVideoPresenter.EnsureStarted(width, height);
+
+    public void HideSplashScreen() =>
+        VulkanVideoPresenter.HideSplashScreen();
+
+    public void Submit(byte[] bgraFrame, uint width, uint height) =>
+        VulkanVideoPresenter.Submit(bgraFrame, width, height);
+
+    public void SubmitGuestDraw(GuestDrawKind drawKind, uint width, uint height) =>
+        VulkanVideoPresenter.SubmitGuestDraw(drawKind, width, height);
+
+    public void SubmitTranslatedDraw(
+        byte[] pixelSpirv,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
+        uint width,
+        uint height,
+        uint attributeCount,
+        byte[]? vertexSpirv = null,
+        uint vertexCount = 3,
+        uint instanceCount = 1,
+        uint primitiveType = 4,
+        GuestIndexBuffer? indexBuffer = null,
+        IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
+        GuestRenderState? renderState = null) =>
+        VulkanVideoPresenter.SubmitTranslatedDraw(
+            pixelSpirv,
+            textures,
+            globalMemoryBuffers,
+            width,
+            height,
+            attributeCount,
+            vertexSpirv,
+            vertexCount,
+            instanceCount,
+            primitiveType,
+            indexBuffer,
+            vertexBuffers,
+            renderState);
+
+    public void SubmitOffscreenTranslatedDraw(
+        byte[] pixelSpirv,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
+        uint attributeCount,
+        IReadOnlyList<GuestRenderTarget> targets,
+        byte[]? vertexSpirv = null,
+        uint vertexCount = 3,
+        uint instanceCount = 1,
+        uint primitiveType = 4,
+        GuestIndexBuffer? indexBuffer = null,
+        IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
+        GuestRenderState? renderState = null) =>
+        VulkanVideoPresenter.SubmitOffscreenTranslatedDraw(
+            pixelSpirv,
+            textures,
+            globalMemoryBuffers,
+            attributeCount,
+            targets,
+            vertexSpirv,
+            vertexCount,
+            instanceCount,
+            primitiveType,
+            indexBuffer,
+            vertexBuffers,
+            renderState);
+
+    public void SubmitStorageTranslatedDraw(
+        byte[] pixelSpirv,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
+        uint attributeCount,
+        uint width,
+        uint height) =>
+        VulkanVideoPresenter.SubmitStorageTranslatedDraw(
+            pixelSpirv,
+            textures,
+            globalMemoryBuffers,
+            attributeCount,
+            width,
+            height);
+
+    public void SubmitComputeDispatch(
+        ulong shaderAddress,
+        byte[] computeSpirv,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
+        uint groupCountX,
+        uint groupCountY,
+        uint groupCountZ) =>
+        VulkanVideoPresenter.SubmitComputeDispatch(
+            shaderAddress,
+            computeSpirv,
+            textures,
+            globalMemoryBuffers,
+            groupCountX,
+            groupCountY,
+            groupCountZ);
+
+    public bool TrySubmitGuestImage(
+        ulong address,
+        uint width,
+        uint height,
+        uint pitchInPixel) =>
+        VulkanVideoPresenter.TrySubmitGuestImage(address, width, height, pitchInPixel);
+
+    public void RegisterKnownDisplayBuffer(ulong address, uint guestFormat) =>
+        VulkanVideoPresenter.RegisterKnownDisplayBuffer(address, guestFormat);
+
+    public bool IsGpuGuestImageAvailable(ulong address, uint format, uint numberType) =>
+        VulkanVideoPresenter.IsGpuGuestImageAvailable(address, format, numberType);
+
+    public bool TrySubmitGuestImageBlit(
+        ulong sourceAddress,
+        uint sourceWidth,
+        uint sourceHeight,
+        uint sourceFormat,
+        ulong destinationAddress,
+        uint destinationWidth,
+        uint destinationHeight,
+        uint destinationFormat) =>
+        VulkanVideoPresenter.TrySubmitGuestImageBlit(
+            sourceAddress,
+            sourceWidth,
+            sourceHeight,
+            sourceFormat,
+            destinationAddress,
+            destinationWidth,
+            destinationHeight,
+            destinationFormat);
+
+    public bool TryGetRenderTargetOutputKind(uint dataFormat, uint numberType, out Gen5PixelOutputKind outputKind)
+    {
+        if (VulkanVideoPresenter.TryDecodeRenderTargetFormat(dataFormat, numberType, out var format))
+        {
+            outputKind = format.OutputKind;
+            return true;
+        }
+
+        outputKind = default;
+        return false;
+    }
+}

--- a/src/SharpEmu.Libs/SharpEmu.Libs.csproj
+++ b/src/SharpEmu.Libs/SharpEmu.Libs.csproj
@@ -7,6 +7,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
   <ItemGroup>
     <ProjectReference Include="..\SharpEmu.HLE\SharpEmu.HLE.csproj" />
     <ProjectReference Include="..\SharpEmu.ShaderCompiler\SharpEmu.ShaderCompiler.csproj" />
+    <ProjectReference Include="..\SharpEmu.ShaderCompiler.Vulkan\SharpEmu.ShaderCompiler.Vulkan.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpEmu.Libs/SharpEmu.Libs.csproj
+++ b/src/SharpEmu.Libs/SharpEmu.Libs.csproj
@@ -6,6 +6,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\SharpEmu.HLE\SharpEmu.HLE.csproj" />
+    <ProjectReference Include="..\SharpEmu.ShaderCompiler\SharpEmu.ShaderCompiler.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpEmu.Libs/SystemService/SystemServiceExports.cs
+++ b/src/SharpEmu.Libs/SystemService/SystemServiceExports.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
+using SharpEmu.Libs.Gpu;
 using SharpEmu.Libs.VideoOut;
 using System.Buffers.Binary;
 
@@ -93,7 +94,7 @@ public static class SystemServiceExports
         LibraryName = "libSceSystemService")]
     public static int SystemServiceHideSplashScreen(CpuContext ctx)
     {
-        VulkanVideoPresenter.HideSplashScreen();
+        GuestGpu.Current.HideSplashScreen();
         return ctx.SetReturn(0);
     }
 

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -3,6 +3,7 @@
 
 using SharpEmu.HLE;
 using SharpEmu.HLE.Host;
+using SharpEmu.Libs.Gpu;
 using SharpEmu.Libs.Audio;
 using SharpEmu.Libs.Kernel;
 using SharpEmu.Logging;
@@ -812,7 +813,7 @@ public static class VideoOutExports
             bgraFrame[offset + 3] = rgbaFrame[offset + 3];
         }
 
-        VulkanVideoPresenter.Submit(bgraFrame, width, height);
+        GuestGpu.Current.Submit(bgraFrame, width, height);
     }
 
     internal static bool TryGetDisplayBufferInfo(int handle, int bufferIndex, out DisplayBufferInfo info)
@@ -1203,7 +1204,7 @@ public static class VideoOutExports
             TryGetDisplayBufferInfo(handle, bufferIndex, out var displayBuffer))
         {
             guestImageAddress = displayBuffer.Address;
-            guestImageSubmitted = VulkanVideoPresenter.TrySubmitGuestImage(
+            guestImageSubmitted = GuestGpu.Current.TrySubmitGuestImage(
                 displayBuffer.Address,
                 displayBuffer.Width,
                 displayBuffer.Height,
@@ -1334,14 +1335,14 @@ public static class VideoOutExports
                 TraceVideoOut(
                     $"videoout.register_buffers handle={port.Handle} group={groupIndex} start={startIndex} count={addresses.Length} fmt=0x{attribute.PixelFormat:X} tile={attribute.TilingMode} {attribute.Width}x{attribute.Height} pitch={attribute.PitchInPixel}");
             }
-            VulkanVideoPresenter.EnsureStarted(attribute.Width, attribute.Height);
+            GuestGpu.Current.EnsureStarted(attribute.Width, attribute.Height);
 
             var guestFormat = MapPixelFormatToGuestTextureFormat(attribute.PixelFormat);
             if (guestFormat != 0)
             {
                 foreach (var address in addresses)
                 {
-                    VulkanVideoPresenter.RegisterKnownDisplayBuffer(address, guestFormat);
+                    GuestGpu.Current.RegisterKnownDisplayBuffer(address, guestFormat);
                 }
             }
 
@@ -1573,7 +1574,7 @@ public static class VideoOutExports
             : 0u;
 
     // Maps the PS5 VideoOut pixel format space to the AGC "guest texture format" tags
-    // VulkanVideoPresenter._availableGuestImages keys on (see VulkanVideoPresenter.
+    // GuestGpu.Current._availableGuestImages keys on (see GuestGpu.Current.
     // GetGuestTextureFormat: format=10 => 56 for 8-bit RGBA variants, format=9 => 9 for 10-bit).
     private static uint MapPixelFormatToGuestTextureFormat(ulong pixelFormat) =>
         NormalizePixelFormat(pixelFormat) switch

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -1574,7 +1574,7 @@ public static class VideoOutExports
             : 0u;
 
     // Maps the PS5 VideoOut pixel format space to the AGC "guest texture format" tags
-    // GuestGpu.Current._availableGuestImages keys on (see GuestGpu.Current.
+    // the backend keys its guest-image registry on (see VulkanVideoPresenter.
     // GetGuestTextureFormat: format=10 => 56 for 8-bit RGBA variants, format=9 => 9 for 10-bit).
     private static uint MapPixelFormatToGuestTextureFormat(ulong pixelFormat) =>
         NormalizePixelFormat(pixelFormat) switch

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -7,6 +7,7 @@ using Silk.NET.Maths;
 using SharpEmu.HLE;
 using SharpEmu.Libs.Agc;
 using Silk.NET.Input;
+using SharpEmu.ShaderCompiler;
 using Silk.NET.Vulkan;
 using Silk.NET.Vulkan.Extensions.KHR;
 using Silk.NET.Vulkan.Extensions.EXT;
@@ -21,12 +22,6 @@ using VkBuffer = Silk.NET.Vulkan.Buffer;
 using VkSemaphore = Silk.NET.Vulkan.Semaphore;
 
 namespace SharpEmu.Libs.VideoOut;
-
-internal enum GuestDrawKind
-{
-    None,
-    FullscreenBarycentric,
-}
 
 internal sealed record VulkanGuestDrawTexture(
     ulong Address,
@@ -5999,15 +5994,15 @@ internal static unsafe class VulkanVideoPresenter
                     var gpuInFlight = _pendingGuestSubmissions.Count +
                         (_presentationInFlight ? 1 : 0);
                     var readCount = Interlocked.Read(
-                        ref Agc.Gen5ShaderScalarEvaluator.GlobalMemoryReadCount);
+                        ref Gen5ShaderScalarEvaluator.GlobalMemoryReadCount);
                     var readBytes = Interlocked.Read(
-                        ref Agc.Gen5ShaderScalarEvaluator.GlobalMemoryReadBytes);
+                        ref Gen5ShaderScalarEvaluator.GlobalMemoryReadBytes);
                     var readHits = Interlocked.Read(
-                        ref Agc.Gen5ShaderScalarEvaluator.GlobalMemoryReadCacheHits);
+                        ref Gen5ShaderScalarEvaluator.GlobalMemoryReadCacheHits);
                     var readPvmBytes = Interlocked.Read(
-                        ref Agc.Gen5ShaderScalarEvaluator.GlobalMemoryReadPvmBytes);
+                        ref Gen5ShaderScalarEvaluator.GlobalMemoryReadPvmBytes);
                     var readLibcBytes = Interlocked.Read(
-                        ref Agc.Gen5ShaderScalarEvaluator.GlobalMemoryReadLibcBytes);
+                        ref Gen5ShaderScalarEvaluator.GlobalMemoryReadLibcBytes);
                     var readsPerSecond =
                         (readCount - _performanceHudLastReadCount) / elapsedSeconds;
                     var readMbPerSecond =

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -8,6 +8,7 @@ using SharpEmu.HLE;
 using SharpEmu.Libs.Agc;
 using Silk.NET.Input;
 using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
 using Silk.NET.Vulkan;
 using Silk.NET.Vulkan.Extensions.KHR;
 using Silk.NET.Vulkan.Extensions.EXT;

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -7,6 +7,7 @@ using Silk.NET.Maths;
 using SharpEmu.HLE;
 using SharpEmu.Libs.Agc;
 using Silk.NET.Input;
+using SharpEmu.Libs.Gpu;
 using SharpEmu.ShaderCompiler;
 using SharpEmu.ShaderCompiler.Vulkan;
 using Silk.NET.Vulkan;
@@ -24,105 +25,6 @@ using VkSemaphore = Silk.NET.Vulkan.Semaphore;
 
 namespace SharpEmu.Libs.VideoOut;
 
-internal sealed record VulkanGuestDrawTexture(
-    ulong Address,
-    uint Width,
-    uint Height,
-    uint Format,
-    uint NumberType,
-    byte[] RgbaPixels,
-    bool IsFallback,
-    bool IsStorage,
-    uint MipLevels = 1,
-    uint MipLevel = 0,
-    uint Pitch = 0,
-    uint TileMode = 0,
-    uint DstSelect = 0xFAC,
-    VulkanGuestSampler Sampler = default);
-
-internal readonly record struct VulkanGuestSampler(
-    uint Word0,
-    uint Word1,
-    uint Word2,
-    uint Word3);
-
-internal sealed record VulkanGuestMemoryBuffer(
-    ulong BaseAddress,
-    byte[] Data);
-
-internal sealed record VulkanGuestVertexBuffer(
-    uint Location,
-    uint ComponentCount,
-    uint DataFormat,
-    uint NumberFormat,
-    ulong BaseAddress,
-    uint Stride,
-    uint OffsetBytes,
-    byte[] Data);
-
-internal sealed record VulkanGuestIndexBuffer(
-    byte[] Data,
-    bool Is32Bit);
-
-internal readonly record struct VulkanGuestRect(
-    int X,
-    int Y,
-    uint Width,
-    uint Height);
-
-internal readonly record struct VulkanGuestViewport(
-    float X,
-    float Y,
-    float Width,
-    float Height,
-    float MinDepth,
-    float MaxDepth);
-
-internal readonly record struct VulkanGuestBlendState(
-    bool Enable,
-    uint ColorSrcFactor,
-    uint ColorDstFactor,
-    uint ColorFunc,
-    uint AlphaSrcFactor,
-    uint AlphaDstFactor,
-    uint AlphaFunc,
-    bool SeparateAlphaBlend,
-    uint WriteMask)
-{
-    public static VulkanGuestBlendState Default { get; } = new(
-        Enable: false,
-        ColorSrcFactor: 1,
-        ColorDstFactor: 0,
-        ColorFunc: 0,
-        AlphaSrcFactor: 1,
-        AlphaDstFactor: 0,
-        AlphaFunc: 0,
-        SeparateAlphaBlend: false,
-        WriteMask: 0xFu);
-}
-
-internal sealed record VulkanGuestRenderState(
-    IReadOnlyList<VulkanGuestBlendState> Blends,
-    VulkanGuestRect? Scissor,
-    VulkanGuestViewport? Viewport)
-{
-    public static VulkanGuestRenderState Default { get; } = new(
-        [VulkanGuestBlendState.Default],
-        Scissor: null,
-        Viewport: null);
-
-    public VulkanGuestBlendState Blend =>
-        Blends.Count == 0 ? VulkanGuestBlendState.Default : Blends[0];
-}
-
-internal sealed record VulkanGuestRenderTarget(
-    ulong Address,
-    uint Width,
-    uint Height,
-    uint Format,
-    uint NumberType,
-    uint MipLevels = 1);
-
 internal readonly record struct VulkanRenderTargetFormat(
     Format Format,
     Gen5PixelOutputKind OutputKind)
@@ -133,26 +35,26 @@ internal readonly record struct VulkanRenderTargetFormat(
 internal sealed record VulkanTranslatedGuestDraw(
     byte[] VertexSpirv,
     byte[] PixelSpirv,
-    IReadOnlyList<VulkanGuestDrawTexture> Textures,
-    IReadOnlyList<VulkanGuestMemoryBuffer> GlobalMemoryBuffers,
-    IReadOnlyList<VulkanGuestVertexBuffer> VertexBuffers,
+    IReadOnlyList<GuestDrawTexture> Textures,
+    IReadOnlyList<GuestMemoryBuffer> GlobalMemoryBuffers,
+    IReadOnlyList<GuestVertexBuffer> VertexBuffers,
     uint AttributeCount,
     uint VertexCount,
     uint InstanceCount,
     uint PrimitiveType,
-    VulkanGuestIndexBuffer? IndexBuffer,
-    VulkanGuestRenderState RenderState);
+    GuestIndexBuffer? IndexBuffer,
+    GuestRenderState RenderState);
 
 internal sealed record VulkanOffscreenGuestDraw(
     VulkanTranslatedGuestDraw Draw,
-    IReadOnlyList<VulkanGuestRenderTarget> Targets,
+    IReadOnlyList<GuestRenderTarget> Targets,
     bool PublishTarget);
 
 internal sealed record VulkanComputeGuestDispatch(
     ulong ShaderAddress,
     byte[] ComputeSpirv,
-    IReadOnlyList<VulkanGuestDrawTexture> Textures,
-    IReadOnlyList<VulkanGuestMemoryBuffer> GlobalMemoryBuffers,
+    IReadOnlyList<GuestDrawTexture> Textures,
+    IReadOnlyList<GuestMemoryBuffer> GlobalMemoryBuffers,
     uint GroupCountX,
     uint GroupCountY,
     uint GroupCountZ);
@@ -403,8 +305,8 @@ internal static unsafe class VulkanVideoPresenter
 
     public static void SubmitTranslatedDraw(
         byte[] pixelSpirv,
-        IReadOnlyList<VulkanGuestDrawTexture> textures,
-        IReadOnlyList<VulkanGuestMemoryBuffer> globalMemoryBuffers,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint width,
         uint height,
         uint attributeCount,
@@ -412,9 +314,9 @@ internal static unsafe class VulkanVideoPresenter
         uint vertexCount = 3,
         uint instanceCount = 1,
         uint primitiveType = 4,
-        VulkanGuestIndexBuffer? indexBuffer = null,
-        IReadOnlyList<VulkanGuestVertexBuffer>? vertexBuffers = null,
-        VulkanGuestRenderState? renderState = null)
+        GuestIndexBuffer? indexBuffer = null,
+        IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
+        GuestRenderState? renderState = null)
     {
         if (pixelSpirv.Length == 0 || width == 0 || height == 0)
         {
@@ -452,7 +354,7 @@ internal static unsafe class VulkanVideoPresenter
                     instanceCount,
                     primitiveType,
                     indexBuffer,
-                    renderState ?? VulkanGuestRenderState.Default),
+                    renderState ?? GuestRenderState.Default),
                 RequiredGuestWorkSequence: _enqueuedGuestWorkSequence,
                 IsSplash: false);
             System.Threading.Monitor.PulseAll(_gate);
@@ -469,17 +371,17 @@ internal static unsafe class VulkanVideoPresenter
 
     public static void SubmitOffscreenTranslatedDraw(
         byte[] pixelSpirv,
-        IReadOnlyList<VulkanGuestDrawTexture> textures,
-        IReadOnlyList<VulkanGuestMemoryBuffer> globalMemoryBuffers,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint attributeCount,
-        VulkanGuestRenderTarget target,
+        GuestRenderTarget target,
         byte[]? vertexSpirv = null,
         uint vertexCount = 3,
         uint instanceCount = 1,
         uint primitiveType = 4,
-        VulkanGuestIndexBuffer? indexBuffer = null,
-        IReadOnlyList<VulkanGuestVertexBuffer>? vertexBuffers = null,
-        VulkanGuestRenderState? renderState = null)
+        GuestIndexBuffer? indexBuffer = null,
+        IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
+        GuestRenderState? renderState = null)
     {
         SubmitOffscreenTranslatedDraw(
             pixelSpirv,
@@ -498,17 +400,17 @@ internal static unsafe class VulkanVideoPresenter
 
     public static void SubmitOffscreenTranslatedDraw(
         byte[] pixelSpirv,
-        IReadOnlyList<VulkanGuestDrawTexture> textures,
-        IReadOnlyList<VulkanGuestMemoryBuffer> globalMemoryBuffers,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint attributeCount,
-        IReadOnlyList<VulkanGuestRenderTarget> targets,
+        IReadOnlyList<GuestRenderTarget> targets,
         byte[]? vertexSpirv = null,
         uint vertexCount = 3,
         uint instanceCount = 1,
         uint primitiveType = 4,
-        VulkanGuestIndexBuffer? indexBuffer = null,
-        IReadOnlyList<VulkanGuestVertexBuffer>? vertexBuffers = null,
-        VulkanGuestRenderState? renderState = null)
+        GuestIndexBuffer? indexBuffer = null,
+        IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
+        GuestRenderState? renderState = null)
     {
         if (pixelSpirv.Length == 0 ||
             targets.Count == 0 ||
@@ -537,7 +439,7 @@ internal static unsafe class VulkanVideoPresenter
                 $"{firstTarget.Width}x{firstTarget.Height} textures={textures.Count}");
         }
 
-        var effectiveRenderState = renderState ?? VulkanGuestRenderState.Default;
+        var effectiveRenderState = renderState ?? GuestRenderState.Default;
         if (effectiveRenderState.Blends.Count == 1 && targets.Count > 1)
         {
             effectiveRenderState = effectiveRenderState with
@@ -585,8 +487,8 @@ internal static unsafe class VulkanVideoPresenter
 
     public static void SubmitStorageTranslatedDraw(
         byte[] pixelSpirv,
-        IReadOnlyList<VulkanGuestDrawTexture> textures,
-        IReadOnlyList<VulkanGuestMemoryBuffer> globalMemoryBuffers,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint attributeCount,
         uint width,
         uint height)
@@ -619,8 +521,8 @@ internal static unsafe class VulkanVideoPresenter
                         1,
                         4,
                         null,
-                        VulkanGuestRenderState.Default),
-                    [new VulkanGuestRenderTarget(
+                        GuestRenderState.Default),
+                    [new GuestRenderTarget(
                         Address: 0,
                         width,
                         height,
@@ -633,8 +535,8 @@ internal static unsafe class VulkanVideoPresenter
     public static void SubmitComputeDispatch(
         ulong shaderAddress,
         byte[] computeSpirv,
-        IReadOnlyList<VulkanGuestDrawTexture> textures,
-        IReadOnlyList<VulkanGuestMemoryBuffer> globalMemoryBuffers,
+        IReadOnlyList<GuestDrawTexture> textures,
+        IReadOnlyList<GuestMemoryBuffer> globalMemoryBuffers,
         uint groupCountX,
         uint groupCountY,
         uint groupCountZ)
@@ -814,7 +716,7 @@ internal static unsafe class VulkanVideoPresenter
         SubmitOffscreenTranslatedDraw(
             fragmentSpirv,
             [
-                new VulkanGuestDrawTexture(
+                new GuestDrawTexture(
                     sourceAddress,
                     sourceWidth,
                     sourceHeight,
@@ -826,7 +728,7 @@ internal static unsafe class VulkanVideoPresenter
             ],
             [],
             attributeCount: 1,
-            new VulkanGuestRenderTarget(
+            new GuestRenderTarget(
                 destinationAddress,
                 destinationWidth,
                 destinationHeight,
@@ -1359,7 +1261,7 @@ internal static unsafe class VulkanVideoPresenter
         private readonly Dictionary<byte[], Pipeline> _computePipelines =
             new(ReferenceEqualityComparer.Instance);
         private readonly Dictionary<GraphicsPipelineKey, Pipeline> _graphicsPipelines = new();
-        private readonly Dictionary<VulkanGuestSampler, Sampler> _samplers = new();
+        private readonly Dictionary<GuestSampler, Sampler> _samplers = new();
         private readonly Dictionary<byte[], string> _shaderDigests =
             new(ReferenceEqualityComparer.Instance);
         private readonly Dictionary<DescriptorLayoutKey, DescriptorLayoutBundle>
@@ -1414,9 +1316,9 @@ internal static unsafe class VulkanVideoPresenter
             public uint VertexCount = 3;
             public uint InstanceCount = 1;
             public PrimitiveTopology Topology = PrimitiveTopology.TriangleList;
-            public VulkanGuestBlendState[] Blends = [VulkanGuestBlendState.Default];
-            public VulkanGuestRect? Scissor;
-            public VulkanGuestViewport? Viewport;
+            public GuestBlendState[] Blends = [GuestBlendState.Default];
+            public GuestRect? Scissor;
+            public GuestViewport? Viewport;
             public RenderPass TransientRenderPass;
             public Framebuffer TransientFramebuffer;
         }
@@ -1436,7 +1338,7 @@ internal static unsafe class VulkanVideoPresenter
             public bool NeedsUpload;
             public bool OwnsStorage;
             public bool IsStorage;
-            public VulkanGuestSampler SamplerState;
+            public GuestSampler SamplerState;
             public Sampler Sampler;
             public GuestImageResource? GuestImage;
             public ulong CpuContentFingerprint;
@@ -1736,11 +1638,11 @@ internal static unsafe class VulkanVideoPresenter
                   $"{dispatch.GroupCountX}x{dispatch.GroupCountY}x{dispatch.GroupCountZ}";
         }
 
-        private static string GuestImageDebugName(VulkanGuestRenderTarget target, Format format) =>
+        private static string GuestImageDebugName(GuestRenderTarget target, Format format) =>
             $"SharpEmu guest 0x{target.Address:X16} {target.Width}x{target.Height} " +
             $"fmt{target.Format}/{format}";
 
-        private static string TextureDebugName(VulkanGuestDrawTexture texture, Format format) =>
+        private static string TextureDebugName(GuestDrawTexture texture, Format format) =>
             $"SharpEmu texture 0x{texture.Address:X16} {texture.Width}x{texture.Height} " +
             $"fmt{texture.Format}/{format}";
 
@@ -3617,7 +3519,7 @@ internal static unsafe class VulkanVideoPresenter
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private TextureResource ResolveTextureResource(VulkanGuestDrawTexture texture)
+        private TextureResource ResolveTextureResource(GuestDrawTexture texture)
         {
             if (texture.IsStorage)
             {
@@ -3691,7 +3593,7 @@ internal static unsafe class VulkanVideoPresenter
         }
 
         private bool TryCreateCpuTextureRefreshResource(
-            VulkanGuestDrawTexture texture,
+            GuestDrawTexture texture,
             GuestImageResource guestImage,
             ImageView view,
             out TextureResource resource)
@@ -3756,7 +3658,7 @@ internal static unsafe class VulkanVideoPresenter
         }
 
         private static bool IsCompatibleGuestImageAlias(
-            VulkanGuestDrawTexture texture,
+            GuestDrawTexture texture,
             GuestImageResource guestImage)
         {
             if (guestImage.Width == texture.Width &&
@@ -3777,7 +3679,7 @@ internal static unsafe class VulkanVideoPresenter
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private TextureResource ResolveStorageImageResource(VulkanGuestDrawTexture texture)
+        private TextureResource ResolveStorageImageResource(GuestDrawTexture texture)
         {
             if (texture.Address == 0)
             {
@@ -3854,7 +3756,7 @@ internal static unsafe class VulkanVideoPresenter
             return resource;
         }
 
-        private TextureResource CreateStorageScratchResource(VulkanGuestDrawTexture texture)
+        private TextureResource CreateStorageScratchResource(GuestDrawTexture texture)
         {
             var width = Math.Max(texture.Width, 1);
             var height = Math.Max(texture.Height, 1);
@@ -3944,7 +3846,7 @@ internal static unsafe class VulkanVideoPresenter
             };
         }
 
-        private GuestImageResource ResolveStorageGuestImage(VulkanGuestDrawTexture texture)
+        private GuestImageResource ResolveStorageGuestImage(GuestDrawTexture texture)
         {
             if (texture.Address == 0)
             {
@@ -3953,7 +3855,7 @@ internal static unsafe class VulkanVideoPresenter
 
             var format = GetTextureFormat(texture.Format, texture.NumberType);
             var guestImage = GetOrCreateGuestImage(
-                new VulkanGuestRenderTarget(
+                new GuestRenderTarget(
                     texture.Address,
                     texture.Width,
                     texture.Height,
@@ -3970,7 +3872,7 @@ internal static unsafe class VulkanVideoPresenter
             return guestImage;
         }
 
-        private TextureResource CreateTextureResource(VulkanGuestDrawTexture texture)
+        private TextureResource CreateTextureResource(GuestDrawTexture texture)
         {
             var width = Math.Max(texture.Width, 1);
             var height = Math.Max(texture.Height, 1);
@@ -4168,7 +4070,7 @@ internal static unsafe class VulkanVideoPresenter
         }
 
         private void DumpTextureUpload(
-            VulkanGuestDrawTexture texture,
+            GuestDrawTexture texture,
             byte[] pixels,
             uint rowLength,
             uint width,
@@ -4260,7 +4162,7 @@ internal static unsafe class VulkanVideoPresenter
         private static void WriteInt32(byte[] output, int offset, int value) =>
             WriteUInt32(output, offset, unchecked((uint)value));
 
-        private Sampler CreateSampler(VulkanGuestSampler sampler)
+        private Sampler CreateSampler(GuestSampler sampler)
         {
             if (_samplers.TryGetValue(sampler, out var cachedSampler))
             {
@@ -4338,7 +4240,7 @@ internal static unsafe class VulkanVideoPresenter
         }
 
         private GlobalBufferResource CreateGlobalBufferResource(
-            VulkanGuestMemoryBuffer guestBuffer)
+            GuestMemoryBuffer guestBuffer)
         {
             var buffer = CreateHostBuffer(
                 guestBuffer.Data,
@@ -4367,7 +4269,7 @@ internal static unsafe class VulkanVideoPresenter
         }
 
         private VertexBufferResource CreateVertexBufferResource(
-            VulkanGuestVertexBuffer guestBuffer)
+            GuestVertexBuffer guestBuffer)
         {
             var buffer = CreateHostBuffer(
                 guestBuffer.Data,
@@ -4590,7 +4492,7 @@ internal static unsafe class VulkanVideoPresenter
         private static uint GetDrawVertexCount(
             uint primitiveType,
             uint vertexCount,
-            VulkanGuestIndexBuffer? indexBuffer)
+            GuestIndexBuffer? indexBuffer)
         {
             if (primitiveType == GuestPrimitiveRectList && indexBuffer is null)
             {
@@ -4636,41 +4538,41 @@ internal static unsafe class VulkanVideoPresenter
                 _ => BlendOp.Add,
             };
 
-        private static uint DecodeSamplerClampX(VulkanGuestSampler sampler) =>
+        private static uint DecodeSamplerClampX(GuestSampler sampler) =>
             sampler.Word0 & 0x7u;
 
-        private static uint DecodeSamplerClampY(VulkanGuestSampler sampler) =>
+        private static uint DecodeSamplerClampY(GuestSampler sampler) =>
             (sampler.Word0 >> 3) & 0x7u;
 
-        private static uint DecodeSamplerClampZ(VulkanGuestSampler sampler) =>
+        private static uint DecodeSamplerClampZ(GuestSampler sampler) =>
             (sampler.Word0 >> 6) & 0x7u;
 
-        private static uint DecodeSamplerDepthCompare(VulkanGuestSampler sampler) =>
+        private static uint DecodeSamplerDepthCompare(GuestSampler sampler) =>
             (sampler.Word0 >> 12) & 0x7u;
 
-        private static float DecodeSamplerMinLod(VulkanGuestSampler sampler) =>
+        private static float DecodeSamplerMinLod(GuestSampler sampler) =>
             (sampler.Word1 & 0xFFFu) / 256.0f;
 
-        private static float DecodeSamplerMaxLod(VulkanGuestSampler sampler) =>
+        private static float DecodeSamplerMaxLod(GuestSampler sampler) =>
             ((sampler.Word1 >> 12) & 0xFFFu) / 256.0f;
 
-        private static float DecodeSamplerLodBias(VulkanGuestSampler sampler)
+        private static float DecodeSamplerLodBias(GuestSampler sampler)
         {
             var raw = sampler.Word2 & 0x3FFFu;
             var signed = (short)((raw ^ 0x2000u) - 0x2000u);
             return signed / 256.0f;
         }
 
-        private static uint DecodeSamplerMagFilter(VulkanGuestSampler sampler) =>
+        private static uint DecodeSamplerMagFilter(GuestSampler sampler) =>
             (sampler.Word2 >> 20) & 0x3u;
 
-        private static uint DecodeSamplerMinFilter(VulkanGuestSampler sampler) =>
+        private static uint DecodeSamplerMinFilter(GuestSampler sampler) =>
             (sampler.Word2 >> 22) & 0x3u;
 
-        private static uint DecodeSamplerMipFilter(VulkanGuestSampler sampler) =>
+        private static uint DecodeSamplerMipFilter(GuestSampler sampler) =>
             (sampler.Word2 >> 26) & 0x3u;
 
-        private static uint DecodeSamplerBorderColor(VulkanGuestSampler sampler) =>
+        private static uint DecodeSamplerBorderColor(GuestSampler sampler) =>
             (sampler.Word3 >> 30) & 0x3u;
 
         private static SamplerAddressMode ToVkSamplerAddressMode(uint mode) =>
@@ -4737,11 +4639,11 @@ internal static unsafe class VulkanVideoPresenter
             return flags;
         }
 
-        private static VulkanGuestRect ClampScissor(VulkanGuestRect? scissor, Extent2D extent)
+        private static GuestRect ClampScissor(GuestRect? scissor, Extent2D extent)
         {
             if (scissor is not { } rect)
             {
-                return new VulkanGuestRect(0, 0, extent.Width, extent.Height);
+                return new GuestRect(0, 0, extent.Width, extent.Height);
             }
 
             var left = Math.Clamp(rect.X, 0, checked((int)extent.Width));
@@ -4754,7 +4656,7 @@ internal static unsafe class VulkanVideoPresenter
                 rect.Y + checked((int)rect.Height),
                 top,
                 checked((int)extent.Height));
-            return new VulkanGuestRect(
+            return new GuestRect(
                 left,
                 top,
                 checked((uint)(right - left)),
@@ -4769,7 +4671,7 @@ internal static unsafe class VulkanVideoPresenter
             ? viewportEpsilon
             : 0f;
 
-        private static Viewport ClampViewport(VulkanGuestViewport? viewport, Extent2D extent)
+        private static Viewport ClampViewport(GuestViewport? viewport, Extent2D extent)
         {
             if (viewport is not { } rect)
             {
@@ -5472,7 +5374,7 @@ internal static unsafe class VulkanVideoPresenter
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private GuestImageResource GetOrCreateGuestImage(
-            VulkanGuestRenderTarget target,
+            GuestRenderTarget target,
             Format format)
         {
             var mipLevels = ClampMipLevels(target.Width, target.Height, target.MipLevels);

--- a/src/SharpEmu.Libs/packages.lock.json
+++ b/src/SharpEmu.Libs/packages.lock.json
@@ -132,6 +132,12 @@
       },
       "sharpemu.logging": {
         "type": "Project"
+      },
+      "sharpemu.shadercompiler": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.HLE": "[1.0.0, )"
+        }
       }
     }
   }

--- a/src/SharpEmu.Libs/packages.lock.json
+++ b/src/SharpEmu.Libs/packages.lock.json
@@ -138,6 +138,12 @@
         "dependencies": {
           "SharpEmu.HLE": "[1.0.0, )"
         }
+      },
+      "sharpemu.shadercompiler.vulkan": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.ShaderCompiler": "[1.0.0, )"
+        }
       }
     }
   }

--- a/src/SharpEmu.Libs/packages.lock.json
+++ b/src/SharpEmu.Libs/packages.lock.json
@@ -127,7 +127,7 @@
       "sharpemu.hle": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.Logging": "[1.0.0, )"
+          "SharpEmu.Logging": "[0.0.1, )"
         }
       },
       "sharpemu.logging": {
@@ -136,13 +136,13 @@
       "sharpemu.shadercompiler": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.HLE": "[1.0.0, )"
+          "SharpEmu.HLE": "[0.0.1, )"
         }
       },
       "sharpemu.shadercompiler.vulkan": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.ShaderCompiler": "[1.0.0, )"
+          "SharpEmu.ShaderCompiler": "[0.0.1, )"
         }
       }
     }

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvShader.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvShader.cs
@@ -3,19 +3,19 @@
 
 using SharpEmu.ShaderCompiler;
 
-namespace SharpEmu.Libs.Agc;
+namespace SharpEmu.ShaderCompiler.Vulkan;
 
 // SPIR-V-specific shader artifact types. These stay beside the SPIR-V emitter (not in
 // the backend-neutral SharpEmu.ShaderCompiler project): each codegen owns its own
 // compiled-shader shape.
-internal enum Gen5SpirvStage
+public enum Gen5SpirvStage
 {
     Vertex,
     Pixel,
     Compute,
 }
 
-internal sealed record Gen5SpirvShader(
+public sealed record Gen5SpirvShader(
     byte[] Spirv,
     IReadOnlyList<Gen5GlobalMemoryBinding> GlobalMemoryBindings,
     IReadOnlyList<Gen5ImageBinding> ImageBindings,

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
@@ -3,9 +3,9 @@
 
 using SharpEmu.ShaderCompiler;
 
-namespace SharpEmu.Libs.Agc;
+namespace SharpEmu.ShaderCompiler.Vulkan;
 
-internal static partial class Gen5SpirvTranslator
+public static partial class Gen5SpirvTranslator
 {
     private sealed partial class CompilationContext
     {

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -3,9 +3,9 @@
 
 using SharpEmu.ShaderCompiler;
 
-namespace SharpEmu.Libs.Agc;
+namespace SharpEmu.ShaderCompiler.Vulkan;
 
-internal static partial class Gen5SpirvTranslator
+public static partial class Gen5SpirvTranslator
 {
     private const uint ScalarRegisterCount = 256;
     private const uint VectorRegisterCount = 512;

--- a/src/SharpEmu.ShaderCompiler.Vulkan/SharpEmu.ShaderCompiler.Vulkan.csproj
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/SharpEmu.ShaderCompiler.Vulkan.csproj
@@ -1,0 +1,19 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- The SPIR-V codegen backend: consumes the backend-neutral shader IR from
+       SharpEmu.ShaderCompiler and emits raw SPIR-V words. Deliberately has no
+       dependency on Vulkan bindings — emitters produce bytes; renderers own APIs. -->
+  <PropertyGroup>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SharpEmu.ShaderCompiler\SharpEmu.ShaderCompiler.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SharpEmu.ShaderCompiler.Vulkan/SpirvFixedShaders.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/SpirvFixedShaders.cs
@@ -1,9 +1,9 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-namespace SharpEmu.Libs.Agc;
+namespace SharpEmu.ShaderCompiler.Vulkan;
 
-internal static class SpirvFixedShaders
+public static class SpirvFixedShaders
 {
     public static byte[] CreateFullscreenVertex(uint attributeCount)
     {

--- a/src/SharpEmu.ShaderCompiler.Vulkan/SpirvModuleBuilder.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/SpirvModuleBuilder.cs
@@ -4,9 +4,9 @@
 using System.Buffers.Binary;
 using System.Text;
 
-namespace SharpEmu.Libs.Agc;
+namespace SharpEmu.ShaderCompiler.Vulkan;
 
-internal enum SpirvOp : ushort
+public enum SpirvOp : ushort
 {
     Nop = 0,
     Name = 5,
@@ -167,7 +167,7 @@ internal enum SpirvOp : ushort
     GroupNonUniformShuffleDown = 348,
 }
 
-internal enum SpirvCapability : uint
+public enum SpirvCapability : uint
 {
     Shader = 1,
     Float16 = 9,
@@ -186,7 +186,7 @@ internal enum SpirvCapability : uint
     RuntimeDescriptorArray = 5302,
 }
 
-internal enum SpirvStorageClass : uint
+public enum SpirvStorageClass : uint
 {
     UniformConstant = 0,
     Input = 1,
@@ -200,21 +200,21 @@ internal enum SpirvStorageClass : uint
     StorageBuffer = 12,
 }
 
-internal enum SpirvExecutionModel : uint
+public enum SpirvExecutionModel : uint
 {
     Vertex = 0,
     Fragment = 4,
     GLCompute = 5,
 }
 
-internal enum SpirvExecutionMode : uint
+public enum SpirvExecutionMode : uint
 {
     OriginUpperLeft = 7,
     DepthReplacing = 12,
     LocalSize = 17,
 }
 
-internal enum SpirvDecoration : uint
+public enum SpirvDecoration : uint
 {
     Block = 2,
     ArrayStride = 6,
@@ -227,7 +227,7 @@ internal enum SpirvDecoration : uint
     Offset = 35,
 }
 
-internal enum SpirvBuiltIn : uint
+public enum SpirvBuiltIn : uint
 {
     Position = 0,
     VertexIndex = 42,
@@ -241,7 +241,7 @@ internal enum SpirvBuiltIn : uint
     SubgroupLocalInvocationId = 41,
 }
 
-internal enum SpirvImageDim : uint
+public enum SpirvImageDim : uint
 {
     Dim1D = 0,
     Dim2D = 1,
@@ -250,7 +250,7 @@ internal enum SpirvImageDim : uint
     Buffer = 5,
 }
 
-internal enum SpirvImageFormat : uint
+public enum SpirvImageFormat : uint
 {
     Unknown = 0,
     Rgba32f = 1,
@@ -294,7 +294,7 @@ internal enum SpirvImageFormat : uint
     R8ui = 39,
 }
 
-internal sealed class SpirvModuleBuilder
+public sealed class SpirvModuleBuilder
 {
     private const uint Magic = 0x07230203;
     private const uint Version15 = 0x00010500;

--- a/src/SharpEmu.ShaderCompiler.Vulkan/packages.lock.json
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/packages.lock.json
@@ -5,7 +5,7 @@
       "sharpemu.hle": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.Logging": "[1.0.0, )"
+          "SharpEmu.Logging": "[0.0.1, )"
         }
       },
       "sharpemu.logging": {
@@ -14,7 +14,7 @@
       "sharpemu.shadercompiler": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.HLE": "[1.0.0, )"
+          "SharpEmu.HLE": "[0.0.1, )"
         }
       }
     }

--- a/src/SharpEmu.ShaderCompiler.Vulkan/packages.lock.json
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/packages.lock.json
@@ -1,0 +1,22 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "sharpemu.hle": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.Logging": "[1.0.0, )"
+        }
+      },
+      "sharpemu.logging": {
+        "type": "Project"
+      },
+      "sharpemu.shadercompiler": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.HLE": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}

--- a/src/SharpEmu.ShaderCompiler/Gen5InlineConstants.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5InlineConstants.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.ShaderCompiler;
+
+/// <summary>
+/// The Gen5 (gfx10) inline-constant operand table, shared by every codegen so backends
+/// cannot drift on constant semantics.
+/// </summary>
+public static class Gen5InlineConstants
+{
+    public static bool TryDecode(uint encoded, out uint value)
+    {
+        if (encoded == 125)
+        {
+            value = 0;
+            return true;
+        }
+
+        if (encoded is >= 128 and <= 192)
+        {
+            value = encoded - 128;
+            return true;
+        }
+
+        if (encoded is >= 193 and <= 208)
+        {
+            value = unchecked((uint)-(int)(encoded - 192));
+            return true;
+        }
+
+        var floatingPoint = encoded switch
+        {
+            240 => 0.5f,
+            241 => -0.5f,
+            242 => 1.0f,
+            243 => -1.0f,
+            244 => 2.0f,
+            245 => -2.0f,
+            246 => 4.0f,
+            247 => -4.0f,
+            248 => 1.0f / (2.0f * MathF.PI),
+            _ => float.NaN,
+        };
+        if (float.IsNaN(floatingPoint))
+        {
+            value = 0;
+            return false;
+        }
+
+        value = BitConverter.SingleToUInt32Bits(floatingPoint);
+        return true;
+    }
+}

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
@@ -1,9 +1,9 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-namespace SharpEmu.Libs.Agc;
+namespace SharpEmu.ShaderCompiler;
 
-internal enum Gen5ShaderEncoding
+public enum Gen5ShaderEncoding
 {
     Sop1,
     Sop2,
@@ -26,7 +26,7 @@ internal enum Gen5ShaderEncoding
     Exp,
 }
 
-internal enum Gen5OperandKind
+public enum Gen5OperandKind
 {
     ScalarRegister,
     VectorRegister,
@@ -34,7 +34,7 @@ internal enum Gen5OperandKind
     LiteralConstant,
 }
 
-internal enum Gen5ShaderResourceKind
+public enum Gen5ShaderResourceKind
 {
     ReadOnlyTexture,
     ReadWriteTexture,
@@ -42,45 +42,31 @@ internal enum Gen5ShaderResourceKind
     ConstantBuffer,
 }
 
-internal enum Gen5PixelOutputKind
+public enum Gen5PixelOutputKind
 {
     Float,
     Uint,
     Sint,
 }
 
-internal readonly record struct Gen5PixelOutputBinding(
+public readonly record struct Gen5PixelOutputBinding(
     uint GuestSlot,
     uint HostLocation,
     Gen5PixelOutputKind Kind);
 
-internal enum Gen5SpirvStage
-{
-    Vertex,
-    Pixel,
-    Compute,
-}
-
-internal sealed record Gen5SpirvShader(
-    byte[] Spirv,
-    IReadOnlyList<Gen5GlobalMemoryBinding> GlobalMemoryBindings,
-    IReadOnlyList<Gen5ImageBinding> ImageBindings,
-    uint AttributeCount,
-    IReadOnlyList<Gen5VertexInputBinding> VertexInputs);
-
-internal readonly record struct Gen5ShaderResourceMapping(
+public readonly record struct Gen5ShaderResourceMapping(
     Gen5ShaderResourceKind Kind,
     uint Slot,
     uint OffsetDwords,
     bool SizeFlag);
 
-internal sealed record Gen5ShaderMetadata(
+public sealed record Gen5ShaderMetadata(
     uint ExtendedUserDataSizeDwords,
     uint ShaderResourceTableSizeDwords,
     IReadOnlyDictionary<uint, uint> DirectResources,
     IReadOnlyList<Gen5ShaderResourceMapping> Resources);
 
-internal readonly record struct Gen5ComputeSystemRegisters(
+public readonly record struct Gen5ComputeSystemRegisters(
     uint? WorkGroupXRegister,
     uint? WorkGroupYRegister,
     uint? WorkGroupZRegister,
@@ -133,14 +119,14 @@ internal readonly record struct Gen5ComputeSystemRegisters(
     }
 }
 
-internal sealed record Gen5ShaderState(
+public sealed record Gen5ShaderState(
     Gen5ShaderProgram Program,
     IReadOnlyList<uint> UserData,
     Gen5ShaderMetadata? Metadata,
     Gen5ComputeSystemRegisters? ComputeSystemRegisters = null,
     uint UserDataScalarRegisterBase = 0);
 
-internal readonly record struct Gen5Operand(Gen5OperandKind Kind, uint Value)
+public readonly record struct Gen5Operand(Gen5OperandKind Kind, uint Value)
 {
     public static Gen5Operand Scalar(uint index) =>
         new(Gen5OperandKind.ScalarRegister, index);
@@ -177,9 +163,9 @@ internal readonly record struct Gen5Operand(Gen5OperandKind Kind, uint Value)
     };
 }
 
-internal abstract record Gen5InstructionControl;
+public abstract record Gen5InstructionControl;
 
-internal sealed record Gen5ImageControl(
+public sealed record Gen5ImageControl(
     uint Dmask,
     uint VectorAddress,
     IReadOnlyList<uint> AddressRegisters,
@@ -197,7 +183,7 @@ internal sealed record Gen5ImageControl(
             : VectorAddress + (uint)component;
 }
 
-internal sealed record Gen5GlobalMemoryControl(
+public sealed record Gen5GlobalMemoryControl(
     uint DwordCount,
     uint VectorAddress,
     uint VectorData,
@@ -206,7 +192,7 @@ internal sealed record Gen5GlobalMemoryControl(
     bool Glc,
     bool Slc) : Gen5InstructionControl;
 
-internal sealed record Gen5BufferMemoryControl(
+public sealed record Gen5BufferMemoryControl(
     uint DwordCount,
     uint VectorAddress,
     uint VectorData,
@@ -217,25 +203,25 @@ internal sealed record Gen5BufferMemoryControl(
     bool Glc,
     bool Slc) : Gen5InstructionControl;
 
-internal sealed record Gen5ExportControl(
+public sealed record Gen5ExportControl(
     uint Target,
     uint EnableMask,
     bool Compressed,
     bool Done,
     bool ValidMask) : Gen5InstructionControl;
 
-internal sealed record Gen5InterpolationControl(
+public sealed record Gen5InterpolationControl(
     uint Attribute,
     uint Channel) : Gen5InstructionControl;
 
-internal sealed record Gen5Vop3Control(
+public sealed record Gen5Vop3Control(
     uint AbsoluteMask,
     uint NegateMask,
     uint OutputModifier,
     bool Clamp,
     uint? ScalarDestination) : Gen5InstructionControl;
 
-internal sealed record Gen5SdwaControl(
+public sealed record Gen5SdwaControl(
     uint DestinationSelect,
     uint Source0Select,
     uint Source1Select,
@@ -244,7 +230,7 @@ internal sealed record Gen5SdwaControl(
     uint OutputModifier,
     bool Clamp) : Gen5InstructionControl;
 
-internal sealed record Gen5DppControl(
+public sealed record Gen5DppControl(
     uint Control,
     bool FetchInactive,
     bool BoundControl,
@@ -253,17 +239,17 @@ internal sealed record Gen5DppControl(
     uint BankMask,
     uint RowMask) : Gen5InstructionControl;
 
-internal sealed record Gen5ScalarMemoryControl(
+public sealed record Gen5ScalarMemoryControl(
     uint DestinationCount,
     int ImmediateOffsetBytes,
     uint? DynamicOffsetRegister) : Gen5InstructionControl;
 
-internal sealed record Gen5DataShareControl(
+public sealed record Gen5DataShareControl(
     uint Offset0,
     uint Offset1,
     bool Gds) : Gen5InstructionControl;
 
-internal sealed record Gen5ImageBinding(
+public sealed record Gen5ImageBinding(
     uint Pc,
     string Opcode,
     Gen5ImageControl Control,
@@ -271,13 +257,13 @@ internal sealed record Gen5ImageBinding(
     IReadOnlyList<uint> SamplerDescriptor,
     uint? MipLevel);
 
-internal sealed record Gen5GlobalMemoryBinding(
+public sealed record Gen5GlobalMemoryBinding(
     uint ScalarAddress,
     ulong BaseAddress,
     IReadOnlyList<uint> InstructionPcs,
     byte[] Data);
 
-internal sealed record Gen5VertexInputBinding(
+public sealed record Gen5VertexInputBinding(
     uint Pc,
     uint Location,
     uint ComponentCount,
@@ -288,7 +274,7 @@ internal sealed record Gen5VertexInputBinding(
     uint OffsetBytes,
     byte[] Data);
 
-internal sealed record Gen5ShaderEvaluation(
+public sealed record Gen5ShaderEvaluation(
     IReadOnlyList<uint> InitialScalarRegisters,
     IReadOnlyList<uint> ScalarRegisters,
     IReadOnlyDictionary<uint, IReadOnlyList<uint>> ScalarRegistersByPc,
@@ -298,7 +284,7 @@ internal sealed record Gen5ShaderEvaluation(
     IReadOnlySet<uint>? RuntimeScalarRegisters = null,
     IReadOnlyList<Gen5VertexInputBinding>? VertexInputs = null);
 
-internal sealed record Gen5ShaderInstruction(
+public sealed record Gen5ShaderInstruction(
     uint Pc,
     Gen5ShaderEncoding Encoding,
     string Opcode,
@@ -307,7 +293,7 @@ internal sealed record Gen5ShaderInstruction(
     IReadOnlyList<Gen5Operand> Destinations,
     Gen5InstructionControl? Control);
 
-internal sealed record Gen5ShaderProgram(
+public sealed record Gen5ShaderProgram(
     ulong Address,
     IReadOnlyList<Gen5ShaderInstruction> Instructions)
 {

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderMetadataReader.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderMetadataReader.cs
@@ -3,9 +3,9 @@
 
 using SharpEmu.HLE;
 
-namespace SharpEmu.Libs.Agc;
+namespace SharpEmu.ShaderCompiler;
 
-internal static class Gen5ShaderMetadataReader
+public static class Gen5ShaderMetadataReader
 {
     private const ulong ShaderUserDataOffset = 0x08;
     private const int ResourceClassCount = 4;

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -2,13 +2,21 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
-using SharpEmu.Libs.Kernel;
 using System.Numerics;
 
-namespace SharpEmu.Libs.Agc;
+namespace SharpEmu.ShaderCompiler;
 
-internal static class Gen5ShaderScalarEvaluator
+public static class Gen5ShaderScalarEvaluator
 {
+    /// <summary>
+    /// Optional fallback for global-memory reads that ctx.Memory cannot satisfy (the
+    /// emulator installs the HLE-tracked libc heap reader here at module load). Kept as
+    /// a hook so this project never depends on the HLE module implementations.
+    /// </summary>
+    public static Gen5FallbackMemoryReader? FallbackMemoryReader { get; set; }
+
+    public delegate bool Gen5FallbackMemoryReader(ulong baseAddress, Span<byte> destination);
+
     private const int ScalarRegisterCount = 256;
     private const int ImageDescriptorDwords = 8;
     private const int SamplerDescriptorDwords = 4;
@@ -20,12 +28,12 @@ internal static class Gen5ShaderScalarEvaluator
             ? Math.Min(configured, MaxGlobalMemoryBindingBytes)
             : 1 * 1024 * 1024;
 
-    internal static long GlobalMemoryReadCount;
-    internal static long GlobalMemoryReadBytes;
-    internal static long GlobalMemoryReadCacheHits;
-    internal static long GlobalMemoryReadPvmBytes;
-    internal static long GlobalMemoryReadLibcBytes;
-    internal static long GlobalMemoryReadReuses;
+    public static long GlobalMemoryReadCount;
+    public static long GlobalMemoryReadBytes;
+    public static long GlobalMemoryReadCacheHits;
+    public static long GlobalMemoryReadPvmBytes;
+    public static long GlobalMemoryReadLibcBytes;
+    public static long GlobalMemoryReadReuses;
 
     private const long CrossFrameReadCacheMaxBytes = 1024L * 1024 * 1024;
     private static readonly object _crossFrameReadGate = new();
@@ -573,12 +581,12 @@ internal static class Gen5ShaderScalarEvaluator
     [ThreadStatic]
     private static Dictionary<(ulong BaseAddress, int SizeBytes), byte[]>? _globalMemoryReadCache;
 
-    internal static void BeginGlobalMemoryReadScope()
+    public static void BeginGlobalMemoryReadScope()
     {
         _globalMemoryReadCache = new Dictionary<(ulong, int), byte[]>();
     }
 
-    internal static void EndGlobalMemoryReadScope()
+    public static void EndGlobalMemoryReadScope()
     {
         _globalMemoryReadCache = null;
     }
@@ -647,7 +655,7 @@ internal static class Gen5ShaderScalarEvaluator
             data = GC.AllocateUninitializedArray<byte>(candidateSize);
             var readFromPvm = ctx.Memory.TryRead(baseAddress, data);
             if (readFromPvm ||
-                KernelMemoryCompatExports.TryReadTrackedLibcHeap(baseAddress, data))
+                FallbackMemoryReader?.Invoke(baseAddress, data) == true)
             {
                 Interlocked.Increment(ref GlobalMemoryReadCount);
                 Interlocked.Add(ref GlobalMemoryReadBytes, data.Length);

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
-using SharpEmu.Libs.VideoOut;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-namespace SharpEmu.Libs.Agc;
+namespace SharpEmu.ShaderCompiler;
 
-internal static class Gen5ShaderTranslator
+public static class Gen5ShaderTranslator
 {
     private const int MaxInstructions = 4096;
     private const int MinimumUserDataDwords = 16;
@@ -276,7 +275,9 @@ internal static class Gen5ShaderTranslator
         return true;
     }
 
-    private static bool TryDecodeProgram(
+    // Public contract entry: emitter test suites and tools drive the decoder directly
+    // from raw instruction words.
+    public static bool TryDecodeProgram(
         CpuContext ctx,
         ulong address,
         out Gen5ShaderProgram program,
@@ -1220,7 +1221,7 @@ internal static class Gen5ShaderTranslator
     private static bool IsMimgInstruction(string name) =>
         name.StartsWith("Image", StringComparison.Ordinal);
 
-    internal static bool IsStorageImageOperation(string name) =>
+    public static bool IsStorageImageOperation(string name) =>
         name.StartsWith("ImageStore", StringComparison.Ordinal) ||
         name.StartsWith("ImageAtomic", StringComparison.Ordinal);
 

--- a/src/SharpEmu.ShaderCompiler/GuestDrawKind.cs
+++ b/src/SharpEmu.ShaderCompiler/GuestDrawKind.cs
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.ShaderCompiler;
+
+/// <summary>
+/// Guest draw patterns the decoder recognizes from known shader programs. Guest-domain,
+/// backend-neutral — it previously lived inside the Vulkan presenter, which is exactly
+/// the kind of placement this project exists to prevent.
+/// </summary>
+public enum GuestDrawKind
+{
+    None,
+    FullscreenBarycentric,
+}

--- a/src/SharpEmu.ShaderCompiler/SharpEmu.ShaderCompiler.csproj
+++ b/src/SharpEmu.ShaderCompiler/SharpEmu.ShaderCompiler.csproj
@@ -1,0 +1,20 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- The backend-neutral half of guest shader compilation: the Gen5 (gfx10) microcode
+       decoder, the scalar evaluator, and the shader IR every codegen consumes. Emitters
+       (SPIR-V, MSL, DXIL) live in sibling SharpEmu.ShaderCompiler.* projects; nothing
+       here may depend on a host graphics API. -->
+  <PropertyGroup>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SharpEmu.HLE\SharpEmu.HLE.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SharpEmu.ShaderCompiler/packages.lock.json
+++ b/src/SharpEmu.ShaderCompiler/packages.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "sharpemu.hle": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.Logging": "[1.0.0, )"
+        }
+      },
+      "sharpemu.logging": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/SharpEmu.ShaderCompiler/packages.lock.json
+++ b/src/SharpEmu.ShaderCompiler/packages.lock.json
@@ -5,7 +5,7 @@
       "sharpemu.hle": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.Logging": "[1.0.0, )"
+          "SharpEmu.Logging": "[0.0.1, )"
         }
       },
       "sharpemu.logging": {

--- a/tests/SharpEmu.Libs.Tests/packages.lock.json
+++ b/tests/SharpEmu.Libs.Tests/packages.lock.json
@@ -81,6 +81,23 @@
           "Ultz.Native.GLFW": "3.4.0"
         }
       },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
       "Silk.NET.Maths": {
         "type": "Transitive",
         "resolved": "2.23.0",
@@ -153,23 +170,24 @@
         "type": "Project",
         "dependencies": {
           "Iced": "[1.21.0, )",
-          "SharpEmu.HLE": "[1.0.0, )",
-          "SharpEmu.Libs": "[1.0.0, )",
-          "SharpEmu.Logging": "[1.0.0, )"
+          "SharpEmu.HLE": "[0.0.1, )",
+          "SharpEmu.Libs": "[0.0.1, )",
+          "SharpEmu.Logging": "[0.0.1, )"
         }
       },
       "sharpemu.hle": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.Logging": "[1.0.0, )"
+          "SharpEmu.Logging": "[0.0.1, )"
         }
       },
       "sharpemu.libs": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.HLE": "[1.0.0, )",
-          "SharpEmu.ShaderCompiler": "[1.0.0, )",
-          "SharpEmu.ShaderCompiler.Vulkan": "[1.0.0, )",
+          "SharpEmu.HLE": "[0.0.1, )",
+          "SharpEmu.ShaderCompiler": "[0.0.1, )",
+          "SharpEmu.ShaderCompiler.Vulkan": "[0.0.1, )",
+          "Silk.NET.Input": "[2.23.0, )",
           "Silk.NET.Vulkan": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.EXT": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.KHR": "[2.23.0, )",
@@ -182,13 +200,13 @@
       "sharpemu.shadercompiler": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.HLE": "[1.0.0, )"
+          "SharpEmu.HLE": "[0.0.1, )"
         }
       },
       "sharpemu.shadercompiler.vulkan": {
         "type": "Project",
         "dependencies": {
-          "SharpEmu.ShaderCompiler": "[1.0.0, )"
+          "SharpEmu.ShaderCompiler": "[0.0.1, )"
         }
       },
       "Iced": {
@@ -196,6 +214,16 @@
         "requested": "[1.21.0, )",
         "resolved": "1.21.0",
         "contentHash": "dv5+81Q1TBQvVMSOOOmRcjJmvWcX3BZPZsIq31+RLc5cNft0IHAyNlkdb7ZarOWG913PyBoFDsDXoCIlKmLclg=="
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
+        }
       },
       "Silk.NET.Vulkan": {
         "type": "CentralTransitive",

--- a/tests/SharpEmu.Libs.Tests/packages.lock.json
+++ b/tests/SharpEmu.Libs.Tests/packages.lock.json
@@ -169,6 +169,7 @@
         "dependencies": {
           "SharpEmu.HLE": "[1.0.0, )",
           "SharpEmu.ShaderCompiler": "[1.0.0, )",
+          "SharpEmu.ShaderCompiler.Vulkan": "[1.0.0, )",
           "Silk.NET.Vulkan": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.EXT": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.KHR": "[2.23.0, )",
@@ -182,6 +183,12 @@
         "type": "Project",
         "dependencies": {
           "SharpEmu.HLE": "[1.0.0, )"
+        }
+      },
+      "sharpemu.shadercompiler.vulkan": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.ShaderCompiler": "[1.0.0, )"
         }
       },
       "Iced": {

--- a/tests/SharpEmu.Libs.Tests/packages.lock.json
+++ b/tests/SharpEmu.Libs.Tests/packages.lock.json
@@ -81,23 +81,6 @@
           "Ultz.Native.GLFW": "3.4.0"
         }
       },
-      "Silk.NET.Input.Common": {
-        "type": "Transitive",
-        "resolved": "2.23.0",
-        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
-        "dependencies": {
-          "Silk.NET.Windowing.Common": "2.23.0"
-        }
-      },
-      "Silk.NET.Input.Glfw": {
-        "type": "Transitive",
-        "resolved": "2.23.0",
-        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
-        "dependencies": {
-          "Silk.NET.Input.Common": "2.23.0",
-          "Silk.NET.Windowing.Glfw": "2.23.0"
-        }
-      },
       "Silk.NET.Maths": {
         "type": "Transitive",
         "resolved": "2.23.0",
@@ -185,7 +168,7 @@
         "type": "Project",
         "dependencies": {
           "SharpEmu.HLE": "[1.0.0, )",
-          "Silk.NET.Input": "[2.23.0, )",
+          "SharpEmu.ShaderCompiler": "[1.0.0, )",
           "Silk.NET.Vulkan": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.EXT": "[2.23.0, )",
           "Silk.NET.Vulkan.Extensions.KHR": "[2.23.0, )",
@@ -195,21 +178,17 @@
       "sharpemu.logging": {
         "type": "Project"
       },
+      "sharpemu.shadercompiler": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.HLE": "[1.0.0, )"
+        }
+      },
       "Iced": {
         "type": "CentralTransitive",
         "requested": "[1.21.0, )",
         "resolved": "1.21.0",
         "contentHash": "dv5+81Q1TBQvVMSOOOmRcjJmvWcX3BZPZsIq31+RLc5cNft0IHAyNlkdb7ZarOWG913PyBoFDsDXoCIlKmLclg=="
-      },
-      "Silk.NET.Input": {
-        "type": "CentralTransitive",
-        "requested": "[2.23.0, )",
-        "resolved": "2.23.0",
-        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
-        "dependencies": {
-          "Silk.NET.Input.Common": "2.23.0",
-          "Silk.NET.Input.Glfw": "2.23.0"
-        }
       },
       "Silk.NET.Vulkan": {
         "type": "CentralTransitive",

--- a/tools/SharpEmu.Tools.ShaderDump/Program.cs
+++ b/tools/SharpEmu.Tools.ShaderDump/Program.cs
@@ -179,15 +179,19 @@ foreach (var (name, expectTranslate, words) in testPrograms)
 
     // Buffer stores need a global-memory binding; the emitter resolves them by
     // instruction PC, so collect store PCs from the decoded program itself.
-    var storePcs = program!.Instructions
-        .Where(instruction => instruction.Opcode.StartsWith("BufferStore", StringComparison.Ordinal))
-        .Select(instruction => instruction.Pc)
-        .ToArray();
+    var storePcs = new List<uint>();
+    foreach (var instruction in program!.Instructions)
+    {
+        if (instruction.Opcode.StartsWith("BufferStore", StringComparison.Ordinal))
+        {
+            storePcs.Add(instruction.Pc);
+        }
+    }
 
     // The binding's scalar base (8 -> s[8:11]) must match the srsrc field of
     // the hand-assembled buffer_store words, and the 64-byte backing store
     // must cover every hand-assembled store offset.
-    var globalBindings = storePcs.Length > 0
+    var globalBindings = storePcs.Count > 0
         ? new[] { new Gen5GlobalMemoryBinding(8u, 0UL, storePcs, new byte[64]) }
         : Array.Empty<Gen5GlobalMemoryBinding>();
 
@@ -238,9 +242,17 @@ foreach (var (name, expectTranslate, words) in testPrograms)
                 new Gen5PixelOutputBinding(0, 0, Gen5PixelOutputKind.Float),
                 new Gen5PixelOutputBinding(1, 1, Gen5PixelOutputKind.Float),
             ],
-            "mrt8" => Enumerable.Range(0, 8)
-                .Select(index => new Gen5PixelOutputBinding((uint)index, (uint)index, Gen5PixelOutputKind.Float))
-                .ToArray(),
+            "mrt8" =>
+            [
+                new Gen5PixelOutputBinding(0, 0, Gen5PixelOutputKind.Float),
+                new Gen5PixelOutputBinding(1, 1, Gen5PixelOutputKind.Float),
+                new Gen5PixelOutputBinding(2, 2, Gen5PixelOutputKind.Float),
+                new Gen5PixelOutputBinding(3, 3, Gen5PixelOutputKind.Float),
+                new Gen5PixelOutputBinding(4, 4, Gen5PixelOutputKind.Float),
+                new Gen5PixelOutputBinding(5, 5, Gen5PixelOutputKind.Float),
+                new Gen5PixelOutputBinding(6, 6, Gen5PixelOutputKind.Float),
+                new Gen5PixelOutputBinding(7, 7, Gen5PixelOutputKind.Float),
+            ],
             _ => [new Gen5PixelOutputBinding(0, 0, Gen5PixelOutputKind.Float)],
         };
 

--- a/tools/SharpEmu.Tools.ShaderDump/Program.cs
+++ b/tools/SharpEmu.Tools.ShaderDump/Program.cs
@@ -4,10 +4,9 @@
 // Synthetic-shader conformance dumper.
 //
 // Feeds hand-assembled Gen5 (gfx10) instruction words through the real
-// decode -> SPIR-V pipeline and writes the resulting vertex, pixel, and compute
-// SPIR-V blobs to disk. The blobs can then be checked with spirv-val / spirv-dis.
-// The decoder and IR are consumed directly from SharpEmu.ShaderCompiler; only the
-// SPIR-V emitter (still internal to SharpEmu.Libs) is reached via reflection.
+// decode -> SPIR-V pipeline (SharpEmu.ShaderCompiler + SharpEmu.ShaderCompiler.Vulkan)
+// and writes the resulting vertex, pixel, and compute SPIR-V blobs to disk. The blobs
+// can then be checked with spirv-val / spirv-dis.
 //
 // Programs that contain buffer_store_dword automatically get a single
 // global-memory binding covering every store, which the emitter exposes as
@@ -21,10 +20,9 @@
 // Usage: SharpEmu.Tools.ShaderDump [output-directory]
 
 using System.Buffers.Binary;
-using System.Reflection;
 using SharpEmu.HLE;
-using SharpEmu.Libs.CxxAbi;
 using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
 
 const ulong ProgramAddress = 0x100000;
 
@@ -139,22 +137,6 @@ const ulong ProgramAddress = 0x100000;
     ]),
 ];
 
-var assembly = typeof(CxaGuardExports).Assembly;
-var spirvTranslator = assembly.GetType("SharpEmu.Libs.Agc.Gen5SpirvTranslator")
-    ?? throw new InvalidOperationException("Gen5SpirvTranslator not found");
-var tryCompile = spirvTranslator.GetMethod(
-    "TryCompileVertexShader",
-    BindingFlags.Public | BindingFlags.Static)
-    ?? throw new InvalidOperationException("Gen5SpirvTranslator.TryCompileVertexShader not found");
-var tryCompilePixel = spirvTranslator.GetMethods(BindingFlags.Public | BindingFlags.Static)
-    .Single(method =>
-        method.Name == "TryCompilePixelShader" &&
-        method.GetParameters()[2].ParameterType.IsGenericType);
-var tryCompileCompute = spirvTranslator.GetMethod(
-    "TryCompileComputeShader",
-    BindingFlags.Public | BindingFlags.Static)
-    ?? throw new InvalidOperationException("Gen5SpirvTranslator.TryCompileComputeShader not found");
-
 var outputDirectory = args.Length > 0
     ? args[0]
     : Path.Combine(AppContext.BaseDirectory, "spv");
@@ -217,34 +199,28 @@ foreach (var (name, expectTranslate, words) in testPrograms)
         Array.Empty<Gen5ImageBinding>(),
         globalBindings);
 
-    var compileArgs = PadWithDefaults(tryCompile, [state, evaluation, null, null]);
-    if ((bool)tryCompile.Invoke(null, BindingFlags.OptionalParamBinding, null, compileArgs, null)!)
+    if (Gen5SpirvTranslator.TryCompileVertexShader(state, evaluation, out var vertexShader, out var vertexError))
     {
-        var shader = compileArgs[2]!;
-        var spirv = (byte[])shader.GetType().GetProperty("Spirv")!.GetValue(shader)!;
         var path = Path.Combine(outputDirectory, $"{name}.spv");
-        File.WriteAllBytes(path, spirv);
-        Console.WriteLine($"[{name}] emit: success, {spirv.Length} bytes -> {path}");
+        File.WriteAllBytes(path, vertexShader.Spirv);
+        Console.WriteLine($"[{name}] emit: success, {vertexShader.Spirv.Length} bytes -> {path}");
     }
     else
     {
         failures++;
-        Console.WriteLine($"[{name}] emit: FAILED ({compileArgs[3]})");
+        Console.WriteLine($"[{name}] emit: FAILED ({vertexError})");
     }
 
-    var computeArgs = PadWithDefaults(tryCompileCompute, [state, evaluation, 1u, 1u, 1u, null, null]);
-    if ((bool)tryCompileCompute.Invoke(null, BindingFlags.OptionalParamBinding, null, computeArgs, null)!)
+    if (Gen5SpirvTranslator.TryCompileComputeShader(state, evaluation, 1, 1, 1, out var computeShader, out var computeError))
     {
-        var shader = computeArgs[5]!;
-        var spirv = (byte[])shader.GetType().GetProperty("Spirv")!.GetValue(shader)!;
         var path = Path.Combine(outputDirectory, $"{name}-cs.spv");
-        File.WriteAllBytes(path, spirv);
-        Console.WriteLine($"[{name}] compute emit: success, {spirv.Length} bytes -> {path}");
+        File.WriteAllBytes(path, computeShader.Spirv);
+        Console.WriteLine($"[{name}] compute emit: success, {computeShader.Spirv.Length} bytes -> {path}");
     }
     else
     {
         failures++;
-        Console.WriteLine($"[{name}] compute emit: FAILED ({computeArgs[6]})");
+        Console.WriteLine($"[{name}] compute emit: FAILED ({computeError})");
     }
 
     if (name.StartsWith("mrt", StringComparison.Ordinal))
@@ -268,26 +244,16 @@ foreach (var (name, expectTranslate, words) in testPrograms)
             _ => [new Gen5PixelOutputBinding(0, 0, Gen5PixelOutputKind.Float)],
         };
 
-        var pixelArgs = PadWithDefaults(
-            tryCompilePixel,
-            [state, evaluation, pixelOutputs, null, null]);
-        if ((bool)tryCompilePixel.Invoke(
-                null,
-                BindingFlags.OptionalParamBinding,
-                null,
-                pixelArgs,
-                null)!)
+        if (Gen5SpirvTranslator.TryCompilePixelShader(state, evaluation, pixelOutputs, out var pixelShader, out var pixelError))
         {
-            var shader = pixelArgs[3]!;
-            var spirv = (byte[])shader.GetType().GetProperty("Spirv")!.GetValue(shader)!;
             var path = Path.Combine(outputDirectory, $"{name}-ps.spv");
-            File.WriteAllBytes(path, spirv);
-            Console.WriteLine($"[{name}] pixel emit: success, {spirv.Length} bytes -> {path}");
+            File.WriteAllBytes(path, pixelShader.Spirv);
+            Console.WriteLine($"[{name}] pixel emit: success, {pixelShader.Spirv.Length} bytes -> {path}");
         }
         else
         {
             failures++;
-            Console.WriteLine($"[{name}] pixel emit: FAILED ({pixelArgs[4]})");
+            Console.WriteLine($"[{name}] pixel emit: FAILED ({pixelError})");
         }
 
         if (name == "mrt")
@@ -297,22 +263,14 @@ foreach (var (name, expectTranslate, words) in testPrograms)
                 new Gen5PixelOutputBinding(0, 0, Gen5PixelOutputKind.Float),
                 new Gen5PixelOutputBinding(3, 7, Gen5PixelOutputKind.Float),
             ];
-            var invalidPixelArgs = PadWithDefaults(
-                tryCompilePixel,
-                [state, evaluation, invalidOutputs, null, null]);
-            if ((bool)tryCompilePixel.Invoke(
-                    null,
-                    BindingFlags.OptionalParamBinding,
-                    null,
-                    invalidPixelArgs,
-                    null)!)
+            if (Gen5SpirvTranslator.TryCompilePixelShader(state, evaluation, invalidOutputs, out _, out var invalidError))
             {
                 failures++;
                 Console.WriteLine("[mrt] FAILED: sparse host locations were accepted");
             }
             else
             {
-                Console.WriteLine($"[mrt] sparse host locations rejected as expected ({invalidPixelArgs[4]})");
+                Console.WriteLine($"[mrt] sparse host locations rejected as expected ({invalidError})");
             }
         }
     }
@@ -322,37 +280,6 @@ Console.WriteLine(failures == 0
     ? "RESULT: all programs behaved as expected"
     : $"RESULT: {failures} unexpected outcome(s)");
 Environment.ExitCode = failures == 0 ? 0 : 1;
-
-// Reflection Invoke does not apply C# default parameter values, so a newly
-// added optional parameter on a translator entry point would otherwise throw
-// TargetParameterCountException. Type.Missing + OptionalParamBinding lets the
-// runtime substitute the declared defaults; only a new *required* parameter
-// should force a tool update.
-static object?[] PadWithDefaults(MethodInfo method, object?[] arguments)
-{
-    var parameters = method.GetParameters();
-    if (arguments.Length > parameters.Length)
-    {
-        throw new InvalidOperationException(
-            $"{method.DeclaringType?.Name}.{method.Name} takes fewer parameters than the tool supplies");
-    }
-
-    var padded = new object?[parameters.Length];
-    arguments.CopyTo(padded, 0);
-    for (var i = arguments.Length; i < padded.Length; i++)
-    {
-        if (!parameters[i].IsOptional)
-        {
-            throw new InvalidOperationException(
-                $"{method.DeclaringType?.Name}.{method.Name} gained a required parameter " +
-                $"'{parameters[i].Name}' — the tool needs updating");
-        }
-
-        padded[i] = Type.Missing;
-    }
-
-    return padded;
-}
 
 internal sealed class FakeMemory : ICpuMemory
 {

--- a/tools/SharpEmu.Tools.ShaderDump/Program.cs
+++ b/tools/SharpEmu.Tools.ShaderDump/Program.cs
@@ -4,10 +4,10 @@
 // Synthetic-shader conformance dumper.
 //
 // Feeds hand-assembled Gen5 (gfx10) instruction words through the real
-// decode -> SPIR-V pipeline (Gen5ShaderTranslator / Gen5SpirvTranslator, via
-// reflection so no emulator source changes are required) and writes the
-// resulting vertex, pixel, and compute SPIR-V blobs to disk. The blobs can then be
-// checked with spirv-val / spirv-dis.
+// decode -> SPIR-V pipeline and writes the resulting vertex, pixel, and compute
+// SPIR-V blobs to disk. The blobs can then be checked with spirv-val / spirv-dis.
+// The decoder and IR are consumed directly from SharpEmu.ShaderCompiler; only the
+// SPIR-V emitter (still internal to SharpEmu.Libs) is reached via reflection.
 //
 // Programs that contain buffer_store_dword automatically get a single
 // global-memory binding covering every store, which the emitter exposes as
@@ -24,6 +24,7 @@ using System.Buffers.Binary;
 using System.Reflection;
 using SharpEmu.HLE;
 using SharpEmu.Libs.CxxAbi;
+using SharpEmu.ShaderCompiler;
 
 const ulong ProgramAddress = 0x100000;
 
@@ -139,30 +140,8 @@ const ulong ProgramAddress = 0x100000;
 ];
 
 var assembly = typeof(CxaGuardExports).Assembly;
-var shaderTranslator = assembly.GetType("SharpEmu.Libs.Agc.Gen5ShaderTranslator")
-    ?? throw new InvalidOperationException("Gen5ShaderTranslator not found");
 var spirvTranslator = assembly.GetType("SharpEmu.Libs.Agc.Gen5SpirvTranslator")
     ?? throw new InvalidOperationException("Gen5SpirvTranslator not found");
-var describe = shaderTranslator.GetMethod(
-    "Describe",
-    BindingFlags.Public | BindingFlags.Static)
-    ?? throw new InvalidOperationException("Gen5ShaderTranslator.Describe not found");
-var tryDecode = shaderTranslator.GetMethod(
-    "TryDecodeProgram",
-    BindingFlags.NonPublic | BindingFlags.Static)
-    ?? throw new InvalidOperationException("Gen5ShaderTranslator.TryDecodeProgram not found");
-var stateType = assembly.GetType("SharpEmu.Libs.Agc.Gen5ShaderState")
-    ?? throw new InvalidOperationException("Gen5ShaderState not found");
-var evaluationType = assembly.GetType("SharpEmu.Libs.Agc.Gen5ShaderEvaluation")
-    ?? throw new InvalidOperationException("Gen5ShaderEvaluation not found");
-var imageBindingType = assembly.GetType("SharpEmu.Libs.Agc.Gen5ImageBinding")
-    ?? throw new InvalidOperationException("Gen5ImageBinding not found");
-var globalBindingType = assembly.GetType("SharpEmu.Libs.Agc.Gen5GlobalMemoryBinding")
-    ?? throw new InvalidOperationException("Gen5GlobalMemoryBinding not found");
-var pixelOutputBindingType = assembly.GetType("SharpEmu.Libs.Agc.Gen5PixelOutputBinding")
-    ?? throw new InvalidOperationException("Gen5PixelOutputBinding not found");
-var pixelOutputKindType = assembly.GetType("SharpEmu.Libs.Agc.Gen5PixelOutputKind")
-    ?? throw new InvalidOperationException("Gen5PixelOutputKind not found");
 var tryCompile = spirvTranslator.GetMethod(
     "TryCompileVertexShader",
     BindingFlags.Public | BindingFlags.Static)
@@ -190,19 +169,18 @@ foreach (var (name, expectTranslate, words) in testPrograms)
 
     Console.WriteLine(
         $"[{name}] decode: " +
-        (string)describe.Invoke(null, [ctx, ProgramAddress, ProgramAddress])!);
+        Gen5ShaderTranslator.Describe(ctx, ProgramAddress, ProgramAddress));
 
-    object?[] decodeArgs = [ctx, ProgramAddress, null, null];
-    if (!(bool)tryDecode.Invoke(null, decodeArgs)!)
+    if (!Gen5ShaderTranslator.TryDecodeProgram(ctx, ProgramAddress, out var program, out var decodeError))
     {
         if (expectTranslate)
         {
             failures++;
-            Console.WriteLine($"[{name}] FAILED: decode error ({decodeArgs[3]})");
+            Console.WriteLine($"[{name}] FAILED: decode error ({decodeError})");
         }
         else
         {
-            Console.WriteLine($"[{name}] decode failed as expected ({decodeArgs[3]})");
+            Console.WriteLine($"[{name}] decode failed as expected ({decodeError})");
         }
 
         continue;
@@ -219,52 +197,25 @@ foreach (var (name, expectTranslate, words) in testPrograms)
 
     // Buffer stores need a global-memory binding; the emitter resolves them by
     // instruction PC, so collect store PCs from the decoded program itself.
-    var programObj = decodeArgs[2]!;
-    var instructions = (System.Collections.IEnumerable)programObj
-        .GetType().GetProperty("Instructions")!.GetValue(programObj)!;
-    var storePcs = new List<uint>();
-    foreach (var instruction in instructions)
-    {
-        var op = (string)instruction.GetType().GetProperty("Opcode")!.GetValue(instruction)!;
-        if (op.StartsWith("BufferStore", StringComparison.Ordinal))
-        {
-            storePcs.Add((uint)instruction.GetType().GetProperty("Pc")!.GetValue(instruction)!);
-        }
-    }
+    var storePcs = program!.Instructions
+        .Where(instruction => instruction.Opcode.StartsWith("BufferStore", StringComparison.Ordinal))
+        .Select(instruction => instruction.Pc)
+        .ToArray();
 
     // The binding's scalar base (8 -> s[8:11]) must match the srsrc field of
     // the hand-assembled buffer_store words, and the 64-byte backing store
     // must cover every hand-assembled store offset.
-    var globalBindings = Array.CreateInstance(globalBindingType, storePcs.Count > 0 ? 1 : 0);
-    if (storePcs.Count > 0)
-    {
-        globalBindings.SetValue(
-            Activator.CreateInstance(
-                globalBindingType,
-                8u,
-                0UL,
-                (IReadOnlyList<uint>)storePcs,
-                new byte[64]),
-            0);
-    }
+    var globalBindings = storePcs.Length > 0
+        ? new[] { new Gen5GlobalMemoryBinding(8u, 0UL, storePcs, new byte[64]) }
+        : Array.Empty<Gen5GlobalMemoryBinding>();
 
-    var state = Activator.CreateInstance(
-        stateType,
-        programObj,
-        new uint[16],
-        null,
-        null,
-        0u)!;
-    var evaluation = Activator.CreateInstance(
-        evaluationType,
+    var state = new Gen5ShaderState(program, new uint[16], Metadata: null);
+    var evaluation = new Gen5ShaderEvaluation(
         new uint[256],
         new uint[256],
         new Dictionary<uint, IReadOnlyList<uint>>(),
-        Array.CreateInstance(imageBindingType, 0),
-        globalBindings,
-        null,
-        null,
-        null)!;
+        Array.Empty<Gen5ImageBinding>(),
+        globalBindings);
 
     var compileArgs = PadWithDefaults(tryCompile, [state, evaluation, null, null]);
     if ((bool)tryCompile.Invoke(null, BindingFlags.OptionalParamBinding, null, compileArgs, null)!)
@@ -298,32 +249,24 @@ foreach (var (name, expectTranslate, words) in testPrograms)
 
     if (name.StartsWith("mrt", StringComparison.Ordinal))
     {
-        (uint GuestSlot, uint HostLocation, string Kind)[] outputSpecs = name switch
+        Gen5PixelOutputBinding[] pixelOutputs = name switch
         {
-            "mrt" => new (uint GuestSlot, uint HostLocation, string Kind)[]
-            {
-                (0, 0, "Float"),
-                (3, 1, "Uint"),
-                (6, 2, "Sint"),
-            },
-            "mrt-float2" => [(0, 0, "Float"), (1, 1, "Float")],
+            "mrt" =>
+            [
+                new Gen5PixelOutputBinding(0, 0, Gen5PixelOutputKind.Float),
+                new Gen5PixelOutputBinding(3, 1, Gen5PixelOutputKind.Uint),
+                new Gen5PixelOutputBinding(6, 2, Gen5PixelOutputKind.Sint),
+            ],
+            "mrt-float2" =>
+            [
+                new Gen5PixelOutputBinding(0, 0, Gen5PixelOutputKind.Float),
+                new Gen5PixelOutputBinding(1, 1, Gen5PixelOutputKind.Float),
+            ],
             "mrt8" => Enumerable.Range(0, 8)
-                .Select(index => ((uint)index, (uint)index, "Float"))
+                .Select(index => new Gen5PixelOutputBinding((uint)index, (uint)index, Gen5PixelOutputKind.Float))
                 .ToArray(),
-            _ => [(0, 0, "Float")],
+            _ => [new Gen5PixelOutputBinding(0, 0, Gen5PixelOutputKind.Float)],
         };
-        var pixelOutputs = Array.CreateInstance(pixelOutputBindingType, outputSpecs.Length);
-        for (var index = 0; index < outputSpecs.Length; index++)
-        {
-            var spec = outputSpecs[index];
-            pixelOutputs.SetValue(
-                Activator.CreateInstance(
-                    pixelOutputBindingType,
-                    spec.GuestSlot,
-                    spec.HostLocation,
-                    Enum.Parse(pixelOutputKindType, spec.Kind)),
-                index);
-        }
 
         var pixelArgs = PadWithDefaults(
             tryCompilePixel,
@@ -349,21 +292,11 @@ foreach (var (name, expectTranslate, words) in testPrograms)
 
         if (name == "mrt")
         {
-            var invalidOutputs = Array.CreateInstance(pixelOutputBindingType, 2);
-            invalidOutputs.SetValue(
-                Activator.CreateInstance(
-                    pixelOutputBindingType,
-                    0u,
-                    0u,
-                    Enum.Parse(pixelOutputKindType, "Float")),
-                0);
-            invalidOutputs.SetValue(
-                Activator.CreateInstance(
-                    pixelOutputBindingType,
-                    3u,
-                    7u,
-                    Enum.Parse(pixelOutputKindType, "Float")),
-                1);
+            Gen5PixelOutputBinding[] invalidOutputs =
+            [
+                new Gen5PixelOutputBinding(0, 0, Gen5PixelOutputKind.Float),
+                new Gen5PixelOutputBinding(3, 7, Gen5PixelOutputKind.Float),
+            ];
             var invalidPixelArgs = PadWithDefaults(
                 tryCompilePixel,
                 [state, evaluation, invalidOutputs, null, null]);

--- a/tools/SharpEmu.Tools.ShaderDump/SharpEmu.Tools.ShaderDump.csproj
+++ b/tools/SharpEmu.Tools.ShaderDump/SharpEmu.Tools.ShaderDump.csproj
@@ -14,6 +14,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\SharpEmu.Libs\SharpEmu.Libs.csproj" />
+    <ProjectReference Include="..\..\src\SharpEmu.ShaderCompiler\SharpEmu.ShaderCompiler.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/SharpEmu.Tools.ShaderDump/SharpEmu.Tools.ShaderDump.csproj
+++ b/tools/SharpEmu.Tools.ShaderDump/SharpEmu.Tools.ShaderDump.csproj
@@ -12,9 +12,11 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
   </PropertyGroup>
 
+  <!-- References only the shader-compiler projects: the conformance tool is
+       emulator-independent by design. -->
   <ItemGroup>
-    <ProjectReference Include="..\..\src\SharpEmu.Libs\SharpEmu.Libs.csproj" />
     <ProjectReference Include="..\..\src\SharpEmu.ShaderCompiler\SharpEmu.ShaderCompiler.csproj" />
+    <ProjectReference Include="..\..\src\SharpEmu.ShaderCompiler.Vulkan\SharpEmu.ShaderCompiler.Vulkan.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #199 — the proposal explaining the design, the neutrality rules, and the working Metal codegen proof it was validated against. This PR is the implementation, up for the same review as the proposal itself.

## What

Eight commits, each building and verified independently:

1. **`SharpEmu.ShaderCompiler`** — the backend-neutral half of shader compilation (Gen5 decoder, scalar evaluator, IR, metadata reader) extracted from `SharpEmu.Libs/Agc`. Three couplings surfaced and were fixed at the right depth: `GuestDrawKind` (a guest-domain, decoder-produced enum) was defined inside the Vulkan presenter and moves to the shared project; the evaluator's one HLE dependency (tracked-libc-heap read fallback) becomes an injectable hook installed by a Libs module initializer before any caller can reach it; the inline-constant table is promoted to a shared `Gen5InlineConstants` so codegens cannot drift.
2. **`SharpEmu.ShaderCompiler.Vulkan`** — the SPIR-V emitter moves whole, with no Vulkan bindings reference (emitters produce bytes; renderers own APIs). The ShaderDump tool drops all reflection for direct typed calls and no longer references `SharpEmu.Libs` at all — the conformance tool is emulator-independent now.
3. **`IGuestGpuBackend`** — the renderer seam. Export layers reach the renderer through `GuestGpu.Current` (mirroring `HostPlatform`); the Vulkan backend is a thin adapter over the existing presenter, so the extraction stays mechanical. The crossing types drop their `Vulkan` prefixes, which an audit showed were misnomers — every field is a neutral primitive or raw guest value. The one genuine Vulkan value in the old surface (a `Silk.NET.Format` callers never read) stops crossing: `TryGetRenderTargetOutputKind` surfaces only what callers consume.
4. **Shader compilation behind the seam** — backends own codegen and return opaque `IGuestCompiledShader` handles that only the producing backend can submit; the shader caches store handles; `AgcExports` no longer knows SPIR-V exists.
5–6. Review-finding fixes (rename collateral; diagnostics dumps labeled with the backend's payload extension instead of hardcoded `.spv`).
7. **Perf: the shader-cache hit path is now allocation-free and lock-free.** Every translated draw previously built its cache key with LINQ + `string.Join` + one interpolated string per render target — steady per-draw allocation even on cache hits — and looked it up under a lock shared with the tracing gate. The layout is now packed exactly (not hashed) into a `ulong`, the pixel-output array only materializes on cache misses, the caches are `ConcurrentDictionary`, and the seam-shaped render-target list is built once per translated draw instead of per submission. Same species of win as the reflection removal in the host abstraction PR.
8. LINQ removed from all code this branch introduced (explicit loops; adopting this as the going-forward rule for new code).

## Behavior

Everything except commit 7 is provably behavior-preserving — mechanical moves verified 1:1 against the originals by a multi-angle review (removed-behavior audit, cross-file caller trace, line-by-line): flag maps, cache keys, decode caching, and log strings unchanged; zero correctness findings. Commit 7 changes only allocation/locking on the hit path; cache keys remain exact (packed encoding, no hashing).

The one recorded design follow-up (see #199): the compile entry points still carry the Vulkan emitter's flat slot-base packing (`globalBufferBase` etc.). Deliberately deferred — the linked-program API that fixes it needs the Metal backend's requirements as design input, and folding a descriptor-layout rework into a mechanical lift would make this PR need deep game regression testing instead of being reviewable as a safe move.

## How verified

- Clean solution build, 0 warnings; locked-mode restore under the pinned SDK (lock diffs contain only project-reference additions, no package drift).
- Existing test suite passes; full ShaderDump conformance run passes (now driving the extracted projects typed).
- Adversarial multi-angle review with zero correctness findings; the two actionable cleanups it raised are fixed in commits 5–6.
- Needs a Windows game run for final confidence, as with any branch developed off-target: any known-rendering title exercising translated draws + compute, plus one run with `SHARPEMU_DUMP_SPIRV=1` to confirm shader dumps still appear (now honestly labeled). Draw-heavy titles should also show a lower allocation rate under `dotnet-counters` from commit 7.
