### PR TITLE
[Vulkan] Put a limit on the temporary buffer pool

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanHostBufferPool.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanHostBufferPool.cs
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Silk.NET.Vulkan;
+using VkBuffer = Silk.NET.Vulkan.Buffer;
+
+namespace SharpEmu.Libs.VideoOut;
+
+internal readonly record struct VulkanHostBufferPoolKey(
+    BufferUsageFlags Usage,
+    ulong Capacity);
+
+internal readonly record struct VulkanHostBufferAllocation(
+    VkBuffer Buffer,
+    DeviceMemory Memory,
+    VulkanHostBufferPoolKey Key,
+    nint Mapped);
+
+internal sealed class VulkanHostBufferPool : IDisposable
+{
+    private readonly Dictionary<VulkanHostBufferPoolKey, Stack<VulkanHostBufferAllocation>>
+        _available = [];
+    private readonly Dictionary<ulong, VulkanHostBufferAllocation> _allocations = [];
+    private readonly HashSet<ulong> _cachedHandles = [];
+    private readonly Action<VulkanHostBufferAllocation> _destroy;
+
+    public VulkanHostBufferPool(
+        ulong maximumCachedBytes,
+        Action<VulkanHostBufferAllocation> destroy)
+    {
+        MaximumCachedBytes = maximumCachedBytes;
+        _destroy = destroy;
+    }
+
+    public ulong MaximumCachedBytes { get; }
+
+    public ulong CachedBytes { get; private set; }
+
+    public bool TryRent(
+        VulkanHostBufferPoolKey key,
+        out VulkanHostBufferAllocation allocation)
+    {
+        if (!_available.TryGetValue(key, out var available) ||
+            !available.TryPop(out allocation))
+        {
+            allocation = default;
+            return false;
+        }
+
+        _cachedHandles.Remove(allocation.Buffer.Handle);
+        CachedBytes -= allocation.Key.Capacity;
+        return true;
+    }
+
+    public void Register(VulkanHostBufferAllocation allocation)
+    {
+        if (allocation.Buffer.Handle == 0)
+        {
+            throw new ArgumentException("A pooled buffer must have a valid handle.", nameof(allocation));
+        }
+
+        _allocations.Add(allocation.Buffer.Handle, allocation);
+    }
+
+    public bool Return(VkBuffer buffer, DeviceMemory memory)
+    {
+        if (!_allocations.TryGetValue(buffer.Handle, out var allocation) ||
+            allocation.Memory.Handle != memory.Handle)
+        {
+            return false;
+        }
+
+        if (!_cachedHandles.Add(buffer.Handle))
+        {
+            return true;
+        }
+
+        if (allocation.Key.Capacity > MaximumCachedBytes - CachedBytes)
+        {
+            _cachedHandles.Remove(buffer.Handle);
+            _allocations.Remove(buffer.Handle);
+            _destroy(allocation);
+            return true;
+        }
+
+        if (!_available.TryGetValue(allocation.Key, out var available))
+        {
+            available = [];
+            _available.Add(allocation.Key, available);
+        }
+
+        available.Push(allocation);
+        CachedBytes += allocation.Key.Capacity;
+        return true;
+    }
+
+    public void Dispose()
+    {
+        foreach (var allocation in _allocations.Values)
+        {
+            _destroy(allocation);
+        }
+
+        _allocations.Clear();
+        _available.Clear();
+        _cachedHandles.Clear();
+        CachedBytes = 0;
+    }
+}

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -124,6 +124,7 @@ internal static unsafe class VulkanVideoPresenter
     // stays tighter than the drain budget because queued draws pin their
     // pooled guest-data arrays until the render thread uploads them.
     private const int MaxPendingGuestWork = 64;
+    private const ulong MaximumCachedHostBufferBytes = 128UL * 1024 * 1024;
     // A captured 4K flip can consume tens of MiB of device-local memory.
     // Retain only a short presentation queue while always preserving the
     // newest generation; older immutable versions are retired immediately.
@@ -2357,9 +2358,7 @@ internal static unsafe class VulkanVideoPresenter
             new(ReferenceEqualityComparer.Instance);
         private readonly Dictionary<DescriptorLayoutKey, DescriptorLayoutBundle>
             _descriptorLayouts = new();
-        private readonly Dictionary<HostBufferPoolKey, Stack<HostBufferAllocation>>
-            _hostBufferPool = new();
-        private readonly Dictionary<ulong, HostBufferAllocation> _hostBufferAllocations = new();
+        private readonly VulkanHostBufferPool _hostBufferPool;
         private readonly List<GuestBufferAllocation> _guestBufferAllocations = [];
         private readonly Queue<PendingGuestSubmission> _pendingGuestSubmissions = new();
         private readonly Dictionary<string, ulong> _lastSubmittedTimelineByGuestQueue =
@@ -2381,10 +2380,6 @@ internal static unsafe class VulkanVideoPresenter
             GuestRasterState Raster,
             GuestDepthState Depth);
 
-        private readonly record struct HostBufferPoolKey(
-            BufferUsageFlags Usage,
-            ulong Capacity);
-
         private readonly record struct DescriptorLayoutKey(
             ShaderStageFlags Stages,
             string Resources);
@@ -2396,12 +2391,6 @@ internal static unsafe class VulkanVideoPresenter
         private sealed record DescriptorLayoutBundle(
             DescriptorSetLayout DescriptorSetLayout,
             PipelineLayout PipelineLayout);
-
-        private sealed record HostBufferAllocation(
-            VkBuffer Buffer,
-            DeviceMemory Memory,
-            HostBufferPoolKey Key,
-            nint Mapped);
 
         private readonly record struct DirtyGuestBufferRange(ulong Offset, ulong Length);
 
@@ -2592,6 +2581,9 @@ internal static unsafe class VulkanVideoPresenter
 
         public Presenter(uint width, uint height)
         {
+            _hostBufferPool = new VulkanHostBufferPool(
+                MaximumCachedHostBufferBytes,
+                DestroyHostBufferAllocation);
             var options = WindowOptions.DefaultVulkan;
             options.Size = new Vector2D<int>((int)DefaultWindowWidth, (int)DefaultWindowHeight);
             options.Title = VideoOutExports.GetWindowTitle();
@@ -5316,7 +5308,8 @@ internal static unsafe class VulkanVideoPresenter
                     resources.IndexBuffer = CreateHostBuffer(
                         indexBuffer.Data.AsSpan(0, indexBuffer.Length),
                         BufferUsageFlags.IndexBufferBit,
-                        out resources.IndexMemory);
+                        out resources.IndexMemory,
+                        out _);
                     resources.Index32Bit = indexBuffer.Is32Bit;
                     if (indexBuffer.Pooled)
                     {
@@ -7612,8 +7605,8 @@ internal static unsafe class VulkanVideoPresenter
             var buffer = CreateHostBuffer(
                 guestBuffer.Data.AsSpan(0, guestBuffer.Length),
                 BufferUsageFlags.StorageBufferBit,
-                out var memory);
-            var allocation = _hostBufferAllocations[buffer.Handle];
+                out var memory,
+                out var mapped);
             if (guestBuffer.Pooled)
             {
                 GuestDataPool.Return(guestBuffer.Data);
@@ -7626,7 +7619,7 @@ internal static unsafe class VulkanVideoPresenter
                 WriteBackToGuest = false,
                 Buffer = buffer,
                 Memory = memory,
-                Mapped = allocation.Mapped,
+                Mapped = mapped,
                 Offset = 0,
                 Size = (ulong)Math.Max(guestBuffer.Length, sizeof(uint)),
                 GuestOffset = 0,
@@ -7846,7 +7839,8 @@ internal static unsafe class VulkanVideoPresenter
             var buffer = CreateHostBuffer(
                 source,
                 BufferUsageFlags.VertexBufferBit,
-                out var memory);
+                out var memory,
+                out _);
             var size = (ulong)Math.Max(guestBuffer.Length, sizeof(uint));
             if (_setDebugUtilsObjectName is not null)
             {
@@ -7915,19 +7909,15 @@ internal static unsafe class VulkanVideoPresenter
         private VkBuffer CreateHostBuffer(
             ReadOnlySpan<byte> data,
             BufferUsageFlags usage,
-            out DeviceMemory memory)
+            out DeviceMemory memory,
+            out nint mapped)
         {
             var size = (ulong)Math.Max(data.Length, sizeof(uint));
             var capacity = BitOperations.RoundUpToPowerOf2(size);
-            var key = new HostBufferPoolKey(usage, capacity);
-            if (!_hostBufferPool.TryGetValue(key, out var available))
-            {
-                available = new Stack<HostBufferAllocation>();
-                _hostBufferPool.Add(key, available);
-            }
+            var key = new VulkanHostBufferPoolKey(usage, capacity);
 
-            HostBufferAllocation allocation;
-            if (available.TryPop(out var pooled))
+            VulkanHostBufferAllocation allocation;
+            if (_hostBufferPool.TryRent(key, out var pooled))
             {
                 allocation = pooled;
             }
@@ -7945,15 +7935,16 @@ internal static unsafe class VulkanVideoPresenter
                 Check(
                     _vk.MapMemory(_device, allocatedMemory, 0, capacity, 0, &persistentMapping),
                     "vkMapMemory(host persistent)");
-                allocation = new HostBufferAllocation(
+                allocation = new VulkanHostBufferAllocation(
                     buffer,
                     allocatedMemory,
                     key,
                     (nint)persistentMapping);
-                _hostBufferAllocations.Add(buffer.Handle, allocation);
+                _hostBufferPool.Register(allocation);
             }
 
             memory = allocation.Memory;
+            mapped = allocation.Mapped;
             fixed (byte* source = data)
             {
                 System.Buffer.MemoryCopy(
@@ -7973,10 +7964,8 @@ internal static unsafe class VulkanVideoPresenter
                 return;
             }
 
-            if (_hostBufferAllocations.TryGetValue(buffer.Handle, out var allocation) &&
-                allocation.Memory.Handle == memory.Handle)
+            if (_hostBufferPool.Return(buffer, memory))
             {
-                _hostBufferPool[allocation.Key].Push(allocation);
                 return;
             }
 
@@ -7985,6 +7974,13 @@ internal static unsafe class VulkanVideoPresenter
             {
                 _vk.FreeMemory(_device, memory, null);
             }
+        }
+
+        private void DestroyHostBufferAllocation(VulkanHostBufferAllocation allocation)
+        {
+            _vk.UnmapMemory(_device, allocation.Memory);
+            _vk.DestroyBuffer(_device, allocation.Buffer, null);
+            _vk.FreeMemory(_device, allocation.Memory, null);
         }
 
         private static PrimitiveTopology GetPrimitiveTopology(uint primitiveType) =>
@@ -13700,13 +13696,7 @@ internal static unsafe class VulkanVideoPresenter
                 DestroyGuestBufferAllocation(allocation);
             }
             _guestBufferAllocations.Clear();
-            foreach (var allocation in _hostBufferAllocations.Values)
-            {
-                _vk.DestroyBuffer(_device, allocation.Buffer, null);
-                _vk.FreeMemory(_device, allocation.Memory, null);
-            }
-            _hostBufferAllocations.Clear();
-            _hostBufferPool.Clear();
+            _hostBufferPool.Dispose();
             foreach (var guestImage in _guestImages.Values)
             {
                 DestroyGuestImage(guestImage);

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanHostBufferPoolTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanHostBufferPoolTests.cs
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.VideoOut;
+using Silk.NET.Vulkan;
+using VkBuffer = Silk.NET.Vulkan.Buffer;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VulkanHostBufferPoolTests
+{
+    [Fact]
+    public void ReturnedAllocationCanBeRentedAgain()
+    {
+        var destroyed = new List<VulkanHostBufferAllocation>();
+        using var pool = new VulkanHostBufferPool(1024, destroyed.Add);
+        var key = new VulkanHostBufferPoolKey(BufferUsageFlags.StorageBufferBit, 256);
+        var allocation = Allocation(1, 2, key);
+
+        pool.Register(allocation);
+        Assert.True(pool.Return(allocation.Buffer, allocation.Memory));
+        Assert.Equal(256UL, pool.CachedBytes);
+
+        Assert.True(pool.TryRent(key, out var rented));
+        Assert.Equal(allocation, rented);
+        Assert.Equal(0UL, pool.CachedBytes);
+        Assert.Empty(destroyed);
+    }
+
+    [Fact]
+    public void ReturnDestroysAllocationThatWouldExceedBudget()
+    {
+        var destroyed = new List<VulkanHostBufferAllocation>();
+        using var pool = new VulkanHostBufferPool(256, destroyed.Add);
+        var key = new VulkanHostBufferPoolKey(BufferUsageFlags.VertexBufferBit, 512);
+        var allocation = Allocation(3, 4, key);
+
+        pool.Register(allocation);
+
+        Assert.True(pool.Return(allocation.Buffer, allocation.Memory));
+        Assert.Equal(0UL, pool.CachedBytes);
+        Assert.Equal([allocation], destroyed);
+        Assert.False(pool.TryRent(key, out _));
+    }
+
+    [Fact]
+    public void UnknownAllocationIsNotClaimedByPool()
+    {
+        using var pool = new VulkanHostBufferPool(1024, _ => { });
+
+        Assert.False(pool.Return(new VkBuffer(9), new DeviceMemory(10)));
+    }
+
+    private static VulkanHostBufferAllocation Allocation(
+        ulong buffer,
+        ulong memory,
+        VulkanHostBufferPoolKey key) =>
+        new(new VkBuffer(buffer), new DeviceMemory(memory), key, 0);
+}


### PR DESCRIPTION
SharpEmu already recycles its temporary host-visible buffers once a guest submission is finished. The useful part was there, but the pool lived inside `VulkanVideoPresenter` and kept every allocation until shutdown. A game that rotates through enough buffer sizes and usages could therefore leave a lot of idle Vulkan memory behind.

This moves that bookkeeping into a small `VulkanHostBufferPool` and gives idle allocations a 128 MiB budget. Returned buffers are still reused by usage and power-of-two capacity. If keeping one would cross the budget, it is released instead.

The existing fence lifetime does not change: buffers only return to the pool after their submission completes. Upload behavior also does not change; the current CPU snapshot is copied on every use. This PR does not try to preserve guest buffer contents or infer CPU/GPU ownership.

In practice this should make long sessions and games with varied transient workloads less likely to accumulate host-visible memory, while taking one more resource-lifetime concern out of the presenter.

Validation:

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release` (29 passed)
- `dotnet build SharpEmu.slnx -c Release --no-restore` (0 warnings, 0 errors)
- ShaderDump synthetic suite (all programs behaved as expected)