### PR TITLE
HLE/AGC: stopgap wake all graphics events on unmatched EVENT_WRITE

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -2723,6 +2723,18 @@ public static class AgcExports
                     eventType,
                     KernelEventQueueCompatExports.KernelEventFilterGraphics,
                     eventType);
+
+                // Stopgap: real PS5 command buffers use EVENT_TYPE values that don't
+                // line up with the eventId games register via sceAgcDriverAddEqEvent.
+                // If the exact match doesn't wake anything, fire all registered graphics
+                // events so completion waiters can proceed.
+                if (triggered == 0)
+                {
+                    triggered = KernelEventQueueCompatExports.TriggerAllRegisteredEvents(
+                        KernelEventQueueCompatExports.KernelEventFilterGraphics,
+                        eventType);
+                }
+
                 if (tracePackets)
                 {
                     TraceAgc($"agc.dcb.event type=0x{eventType:X2} queues={triggered}");

--- a/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
@@ -589,6 +589,58 @@ public static class KernelEventQueueCompatExports
         return triggeredCount;
     }
 
+    /// <summary>
+    /// Wake every registration with the given filter, regardless of identifier.
+    /// This is a stopgap for command-buffer EVENT_WRITE packets where the PM4
+    /// EVENT_TYPE does not match the application-registered eventId.
+    /// </summary>
+    public static int TriggerAllRegisteredEvents(short filter, ulong data)
+    {
+        List<ulong>? wakeHandles = null;
+        var triggeredCount = 0;
+        lock (_eventQueueGate)
+        {
+            foreach (var (handle, registrations) in _registeredEvents)
+            {
+                foreach (var registration in registrations.Values)
+                {
+                    if (registration.Filter != filter)
+                    {
+                        continue;
+                    }
+
+                    if (!_pendingEvents.TryGetValue(handle, out var queue))
+                    {
+                        queue = new KernelEventDeque();
+                        _pendingEvents[handle] = queue;
+                    }
+
+                    QueueOrUpdateEvent(
+                        queue,
+                        new KernelQueuedEvent(
+                            registration.Ident,
+                            registration.Filter,
+                            0,
+                            1,
+                            data,
+                            registration.UserData));
+                    (wakeHandles ??= new List<ulong>()).Add(handle);
+                    triggeredCount++;
+                }
+            }
+        }
+
+        if (wakeHandles is not null)
+        {
+            foreach (var handle in wakeHandles)
+            {
+                WakeEventQueue(handle);
+            }
+        }
+
+        return triggeredCount;
+    }
+
     private static bool TriggerRegisteredEvent(
         ulong handle,
         ulong ident,


### PR DESCRIPTION
Closes #173.

The issue shows that `sceAgcDriverAddEqEvent` registers listeners with an `eventId` (e.g. `0x20`, `0x00`) while PM4 `EVENT_WRITE` packets fire with `EVENT_TYPE` values (`0x07`, `0x10`, `0x2E`, `0x2C`). The two identifier spaces never match, so `sceKernelWaitEqueue` waits forever and games hang.

This change adds a fallback: when an exact-match trigger returns zero, we wake every `KernelEventFilterGraphics` registration using the raw `EVENT_TYPE` as event data. This is the stopgap option suggested in #173 and should unblock many games that wait on command-buffer completion events.

I cannot run Windows + Vulkan builds locally, so this needs testing against Poppy Playtime Chapter 1 or any title discussed in #173.