### PR TITLE
Void Terrarium (PPSA03061): fully playable — Gen5/RDNA2 shader coverage, ordered GPU queues, HLE and input work

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.PosixSignals.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.PosixSignals.cs
@@ -310,6 +310,36 @@ public sealed unsafe partial class DirectExecutionBackend
 		}
 		if (disposition != -1 && !_posixSignalWarmup)
 		{
+			// Unrecovered: the process is about to die on the re-raised signal.
+			// Dump registers and the code window around RIP the way the Windows
+			// reporter does — the byte window is what identifies which emitted
+			// stub (and which instruction) an intermittent native fault is in.
+			try
+			{
+				var faultRip = ReadCtxU64(contextRecord, CTX_RIP);
+				Console.Error.WriteLine(
+					$"[LOADER][ERROR] posix-signal unrecovered: sig={signal} rip=0x{faultRip:X16} " +
+					$"fault=0x{record.ExceptionInformation[1]:X16} access={record.ExceptionInformation[0]} " +
+					$"rsp=0x{ReadCtxU64(contextRecord, CTX_RSP):X16} rax=0x{ReadCtxU64(contextRecord, CTX_RAX):X16} " +
+					$"rcx=0x{ReadCtxU64(contextRecord, CTX_RCX):X16} rdx=0x{ReadCtxU64(contextRecord, CTX_RDX):X16} " +
+					$"r11=0x{ReadCtxU64(contextRecord, CTX_R11):X16}");
+				var windowStart = faultRip >= 0x20 ? faultRip - 0x20 : 0;
+				var window = new byte[0x40];
+				if (TryReadHostBytes(windowStart, window))
+				{
+					Console.Error.WriteLine(
+						$"[LOADER][ERROR]   code [rip-0x20..]: {Convert.ToHexString(window)}");
+				}
+				else if (TryReadHostBytes(faultRip, window))
+				{
+					Console.Error.WriteLine(
+						$"[LOADER][ERROR]   code [rip..]: {Convert.ToHexString(window)}");
+				}
+				Console.Error.Flush();
+			}
+			catch
+			{
+			}
 			return false;
 		}
 

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -1759,6 +1759,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		}
 	}
 
+	// ldmxcsr raises #GP for any set bit outside the low 16 (the observed
+	// intermittent "boot crash" was an emitted stub executing ldmxcsr with a
+	// polluted continuation value, e.g. 0x00102510). All 16 low bits are
+	// architecturally loadable on x86-64, so masking is always safe; an
+	// all-clear value falls back to the SDK default control state.
+	private static uint SanitizeGuestMxcsr(uint value)
+	{
+		value &= 0xFFFFu;
+		return value == 0 ? 0x1F80u : value;
+	}
+
 	private unsafe bool TryPrepareGuestContextTransfer(
 		GuestCpuContinuation target,
 		out nint frameAddress,
@@ -1815,7 +1826,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		frame[14] = target.R13;
 		frame[15] = target.R14;
 		frame[16] = target.R15;
-		frame[17] = target.Mxcsr == 0 ? 0x1F80u : target.Mxcsr;
+		frame[17] = SanitizeGuestMxcsr(target.Mxcsr);
 		frame[18] = target.FpuControlWord == 0 ? 0x037Fu : target.FpuControlWord;
 		frame[19] = target.RestoreFullFpuState ? 1u : 0u;
 		return true;
@@ -3675,7 +3686,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			FsBase = callerContext.FsBase != 0 ? callerContext.FsBase : (continuation.FsBase != 0 ? continuation.FsBase : fallbackTlsBase),
 			GsBase = callerContext.GsBase != 0 ? callerContext.GsBase : (continuation.GsBase != 0 ? continuation.GsBase : fallbackTlsBase),
 			FpuControlWord = continuation.FpuControlWord == 0 ? (ushort)0x037F : continuation.FpuControlWord,
-			Mxcsr = continuation.Mxcsr == 0 ? 0x1F80u : continuation.Mxcsr,
+			Mxcsr = SanitizeGuestMxcsr(continuation.Mxcsr),
 		};
 
 		context[CpuRegister.Rax] = continuation.Rax;
@@ -4870,7 +4881,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		context.FpuControlWord = continuation.FpuControlWord == 0
 			? (ushort)0x037F
 			: continuation.FpuControlWord;
-		context.Mxcsr = continuation.Mxcsr == 0 ? 0x1F80u : continuation.Mxcsr;
+		context.Mxcsr = SanitizeGuestMxcsr(continuation.Mxcsr);
 	}
 
 	private unsafe GuestNativeCallExitReason ExecuteGuestThreadEntry(CpuContext context, ulong entryPoint, string name, out string? reason)
@@ -5156,7 +5167,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			// continuation migrates to another managed worker.
 			Emit(0x48); Emit(0x83); Emit(0xEC); Emit(0x08); // sub rsp,8
 			Emit(0xC7); Emit(0x04); Emit(0x24);             // mov dword [rsp],imm32
-			*(uint*)(ptr2 + offset) = context.Mxcsr; offset += sizeof(uint);
+			*(uint*)(ptr2 + offset) = SanitizeGuestMxcsr(context.Mxcsr); offset += sizeof(uint);
 			Emit(0x0F); Emit(0xAE); Emit(0x14); Emit(0x24); // ldmxcsr [rsp]
 			Emit(0x66); Emit(0xC7); Emit(0x04); Emit(0x24); // mov word [rsp],imm16
 			*(ushort*)(ptr2 + offset) = context.FpuControlWord; offset += sizeof(ushort);

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -401,6 +401,7 @@ public static partial class AgcExports
         uint Height,
         uint Format,
         uint NumberType,
+        uint ComponentSwap,
         uint TileMode);
 
     private sealed record TranslatedGuestDraw(
@@ -3370,7 +3371,8 @@ public static partial class AgcExports
                             pendingDisplayTarget.Width,
                             pendingDisplayTarget.Height,
                             pendingDisplayTarget.Format,
-                            pendingDisplayTarget.NumberType)],
+                            pendingDisplayTarget.NumberType,
+                            ComponentSwap: pendingDisplayTarget.ComponentSwap)],
                         pendingComposite.VertexShader,
                         pendingComposite.VertexCount,
                         pendingComposite.InstanceCount,
@@ -5779,6 +5781,7 @@ public static partial class AgcExports
             depthTarget.Height,
             Format: 0,
             NumberType: 0,
+            ComponentSwap: 0,
             TileMode: 0);
         var renderState = CreateRenderState(state.CxRegisters, syntheticTarget) with
         {
@@ -6145,7 +6148,8 @@ public static partial class AgcExports
                 renderTargets[index].Width,
                 renderTargets[index].Height,
                 renderTargets[index].Format,
-                renderTargets[index].NumberType);
+                renderTargets[index].NumberType,
+                ComponentSwap: renderTargets[index].ComponentSwap);
         }
 
         draw = new TranslatedGuestDraw(
@@ -6604,6 +6608,7 @@ public static partial class AgcExports
                 (attrib2 & 0x3FFFu) + 1,
                 (info >> 2) & 0x1Fu,
                 (info >> 8) & 0x7u,
+                (info >> 11) & 0x3u,
                 (attrib3 >> 14) & 0x1Fu));
         }
 

--- a/src/SharpEmu.Libs/Gpu/GuestGpuTypes.cs
+++ b/src/SharpEmu.Libs/Gpu/GuestGpuTypes.cs
@@ -139,14 +139,15 @@ internal sealed record GuestRenderState(
         Blends.Count == 0 ? GuestBlendState.Default : Blends[0];
 }
 
-/// <summary>Format/NumberType are raw guest render-target register codes.</summary>
+/// <summary>Format/NumberType/ComponentSwap are raw guest render-target register codes.</summary>
 internal sealed record GuestRenderTarget(
     ulong Address,
     uint Width,
     uint Height,
     uint Format,
     uint NumberType,
-    uint MipLevels = 1);
+    uint MipLevels = 1,
+    uint ComponentSwap = 0);
 
 /// <summary>Guest DB surface bound alongside a color render target.</summary>
 internal sealed record GuestDepthTarget(

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -2226,6 +2226,14 @@ internal static unsafe class VulkanVideoPresenter
         return keys;
     }
 
+    internal static bool ShouldAttachGuestDepth(
+        bool depthAttachmentsEnabled,
+        GuestDepthTarget? target,
+        GuestDepthState state) =>
+        depthAttachmentsEnabled &&
+        target is not null &&
+        (state.TestEnable || state.WriteEnable);
+
     private readonly record struct Presentation(
         byte[]? Pixels,
         uint Width,
@@ -9469,9 +9477,11 @@ internal static unsafe class VulkanVideoPresenter
                 }
                 GuestDepthResource? depth = null;
                 DepthFramebufferResource? depthFramebuffer = null;
-                if (work.DepthTarget is { } depthTarget &&
-                    (draw.RenderState.Depth.TestEnable ||
-                     draw.RenderState.Depth.WriteEnable))
+                if (ShouldAttachGuestDepth(
+                        _depthAttachmentsEnabled,
+                        work.DepthTarget,
+                        draw.RenderState.Depth) &&
+                    work.DepthTarget is { } depthTarget)
                 {
                     var effectiveDepthTarget = depthTarget;
                     if (depthTarget.Width < firstTarget.Width || depthTarget.Height < firstTarget.Height)
@@ -12831,6 +12841,16 @@ internal static unsafe class VulkanVideoPresenter
         private static readonly bool _traceDepthInitialization =
             string.Equals(
                 Environment.GetEnvironmentVariable("SHARPEMU_TRACE_DEPTH_INIT"),
+                "1",
+                StringComparison.Ordinal);
+        // Guest depth attachments are still experimental: the presenter does
+        // not yet reproduce every guest clear/resolve transition. Attaching a
+        // stale host depth image can reject otherwise valid color draws, so
+        // preserve the established color path unless depth is explicitly
+        // requested for validation.
+        private static readonly bool _depthAttachmentsEnabled =
+            string.Equals(
+                Environment.GetEnvironmentVariable("SHARPEMU_DEPTH"),
                 "1",
                 StringComparison.Ordinal);
         private static readonly long _traceGuestImageOccurrence =

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1463,6 +1463,13 @@ internal static unsafe class VulkanVideoPresenter
     internal static bool TryDecodeRenderTargetFormat(
         uint dataFormat,
         uint numberType,
+        out VulkanRenderTargetFormat result) =>
+        TryDecodeRenderTargetFormat(dataFormat, numberType, componentSwap: 0, out result);
+
+    internal static bool TryDecodeRenderTargetFormat(
+        uint dataFormat,
+        uint numberType,
+        uint componentSwap,
         out VulkanRenderTargetFormat result)
     {
         var format = (dataFormat, numberType) switch
@@ -1474,7 +1481,13 @@ internal static unsafe class VulkanVideoPresenter
             (5, 5) => Format.R16G16Sint,
             (5, 7) => Format.R16G16Sfloat,
             (6, 7) or (7, 7) => Format.B10G11R11UfloatPack32,
-            (9, _) => Format.A2R10G10B10UnormPack32,
+            // CB_COLOR_INFO.COMP_SWAP is independent from FORMAT. For
+            // COLOR_2_10_10_10, STD exposes the low 10-bit component as R
+            // (A2B10G10R10 in Vulkan); ALT reverses R/B. Void Terrarium uses
+            // STD (CB_COLOR_INFO=0x00008024).
+            (9, _) when componentSwap == 0 => Format.A2B10G10R10UnormPack32,
+            (9, _) when componentSwap == 1 => Format.A2R10G10B10UnormPack32,
+            (9, _) => Format.Undefined,
             (10, 4) => Format.R8G8B8A8Uint,
             (10, 5) => Format.R8G8B8A8Sint,
             (10, 9) => Format.R8G8B8A8Srgb,
@@ -9356,7 +9369,11 @@ internal static unsafe class VulkanVideoPresenter
             for (var index = 0; index < targetFormats.Length; index++)
             {
                 var target = work.Targets[index];
-                if (!TryDecodeRenderTargetFormat(target.Format, target.NumberType, out targetFormats[index]) ||
+                if (!TryDecodeRenderTargetFormat(
+                        target.Format,
+                        target.NumberType,
+                        target.ComponentSwap,
+                        out targetFormats[index]) ||
                     !SupportsColorAttachment(targetFormats[index].Format))
                 {
                     Console.Error.WriteLine(

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
@@ -927,9 +927,6 @@ public static partial class Gen5SpirvTranslator
                         first,
                         second);
                     result = Ext(58, _uintType, vector);
-                    StorePackedHalf(
-                        destination,
-                        vector);
                     break;
                 }
                 case "VCvtPknormI16F32":

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -255,7 +255,6 @@ public static partial class Gen5SpirvTranslator
         private uint _runtimeBufferBiases;
         private uint _scalarRegisters;
         private uint _vectorRegisters;
-        private uint _packedHalfRegisters;
         private uint _scc;
         private uint _vcc;
         private uint _exec;
@@ -721,13 +720,10 @@ public static partial class Gen5SpirvTranslator
 
             var scalarArrayType = _module.TypeArray(_uintType, ScalarRegisterCount);
             var vectorArrayType = _module.TypeArray(_uintType, VectorRegisterCount);
-            var packedHalfArrayType = _module.TypeArray(_vec2Type, VectorRegisterCount);
             var privateScalarArrayPointer =
                 _module.TypePointer(SpirvStorageClass.Private, scalarArrayType);
             var privateVectorArrayPointer =
                 _module.TypePointer(SpirvStorageClass.Private, vectorArrayType);
-            var privatePackedHalfArrayPointer =
-                _module.TypePointer(SpirvStorageClass.Private, packedHalfArrayType);
             _scalarRegisters = _module.AddGlobalVariable(
                 privateScalarArrayPointer,
                 SpirvStorageClass.Private,
@@ -736,10 +732,6 @@ public static partial class Gen5SpirvTranslator
                 privateVectorArrayPointer,
                 SpirvStorageClass.Private,
                 _module.ConstantNull(vectorArrayType));
-            _packedHalfRegisters = _module.AddGlobalVariable(
-                privatePackedHalfArrayPointer,
-                SpirvStorageClass.Private,
-                _module.ConstantNull(packedHalfArrayType));
             _scc = _module.AddGlobalVariable(
                 _privateBoolPointer,
                 SpirvStorageClass.Private,
@@ -776,7 +768,6 @@ public static partial class Gen5SpirvTranslator
 
             _interfaces.Add(_scalarRegisters);
             _interfaces.Add(_vectorRegisters);
-            _interfaces.Add(_packedHalfRegisters);
             _interfaces.Add(_scc);
             _interfaces.Add(_vcc);
             _interfaces.Add(_exec);
@@ -785,7 +776,6 @@ public static partial class Gen5SpirvTranslator
             _interfaces.Add(_programActive);
             _module.AddName(_scalarRegisters, "sgpr");
             _module.AddName(_vectorRegisters, "vgpr");
-            _module.AddName(_packedHalfRegisters, "vgprPackedHalf");
 
             var runtimeBufferBiasCount =
                 _globalBufferBase + _evaluation.GlobalMemoryBindings.Count;
@@ -4629,14 +4619,6 @@ public static partial class Gen5SpirvTranslator
             Gen5ShaderInstruction instruction,
             int component)
         {
-            if (TryLoadPackedHalfExportComponent(
-                    instruction,
-                    component,
-                    out var shadowValue))
-            {
-                return shadowValue;
-            }
-
             var packed = LoadV(instruction.Sources[component >> 1].Value);
             var unpacked = Ext(62, _vec2Type, packed);
             return _module.AddInstruction(
@@ -4644,132 +4626,6 @@ public static partial class Gen5SpirvTranslator
                 _floatType,
                 unpacked,
                 (uint)(component & 1));
-        }
-
-        private bool TryLoadPackedHalfExportComponent(
-            Gen5ShaderInstruction exportInstruction,
-            int component,
-            out uint value)
-        {
-            value = 0;
-            var packedSource = exportInstruction.Sources[component >> 1];
-            var tracePackedExport =
-                Environment.GetEnvironmentVariable(
-                    "SHARPEMU_TRACE_PACKED_EXPORT") == "1" &&
-                _state.Program.Address == 0x0000000500781200ul;
-            if (tracePackedExport)
-            {
-                Console.Error.WriteLine(
-                    $"[AGC][PACKED-EXPORT] exp_pc=0x{exportInstruction.Pc:X} " +
-                    $"component={component} source={packedSource.Kind}:" +
-                    $"{packedSource.Value}");
-                if (component == 0 && exportInstruction.Pc == 0x630)
-                {
-                    foreach (var decoded in _state.Program.Instructions.Where(
-                                 static decoded => decoded.Pc <= 0x640))
-                    {
-                        Console.Error.WriteLine(
-                            $"[AGC][TITLE-IR] 0x{decoded.Pc:X4} " +
-                            $"{decoded.Opcode} dst=[" +
-                            string.Join(',', decoded.Destinations) +
-                            "] src=[" +
-                            string.Join(',', decoded.Sources) + "] words=[" +
-                            string.Join(',', decoded.Words.Select(static word => $"{word:X8}")) +
-                            "] ctrl=" + decoded.Control);
-                    }
-                }
-            }
-            if (packedSource.Kind != Gen5OperandKind.VectorRegister)
-            {
-                if (tracePackedExport)
-                {
-                    Console.Error.WriteLine(
-                        "[AGC][PACKED-EXPORT] rejected: source is not a VGPR");
-                }
-                return false;
-            }
-
-            for (var index = _state.Program.Instructions.Count - 1; index >= 0; index--)
-            {
-                var candidate = _state.Program.Instructions[index];
-                if (candidate.Pc >= exportInstruction.Pc)
-                {
-                    continue;
-                }
-
-                if (exportInstruction.Pc - candidate.Pc > 128)
-                {
-                    break;
-                }
-
-                if (!candidate.Destinations.Any(destination =>
-                        destination.Kind == Gen5OperandKind.VectorRegister &&
-                        destination.Value == packedSource.Value))
-                {
-                    continue;
-                }
-
-                if (tracePackedExport)
-                {
-                    Console.Error.WriteLine(
-                        $"[AGC][PACKED-EXPORT] nearest_pc=0x{candidate.Pc:X} " +
-                        $"opcode={candidate.Opcode} distance=" +
-                        $"{exportInstruction.Pc - candidate.Pc}");
-                }
-
-                if (candidate.Opcode != "VCvtPkrtzF16F32" ||
-                    candidate.Sources.Count < 2)
-                {
-                    if (tracePackedExport)
-                    {
-                        Console.Error.WriteLine(
-                            "[AGC][PACKED-EXPORT] rejected: nearest writer is " +
-                            candidate.Opcode);
-                    }
-                    return false;
-                }
-
-                var packedPointer = PackedHalfPointer(packedSource.Value);
-                if (Environment.GetEnvironmentVariable(
-                        "SHARPEMU_FORCE_PACKED_EXPORT_STORE_ONE") == "1" &&
-                    _state.Program.Address == 0x0000000500781200ul)
-                {
-                    Store(
-                        packedPointer,
-                        _module.AddInstruction(
-                            SpirvOp.CompositeConstruct,
-                            _vec2Type,
-                            Float(1f),
-                            Float(1f)));
-                }
-
-                var packedPair = Load(
-                    _vec2Type,
-                    packedPointer);
-                value = _module.AddInstruction(
-                    SpirvOp.CompositeExtract,
-                    _floatType,
-                    packedPair,
-                    (uint)(component & 1));
-                if (Environment.GetEnvironmentVariable(
-                        "SHARPEMU_FORCE_PACKED_EXPORT_ONE") == "1")
-                {
-                    value = Float(1f);
-                }
-                if (tracePackedExport)
-                {
-                    Console.Error.WriteLine(
-                        "[AGC][PACKED-EXPORT] selected shadow pair");
-                }
-                return true;
-            }
-
-            if (tracePackedExport)
-            {
-                Console.Error.WriteLine(
-                    "[AGC][PACKED-EXPORT] rejected: no nearby writer");
-            }
-            return false;
         }
 
         private uint GetPixelOutputType(Gen5PixelOutputKind kind) =>
@@ -4895,13 +4751,6 @@ public static partial class Gen5SpirvTranslator
                 _vectorRegisters,
                 UInt(register));
 
-        private uint PackedHalfPointer(uint register) =>
-            _module.AddInstruction(
-                SpirvOp.AccessChain,
-                _privateVec2Pointer,
-                _packedHalfRegisters,
-                UInt(register));
-
         private uint LoadS(uint register) => Load(_uintType, ScalarPointer(register));
 
         private uint LoadV(uint register) => Load(_uintType, VectorPointer(register));
@@ -4934,42 +4783,6 @@ public static partial class Gen5SpirvTranslator
             }
 
             Store(VectorPointer(register), value);
-        }
-
-        private void StorePackedHalf(uint register, uint value)
-        {
-            var active = Load(_boolType, _exec);
-            if (Environment.GetEnvironmentVariable(
-                    "SHARPEMU_FORCE_PACKED_STORE_EXEC_VALUES") == "1" &&
-                _state.Program.Address == 0x0000000500781200ul)
-            {
-                var activePair = _module.AddInstruction(
-                    SpirvOp.CompositeConstruct,
-                    _vec2Type,
-                    Float(1f),
-                    Float(1f));
-                var inactivePair = _module.AddInstruction(
-                    SpirvOp.CompositeConstruct,
-                    _vec2Type,
-                    Float(0.5f),
-                    Float(0.5f));
-                value = _module.AddInstruction(
-                    SpirvOp.Select,
-                    _vec2Type,
-                    active,
-                    activePair,
-                    inactivePair);
-                Store(PackedHalfPointer(register), value);
-                return;
-            }
-
-            value = _module.AddInstruction(
-                SpirvOp.Select,
-                _vec2Type,
-                active,
-                value,
-                Load(_vec2Type, PackedHalfPointer(register)));
-            Store(PackedHalfPointer(register), value);
         }
 
         private uint Load(uint type, uint pointer)

--- a/tests/SharpEmu.Libs.Tests/Agc/Gen5SpirvPackedHalfExportTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/Gen5SpirvPackedHalfExportTests.cs
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class Gen5SpirvPackedHalfExportTests
+{
+    private const ulong ShaderAddress = 0x1_0000_0000;
+    private const uint PsUserDataRegister = 0x0C;
+
+    [Fact]
+    public void CompressedExport_UnpacksTheStoredHalfPrecisionVgpr()
+    {
+        var memory = new FakeCpuMemory(ShaderAddress, 0x1000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Gen5ShaderAtomicDecodeTests.WriteProgram(
+            memory,
+            ShaderAddress,
+            [
+                // v_cvt_pkrtz_f16_f32 v2, v2, v3
+                0x5E040702,
+                // v_cvt_pkrtz_f16_f32 v3, v4, v5
+                0x5E060B04,
+                // exp mrt0, v2, v3 compr done vm
+                0xF8001C0F, 0x00000302,
+            ]);
+        var shaderRegisters = new Dictionary<uint, uint>
+        {
+            // SPI_SHADER_PGM_RSRC2_PS advertises zero user SGPRs.
+            [PsUserDataRegister - 1] = 0,
+        };
+
+        Assert.True(
+            Gen5ShaderTranslator.TryCreateState(
+                ctx,
+                ShaderAddress,
+                0,
+                shaderRegisters,
+                PsUserDataRegister,
+                out var state,
+                out var error),
+            error);
+        Assert.True(
+            Gen5ShaderScalarEvaluator.TryEvaluate(ctx, state, out var evaluation, out error),
+            error);
+        Assert.True(
+            Gen5SpirvTranslator.TryCompilePixelShader(
+                state,
+                evaluation,
+                Gen5PixelOutputKind.Float,
+                out var shader,
+                out error),
+            error);
+
+        // GLSL.std.450 instruction 62 is UnpackHalf2x16. The compressed export
+        // must consume the packed VGPR value, including its half-precision
+        // rounding, instead of bypassing it through a float32 shadow value.
+        Assert.Contains(62u, CollectExtInstNumbers(shader.Spirv));
+    }
+
+    private static HashSet<uint> CollectExtInstNumbers(byte[] spirv)
+    {
+        var instructions = new HashSet<uint>();
+        for (var offset = 5 * sizeof(uint); offset + sizeof(uint) <= spirv.Length;)
+        {
+            var word = BinaryPrimitives.ReadUInt32LittleEndian(
+                spirv.AsSpan(offset, sizeof(uint)));
+            var wordCount = Math.Max((int)(word >> 16), 1);
+            if ((ushort)word == (ushort)SpirvOp.ExtInst && wordCount >= 5)
+            {
+                instructions.Add(
+                    BinaryPrimitives.ReadUInt32LittleEndian(
+                        spirv.AsSpan(offset + (4 * sizeof(uint)), sizeof(uint))));
+            }
+
+            offset += wordCount * sizeof(uint);
+        }
+
+        return instructions;
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanDepthAttachmentPolicyTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanDepthAttachmentPolicyTests.cs
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.Gpu;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VulkanDepthAttachmentPolicyTests
+{
+    private static readonly GuestDepthTarget Target = new(
+        ReadAddress: 0x1000,
+        WriteAddress: 0x1000,
+        Width: 1920,
+        Height: 1080,
+        GuestFormat: 1,
+        SwizzleMode: 0,
+        ClearDepth: 1f,
+        ReadOnly: false);
+
+    [Fact]
+    public void ExperimentalDepthDisabled_DoesNotAttachGuestDepth()
+    {
+        var state = new GuestDepthState(
+            TestEnable: true,
+            WriteEnable: true,
+            CompareOp: 3);
+
+        Assert.False(VulkanVideoPresenter.ShouldAttachGuestDepth(
+            depthAttachmentsEnabled: false,
+            Target,
+            state));
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void ExperimentalDepthEnabled_AttachesForDepthWork(
+        bool testEnable,
+        bool writeEnable)
+    {
+        var state = new GuestDepthState(testEnable, writeEnable, CompareOp: 3);
+
+        Assert.True(VulkanVideoPresenter.ShouldAttachGuestDepth(
+            depthAttachmentsEnabled: true,
+            Target,
+            state));
+    }
+
+    [Fact]
+    public void ExperimentalDepthEnabled_RequiresTargetAndDepthWork()
+    {
+        var state = GuestDepthState.Default;
+
+        Assert.False(VulkanVideoPresenter.ShouldAttachGuestDepth(
+            depthAttachmentsEnabled: true,
+            Target,
+            state));
+        Assert.False(VulkanVideoPresenter.ShouldAttachGuestDepth(
+            depthAttachmentsEnabled: true,
+            target: null,
+            new GuestDepthState(true, false, CompareOp: 3)));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanRenderTargetFormatTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanRenderTargetFormatTests.cs
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Silk.NET.Vulkan;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VulkanRenderTargetFormatTests
+{
+    [Theory]
+    [InlineData(0u, Format.A2B10G10R10UnormPack32)]
+    [InlineData(1u, Format.A2R10G10B10UnormPack32)]
+    public void Color2101010HonorsComponentSwap(uint componentSwap, Format expected)
+    {
+        Assert.True(VulkanVideoPresenter.TryDecodeRenderTargetFormat(
+            dataFormat: 9,
+            numberType: 0,
+            componentSwap,
+            out var result));
+        Assert.Equal(expected, result.Format);
+    }
+
+    [Theory]
+    [InlineData(2u)]
+    [InlineData(3u)]
+    public void Color2101010RejectsUnsupportedComponentSwap(uint componentSwap)
+    {
+        Assert.False(VulkanVideoPresenter.TryDecodeRenderTargetFormat(
+            dataFormat: 9,
+            numberType: 0,
+            componentSwap,
+            out _));
+    }
+}


### PR DESCRIPTION
Based on current upstream `main` (includes the merged #47); the branch is a **small commit series on top of it** (port, APR streaming restore, gfx10 decode + validation-gate alignment, Windows TLS prefix). This brings `void tRrLM();++ //Void Terrarium++` [PPSA03061] from "boots to a frozen splash" to **fully playable** on the POSIX port: boot → title menu → New Game → intro → gameplay, verified end-to-end unattended (`SHARPEMU_AUTO_CROSS=repeat:4`) with clean rendering and no crash over multiple 15-minute soaks.

### What's in here

**GPU / AGC.** The Gen5 (RDNA2) shader front end learns the instructions this game's shaders actually use: `ds_write/ds_read_b96/b128` with graphics-stage LDS modeled as per-invocation private memory (the missing piece that silently dropped the scene geometry draws — the "black screen" was never a game stall), DPP, wave masks, gradient sampling, typed buffer resources, and stricter descriptor validation. Draws that still fail translation degrade (1×1 fallback texture, unresolved-scalar degradation) instead of being dropped. Texture format 50 (sampled A2R10G10B10) aliases the on-GPU render target. CPU-side detiling (GnmTiling) runs by default for the linearly-ordered base swizzle modes 1–12 with a precomputed per-block offset table; `_T`/`_X` variants stay opt-in behind `SHARPEMU_DETILE=1`.

**Command processor.** DCB submissions are queued per logical queue and pumped in order: an unsatisfied `WAIT_REG_MEM` suspends the queue and resumes when the label is written, instead of parsing packets out of order (this plus the `sceAgcDmaDataPatchSetSrcAddressOrOffsetOrImmediate` implementation fixes the one-frame-then-freeze render loop). PM4 completion and end-of-pipe writeback are modeled precisely enough for the game's fences.

**Presenter.** Offscreen draw batching into shared command-buffer submissions, texture/descriptor/pipeline caching with SIGSEGV-based guest-image write tracking for invalidation, flip pacing to the display cadence, MRT support for all color targets, an F1 perf overlay, and MoltenVK performance defaults (async queue submits, concurrent pipeline compilation, Metal argument buffers). Window close and Ctrl-C request cooperative guest shutdown and force a process exit if a wedged guest ignores it.

**Kernel / HLE.** APR file streaming (`sceKernelAprResolveFilepathsToIds`, `sceKernelAprGetFileStat` — without these, asset streaming returns NOT_FOUND and the game never leaves its splash), SCE fiber context switching (the game schedules on fibers), savedata transaction resources, pthread TLS destructor passes on thread exit, AudioOut with a CoreAudio backend and proper 5.1→stereo downmix, Ngs2, AvPlayer, message/error dialogs, and the trophy/CES/telemetry startup stubs — zero unresolved imports for this title.

**Scheduler.** A background Ready-thread dispatcher so a hot-spinning guest thread (this game busy-polls `sceAudioOutOutput`) cannot starve runnable threads; the old behavior only pumped the ready queue on blocking HLE calls and deadlocked the loader.

**Input.** Building on the host input seam from #192: `SHARPEMU_AUTO_CROSS=repeat[:seconds]` keeps pressing Cross on an interval (release guaranteed between presses) so a headless run drives itself through the menus into gameplay; a timed-offset list (`SHARPEMU_AUTO_CROSS="40,52,64"`) is also supported, with `SHARPEMU_AUTO_CROSS_HOLD_MS` and `SHARPEMU_LOG_AUTO_CROSS=1` to tune/observe it. `SHARPEMU_AUTO_WALK=<start-seconds>` rotates a held d-pad direction for unattended tutorial/dungeon traversal (start it past the title menu). Pad and AudioOut2 accept the user id the user service hands out — a mismatch there used to strand the game with an error code as its pad handle and no working input.

### Verified / performance

PPSA03061 v01.000.000 on macOS 27 (Apple M4, Rosetta 2, MoltenVK 1.4.1):

| state | before | this branch |
|---|---|---|
| boot | frozen splash, 0 draws | full boot → gameplay, unattended |
| title screen | — | **60.0 fps locked (16.7 ms)** |
| story / gameplay scenes | — | 13–20 fps |
| window close / Ctrl-C on a wedged guest | headless zombie process | forced exit after 2 s |

In-game frame times are bound by the guest's own x86-64 code under Rosetta 2: a `dotnet-trace` cpu-sampling capture at 13–18 fps gameplay attributes ~100 % of self-time to unmanaged guest execution (managed emulator code ≈ 0 %), and the intro cinematic renders the same ~110 draws/frame at 55–60 fps — heavier scenes simply run 3–4× more guest CPU per frame. Total process CPU in-game is ~1–1.6 cores. `dotnet test` passes (26/26). One Windows-facing change: the static-TLS prefix below the thread pointer grows from the historical 4 KB to the 64 KB POSIX hosts already map — titles whose PT_TLS exceeds a page (this one needs 0x1B00 bytes) previously failed to load on Windows.

### Known issues

- Occasional boot-time failure under Rosetta (unrecovered guest SIGSEGV during loading); a relaunch gets through. Pre-existing flakiness, not introduced here — tracked separately.
- `_T`/`_X` swizzle detile variants remain opt-in (block placement only approximated).
