### PR TITLE
[Vulkan] Gate texture upload diagnostics behind the trace flag

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -3984,7 +3984,8 @@ internal static unsafe class VulkanVideoPresenter
             var vkFormat = GetTextureFormat(texture.Format, texture.NumberType);
 
             var expectedSize = GetTextureByteCount(texture.Format, rowLength, height);
-            if (_tracedTextureUploads.Add((texture.Address, width, height, vkFormat)))
+            if (ShouldTraceVulkanResources() &&
+                _tracedTextureUploads.Add((texture.Address, width, height, vkFormat)))
             {
                 Console.Error.WriteLine(
                     $"[LOADER][TRACE] vk.texture addr=0x{texture.Address:X16} " +


### PR DESCRIPTION
## What changed

Texture upload diagnostics now follow the existing `SHARPEMU_LOG_VK_RESOURCES=1` opt-in, matching texture cache-hit and global-buffer traces.

## Why

`CreateTextureResource` was adding every unique texture upload to `_tracedTextureUploads` and writing a `vk.texture` line to stderr during normal runs. Games that stream many textures could therefore grow a diagnostic-only set and perform avoidable console I/O even when Vulkan resource tracing was disabled.

This keeps the diagnostic behavior unchanged when the flag is enabled, while removing that work from regular emulation.

## Scope

This is intentionally a one-condition fix. It does not change texture data, image creation, caching, synchronization, or rendering behavior.

## Validation

- `dotnet build src/SharpEmu.Libs/SharpEmu.Libs.csproj --configuration Release --no-restore`
- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj --configuration Release --no-restore` (26 passed)
- `git diff --check`

I have not claimed an in-game FPS improvement; the expected result is simply no unsolicited texture trace I/O or trace-key retention in normal runs.