### PR TITLE
[HLE] Trigger AGC graphics events by filter instead of exact ident (#173)

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -2720,8 +2720,12 @@ public static class AgcExports
                 ctx.TryReadUInt32(currentAddress + sizeof(uint), out var eventTypeRaw))
             {
                 var eventType = eventTypeRaw & 0x3Fu;
-                var triggered = KernelEventQueueCompatExports.TriggerRegisteredEvents(
-                    eventType,
+
+                // The guest registers AGC events with a full eventId, but the command buffer
+                // only carries a 6-bit EVENT_TYPE. Those two values are not the same numbering
+                // scheme, so exact ident matching never wakes anything. Trigger every graphics
+                // event registration instead (workaround for issue #173).
+                var triggered = KernelEventQueueCompatExports.TriggerRegisteredEventsByFilter(
                     KernelEventQueueCompatExports.KernelEventFilterGraphics,
                     eventType);
                 if (tracePackets)

--- a/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
@@ -589,6 +589,66 @@ public static class KernelEventQueueCompatExports
         return triggeredCount;
     }
 
+    /// <summary>
+    /// Triggers every registered event on every queue that matches <paramref name="filter"/>
+    /// regardless of the registration's <c>ident</c>. This is a workaround for PS5 AGC command
+    /// buffers, where <c>IT_EVENT_WRITE</c> carries a hardware <c>EVENT_TYPE</c> that does not
+    /// match the <c>eventId</c> the guest registered with <c>sceAgcDriverAddEqEvent</c>.
+    /// See issue #173.
+    /// </summary>
+    public static int TriggerRegisteredEventsByFilter(
+        short filter,
+        ulong data)
+    {
+        List<ulong>? wakeHandles = null;
+        var triggeredCount = 0;
+        lock (_eventQueueGate)
+        {
+            foreach (var (handle, registrations) in _registeredEvents)
+            {
+                foreach (var registration in registrations.Values)
+                {
+                    if (registration.Filter != filter)
+                    {
+                        continue;
+                    }
+
+                    if (!_pendingEvents.TryGetValue(handle, out var queue))
+                    {
+                        queue = new KernelEventDeque();
+                        _pendingEvents[handle] = queue;
+                    }
+
+                    QueueOrUpdateEvent(
+                        queue,
+                        new KernelQueuedEvent(
+                            registration.Ident,
+                            registration.Filter,
+                            0,
+                            1,
+                            data,
+                            registration.UserData));
+                    (wakeHandles ??= new List<ulong>()).Add(handle);
+                    triggeredCount++;
+
+                    // A single queue only needs to be woken once, even if multiple
+                    // registrations matched.
+                    break;
+                }
+            }
+        }
+
+        if (wakeHandles is not null)
+        {
+            foreach (var handle in wakeHandles)
+            {
+                WakeEventQueue(handle);
+            }
+        }
+
+        return triggeredCount;
+    }
+
     private static bool TriggerRegisteredEvent(
         ulong handle,
         ulong ident,

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcEventQueueTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcEventQueueTests.cs
@@ -1,0 +1,136 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+// IT_EVENT_WRITE carries a 6-bit hardware EVENT_TYPE, but sceAgcDriverAddEqEvent registers the
+// listener with a guest-defined eventId. Those two values are not the same numbering scheme, so
+// exact ident matching never wakes anything (issue #173). TriggerRegisteredEventsByFilter wakes
+// every graphics registration instead.
+public sealed class AgcEventQueueTests
+{
+    private const ulong BaseAddress = 0x1_0000_0000;
+    private const int MemorySize = 0x2000;
+
+    [Fact]
+    public void TriggerRegisteredEventsByFilter_DifferentIdentThanEventType_WakesGraphicsWaiter()
+    {
+        var memory = new FakeCpuMemory(BaseAddress, MemorySize);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+
+        const ulong handleOutAddress = BaseAddress + 0x100;
+        const ulong eventsAddress = BaseAddress + 0x200;
+        const ulong outCountAddress = BaseAddress + 0x300;
+        const ulong timeoutAddress = BaseAddress + 0x400;
+
+        // Create an event queue.
+        ctx[CpuRegister.Rdi] = handleOutAddress;
+        var createResult = KernelEventQueueCompatExports.KernelCreateEqueue(ctx);
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, createResult);
+
+        var handle = ReadUInt64(memory, handleOutAddress);
+
+        // Register a graphics event with eventId 0x20 (as Poppy Playtime does).
+        const ulong registeredEventId = 0x20;
+        const ulong userData = 0xDEAD_BEEF;
+        var registered = KernelEventQueueCompatExports.RegisterEvent(
+            handle,
+            registeredEventId,
+            KernelEventQueueCompatExports.KernelEventFilterGraphics,
+            userData);
+        Assert.True(registered);
+
+        // The command buffer fires EVENT_WRITE with eventType 0x07. This does not match 0x20.
+        const ulong eventType = 0x07;
+        var triggered = KernelEventQueueCompatExports.TriggerRegisteredEventsByFilter(
+            KernelEventQueueCompatExports.KernelEventFilterGraphics,
+            eventType);
+        Assert.Equal(1, triggered);
+
+        // Wait with timeout=0. The event is already pending, so this returns immediately.
+        WriteUInt64(memory, timeoutAddress, 0);
+        ctx[CpuRegister.Rdi] = handle;
+        ctx[CpuRegister.Rsi] = eventsAddress;
+        ctx[CpuRegister.Rdx] = 4;
+        ctx[CpuRegister.Rcx] = outCountAddress;
+        ctx[CpuRegister.R8] = timeoutAddress;
+        var waitResult = KernelEventQueueCompatExports.KernelWaitEqueue(ctx);
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, waitResult);
+        Assert.Equal(1u, ReadUInt32(memory, outCountAddress));
+
+        // Verify the queued event carries the registered ident and the event type as data.
+        Assert.Equal(registeredEventId, ReadUInt64(memory, eventsAddress + 0x00));
+        Assert.Equal(KernelEventQueueCompatExports.KernelEventFilterGraphics, ReadInt16(memory, eventsAddress + 0x08));
+        Assert.Equal(0u, ReadUInt16(memory, eventsAddress + 0x0A));
+        Assert.Equal(1u, ReadUInt32(memory, eventsAddress + 0x0C));
+        Assert.Equal(eventType, ReadUInt64(memory, eventsAddress + 0x10));
+        Assert.Equal(userData, ReadUInt64(memory, eventsAddress + 0x18));
+    }
+
+    [Fact]
+    public void TriggerRegisteredEventsByFilter_NoGraphicsRegistrations_ReturnsZero()
+    {
+        var memory = new FakeCpuMemory(BaseAddress, MemorySize);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+
+        const ulong handleOutAddress = BaseAddress + 0x100;
+        ctx[CpuRegister.Rdi] = handleOutAddress;
+        var createResult = KernelEventQueueCompatExports.KernelCreateEqueue(ctx);
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, createResult);
+
+        var handle = ReadUInt64(memory, handleOutAddress);
+
+        // Register a user event, not a graphics event.
+        KernelEventQueueCompatExports.RegisterEvent(
+            handle,
+            0x1,
+            KernelEventQueueCompatExports.KernelEventFilterUser,
+            0);
+
+        var triggered = KernelEventQueueCompatExports.TriggerRegisteredEventsByFilter(
+            KernelEventQueueCompatExports.KernelEventFilterGraphics,
+            0x07);
+
+        Assert.Equal(0, triggered);
+    }
+
+    private static ulong ReadUInt64(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> buffer = stackalloc byte[8];
+        Assert.True(memory.TryRead(address, buffer));
+        return BinaryPrimitives.ReadUInt64LittleEndian(buffer);
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> buffer = stackalloc byte[4];
+        Assert.True(memory.TryRead(address, buffer));
+        return BinaryPrimitives.ReadUInt32LittleEndian(buffer);
+    }
+
+    private static ushort ReadUInt16(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> buffer = stackalloc byte[2];
+        Assert.True(memory.TryRead(address, buffer));
+        return BinaryPrimitives.ReadUInt16LittleEndian(buffer);
+    }
+
+    private static short ReadInt16(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> buffer = stackalloc byte[2];
+        Assert.True(memory.TryRead(address, buffer));
+        return BinaryPrimitives.ReadInt16LittleEndian(buffer);
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> buffer = stackalloc byte[8];
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+        Assert.True(memory.TryWrite(address, buffer));
+    }
+}


### PR DESCRIPTION
The IT_EVENT_WRITE handler uses the 6-bit EVENT_TYPE as ident to wake events, but sceAgcDriverAddEqEvent registers with a full 64-bit eventId. Different numbering schemes, so exact lookup never matches and the queue never wakes anyone.

Added TriggerRegisteredEventsByFilter that fires all graphics-filtered registrations without exact ident matching. Workaround until we have the real PS5 kernel mapping.

Tests included, 28/28 pass.

Fixes #173