### PR TITLE
CLI: add optional diagnostic report output

### DIFF
--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -15,6 +15,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <Project Path="src/SharpEmu.ShaderCompiler.Vulkan/SharpEmu.ShaderCompiler.Vulkan.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/SharpEmu.CLI.Tests/SharpEmu.CLI.Tests.csproj" />
     <Project Path="tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -197,7 +197,13 @@ internal static partial class Program
             return childExitCode;
         }
 
-        if (!TryParseArguments(args, out var ebootPath, out var runtimeOptions, out var logLevel, out var logFilePath))
+        if (!TryParseArguments(
+                args,
+                out var ebootPath,
+                out var runtimeOptions,
+                out var logLevel,
+                out var logFilePath,
+                out var diagnosticReportPath))
         {
             PrintUsage();
             return 1;
@@ -245,6 +251,17 @@ internal static partial class Program
         {
             Console.Error.WriteLine($"[DEBUG] Exception: {ex}");
             Log.Error("SharpEmu failed to run.", ex);
+
+            if (!string.IsNullOrWhiteSpace(diagnosticReportPath))
+            {
+                TryWriteDiagnosticReport(
+                    diagnosticReportPath,
+                    ebootPath,
+                    result: null,
+                    runtime: runtime,
+                    exception: ex);
+            }
+
             return 3;
         }
         finally
@@ -283,7 +300,116 @@ internal static partial class Program
             Log.Info(runtime.LastExecutionTrace);
         }
 
+        if (!string.IsNullOrWhiteSpace(diagnosticReportPath))
+        {
+            TryWriteDiagnosticReport(
+                diagnosticReportPath,
+                ebootPath,
+                result,
+                runtime);
+        }
+
         return result == OrbisGen2Result.ORBIS_GEN2_OK ? 0 : 4;
+    }
+
+    private static void TryWriteDiagnosticReport(
+        string reportPath,
+        string ebootPath,
+        OrbisGen2Result? result,
+        ISharpEmuRuntime runtime,
+        Exception? exception = null)
+    {
+        try
+        {
+            var fullPath = Path.GetFullPath(reportPath);
+            var directory = Path.GetDirectoryName(fullPath);
+
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var builder = new StringBuilder(4096);
+
+            builder.AppendLine("SharpEmu Diagnostic Report");
+            builder.AppendLine("==========================");
+            builder.AppendLine($"Generated UTC: {DateTime.UtcNow:O}");
+            builder.AppendLine($"Build: {BuildInfo.Banner}");
+            builder.AppendLine($"Executable: {ebootPath}");
+            if (result.HasValue)
+            {
+                var resultValue = result.Value;
+                builder.AppendLine(
+                    $"Result: {resultValue} (0x{(int)resultValue:X8})");
+            }
+            else
+            {
+                builder.AppendLine("Result: unhandled exception");
+            }
+
+            if (exception is not null)
+            {
+                AppendDiagnosticSection(
+                    builder,
+                    "Unhandled Exception",
+                    exception.ToString());
+            }
+
+            AppendDiagnosticSection(
+                builder,
+                "Session Summary",
+                runtime.LastSessionSummary);
+
+            AppendDiagnosticSection(
+                builder,
+                "Execution Diagnostics",
+                runtime.LastExecutionDiagnostics);
+
+            AppendDiagnosticSection(
+                builder,
+                "Milestones",
+                runtime.LastMilestoneLog);
+
+            AppendDiagnosticSection(
+                builder,
+                "Basic Block Trace",
+                runtime.LastBasicBlockTrace);
+
+            AppendDiagnosticSection(
+                builder,
+                "Import Trace",
+                runtime.LastExecutionTrace);
+
+            File.WriteAllText(
+                fullPath,
+                builder.ToString(),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+            Log.Info($"Diagnostic report written: {fullPath}");
+        }
+        catch (Exception ex)
+        {
+            Log.Warn(
+                $"Failed to write diagnostic report '{reportPath}': " +
+                $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static void AppendDiagnosticSection(
+        StringBuilder builder,
+        string title,
+        string? content)
+    {
+        builder.AppendLine();
+        builder.AppendLine($"=== {title} ===");
+
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            builder.AppendLine("(not available)");
+            return;
+        }
+
+        builder.AppendLine(content.TrimEnd());
     }
 
     private static void EnsureCliConsole()
@@ -613,6 +739,25 @@ internal static partial class Program
         return Path.Combine(logsDirectory, $"{name}-{DateTime.Now:yyyyMMdd-HHmmss}.log");
     }
 
+    private static string BuildDefaultDiagnosticReportPath(string? ebootPath)
+    {
+        var reportsDirectory = Path.Combine(
+            AppContext.BaseDirectory,
+            "user",
+            "reports");
+
+        var name = TryReadTitleId(ebootPath) ?? "UNKNOWN";
+
+        foreach (var invalid in Path.GetInvalidFileNameChars())
+        {
+            name = name.Replace(invalid, '_');
+        }
+
+        return Path.Combine(
+            reportsDirectory,
+            $"{name}-{DateTime.Now:yyyyMMdd-HHmmss}.diagnostic.txt");
+    }
+
     private static string? TryReadTitleId(string? ebootPath)
     {
         if (string.IsNullOrWhiteSpace(ebootPath))
@@ -900,8 +1045,17 @@ internal static partial class Program
 
     private static void PrintUsage()
     {
-        Log.Info("Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] [--cpu-engine=<native>] [--log-level=<level>] [--log-file[=<path>]] <path-to-eboot.bin>");
-        Log.Info(@"Example: SharpEmu.CLI --cpu-engine=native --trace-imports=64 --log-level=debug --log-file ""E:\Games\...\eboot.bin""");
+        Log.Info(
+            "Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] " +
+            "[--cpu-engine=<native>] [--log-level=<level>] " +
+            "[--log-file[=<path>]] [--diagnostic-report[=<path>]] " +
+            "<path-to-eboot.bin>");
+
+        Log.Info(
+            @"Example: SharpEmu.CLI --cpu-engine=native " +
+            @"--trace-imports=64 --log-level=debug " +
+            @"--diagnostic-report=""E:\Reports\sharpemu-diagnostic.txt"" " +
+            @"""E:\Games\...\eboot.bin""");
     }
 
     private static bool TryParseArguments(
@@ -909,8 +1063,11 @@ internal static partial class Program
         out string ebootPath,
         out SharpEmuRuntimeOptions runtimeOptions,
         out LogLevel logLevel,
-        out string? logFilePath)
+        out string? logFilePath,
+        out string? diagnosticReportPath)
     {
+        diagnosticReportPath = null;
+
         if (args.Length == 0)
         {
             ebootPath = string.Empty;
@@ -972,6 +1129,15 @@ internal static partial class Program
                 }
 
                 i++;
+                continue;
+            }
+
+            if (string.Equals(
+                    argument,
+                    "--diagnostic-report",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                diagnosticReportPath = string.Empty;
                 continue;
             }
 
@@ -1053,6 +1219,27 @@ internal static partial class Program
                 continue;
             }
 
+            const string diagnosticReportPrefix = "--diagnostic-report=";
+            if (argument.StartsWith(
+                    diagnosticReportPrefix,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                diagnosticReportPath =
+                    argument[diagnosticReportPrefix.Length..];
+
+                if (string.IsNullOrWhiteSpace(diagnosticReportPath))
+                {
+                    ebootPath = string.Empty;
+                    runtimeOptions = default;
+                    logLevel = SharpEmuLog.MinimumLevel;
+                    logFilePath = null;
+                    diagnosticReportPath = null;
+                    return false;
+                }
+
+                continue;
+            }
+
             if (argument.StartsWith("--", StringComparison.Ordinal))
             {
                 ebootPath = string.Empty;
@@ -1075,6 +1262,14 @@ internal static partial class Program
         }
 
         ebootPath = string.Join(' ', pathTokens);
+
+        if (diagnosticReportPath is not null &&
+            string.IsNullOrWhiteSpace(diagnosticReportPath))
+        {
+            diagnosticReportPath =
+                BuildDefaultDiagnosticReportPath(ebootPath);
+        }
+
         runtimeOptions = new SharpEmuRuntimeOptions
         {
             CpuEngine = cpuEngine,

--- a/tests/SharpEmu.CLI.Tests/DiagnosticReportIntegrationTests.cs
+++ b/tests/SharpEmu.CLI.Tests/DiagnosticReportIntegrationTests.cs
@@ -1,0 +1,329 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace SharpEmu.CLI.Tests;
+
+public sealed class DiagnosticReportIntegrationTests
+{
+    [Fact]
+    public async Task ExplicitPath_WritesReportForUnhandledException()
+    {
+        var temporaryDirectory = CreateTemporaryDirectory();
+
+        try
+        {
+            var ebootDirectory = Path.Combine(
+                temporaryDirectory,
+                "test data");
+
+            Directory.CreateDirectory(ebootDirectory);
+
+            var ebootPath = Path.Combine(
+                ebootDirectory,
+                "invalid-eboot.bin");
+
+            var reportPath = Path.Combine(
+                temporaryDirectory,
+                "diagnostic report.txt");
+
+            await File.WriteAllBytesAsync(
+                ebootPath,
+                Encoding.ASCII.GetBytes("BEREZKA"));
+
+            var result = await RunCliAsync(
+                $"--diagnostic-report={reportPath}",
+                ebootPath);
+
+            Assert.Equal(3, result.ExitCode);
+
+            Assert.True(
+                File.Exists(reportPath),
+                "The diagnostic report was not created." +
+                Environment.NewLine +
+                result.CombinedOutput);
+
+            var report = await File.ReadAllTextAsync(
+                reportPath,
+                Encoding.UTF8);
+
+            Assert.Contains(
+                "SharpEmu Diagnostic Report",
+                report);
+
+            Assert.Contains(
+                $"Executable: {Path.GetFullPath(ebootPath)}",
+                report);
+
+            Assert.Contains(
+                "Result: unhandled exception",
+                report);
+
+            Assert.Contains(
+                "=== Unhandled Exception ===",
+                report);
+
+            Assert.Contains(
+                "System.IO.InvalidDataException",
+                report);
+
+            Assert.Contains(
+                "=== Session Summary ===",
+                report);
+
+            Assert.Contains(
+                "(not available)",
+                report);
+        }
+        finally
+        {
+            TryDeleteDirectory(temporaryDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DefaultPath_UsesTitleIdAndWritesReport()
+    {
+        var temporaryDirectory = CreateTemporaryDirectory();
+        string? createdReportPath = null;
+
+        try
+        {
+            var titleId =
+                $"TEST{Guid.NewGuid():N}"[..12]
+                .ToUpperInvariant();
+
+            var ebootPath = Path.Combine(
+                temporaryDirectory,
+                "invalid-eboot.bin");
+
+            var paramPath = Path.Combine(
+                temporaryDirectory,
+                "param.json");
+
+            await File.WriteAllBytesAsync(
+                ebootPath,
+                Encoding.ASCII.GetBytes("BEREZKA"));
+
+            await File.WriteAllTextAsync(
+                paramPath,
+                "{\"titleId\":\"" + titleId + "\"}",
+                new UTF8Encoding(
+                    encoderShouldEmitUTF8Identifier: false));
+
+            var result = await RunCliAsync(
+                "--diagnostic-report",
+                ebootPath);
+
+            Assert.Equal(3, result.ExitCode);
+
+            var reportsDirectory = Path.Combine(
+                Path.GetDirectoryName(FindCliExecutable())!,
+                "user",
+                "reports");
+
+            var reports = Directory.Exists(reportsDirectory)
+                ? Directory.GetFiles(
+                    reportsDirectory,
+                    $"{titleId}-*.diagnostic.txt")
+                : [];
+
+            createdReportPath = Assert.Single(reports);
+
+            var report = await File.ReadAllTextAsync(
+                createdReportPath,
+                Encoding.UTF8);
+
+            Assert.Contains(
+                "SharpEmu Diagnostic Report",
+                report);
+
+            Assert.Contains(
+                "Result: unhandled exception",
+                report);
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(createdReportPath))
+            {
+                File.Delete(createdReportPath);
+            }
+
+            TryDeleteDirectory(temporaryDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task EmptyExplicitPath_IsRejected()
+    {
+        var temporaryDirectory = CreateTemporaryDirectory();
+
+        try
+        {
+            var ebootPath = Path.Combine(
+                temporaryDirectory,
+                "invalid-eboot.bin");
+
+            await File.WriteAllBytesAsync(
+                ebootPath,
+                Encoding.ASCII.GetBytes("BEREZKA"));
+
+            var result = await RunCliAsync(
+                "--diagnostic-report=",
+                ebootPath);
+
+            Assert.Equal(1, result.ExitCode);
+
+            Assert.Contains(
+                "Usage:",
+                result.CombinedOutput);
+        }
+        finally
+        {
+            TryDeleteDirectory(temporaryDirectory);
+        }
+    }
+
+    private static async Task<ProcessResult> RunCliAsync(
+        params string[] arguments)
+    {
+        var executablePath = FindCliExecutable();
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executablePath,
+            WorkingDirectory =
+                Path.GetDirectoryName(executablePath)!,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        startInfo.Environment[
+            "SHARPEMU_DISABLE_MITIGATION_RELAUNCH"] = "1";
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process =
+            Process.Start(startInfo) ??
+            throw new InvalidOperationException(
+                "Failed to start SharpEmu.");
+
+        var standardOutputTask =
+            process.StandardOutput.ReadToEndAsync();
+
+        var standardErrorTask =
+            process.StandardError.ReadToEndAsync();
+
+        using var timeout = new CancellationTokenSource(
+            TimeSpan.FromSeconds(90));
+
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            try
+            {
+                process.Kill(
+                    entireProcessTree: true);
+            }
+            catch
+            {
+                // Best-effort cleanup after a test timeout.
+            }
+
+            throw new TimeoutException(
+                "SharpEmu did not exit within 90 seconds.");
+        }
+
+        var standardOutput = await standardOutputTask;
+        var standardError = await standardErrorTask;
+
+        return new ProcessResult(
+            process.ExitCode,
+            standardOutput,
+            standardError);
+    }
+
+    private static string FindCliExecutable()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "win-x64",
+                "SharpEmu.exe"),
+
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "linux-x64",
+                "SharpEmu"),
+
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "osx-x64",
+                "SharpEmu"),
+
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "osx-arm64",
+                "SharpEmu"),
+        };
+
+        return candidates.FirstOrDefault(File.Exists) ??
+            throw new FileNotFoundException(
+                "The SharpEmu executable was not found." +
+                Environment.NewLine +
+                string.Join(
+                    Environment.NewLine,
+                    candidates));
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            "SharpEmu.CLI.Tests",
+            Guid.NewGuid().ToString("N"));
+
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(
+                    path,
+                    recursive: true);
+            }
+        }
+        catch
+        {
+            // Temporary test files must not hide the test result.
+        }
+    }
+
+    private sealed record ProcessResult(
+        int ExitCode,
+        string StandardOutput,
+        string StandardError)
+    {
+        public string CombinedOutput =>
+            StandardOutput +
+            Environment.NewLine +
+            StandardError;
+    }
+}

--- a/tests/SharpEmu.CLI.Tests/SharpEmu.CLI.Tests.csproj
+++ b/tests/SharpEmu.CLI.Tests/SharpEmu.CLI.Tests.csproj
@@ -1,0 +1,26 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <SelfContained>false</SelfContained>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <AssemblyName>SharpEmu.CLI.Tests</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference
+      Include="..\..\src\SharpEmu.CLI\SharpEmu.CLI.csproj"
+      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+</Project>

--- a/tests/SharpEmu.CLI.Tests/packages.lock.json
+++ b/tests/SharpEmu.CLI.Tests/packages.lock.json
@@ -1,0 +1,453 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "gNu2zhnuwjq5vQlU4S7yK/lfaKZDLmtcu+vTjnhfTlMAUYn+Hmgu8IIX0UCwWepYkk+Szx03DHx1bDnc9Fd+9w=="
+      },
+      "Avalonia.Angle.Windows.Natives": {
+        "type": "Transitive",
+        "resolved": "2.1.25547.20250602",
+        "contentHash": "ZL0VLc4s9rvNNFt19Pxm5UNAkmKNylugAwJPX9ulXZ6JWs/l6XZihPWWTyezaoNOVyEPU8YbURtW7XMAtqXH5A=="
+      },
+      "Avalonia.BuildServices": {
+        "type": "Transitive",
+        "resolved": "11.3.2",
+        "contentHash": "qHDToxto1e3hci5YqbG9n0Ty8mlp3zBUN5wT66wKqaDVzXyQ0do3EnRILd4Ke9jpvsktaPpgE0YjEk7hornryQ=="
+      },
+      "Avalonia.FreeDesktop": {
+        "type": "Transitive",
+        "resolved": "11.3.18",
+        "contentHash": "aUwv8BNruRUOaUfMu4U3uibIUS60/rSHgGOhd8zBkLkpxY3JFJvgRbeq5ZzHIyKXCuKi18PO00YHAgCarp3wdw==",
+        "dependencies": {
+          "Avalonia": "11.3.18",
+          "Tmds.DBus.Protocol": "0.21.3"
+        }
+      },
+      "Avalonia.Native": {
+        "type": "Transitive",
+        "resolved": "11.3.18",
+        "contentHash": "8g53DROFW6wVJAnTsE1Iu5bdZO5r0oqxbdbMQODs1QDYCK2IU/y/x/vQVKCYOvqxl4tXkzU9tExv8XqSGPWthQ==",
+        "dependencies": {
+          "Avalonia": "11.3.18"
+        }
+      },
+      "Avalonia.Remote.Protocol": {
+        "type": "Transitive",
+        "resolved": "11.3.18",
+        "contentHash": "vw+6ZfgTuu72dA9aVWn6u56t2nrBd5MoMU0wo/qI9XJAl/c0oYYphIvwLvJP1JorubQY4UE3d0ac8ULBhrGBiA=="
+      },
+      "Avalonia.Skia": {
+        "type": "Transitive",
+        "resolved": "11.3.18",
+        "contentHash": "/B4aXmNRNjG8I5U/a1xJI+bIi0XO6DDzS3mBrIKlVnJRY2CyZiUeESRQXLnIU77Z9TvqkUROs+D47s085YjFtA==",
+        "dependencies": {
+          "Avalonia": "11.3.18",
+          "HarfBuzzSharp": "8.3.1.1",
+          "HarfBuzzSharp.NativeAssets.Linux": "8.3.1.1",
+          "HarfBuzzSharp.NativeAssets.WebAssembly": "8.3.1.1",
+          "SkiaSharp": "2.88.9",
+          "SkiaSharp.NativeAssets.Linux": "2.88.9",
+          "SkiaSharp.NativeAssets.WebAssembly": "2.88.9"
+        }
+      },
+      "Avalonia.Win32": {
+        "type": "Transitive",
+        "resolved": "11.3.18",
+        "contentHash": "eioUHkM2PeLPETd1aEks3rvb9plbba6buIrNdrqCpwE/qgHKUjvRNBd5mUQfAbGgTLiAes524gB8uUMDhrsJVQ==",
+        "dependencies": {
+          "Avalonia": "11.3.18",
+          "Avalonia.Angle.Windows.Natives": "2.1.25547.20250602"
+        }
+      },
+      "Avalonia.X11": {
+        "type": "Transitive",
+        "resolved": "11.3.18",
+        "contentHash": "m4Ki/G5Dovnq+6QzfS0iGbK8V77Q6oTjToMLOB0CxPCCrl3Oxywh6kIjuGJDPaN6kopMmjxlNShyQf+vPYL+JA==",
+        "dependencies": {
+          "Avalonia": "11.3.18",
+          "Avalonia.FreeDesktop": "11.3.18",
+          "Avalonia.Skia": "11.3.18"
+        }
+      },
+      "HarfBuzzSharp": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "tLZN66oe/uiRPTZfrCU4i8ScVGwqHNh5MHrXj0yVf4l7Mz0FhTGnQ71RGySROTmdognAs0JtluHkL41pIabWuQ==",
+        "dependencies": {
+          "HarfBuzzSharp.NativeAssets.Win32": "8.3.1.1",
+          "HarfBuzzSharp.NativeAssets.macOS": "8.3.1.1"
+        }
+      },
+      "HarfBuzzSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "3EZ1mpIiKWRLL5hUYA82ZHteeDIVaEA/Z0rA/wU6tjx6crcAkJnBPwDXZugBSfo8+J3EznvRJf49uMsqYfKrHg=="
+      },
+      "HarfBuzzSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "jbtCsgftcaFLCA13tVKo5iWdElJScrulLTKJre36O4YQTIlwDtPPqhRZNk+Y0vv4D1gxbscasGRucUDfS44ofQ=="
+      },
+      "HarfBuzzSharp.NativeAssets.WebAssembly": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "loJweK2u/mH/3C2zBa0ggJlITIszOkK64HLAZB7FUT670dTg965whLFYHDQo69NmC4+d9UN0icLC9VHidXaVCA=="
+      },
+      "HarfBuzzSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "UsJtQsfAJoFDZrXc4hCUfRPMqccfKZ0iumJ/upcUjz/cmsTgVFGNEL5yaJWmkqsuFYdMWbj/En5/kS4PFl9hBA=="
+      },
+      "MicroCom.Runtime": {
+        "type": "Transitive",
+        "resolved": "0.11.0",
+        "contentHash": "MEnrZ3UIiH40hjzMDsxrTyi8dtqB5ziv3iBeeU4bXsL/7NLSal9F1lZKpK+tfBRnUoDSdtcW3KufE4yhATOMCA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "9.0.9",
+        "contentHash": "fNGvKct2De8ghm0Bpfq0iWthtzIWabgOTi+gJhNOPhNJIowXNEUE2eZNW/zNCzrHVA3PXg2yZ+3cWZndC2IqYA=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Silk.NET.Core": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "D7AT/nnwlB+4RZ84XY8QNGBZMJI5z9l4CSSETIJ1wCfRJzRt/341y3MRZ4HbnFz4r/IGaWOEZr86iE+0/65yyQ==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Microsoft.Extensions.DependencyModel": "9.0.9"
+        }
+      },
+      "Silk.NET.GLFW": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "UIs4sH57xlPUNHQ/1bt9rymPWlGy8IMDCNv86h0iM4TOA1CkIx0XM/n/tA4AReh1zQkNrvkxPEdZ3Blvy1dyXg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Ultz.Native.GLFW": "3.4.0"
+        }
+      },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Maths": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "r8PdIVzME8EH0qAgbmRPO87I4GfgR2j8TofT7EMuRJDf1QluoQwnVypDoFJjQ2ZBSRsGYk5unYxxogI05Ogsmw=="
+      },
+      "Silk.NET.Windowing.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "ThStSinmY9KQI8DGiF5XEhkLJVnBcgRTBTzL9ijg1wMZAYuckz7ykrNw04fjRm2Gryh6tCNGbvz2XaY0efeFzg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "aYBudKmENmvLRn9p15HbdvlQTnnXskcDfTfbYwSb/4fr263rGLwYuDw/txUEc2jihHJiWCp5+75Y7z5wTJWl7g==",
+        "dependencies": {
+          "Silk.NET.GLFW": "2.23.0",
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "SkiaSharp": {
+        "type": "Transitive",
+        "resolved": "2.88.9",
+        "contentHash": "3MD5VHjXXieSHCleRLuaTXmL2pD0mB7CcOB1x2kA1I4bhptf4e3R27iM93264ZYuAq6mkUyX5XbcxnZvMJYc1Q==",
+        "dependencies": {
+          "SkiaSharp.NativeAssets.Win32": "2.88.9",
+          "SkiaSharp.NativeAssets.macOS": "2.88.9"
+        }
+      },
+      "SkiaSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "2.88.9",
+        "contentHash": "cWSaJKVPWAaT/WIn9c8T5uT/l4ETwHxNJTkEOtNKjphNo8AW6TF9O32aRkxqw3l8GUdUo66Bu7EiqtFh/XG0Zg==",
+        "dependencies": {
+          "SkiaSharp": "2.88.9"
+        }
+      },
+      "SkiaSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "2.88.9",
+        "contentHash": "Nv5spmKc4505Ep7oUoJ5vp3KweFpeNqxpyGDWyeEPTX2uR6S6syXIm3gj75dM0YJz7NPvcix48mR5laqs8dPuA=="
+      },
+      "SkiaSharp.NativeAssets.WebAssembly": {
+        "type": "Transitive",
+        "resolved": "2.88.9",
+        "contentHash": "kt06RccBHSnAs2wDYdBSfsjIDbY3EpsOVqnlDgKdgvyuRA8ZFDaHRdWNx1VHjGgYzmnFCGiTJBnXFl5BqGwGnA=="
+      },
+      "SkiaSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "2.88.9",
+        "contentHash": "wb2kYgU7iy84nQLYZwMeJXixvK++GoIuECjU4ECaUKNuflyRlJKyiRhN1MAHswvlvzuvkrjRWlK0Za6+kYQK7w=="
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "SharpEmu": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.Core": "[0.0.1, )",
+          "SharpEmu.GUI": "[0.0.1, )",
+          "SharpEmu.Logging": "[0.0.1, )"
+        }
+      },
+      "sharpemu.core": {
+        "type": "Project",
+        "dependencies": {
+          "Iced": "[1.21.0, )",
+          "SharpEmu.HLE": "[0.0.1, )",
+          "SharpEmu.Libs": "[0.0.1, )",
+          "SharpEmu.Logging": "[0.0.1, )"
+        }
+      },
+      "sharpemu.gui": {
+        "type": "Project",
+        "dependencies": {
+          "Avalonia": "[11.3.18, )",
+          "Avalonia.Desktop": "[11.3.18, )",
+          "Avalonia.Fonts.Inter": "[11.3.18, )",
+          "Avalonia.Themes.Fluent": "[11.3.18, )",
+          "SharpEmu.Logging": "[0.0.1, )",
+          "Tmds.DBus.Protocol": "[0.21.3, )"
+        }
+      },
+      "sharpemu.hle": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.Logging": "[0.0.1, )"
+        }
+      },
+      "sharpemu.libs": {
+        "type": "Project",
+        "dependencies": {
+          "SharpEmu.HLE": "[0.0.1, )",
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Vulkan": "[2.23.0, )",
+          "Silk.NET.Vulkan.Extensions.EXT": "[2.23.0, )",
+          "Silk.NET.Vulkan.Extensions.KHR": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "sharpemu.logging": {
+        "type": "Project"
+      },
+      "Avalonia": {
+        "type": "CentralTransitive",
+        "requested": "[11.3.18, )",
+        "resolved": "11.3.18",
+        "contentHash": "2C4UxhWUObWGgYKWic1x5BMMWGJP6SElb91WeOxs+X/iR26rtkqpxFFwwo50FXS9AyYnHfk8QKXDEfe7oT/kZA==",
+        "dependencies": {
+          "Avalonia.BuildServices": "11.3.2",
+          "Avalonia.Remote.Protocol": "11.3.18",
+          "MicroCom.Runtime": "0.11.0"
+        }
+      },
+      "Avalonia.Desktop": {
+        "type": "CentralTransitive",
+        "requested": "[11.3.18, )",
+        "resolved": "11.3.18",
+        "contentHash": "bilMPa5vYiis6fbNovb6esKytBnOCEGojBa1XFegLCRHCP6g6PvZwS0XF/YOAGkENRlHG8dI7lohOpQ9bIkq1g==",
+        "dependencies": {
+          "Avalonia": "11.3.18",
+          "Avalonia.Native": "11.3.18",
+          "Avalonia.Skia": "11.3.18",
+          "Avalonia.Win32": "11.3.18",
+          "Avalonia.X11": "11.3.18"
+        }
+      },
+      "Avalonia.Fonts.Inter": {
+        "type": "CentralTransitive",
+        "requested": "[11.3.18, )",
+        "resolved": "11.3.18",
+        "contentHash": "27u6hB3Y2Ue586yjfeVakberY73VNQXtuKwe/P927XG1QPlhsfmOyifLHDDpSHG85Zl1x/Xv9IZ3+tk9FnjcZQ==",
+        "dependencies": {
+          "Avalonia": "11.3.18"
+        }
+      },
+      "Avalonia.Themes.Fluent": {
+        "type": "CentralTransitive",
+        "requested": "[11.3.18, )",
+        "resolved": "11.3.18",
+        "contentHash": "+Q/TJoynD0zNuu5w2gD+xcTl7GNKJFxlPYAndRLs/mTDrNbbsvv/271WyIysbMPsXSjCyBDp7RCZzQkpD6x5Bg==",
+        "dependencies": {
+          "Avalonia": "11.3.18"
+        }
+      },
+      "Iced": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "dv5+81Q1TBQvVMSOOOmRcjJmvWcX3BZPZsIq31+RLc5cNft0IHAyNlkdb7ZarOWG913PyBoFDsDXoCIlKmLclg=="
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Vulkan": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "3/irtlSWXZ3eTi8N6nelI6L34NTB8ZJHpqVMNzZx2aX7Ek9YEQ34NoQW8/Tljrtmkg8KRhHW8hKTEzZaKV8PgA==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0"
+        }
+      },
+      "Silk.NET.Vulkan.Extensions.EXT": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "+Oth189ksRiL6HvGCwIdnsYHawqrbO8y49u1H61z3wsfcHhQZeVDYe/wF5LD7fk3NcdgDvwFD3mLm1QWhdZySw==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Vulkan": "2.23.0"
+        }
+      },
+      "Silk.NET.Vulkan.Extensions.KHR": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "uRaf4j+SmH3DumjSSSUbFg33BnsGZUyXGj93O9NgGKZSJN3OTmNmQDxRew+/KiVLcgH6qzbto8aNGZ++j9GFWg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Vulkan": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "OPNPmt/lRyUKVYrFLQXVxyATqD3MKLc1iY1oKx1/2GppgmZxVZPwN12tekrQ4C7408kgB1L5JD1Wnirqqeb2kg==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
+      "Tmds.DBus.Protocol": {
+        "type": "CentralTransitive",
+        "requested": "[0.21.3, )",
+        "resolved": "0.21.3",
+        "contentHash": "hDwB8WsQoyALQKqIbwzS68UKdlnafDm4T/DkO/JrA/YIneP/rKv96SxYPVXeh3FP4i/SXfShrYftKLtciJAIlw=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds an optional CLI diagnostic report for collecting the most useful
post-run information in a single UTF-8 text file.

- Adds `--diagnostic-report[=<path>]`.
- Uses `user/reports/<TITLEID>-<timestamp>.diagnostic.txt` when no path
  is provided.
- Includes build information, executable path, result or unhandled
  exception, session summary, execution diagnostics, milestones,
  basic-block trace, and import trace.
- Treats report writing as best-effort so an I/O failure does not replace
  the emulator's original exit result.
- Adds CLI integration tests for explicit paths, automatic paths, and
  invalid empty explicit paths.

## Motivation

SharpEmu currently exposes useful diagnostic information through several
runtime properties and console messages. A single report file makes that
information easier to preserve and attach to bug reports, especially when
the emulator exits because of an exception.

## Verification

- `dotnet restore .\SharpEmu.slnx`
- `dotnet build .\SharpEmu.slnx -c Release --no-restore`
- `dotnet test .\SharpEmu.slnx -c Release --no-build --verbosity minimal`
- Result: 29 tests passed, 0 failed.
- Manually verified explicit and automatic report paths on Windows.
- Manually verified the normal mitigated child-process launch path.
- The manual fixture was a locally created seven-byte invalid file; no
  game files or proprietary assets are included.

## AI assistance

AI assistance was used during implementation and test development.
I reviewed the resulting changes, verified the behavior described above,
and take responsibility for addressing review feedback and maintaining
the submitted code.