### PR TITLE
[AGC] Correct VReadlaneB32 decode and emission

### DIFF
--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
@@ -24,6 +24,11 @@ public static partial class Gen5SpirvTranslator
                 return TryEmitVectorCompare(instruction, out error);
             }
 
+            if (instruction.Opcode == "VReadlaneB32")
+            {
+                return TryEmitReadlane(instruction, out error);
+            }
+
             if (!TryGetVectorDestination(instruction, out var destination))
             {
                 error = "missing vector destination";
@@ -34,7 +39,6 @@ public static partial class Gen5SpirvTranslator
             switch (instruction.Opcode)
             {
                 case "VMovB32":
-                case "VReadlaneB32":
                 case "VReadfirstlaneB32":
                     result = GetRawSource(instruction, 0);
                     break;
@@ -2336,6 +2340,42 @@ public static partial class Gen5SpirvTranslator
             }
 
             StoreWaveMask(106, carry);
+        }
+
+        private bool TryEmitReadlane(
+            Gen5ShaderInstruction instruction,
+            out string error)
+        {
+            error = string.Empty;
+            if (instruction.Destinations.Count == 0 ||
+                instruction.Destinations[0].Kind != Gen5OperandKind.ScalarRegister)
+            {
+                error = "VReadlaneB32 expects scalar destination";
+                return false;
+            }
+
+            var destination = instruction.Destinations[0].Value;
+            var src0 = GetRawSource(instruction, 0);
+
+            if (_subgroupInvocationIdInput != 0)
+            {
+                // sdst = vsrc0[lane(src1)] — broadcast from the specified lane.
+                var laneSelect = GetRawSource(instruction, 1);
+                var broadcast = _module.AddInstruction(
+                    SpirvOp.GroupNonUniformBroadcast,
+                    _uintType,
+                    UInt(3),  // Subgroup scope
+                    src0,
+                    laneSelect);
+                StoreS(destination, broadcast);
+            }
+            else
+            {
+                // Fallback: no subgroup ops, read current lane's value.
+                StoreS(destination, src0);
+            }
+
+            return true;
         }
 
         private uint EmitPermlane16(

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -2507,7 +2507,7 @@ public static partial class Gen5SpirvTranslator
 
         private bool UsesSubgroupShuffle() =>
             _state.Program.Instructions.Any(instruction =>
-                instruction.Opcode is "VPermlane16B32" or "VPermlanex16B32");
+                instruction.Opcode is "VPermlane16B32" or "VPermlanex16B32" or "VReadlaneB32");
 
         private bool UsesWaveControl() =>
             _state.Program.Instructions.Any(instruction =>

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
@@ -1466,6 +1466,12 @@ public static class Gen5ShaderTranslator
                     Gen5Operand.Source((extra >> 18) & 0x1FF, literal),
                 ];
                 destinations = [Gen5Operand.Vector(word & 0xFF)];
+                if (opcode == "VReadlaneB32")
+                {
+                    // VReadlaneB32 writes to scalar destination (bits 8-14), not vector.
+                    // Bits 0-7 are unused for this opcode.
+                    destinations = [Gen5Operand.Scalar((word >> 8) & 0x7F)];
+                }
                 var isVop3B = IsVop3BOpcode((word >> 16) & 0x3FF);
                 control = new Gen5Vop3Control(
                     isVop3B ? 0 : (word >> 8) & 0x7,


### PR DESCRIPTION
## Summary

Follow-up to #232. VReadlaneB32 (VOP3 0x360) had two bugs: wrong destination kind in decode, and simplified emission that ignored the lane select operand.

## ISA semantics

`V_READLANE_B32`: `sdst = vsrc0[lane(src1)]`
- **sdst** = scalar destination register (bits 8-14 of VOP3 word)
- **src0** = vector source (value to read from)
- **src1** = lane select (which lane to read from)
- Bits 0-7 are unused (no vector destination)

## Changes

### 1. Decode (`Gen5ShaderTranslator.cs`)

VOP3 decode always set `destinations = [Gen5Operand.Vector(word & 0xFF)]`. For VReadlaneB32, this created a bogus vector destination from unused bits 0-7. Now decodes as `Gen5Operand.Scalar((word >> 8) & 0x7F)`.

### 2. Emission (`Gen5SpirvTranslator.Alu.cs`)

VReadlaneB32 was in the `VMovB32` fall-through group, just returning `GetRawSource(instruction, 0)` — reading the **current lane's** value. By ISA, `sdst = vsrc0[lane(src1)]` — it reads a **different lane's** value. New `TryEmitReadlane` method uses SPIR-V `GroupNonUniformBroadcast(scope=Subgroup, value=src0, lane=src1)` when subgroup operations are available, with a fallback to the current-lane simplification when not.

### 3. Routing (`Gen5SpirvTranslator.Alu.cs`)

`TryEmitVectorAlu` called `TryGetVectorDestination` first (checks `VectorRegister` kind). With the scalar destination fix, VReadlaneB32 now routes to `TryEmitReadlane` **before** the vector destination check.

### 4. Subgroup capability (`Gen5SpirvTranslator.cs`)

`UsesSubgroupShuffle` now includes `VReadlaneB32` so `GroupNonUniform` capability is enabled when needed.

## Verification

- `dotnet build SharpEmu.slnx -c Release`: 0 errors, 0 warnings
- `dotnet test SharpEmu.Libs.Tests`: 26/26 passed
- ShaderDump synthetic shaders: all programs behaved as expected

## Files

- `src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs` — decode: scalar destination for VReadlaneB32
- `src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs` — routing + TryEmitReadlane + fall-through fix
- `src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs` — UsesSubgroupShuffle includes VReadlaneB32