### PR TITLE
[HLE] Report offline NP reachability state

### DIFF
--- a/src/SharpEmu.Libs/Np/NpManagerExports.cs
+++ b/src/SharpEmu.Libs/Np/NpManagerExports.cs
@@ -10,6 +10,7 @@ public static class NpManagerExports
 {
     private const int NpTitleIdSize = 16;
     private const int NpTitleSecretSize = 128;
+    private const int NpReachabilityStateUnavailable = 0;
 
     [SysAbiExport(
         Nid = "3Zl8BePTh9Y",
@@ -75,8 +76,15 @@ public static class NpManagerExports
         LibraryName = "libSceNpManager")]
     public static int NpGetNpReachabilityState(CpuContext ctx)
     {
-        ctx[CpuRegister.Rax] = 0;
-        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        var stateAddress = ctx[CpuRegister.Rsi];
+        if (stateAddress == 0)
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        return ctx.TryWriteInt32(stateAddress, NpReachabilityStateUnavailable)
+            ? ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK)
+            : ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
     }
 
     [SysAbiExport(


### PR DESCRIPTION
## What

Implement deterministic offline output for `sceNpGetNpReachabilityState`.

## Why

The export previously returned success without writing the requested reachability state, leaving the guest output value unchanged.

## Implementation

- Validate the output state pointer.
- Report the offline/unavailable NP reachability state (`0`).
- Return a guest memory fault if the output value cannot be written.

## Verification

- `dotnet restore SharpEmu.slnx --locked-mode`
- `dotnet build SharpEmu.slnx -c Release --no-restore`
- `dotnet test SharpEmu.slnx -c Release --no-restore` — 26/26 passed
- Synthetic shader validation completed successfully
- `git diff --check` passed