### PR TITLE
improved renderer performance 

### DIFF
--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -197,7 +197,7 @@ internal static partial class Program
             return childExitCode;
         }
 
-        if (!TryParseArguments(args, out var ebootPath, out var runtimeOptions, out var logLevel, out var logFilePath))
+        if (!TryParseArguments(args, out var ebootPath, out var runtimeOptions, out var logLevel, out var logFilePath, out var perfLogPath))
         {
             PrintUsage();
             return 1;
@@ -224,6 +224,19 @@ internal static partial class Program
 
         Console.Error.WriteLine("[DEBUG] Creating runtime...");
 
+        if (!string.IsNullOrWhiteSpace(perfLogPath))
+        {
+            try
+            {
+                PerfLog.Start(perfLogPath);
+                Console.Error.WriteLine($"[DEBUG] Perf log: {Path.GetFullPath(perfLogPath)}");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[WARN] Could not open perf log '{perfLogPath}': {ex.Message}");
+            }
+        }
+
         using var runtime = SharpEmuRuntime.CreateDefault(runtimeOptions);
 
         OrbisGen2Result result;
@@ -249,6 +262,7 @@ internal static partial class Program
         }
         finally
         {
+            PerfLog.Stop();
             if (cancelHandler is not null)
             {
                 Console.CancelKeyPress -= cancelHandler;
@@ -613,6 +627,47 @@ internal static partial class Program
         return Path.Combine(logsDirectory, $"{name}-{DateTime.Now:yyyyMMdd-HHmmss}.log");
     }
 
+    private static string BuildDefaultPerfLogPath(string? ebootPath)
+    {
+        var name = TryReadTitleId(ebootPath);
+        if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(ebootPath))
+        {
+            name = Path.GetFileName(Path.GetDirectoryName(Path.GetFullPath(ebootPath)));
+        }
+
+        name = string.IsNullOrWhiteSpace(name) ? "UNKNOWN" : name;
+        foreach (var invalid in Path.GetInvalidFileNameChars())
+        {
+            name = name.Replace(invalid, '_');
+        }
+
+        return Path.Combine(
+            AppContext.BaseDirectory,
+            $"{name}-perf-{DateTime.Now:yyyyMMdd-HHmmss}.csv");
+    }
+
+    private static bool ShouldConsumePerfLogPath(IReadOnlyList<string> args, int candidateIndex)
+    {
+        if (string.Equals(
+                Path.GetExtension(args[candidateIndex]),
+                ".csv",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        for (var i = candidateIndex + 1; i < args.Count; i++)
+        {
+            if (!string.IsNullOrWhiteSpace(args[i]) &&
+                !args[i].StartsWith("--", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static string? TryReadTitleId(string? ebootPath)
     {
         if (string.IsNullOrWhiteSpace(ebootPath))
@@ -900,7 +955,7 @@ internal static partial class Program
 
     private static void PrintUsage()
     {
-        Log.Info("Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] [--cpu-engine=<native>] [--log-level=<level>] [--log-file[=<path>]] <path-to-eboot.bin>");
+        Log.Info("Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] [--cpu-engine=<native>] [--log-level=<level>] [--log-file[=<path>]] [--perf-logs[=<path.csv>]] <path-to-eboot.bin>");
         Log.Info(@"Example: SharpEmu.CLI --cpu-engine=native --trace-imports=64 --log-level=debug --log-file ""E:\Games\...\eboot.bin""");
     }
 
@@ -909,7 +964,8 @@ internal static partial class Program
         out string ebootPath,
         out SharpEmuRuntimeOptions runtimeOptions,
         out LogLevel logLevel,
-        out string? logFilePath)
+        out string? logFilePath,
+        out string? perfLogPath)
     {
         if (args.Length == 0)
         {
@@ -917,6 +973,7 @@ internal static partial class Program
             runtimeOptions = default;
             logLevel = SharpEmuLog.MinimumLevel;
             logFilePath = null;
+            perfLogPath = null;
             return false;
         }
 
@@ -924,6 +981,7 @@ internal static partial class Program
         var importTraceLimit = 0;
         var cpuEngine = CpuExecutionEngine.NativeOnly;
         logFilePath = null;
+        perfLogPath = null;
         logLevel = SharpEmuLog.MinimumLevel;
         var pathTokens = new List<string>(args.Length);
         for (var i = 0; i < args.Length; i++)
@@ -987,6 +1045,35 @@ internal static partial class Program
                 else
                 {
                     logFilePath = BuildDefaultLogFilePath(TryFindEbootPathToken(args));
+                }
+
+                continue;
+            }
+
+            if (string.Equals(argument, "--perf-logs", StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 < args.Length &&
+                    !string.IsNullOrWhiteSpace(args[i + 1]) &&
+                    !args[i + 1].StartsWith("--", StringComparison.Ordinal) &&
+                    ShouldConsumePerfLogPath(args, i + 1))
+                {
+                    perfLogPath = args[++i];
+                }
+                else
+                {
+                    perfLogPath = BuildDefaultPerfLogPath(TryFindEbootPathToken(args));
+                }
+
+                continue;
+            }
+
+            const string perfLogPrefix = "--perf-logs=";
+            if (argument.StartsWith(perfLogPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                perfLogPath = argument[perfLogPrefix.Length..];
+                if (string.IsNullOrWhiteSpace(perfLogPath))
+                {
+                    perfLogPath = BuildDefaultPerfLogPath(TryFindEbootPathToken(args));
                 }
 
                 continue;

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -195,6 +195,7 @@ public static class AgcExports
     private static long _standardDmaTraceCount;
     private static readonly object _softwarePresenterGate = new();
     private static readonly Dictionary<(ulong Source, ulong Destination), ulong> _softwarePresenterFingerprints = new();
+    private static byte[] _softwarePresentSourceScratch = [];
     private static readonly object _textureSourceGate = new();
     private static readonly Dictionary<(ulong Address, int ByteCount), CachedTextureSource> _textureSourceCache = new();
     private static byte[] _textureSourceScratch = [];
@@ -207,6 +208,10 @@ public static class AgcExports
         public ulong Fingerprint;
         public long LastUseSequence;
     }
+
+    private static readonly Dictionary<(ulong Address, int ByteCount), CachedTextureSource> _indexSourceCache = new();
+    private static long _indexSourceCacheBytes;
+    private const long MaxIndexSourceCacheBytes = 256L * 1024 * 1024;
     private static readonly Dictionary<(ulong Shader, ulong Source, ulong Destination), ulong> _softwareComputeBlitFingerprints = new();
     private static readonly object _registerDefaultsGate = new();
     private static readonly ConditionalWeakTable<object, RegisterDefaultsAllocation> _registerDefaultsAllocations = new();
@@ -2993,6 +2998,11 @@ public static class AgcExports
                         cachedDisplayBuffer.Height,
                         cachedDisplayBuffer.PitchInPixel))
                 {
+                    if (PerfLog.Enabled)
+                    {
+                        Interlocked.Increment(ref PerfLog.FlipGpuCache);
+                    }
+
                     TraceDisplayBuffer(
                         handle,
                         displayBufferIndex,
@@ -3006,6 +3016,11 @@ public static class AgcExports
                         displayBufferIndex,
                         out var translatedDisplayBuffer))
                 {
+                    if (PerfLog.Enabled)
+                    {
+                        Interlocked.Increment(ref PerfLog.FlipDrawFallback);
+                    }
+
                     TraceDisplayBuffer(
                         handle,
                         displayBufferIndex,
@@ -3045,6 +3060,11 @@ public static class AgcExports
                 }
                 else if (state.SawIndexedDraw && state.PresenterTexture is { } sourceTexture)
                 {
+                    if (PerfLog.Enabled)
+                    {
+                        Interlocked.Increment(ref PerfLog.FlipSoftware);
+                    }
+
                     _ = TrySoftwarePresent(
                         ctx,
                         sourceTexture,
@@ -3058,10 +3078,19 @@ public static class AgcExports
                              displayBufferIndex,
                              out var displayBuffer))
                 {
+                    if (PerfLog.Enabled)
+                    {
+                        Interlocked.Increment(ref PerfLog.FlipGuestDraw);
+                    }
+
                     GuestGpu.Current.SubmitGuestDraw(
                         state.GuestDrawKind,
                         displayBuffer.Width,
                         displayBuffer.Height);
+                }
+                else if (PerfLog.Enabled)
+                {
+                    Interlocked.Increment(ref PerfLog.FlipUnhandled);
                 }
 
                 _ = VideoOutExports.SubmitFlipFromAgc(ctx, handle, displayBufferIndex, unchecked((int)flipMode), flipArg);
@@ -3843,8 +3872,40 @@ public static class AgcExports
         var bytesPerIndex = is32Bit ? sizeof(uint) : sizeof(ushort);
         var byteOffset = checked((ulong)state.DrawIndexOffset * (uint)bytesPerIndex);
         var byteCount = checked((int)(indexCount * (uint)bytesPerIndex));
-        var data = GC.AllocateUninitializedArray<byte>(byteCount);
         var address = state.IndexBufferAddress + byteOffset;
+        var key = (address, byteCount);
+        byte[] data;
+        lock (_indexSourceCache)
+        {
+            if (_indexSourceCache.TryGetValue(key, out var cached) &&
+                VulkanVideoPresenter.CompletedGuestWorkSequence >= cached.LastUseSequence)
+            {
+                cached.LastUseSequence = VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1;
+                data = cached.Pixels;
+            }
+            else
+            {
+                data = GC.AllocateUninitializedArray<byte>(byteCount);
+                if (_indexSourceCache.Remove(key, out var evicted))
+                {
+                    _indexSourceCacheBytes -= evicted.Pixels.Length;
+                }
+
+                if (_indexSourceCacheBytes + byteCount > MaxIndexSourceCacheBytes)
+                {
+                    _indexSourceCache.Clear();
+                    _indexSourceCacheBytes = 0;
+                }
+
+                _indexSourceCache[key] = new CachedTextureSource
+                {
+                    Pixels = data,
+                    LastUseSequence = VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1,
+                };
+                _indexSourceCacheBytes += byteCount;
+            }
+        }
+
         return (ctx.Memory.TryRead(address, data) ||
                 KernelMemoryCompatExports.TryReadTrackedLibcHeap(address, data))
             ? new GuestIndexBuffer(data, is32Bit)
@@ -5898,13 +5959,25 @@ public static class AgcExports
             return false;
         }
 
-        var sourceBytes = GC.AllocateUninitializedArray<byte>((int)sourceByteCount);
-        if (!ctx.Memory.TryRead(source.Address, sourceBytes))
+        byte[] sourceBytes;
+        lock (_softwarePresenterGate)
+        {
+            if (_softwarePresentSourceScratch.Length < (int)sourceByteCount)
+            {
+                _softwarePresentSourceScratch =
+                    GC.AllocateUninitializedArray<byte>((int)sourceByteCount);
+            }
+
+            sourceBytes = _softwarePresentSourceScratch;
+        }
+
+        var sourceSpan = sourceBytes.AsSpan(0, (int)sourceByteCount);
+        if (!ctx.Memory.TryRead(source.Address, sourceSpan))
         {
             return false;
         }
 
-        var fingerprint = ComputeFingerprint(sourceBytes);
+        var fingerprint = ComputeFingerprint(sourceSpan);
         var fingerprintKey = (source.Address, destination.Address);
         lock (_softwarePresenterGate)
         {
@@ -5927,7 +6000,7 @@ public static class AgcExports
         var rgbaDestination = destination.PixelFormat is
             VideoOutPixelFormatA8B8G8R8Srgb or
             VideoOutPixelFormatR8G8B8A8Unorm;
-        var sourcePixels = MemoryMarshal.Cast<byte, uint>(sourceBytes);
+        var sourcePixels = MemoryMarshal.Cast<byte, uint>(sourceSpan);
         for (uint y = 0; y < destination.Height; y++)
         {
             var sourceY = (uint)(((ulong)y * source.Height) / destination.Height);
@@ -5965,7 +6038,7 @@ public static class AgcExports
             _softwarePresenterFingerprints[fingerprintKey] = fingerprint;
         }
 
-        VideoOutExports.SubmitHostRgbaFrame(sourceBytes, source.Width, source.Height);
+        VideoOutExports.SubmitHostRgbaFrame(sourceSpan, source.Width, source.Height);
         TraceAgc(
             $"agc.software_presenter src=0x{source.Address:X16} {source.Width}x{source.Height} fmt={source.Format}/num{source.NumberType} " +
             $"dst=0x{destination.Address:X16} {destination.Width}x{destination.Height} fingerprint=0x{fingerprint:X16}");

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -7,7 +7,9 @@ using SharpEmu.Libs.Gpu;
 using SharpEmu.ShaderCompiler;
 using SharpEmu.Libs.Kernel;
 using SharpEmu.Libs.VideoOut;
+using SharpEmu.Logging;
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -2680,6 +2682,11 @@ public static class AgcExports
             return;
         }
 
+        if (PerfLog.Enabled)
+        {
+            Interlocked.Increment(ref PerfLog.DcbSubmits);
+        }
+
         var offset = 0u;
         while (offset < dwordCount)
         {
@@ -3417,6 +3424,7 @@ public static class AgcExports
         }
 
         var translationError = string.Empty;
+        var translateStart = PerfLog.Enabled ? Stopwatch.GetTimestamp() : 0L;
         if (hasExportShader &&
             hasPixelShader &&
             hasPsInputEna &&
@@ -3431,6 +3439,14 @@ public static class AgcExports
                 out var translatedDraw,
                 out translationError))
         {
+            if (PerfLog.Enabled)
+            {
+                Interlocked.Increment(ref PerfLog.DrawsTranslated);
+                Interlocked.Add(
+                    ref PerfLog.ShaderEvalTicks,
+                    Stopwatch.GetTimestamp() - translateStart);
+            }
+
             state.TranslatedDraw = translatedDraw;
             var firstTarget = translatedDraw.RenderTargets.FirstOrDefault();
             if (firstTarget.Address != 0)
@@ -3622,6 +3638,14 @@ public static class AgcExports
             pixelEvaluation.GlobalMemoryBindings.Count +
             exportEvaluation.GlobalMemoryBindings.Count;
         _graphicsShaderCache.TryGetValue(shaderKey, out var compiled);
+
+        if (PerfLog.Enabled)
+        {
+            Interlocked.Increment(
+                ref compiled.Vertex is null || compiled.Pixel is null
+                    ? ref PerfLog.SpirvCacheMisses
+                    : ref PerfLog.SpirvCacheHits);
+        }
 
         if (compiled.Vertex is null || compiled.Pixel is null)
         {
@@ -4518,6 +4542,11 @@ public static class AgcExports
             return true;
         }
 
+        if (PerfLog.Enabled)
+        {
+            Interlocked.Add(ref PerfLog.GuestTextureBytesRead, source.Length);
+        }
+
         TraceTextureHash(descriptor, source);
 
         if (_traceAgcShader)
@@ -4965,6 +4994,14 @@ public static class AgcExports
                 localSizeY,
                 localSizeZ);
             _computeShaderCache.TryGetValue(shaderKey, out var computeShader);
+
+            if (PerfLog.Enabled)
+            {
+                Interlocked.Increment(
+                    ref computeShader is null
+                        ? ref PerfLog.SpirvCacheMisses
+                        : ref PerfLog.SpirvCacheHits);
+            }
 
             if (computeShader is null &&
                 GuestGpu.Current.TryCompileComputeShader(

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -9,6 +9,7 @@ using SharpEmu.Libs.Kernel;
 using SharpEmu.Libs.VideoOut;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace SharpEmu.Libs.Agc;
 
@@ -3806,7 +3807,7 @@ public static class AgcExports
         var bytesPerIndex = is32Bit ? sizeof(uint) : sizeof(ushort);
         var byteOffset = checked((ulong)state.DrawIndexOffset * (uint)bytesPerIndex);
         var byteCount = checked((int)(indexCount * (uint)bytesPerIndex));
-        var data = new byte[byteCount];
+        var data = GC.AllocateUninitializedArray<byte>(byteCount);
         var address = state.IndexBufferAddress + byteOffset;
         return (ctx.Memory.TryRead(address, data) ||
                 KernelMemoryCompatExports.TryReadTrackedLibcHeap(address, data))
@@ -4475,7 +4476,7 @@ public static class AgcExports
             var initialPixels = Array.Empty<byte>();
             if (descriptor.Address != 0)
             {
-                var storageSource = new byte[(int)sourceByteCount];
+                var storageSource = GC.AllocateUninitializedArray<byte>((int)sourceByteCount);
                 if ((ctx.Memory.TryRead(descriptor.Address, storageSource) ||
                      KernelMemoryCompatExports.TryReadTrackedLibcHeapGpuAlias(
                          descriptor.Address,
@@ -4504,7 +4505,7 @@ public static class AgcExports
             return true;
         }
 
-        var source = new byte[(int)sourceByteCount];
+        var source = GC.AllocateUninitializedArray<byte>((int)sourceByteCount);
         if (!ctx.Memory.TryRead(descriptor.Address, source) &&
             !KernelMemoryCompatExports.TryReadTrackedLibcHeapGpuAlias(
                 descriptor.Address,
@@ -4519,25 +4520,29 @@ public static class AgcExports
 
         TraceTextureHash(descriptor, source);
 
-        var nonZero = 0;
-        for (var i = 0; i < source.Length; i++)
+        if (_traceAgcShader)
         {
-            if (source[i] != 0)
+            var nonZero = 0;
+            for (var i = 0; i < source.Length; i++)
             {
-                nonZero++;
-                if (nonZero >= 64)
+                if (source[i] != 0)
                 {
-                    break;
+                    nonZero++;
+                    if (nonZero >= 64)
+                    {
+                        break;
+                    }
                 }
             }
+
+            TraceAgcShader(
+                $"agc.texture_source addr=0x{descriptor.Address:X16} " +
+                $"fmt={descriptor.Format} num={descriptor.NumberType} tile={descriptor.TileMode} " +
+                $"size={descriptor.Width}x{descriptor.Height} pitch={descriptor.Pitch} " +
+                $"dst=0x{descriptor.DstSelect:X3} " +
+                $"bytes={source.Length} nonzero64={nonZero}");
         }
 
-        TraceAgcShader(
-            $"agc.texture_source addr=0x{descriptor.Address:X16} " +
-            $"fmt={descriptor.Format} num={descriptor.NumberType} tile={descriptor.TileMode} " +
-            $"size={descriptor.Width}x{descriptor.Height} pitch={descriptor.Pitch} " +
-            $"dst=0x{descriptor.DstSelect:X3} " +
-            $"bytes={source.Length} nonzero64={nonZero}");
         DumpTextureSourceIfRequested(descriptor, sourceWidth, source);
 
         var rgba = source;
@@ -5786,7 +5791,7 @@ public static class AgcExports
             return false;
         }
 
-        var sourceBytes = new byte[(int)sourceByteCount];
+        var sourceBytes = GC.AllocateUninitializedArray<byte>((int)sourceByteCount);
         if (!ctx.Memory.TryRead(source.Address, sourceBytes))
         {
             return false;
@@ -5815,28 +5820,30 @@ public static class AgcExports
         var rgbaDestination = destination.PixelFormat is
             VideoOutPixelFormatA8B8G8R8Srgb or
             VideoOutPixelFormatR8G8B8A8Unorm;
+        var sourcePixels = MemoryMarshal.Cast<byte, uint>(sourceBytes);
         for (uint y = 0; y < destination.Height; y++)
         {
             var sourceY = (uint)(((ulong)y * source.Height) / destination.Height);
-            for (uint x = 0; x < destination.Width; x++)
+            var sourceRow = sourcePixels.Slice(
+                checked((int)(sourceY * source.Width)),
+                (int)source.Width);
+            var rowPixels = MemoryMarshal.Cast<byte, uint>(
+                destinationRow.AsSpan(0, checked((int)destination.Width * 4)));
+            if (rgbaDestination && source.Width == destination.Width)
             {
-                var sourceX = (uint)(((ulong)x * source.Width) / destination.Width);
-                var sourceOffset = checked((int)(((ulong)sourceY * source.Width + sourceX) * 4));
-                var destinationOffset = checked((int)x * 4);
-                if (rgbaDestination)
+                sourceRow.CopyTo(rowPixels);
+            }
+            else
+            {
+                for (uint x = 0; x < destination.Width; x++)
                 {
-                    destinationRow[destinationOffset + 0] = sourceBytes[sourceOffset + 0];
-                    destinationRow[destinationOffset + 1] = sourceBytes[sourceOffset + 1];
-                    destinationRow[destinationOffset + 2] = sourceBytes[sourceOffset + 2];
+                    var value = sourceRow[(int)(((ulong)x * source.Width) / destination.Width)];
+                    rowPixels[(int)x] = rgbaDestination
+                        ? value
+                        : (value & 0xFF00FF00u) |
+                          ((value & 0x00FF0000u) >> 16) |
+                          ((value & 0x000000FFu) << 16);
                 }
-                else
-                {
-                    destinationRow[destinationOffset + 0] = sourceBytes[sourceOffset + 2];
-                    destinationRow[destinationOffset + 1] = sourceBytes[sourceOffset + 1];
-                    destinationRow[destinationOffset + 2] = sourceBytes[sourceOffset + 0];
-                }
-
-                destinationRow[destinationOffset + 3] = sourceBytes[sourceOffset + 3];
             }
 
             var destinationAddress = destination.Address + ((ulong)y * destinationPitch * 4);
@@ -5862,13 +5869,32 @@ public static class AgcExports
     {
         const ulong fnvOffsetBasis = 14695981039346656037UL;
         const ulong fnvPrime = 1099511628211UL;
-        var fingerprint = fnvOffsetBasis;
-        foreach (var value in bytes)
+        var h0 = fnvOffsetBasis ^ (ulong)bytes.Length;
+        var h1 = fnvOffsetBasis;
+        var h2 = fnvOffsetBasis;
+        var h3 = fnvOffsetBasis;
+        var words = MemoryMarshal.Cast<byte, ulong>(bytes);
+        var index = 0;
+        var blockEnd = words.Length - (words.Length & 3);
+        for (; index < blockEnd; index += 4)
         {
-            fingerprint = (fingerprint ^ value) * fnvPrime;
+            h0 = (h0 ^ words[index]) * fnvPrime;
+            h1 = (h1 ^ words[index + 1]) * fnvPrime;
+            h2 = (h2 ^ words[index + 2]) * fnvPrime;
+            h3 = (h3 ^ words[index + 3]) * fnvPrime;
         }
 
-        return fingerprint;
+        for (; index < words.Length; index++)
+        {
+            h0 = (h0 ^ words[index]) * fnvPrime;
+        }
+
+        foreach (var value in bytes[(words.Length * 8)..])
+        {
+            h0 = (h0 ^ value) * fnvPrime;
+        }
+
+        return (((h0 * fnvPrime + h1) * fnvPrime + h2) * fnvPrime) + h3;
     }
 
     private static void TraceSubmittedPacket(

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -195,6 +195,18 @@ public static class AgcExports
     private static long _standardDmaTraceCount;
     private static readonly object _softwarePresenterGate = new();
     private static readonly Dictionary<(ulong Source, ulong Destination), ulong> _softwarePresenterFingerprints = new();
+    private static readonly object _textureSourceGate = new();
+    private static readonly Dictionary<(ulong Address, int ByteCount), CachedTextureSource> _textureSourceCache = new();
+    private static byte[] _textureSourceScratch = [];
+    private static long _textureSourceCacheBytes;
+    private const long MaxTextureSourceCacheBytes = 512L * 1024 * 1024;
+
+    private sealed class CachedTextureSource
+    {
+        public byte[] Pixels = [];
+        public ulong Fingerprint;
+        public long LastUseSequence;
+    }
     private static readonly Dictionary<(ulong Shader, ulong Source, ulong Destination), ulong> _softwareComputeBlitFingerprints = new();
     private static readonly object _registerDefaultsGate = new();
     private static readonly ConditionalWeakTable<object, RegisterDefaultsAllocation> _registerDefaultsAllocations = new();
@@ -4498,17 +4510,11 @@ public static class AgcExports
         if (isStorage)
         {
             var initialPixels = Array.Empty<byte>();
-            if (descriptor.Address != 0)
+            if (descriptor.Address != 0 &&
+                TryReadGuestTextureSource(ctx, descriptor.Address, (int)sourceByteCount, out var storageSource) &&
+                storageSource.AsSpan().IndexOfAnyExcept((byte)0) >= 0)
             {
-                var storageSource = GC.AllocateUninitializedArray<byte>((int)sourceByteCount);
-                if ((ctx.Memory.TryRead(descriptor.Address, storageSource) ||
-                     KernelMemoryCompatExports.TryReadTrackedLibcHeapGpuAlias(
-                         descriptor.Address,
-                         storageSource)) &&
-                    storageSource.AsSpan().IndexOfAnyExcept((byte)0) >= 0)
-                {
-                    initialPixels = storageSource;
-                }
+                initialPixels = storageSource;
             }
 
             texture = new GuestDrawTexture(
@@ -4529,11 +4535,7 @@ public static class AgcExports
             return true;
         }
 
-        var source = GC.AllocateUninitializedArray<byte>((int)sourceByteCount);
-        if (!ctx.Memory.TryRead(descriptor.Address, source) &&
-            !KernelMemoryCompatExports.TryReadTrackedLibcHeapGpuAlias(
-                descriptor.Address,
-                source))
+        if (!TryReadGuestTextureSource(ctx, descriptor.Address, (int)sourceByteCount, out var source))
         {
             TraceTextureFallback(
                 descriptor,
@@ -4591,6 +4593,74 @@ public static class AgcExports
             DstSelect: descriptor.DstSelect,
             Sampler: ToGuestSampler(samplerDescriptor));
         return true;
+    }
+
+    private static bool TryReadGuestTextureSource(
+        CpuContext ctx,
+        ulong address,
+        int byteCount,
+        out byte[] source)
+    {
+        lock (_textureSourceGate)
+        {
+            if (_textureSourceScratch.Length < byteCount)
+            {
+                _textureSourceScratch = GC.AllocateUninitializedArray<byte>(byteCount);
+            }
+
+            var scratch = _textureSourceScratch.AsSpan(0, byteCount);
+            if (!ctx.Memory.TryRead(address, scratch) &&
+                !KernelMemoryCompatExports.TryReadTrackedLibcHeapGpuAlias(address, scratch))
+            {
+                source = [];
+                return false;
+            }
+
+            var fingerprint = ComputeFingerprint(scratch);
+            var key = (address, byteCount);
+            if (_textureSourceCache.TryGetValue(key, out var cached))
+            {
+                if (cached.Fingerprint == fingerprint)
+                {
+                    cached.LastUseSequence =
+                        VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1;
+                    source = cached.Pixels;
+                    return true;
+                }
+
+                if (VulkanVideoPresenter.CompletedGuestWorkSequence >= cached.LastUseSequence)
+                {
+                    scratch.CopyTo(cached.Pixels);
+                    cached.Fingerprint = fingerprint;
+                    cached.LastUseSequence =
+                        VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1;
+                    source = cached.Pixels;
+                    return true;
+                }
+            }
+
+            source = GC.AllocateUninitializedArray<byte>(byteCount);
+            scratch.CopyTo(source);
+            if (_textureSourceCache.Remove(key, out var evicted))
+            {
+                _textureSourceCacheBytes -= evicted.Pixels.Length;
+            }
+
+            if (_textureSourceCacheBytes + byteCount > MaxTextureSourceCacheBytes)
+            {
+                _textureSourceCache.Clear();
+                _textureSourceCacheBytes = 0;
+            }
+
+            _textureSourceCache[key] = new CachedTextureSource
+            {
+                Pixels = source,
+                Fingerprint = fingerprint,
+                LastUseSequence = VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1,
+            };
+            _textureSourceCacheBytes += byteCount;
+            return true;
+        }
     }
 
     private static int _textureFallbackTraceCount;

--- a/src/SharpEmu.Libs/Agc/AgcShaderCompilerHooks.cs
+++ b/src/SharpEmu.Libs/Agc/AgcShaderCompilerHooks.cs
@@ -26,5 +26,6 @@ internal static class AgcShaderCompilerHooks
     {
         Gen5ShaderScalarEvaluator.FallbackMemoryReader =
             KernelMemoryCompatExports.TryReadTrackedLibcHeap;
+        Gen5ShaderScalarEvaluator.CompletedGuestWorkSequence = 0;
     }
 }

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -11,6 +11,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace SharpEmu.Libs.VideoOut;
@@ -804,13 +805,16 @@ public static class VideoOutExports
             return;
         }
 
-        var bgraFrame = new byte[rgbaFrame.Length];
-        for (var offset = 0; offset < rgbaFrame.Length; offset += 4)
+        var bgraFrame = GC.AllocateUninitializedArray<byte>(rgbaFrame.Length);
+        var source = MemoryMarshal.Cast<byte, uint>(rgbaFrame);
+        var destination = MemoryMarshal.Cast<byte, uint>(bgraFrame.AsSpan());
+        for (var index = 0; index < source.Length; index++)
         {
-            bgraFrame[offset + 0] = rgbaFrame[offset + 2];
-            bgraFrame[offset + 1] = rgbaFrame[offset + 1];
-            bgraFrame[offset + 2] = rgbaFrame[offset + 0];
-            bgraFrame[offset + 3] = rgbaFrame[offset + 3];
+            var value = source[index];
+            destination[index] =
+                (value & 0xFF00FF00u) |
+                ((value & 0x00FF0000u) >> 16) |
+                ((value & 0x000000FFu) << 16);
         }
 
         GuestGpu.Current.Submit(bgraFrame, width, height);
@@ -1553,13 +1557,32 @@ public static class VideoOutExports
     {
         const ulong fnvOffsetBasis = 14695981039346656037UL;
         const ulong fnvPrime = 1099511628211UL;
-        var fingerprint = fnvOffsetBasis;
-        foreach (var value in bytes)
+        var h0 = fnvOffsetBasis ^ (ulong)bytes.Length;
+        var h1 = fnvOffsetBasis;
+        var h2 = fnvOffsetBasis;
+        var h3 = fnvOffsetBasis;
+        var words = MemoryMarshal.Cast<byte, ulong>(bytes);
+        var index = 0;
+        var blockEnd = words.Length - (words.Length & 3);
+        for (; index < blockEnd; index += 4)
         {
-            fingerprint = (fingerprint ^ value) * fnvPrime;
+            h0 = (h0 ^ words[index]) * fnvPrime;
+            h1 = (h1 ^ words[index + 1]) * fnvPrime;
+            h2 = (h2 ^ words[index + 2]) * fnvPrime;
+            h3 = (h3 ^ words[index + 3]) * fnvPrime;
         }
 
-        return fingerprint;
+        for (; index < words.Length; index++)
+        {
+            h0 = (h0 ^ words[index]) * fnvPrime;
+        }
+
+        foreach (var value in bytes[(words.Length * 8)..])
+        {
+            h0 = (h0 ^ value) * fnvPrime;
+        }
+
+        return (((h0 * fnvPrime + h1) * fnvPrime + h2) * fnvPrime) + h3;
     }
 
     private static uint GetBytesPerPixel(ulong pixelFormat) =>

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -1201,6 +1201,11 @@ public static class VideoOutExports
             }
         }
 
+        if (PerfLog.Enabled)
+        {
+            Interlocked.Increment(ref PerfLog.FlipsSubmitted);
+        }
+
         var guestImageSubmitted = false;
         ulong guestImageAddress = 0;
         if (submitGpuImage &&

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1117,6 +1117,13 @@ internal static unsafe class VulkanVideoPresenter
                 latest.Sequence == presentedSequence ||
                 latest.RequiredGuestWorkSequence > _completedGuestWorkSequence)
             {
+                if (PerfLog.Enabled &&
+                    _latestPresentation is { } pending &&
+                    pending.Sequence != presentedSequence)
+                {
+                    Interlocked.Increment(ref PerfLog.PresentSkipsNotReady);
+                }
+
                 presentation = default;
                 return false;
             }
@@ -6023,6 +6030,16 @@ internal static unsafe class VulkanVideoPresenter
         [return: MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
         private static extern bool CloseHandle(nint handle);
 
+        private bool HasReadyPresentation()
+        {
+            lock (_gate)
+            {
+                return _latestPresentation is { } latest &&
+                       latest.Sequence != _presentedSequence &&
+                       latest.RequiredGuestWorkSequence <= _completedGuestWorkSequence;
+            }
+        }
+
         private void WaitForRenderWork()
         {
             var gpuWorkInFlight = _pendingGuestSubmissions.Count > 0 || _presentationInFlight;
@@ -6065,6 +6082,7 @@ internal static unsafe class VulkanVideoPresenter
 
             var completedWork = 0;
             while (completedWork < MaxGuestWorkPerRender &&
+                   !HasReadyPresentation() &&
                    TryTakeGuestWork(out var work))
             {
                 try

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1286,6 +1286,10 @@ internal static unsafe class VulkanVideoPresenter
             _descriptorPoolPool = new();
         private readonly Dictionary<ulong, HostBufferAllocation> _hostBufferAllocations = new();
         private readonly Queue<PendingGuestSubmission> _pendingGuestSubmissions = new();
+        private CommandBuffer _batchCommandBuffer;
+        private readonly List<TranslatedDrawResources> _batchResources = new();
+        private readonly HashSet<GuestImageResource> _batchTraceImages = new();
+        private const int MaxDrawsPerBatch = 32;
 
         private readonly record struct GraphicsPipelineKey(
             string VertexShader,
@@ -1410,7 +1414,7 @@ internal static unsafe class VulkanVideoPresenter
         private sealed record PendingGuestSubmission(
             Fence Fence,
             CommandBuffer CommandBuffer,
-            TranslatedDrawResources Resources,
+            IReadOnlyList<TranslatedDrawResources> Resources,
             IReadOnlyList<GuestImageResource> TraceImages,
             string DebugName);
 
@@ -2432,8 +2436,9 @@ internal static unsafe class VulkanVideoPresenter
 
         private void SubmitGuestCommandBuffer(
             CommandBuffer commandBuffer,
-            TranslatedDrawResources resources,
-            IReadOnlyList<GuestImageResource> traceImages)
+            IReadOnlyList<TranslatedDrawResources> resources,
+            IReadOnlyList<GuestImageResource> traceImages,
+            string debugName)
         {
             var fenceInfo = new FenceCreateInfo
             {
@@ -2467,7 +2472,63 @@ internal static unsafe class VulkanVideoPresenter
                     commandBuffer,
                     resources,
                     traceImages,
-                    resources.DebugName));
+                    debugName));
+        }
+
+        private void EnsureGuestBatch()
+        {
+            if (_batchCommandBuffer.Handle != 0)
+            {
+                _commandBuffer = _batchCommandBuffer;
+                return;
+            }
+
+            EnsureGuestSubmissionCapacity();
+            _batchCommandBuffer = AllocateGuestCommandBuffer();
+            _commandBuffer = _batchCommandBuffer;
+            var beginInfo = new CommandBufferBeginInfo
+            {
+                SType = StructureType.CommandBufferBeginInfo,
+                Flags = CommandBufferUsageFlags.OneTimeSubmitBit,
+            };
+            Check(
+                _vk.BeginCommandBuffer(_commandBuffer, &beginInfo),
+                "vkBeginCommandBuffer(batch)");
+        }
+
+        private void FlushGuestBatch()
+        {
+            if (_batchCommandBuffer.Handle == 0)
+            {
+                return;
+            }
+
+            var commandBuffer = _batchCommandBuffer;
+            var resources = _batchResources.ToArray();
+            var traceImages = _batchTraceImages.ToArray();
+            var debugName = resources.Length == 1
+                ? resources[0].DebugName
+                : $"SharpEmu batch x{resources.Length}";
+            _batchCommandBuffer = default;
+            _batchResources.Clear();
+            _batchTraceImages.Clear();
+            _commandBuffer = _presentationCommandBuffer;
+
+            try
+            {
+                Check(_vk.EndCommandBuffer(commandBuffer), "vkEndCommandBuffer(batch)");
+                SubmitGuestCommandBuffer(commandBuffer, resources, traceImages, debugName);
+            }
+            catch
+            {
+                foreach (var resource in resources)
+                {
+                    DestroyTranslatedDrawResources(resource);
+                }
+
+                _vk.FreeCommandBuffers(_device, _commandPool, 1, &commandBuffer);
+                throw;
+            }
         }
 
         private void SubmitGuestCommandBufferAndWait(CommandBuffer commandBuffer)
@@ -2514,6 +2575,7 @@ internal static unsafe class VulkanVideoPresenter
 
         private void WaitForAllGuestSubmissions()
         {
+            FlushGuestBatch();
             while (_pendingGuestSubmissions.Count != 0)
             {
                 CollectCompletedGuestSubmissions(waitForOldest: true);
@@ -2550,7 +2612,11 @@ internal static unsafe class VulkanVideoPresenter
                     TraceGuestImageContents(image);
                 }
 
-                DestroyTranslatedDrawResources(submission.Resources);
+                foreach (var resources in submission.Resources)
+                {
+                    DestroyTranslatedDrawResources(resources);
+                }
+
                 var commandBuffer = submission.CommandBuffer;
                 _vk.FreeCommandBuffers(
                     _device,
@@ -4987,8 +5053,9 @@ internal static unsafe class VulkanVideoPresenter
                     {
                         SubmitGuestCommandBuffer(
                             commandBuffer,
-                            resources,
-                            GetTraceImages(resources));
+                            [resources],
+                            GetTraceImages(resources),
+                            resources.DebugName);
                         submitted = true;
                     }
                     else
@@ -5145,7 +5212,6 @@ internal static unsafe class VulkanVideoPresenter
             }
 
             var targets = new GuestImageResource[work.Targets.Count];
-            EnsureGuestSubmissionCapacity();
             for (var index = 0; index < targets.Length; index++)
             {
                 targets[index] = GetOrCreateGuestImage(work.Targets[index], formats[index]);
@@ -5153,12 +5219,17 @@ internal static unsafe class VulkanVideoPresenter
 
             var firstTarget = targets[0];
             TranslatedDrawResources? resources = null;
-            CommandBuffer commandBuffer = default;
-            var submitted = false;
+            var recorded = false;
             RenderPass transientRenderPass = default;
             Framebuffer transientFramebuffer = default;
             try
             {
+                if (_batchResources.Count >= MaxDrawsPerBatch)
+                {
+                    FlushGuestBatch();
+                }
+
+                EnsureGuestBatch();
                 var extent = new Extent2D(firstTarget.Width, firstTarget.Height);
                 var renderPass = firstTarget.RenderPass;
                 var framebuffer = firstTarget.Framebuffer;
@@ -5186,17 +5257,6 @@ internal static unsafe class VulkanVideoPresenter
                     $"SharpEmu offscreen mrt={targets.Length} " +
                     $"first=0x{work.Targets[0].Address:X16} " +
                     $"{firstTarget.Width}x{firstTarget.Height}";
-
-                commandBuffer = AllocateGuestCommandBuffer();
-                _commandBuffer = commandBuffer;
-                var beginInfo = new CommandBufferBeginInfo
-                {
-                    SType = StructureType.CommandBufferBeginInfo,
-                    Flags = CommandBufferUsageFlags.OneTimeSubmitBit,
-                };
-                Check(
-                    _vk.BeginCommandBuffer(_commandBuffer, &beginInfo),
-                    "vkBeginCommandBuffer(offscreen)");
 
                 BeginDebugLabel(_commandBuffer, resources.DebugName);
                 RecordTextureUploads(resources, PipelineStageFlags.FragmentShaderBit);
@@ -5273,12 +5333,13 @@ internal static unsafe class VulkanVideoPresenter
                     toShaderRead);
                 EndDebugLabel(_commandBuffer);
 
-                Check(_vk.EndCommandBuffer(_commandBuffer), "vkEndCommandBuffer(offscreen)");
-                SubmitGuestCommandBuffer(
-                    commandBuffer,
-                    resources,
-                    GetTraceImages(resources, targets));
-                submitted = true;
+                _batchResources.Add(resources);
+                foreach (var image in GetTraceImages(resources, targets))
+                {
+                    _batchTraceImages.Add(image);
+                }
+
+                recorded = true;
                 foreach (var target in targets)
                 {
                     target.Initialized = true;
@@ -5320,7 +5381,7 @@ internal static unsafe class VulkanVideoPresenter
                         _tracedGuestWriteCounts[target.Address] = writeCount;
                         if (writeCount <= (traceSmallWrites ? 48 : 3))
                         {
-                            _commandBuffer = _presentationCommandBuffer;
+                            FlushGuestBatch();
                             Check(
                                 _vk.QueueWaitIdle(_queue),
                                 "vkQueueWaitIdle(guest write trace)");
@@ -5363,17 +5424,7 @@ internal static unsafe class VulkanVideoPresenter
             }
             finally
             {
-                _commandBuffer = _presentationCommandBuffer;
-                if (!submitted && commandBuffer.Handle != 0)
-                {
-                    _vk.FreeCommandBuffers(
-                        _device,
-                        _commandPool,
-                        1,
-                        &commandBuffer);
-                }
-
-                if (!submitted && resources is not null)
+                if (!recorded && resources is not null)
                 {
                     DestroyTranslatedDrawResources(resources);
                 }
@@ -6093,6 +6144,7 @@ internal static unsafe class VulkanVideoPresenter
                             ExecuteOffscreenDraw(offscreenDraw);
                             break;
                         case VulkanComputeGuestDispatch computeDispatch:
+                            FlushGuestBatch();
                             ExecuteComputeDispatch(computeDispatch);
                             if (PerfLog.Enabled)
                             {
@@ -6113,6 +6165,8 @@ internal static unsafe class VulkanVideoPresenter
 
                 completedWork++;
             }
+
+            FlushGuestBatch();
 
             if (!TryTakePresentation(_presentedSequence, out var presentation))
             {
@@ -7662,6 +7716,7 @@ internal static unsafe class VulkanVideoPresenter
                 _debugUtils.DestroyDebugUtilsMessenger(_instance, _debugMessenger, null);
             }
             _vulkanReady = false;
+            FlushGuestBatch();
             _vk.DeviceWaitIdle(_device);
             CompletePendingPresentation(wait: false);
             CollectCompletedGuestSubmissions(waitForOldest: false);

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1268,6 +1268,8 @@ internal static unsafe class VulkanVideoPresenter
             _descriptorLayouts = new();
         private readonly Dictionary<HostBufferPoolKey, Stack<HostBufferAllocation>>
             _hostBufferPool = new();
+        private readonly Dictionary<DescriptorPoolKey, Stack<DescriptorPool>>
+            _descriptorPoolPool = new();
         private readonly Dictionary<ulong, HostBufferAllocation> _hostBufferAllocations = new();
         private readonly Queue<PendingGuestSubmission> _pendingGuestSubmissions = new();
 
@@ -1283,6 +1285,11 @@ internal static unsafe class VulkanVideoPresenter
         private readonly record struct HostBufferPoolKey(
             BufferUsageFlags Usage,
             ulong Capacity);
+
+        private readonly record struct DescriptorPoolKey(
+            int SampledImages,
+            int StorageImages,
+            int StorageBuffers);
 
         private readonly record struct DescriptorLayoutKey(
             ShaderStageFlags Stages,
@@ -1306,6 +1313,7 @@ internal static unsafe class VulkanVideoPresenter
             public bool DescriptorLayoutCached;
             public DescriptorSetLayout DescriptorSetLayout;
             public DescriptorPool DescriptorPool;
+            public DescriptorPoolKey? DescriptorPoolRecycleKey;
             public DescriptorSet DescriptorSet;
             public TextureResource[] Textures = [];
             public GlobalBufferResource[] GlobalMemoryBuffers = [];
@@ -3034,25 +3042,42 @@ internal static unsafe class VulkanVideoPresenter
                 };
             }
 
-            fixed (DescriptorPoolSize* poolSizePointer = poolSizes)
+            var poolKey = new DescriptorPoolKey(
+                sampledImageCount,
+                storageImageCount,
+                globalBufferCount);
+            if (_descriptorPoolPool.TryGetValue(poolKey, out var availablePools) &&
+                availablePools.TryPop(out var recycledPool))
             {
-                var poolInfo = new DescriptorPoolCreateInfo
-                {
-                    SType = StructureType.DescriptorPoolCreateInfo,
-                    MaxSets = 1,
-                    PoolSizeCount = (uint)poolSizes.Length,
-                    PPoolSizes = poolSizePointer,
-                };
-                DescriptorPool descriptorPool;
                 Check(
-                    _vk.CreateDescriptorPool(
-                        _device,
-                        &poolInfo,
-                        null,
-                        out descriptorPool),
-                    "vkCreateDescriptorPool");
-                resources.DescriptorPool = descriptorPool;
+                    _vk.ResetDescriptorPool(_device, recycledPool, 0),
+                    "vkResetDescriptorPool");
+                resources.DescriptorPool = recycledPool;
             }
+            else
+            {
+                fixed (DescriptorPoolSize* poolSizePointer = poolSizes)
+                {
+                    var poolInfo = new DescriptorPoolCreateInfo
+                    {
+                        SType = StructureType.DescriptorPoolCreateInfo,
+                        MaxSets = 1,
+                        PoolSizeCount = (uint)poolSizes.Length,
+                        PPoolSizes = poolSizePointer,
+                    };
+                    DescriptorPool descriptorPool;
+                    Check(
+                        _vk.CreateDescriptorPool(
+                            _device,
+                            &poolInfo,
+                            null,
+                            out descriptorPool),
+                        "vkCreateDescriptorPool");
+                    resources.DescriptorPool = descriptorPool;
+                }
+            }
+
+            resources.DescriptorPoolRecycleKey = poolKey;
 
             var allocateInfo = new DescriptorSetAllocateInfo
             {
@@ -3718,33 +3743,10 @@ internal static unsafe class VulkanVideoPresenter
                 if ((ulong)texture.RgbaPixels.Length == expectedSize &&
                     texture.RgbaPixels.AsSpan().IndexOfAnyExcept((byte)0) >= 0)
                 {
-                    resource.StagingBuffer = CreateBuffer(
-                        expectedSize,
+                    resource.StagingBuffer = CreateHostBuffer(
+                        texture.RgbaPixels,
                         BufferUsageFlags.TransferSrcBit,
-                        MemoryPropertyFlags.HostVisibleBit |
-                        MemoryPropertyFlags.HostCoherentBit,
                         out resource.StagingMemory);
-
-                    void* mapped;
-                    Check(
-                        _vk.MapMemory(
-                            _device,
-                            resource.StagingMemory,
-                            0,
-                            expectedSize,
-                            0,
-                            &mapped),
-                        "vkMapMemory(storage texture)");
-                    fixed (byte* source = texture.RgbaPixels)
-                    {
-                        System.Buffer.MemoryCopy(
-                            source,
-                            mapped,
-                            texture.RgbaPixels.Length,
-                            texture.RgbaPixels.Length);
-                    }
-
-                    _vk.UnmapMemory(_device, resource.StagingMemory);
                     resource.NeedsUpload = true;
                     guestImage.InitialUploadPending = true;
                     TraceVulkanShader(
@@ -4013,19 +4015,10 @@ internal static unsafe class VulkanVideoPresenter
             byte[] pixels,
             string debugName)
         {
-            var size = (ulong)pixels.Length;
-            var buffer = CreateBuffer(
-                size,
+            var buffer = CreateHostBuffer(
+                pixels,
                 BufferUsageFlags.TransferSrcBit,
-                MemoryPropertyFlags.HostVisibleBit | MemoryPropertyFlags.HostCoherentBit,
                 out var memory);
-            void* mapped;
-            Check(_vk.MapMemory(_device, memory, 0, size, 0, &mapped), "vkMapMemory(texture)");
-            fixed (byte* source = pixels)
-            {
-                System.Buffer.MemoryCopy(source, mapped, pixels.Length, pixels.Length);
-            }
-            _vk.UnmapMemory(_device, memory);
             SetDebugName(ObjectType.Buffer, buffer.Handle, debugName);
             return (buffer, memory);
         }
@@ -7093,15 +7086,7 @@ internal static unsafe class VulkanVideoPresenter
                     _vk.FreeMemory(_device, texture.ImageMemory, null);
                 }
 
-                if (texture.StagingBuffer.Handle != 0)
-                {
-                    _vk.DestroyBuffer(_device, texture.StagingBuffer, null);
-                }
-
-                if (texture.StagingMemory.Handle != 0)
-                {
-                    _vk.FreeMemory(_device, texture.StagingMemory, null);
-                }
+                RecycleHostBuffer(texture.StagingBuffer, texture.StagingMemory);
 
                 if (texture.NeedsUpload &&
                     texture.GuestImage is { Initialized: false } guestImage)
@@ -7139,7 +7124,22 @@ internal static unsafe class VulkanVideoPresenter
 
             if (resources.DescriptorPool.Handle != 0)
             {
-                _vk.DestroyDescriptorPool(_device, resources.DescriptorPool, null);
+                if (resources.DescriptorPoolRecycleKey is { } poolKey)
+                {
+                    if (!_descriptorPoolPool.TryGetValue(poolKey, out var availablePools))
+                    {
+                        availablePools = new Stack<DescriptorPool>();
+                        _descriptorPoolPool.Add(poolKey, availablePools);
+                    }
+
+                    availablePools.Push(resources.DescriptorPool);
+                    resources.DescriptorPool = default;
+                    resources.DescriptorPoolRecycleKey = null;
+                }
+                else
+                {
+                    _vk.DestroyDescriptorPool(_device, resources.DescriptorPool, null);
+                }
             }
 
             if (!resources.DescriptorLayoutCached &&
@@ -7567,18 +7567,34 @@ internal static unsafe class VulkanVideoPresenter
                 LayerCount = 1,
             };
 
-        private static byte[] ScaleBgra(byte[] source, uint sourceWidth, uint sourceHeight, uint width, uint height)
+        private byte[]? _scaleBuffer;
+
+        private byte[] ScaleBgra(byte[] source, uint sourceWidth, uint sourceHeight, uint width, uint height)
         {
-            var destination = new byte[checked((int)(width * height * 4))];
+            var byteCount = checked((int)(width * height * 4));
+            if (_scaleBuffer is null || _scaleBuffer.Length != byteCount)
+            {
+                _scaleBuffer = GC.AllocateUninitializedArray<byte>(byteCount);
+            }
+
+            var destination = _scaleBuffer;
+            var sourcePixels = MemoryMarshal.Cast<byte, uint>(source);
+            var destinationPixels = MemoryMarshal.Cast<byte, uint>(destination.AsSpan());
             for (uint y = 0; y < height; y++)
             {
-                var sourceY = (uint)(((ulong)y * sourceHeight) / height);
+                var sourceRow = sourcePixels.Slice(
+                    checked((int)((((ulong)y * sourceHeight) / height) * sourceWidth)),
+                    (int)sourceWidth);
+                var destinationRow = destinationPixels.Slice((int)(y * width), (int)width);
+                if (sourceWidth == width)
+                {
+                    sourceRow.CopyTo(destinationRow);
+                    continue;
+                }
+
                 for (uint x = 0; x < width; x++)
                 {
-                    var sourceX = (uint)(((ulong)x * sourceWidth) / width);
-                    var sourceOffset = checked((int)(((ulong)sourceY * sourceWidth + sourceX) * 4));
-                    var destinationOffset = checked((int)(((ulong)y * width + x) * 4));
-                    source.AsSpan(sourceOffset, 4).CopyTo(destination.AsSpan(destinationOffset, 4));
+                    destinationRow[(int)x] = sourceRow[(int)(((ulong)x * sourceWidth) / width)];
                 }
             }
 
@@ -7641,6 +7657,14 @@ internal static unsafe class VulkanVideoPresenter
             }
             _hostBufferAllocations.Clear();
             _hostBufferPool.Clear();
+            foreach (var pools in _descriptorPoolPool.Values)
+            {
+                while (pools.TryPop(out var pool))
+                {
+                    _vk.DestroyDescriptorPool(_device, pool, null);
+                }
+            }
+            _descriptorPoolPool.Clear();
             foreach (var guestImage in _guestImages.Values)
             {
                 DestroyGuestImage(guestImage);

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -6,6 +6,7 @@ using Silk.NET.Core.Native;
 using Silk.NET.Maths;
 using SharpEmu.HLE;
 using SharpEmu.Libs.Agc;
+using SharpEmu.Logging;
 using Silk.NET.Input;
 using SharpEmu.Libs.Gpu;
 using SharpEmu.ShaderCompiler;
@@ -2371,9 +2372,16 @@ internal static unsafe class VulkanVideoPresenter
             }
 
             var fence = _presentationFence;
+            var waitStart = wait && PerfLog.Enabled ? Stopwatch.GetTimestamp() : 0L;
             var result = wait
                 ? _vk.WaitForFences(_device, 1, &fence, true, ulong.MaxValue)
                 : _vk.GetFenceStatus(_device, fence);
+            if (waitStart != 0)
+            {
+                Interlocked.Add(
+                    ref PerfLog.PresentFenceWaitTicks,
+                    Stopwatch.GetTimestamp() - waitStart);
+            }
             if (!wait && result == Result.NotReady)
             {
                 return;
@@ -3351,6 +3359,10 @@ internal static unsafe class VulkanVideoPresenter
                     resources.Pipeline = pipeline;
                     resources.PipelineCached = true;
                     _graphicsPipelines.Add(pipelineKey, pipeline);
+                    if (PerfLog.Enabled)
+                    {
+                        Interlocked.Increment(ref PerfLog.PipelinesCreated);
+                    }
                     SetDebugName(
                         ObjectType.Pipeline,
                         pipeline.Handle,
@@ -6058,12 +6070,21 @@ internal static unsafe class VulkanVideoPresenter
                             break;
                         case VulkanComputeGuestDispatch computeDispatch:
                             ExecuteComputeDispatch(computeDispatch);
+                            if (PerfLog.Enabled)
+                            {
+                                Interlocked.Increment(ref PerfLog.ComputeDispatches);
+                            }
+
                             break;
                     }
                 }
                 finally
                 {
                     CompleteGuestWork();
+                    if (PerfLog.Enabled)
+                    {
+                        Interlocked.Increment(ref PerfLog.GuestWorkExecuted);
+                    }
                 }
 
                 completedWork++;
@@ -6304,6 +6325,10 @@ internal static unsafe class VulkanVideoPresenter
             recreateAfterPresent |= presentResult == Result.SuboptimalKhr;
             VideoOutExports.ReportPresentedFrame();
             _performanceHudPresentedFrames++;
+            if (PerfLog.Enabled)
+            {
+                Interlocked.Increment(ref PerfLog.FramesPresented);
+            }
             if (_swapchainReadbackPending)
             {
                 CompletePendingPresentation(wait: true);

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1149,6 +1149,7 @@ internal static unsafe class VulkanVideoPresenter
 
         _pendingGuestWork.Enqueue(work);
         _enqueuedGuestWorkSequence++;
+        Gen5ShaderScalarEvaluator.EnqueuedGuestWorkSequence = _enqueuedGuestWorkSequence;
         System.Threading.Monitor.PulseAll(_gate);
     }
 
@@ -1165,6 +1166,7 @@ internal static unsafe class VulkanVideoPresenter
         lock (_gate)
         {
             _completedGuestWorkSequence++;
+            Gen5ShaderScalarEvaluator.CompletedGuestWorkSequence = _completedGuestWorkSequence;
             System.Threading.Monitor.PulseAll(_gate);
         }
     }

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -102,6 +102,12 @@ internal static unsafe class VulkanVideoPresenter
     private static long _enqueuedGuestWorkSequence;
     private static long _completedGuestWorkSequence;
 
+    internal static long EnqueuedGuestWorkSequence =>
+        Interlocked.Read(ref _enqueuedGuestWorkSequence);
+
+    internal static long CompletedGuestWorkSequence =>
+        Interlocked.Read(ref _completedGuestWorkSequence);
+
     private static bool ShouldTracePresentedGuestImageContentsForDiagnostics()
     {
         var mode = Environment.GetEnvironmentVariable("SHARPEMU_TRACE_GUEST_IMAGES");

--- a/src/SharpEmu.Logging/PerfLog.cs
+++ b/src/SharpEmu.Logging/PerfLog.cs
@@ -28,6 +28,12 @@ public static class PerfLog
     public static long GuestTextureBytesRead;
     public static long PresentFenceWaitTicks;
     public static long ShaderEvalTicks;
+    public static long FlipGpuCache;
+    public static long FlipDrawFallback;
+    public static long FlipSoftware;
+    public static long FlipGuestDraw;
+    public static long FlipUnhandled;
+    public static long PresentSkipsNotReady;
 
     private static readonly object Gate = new();
     private static StreamWriter? _writer;
@@ -57,7 +63,9 @@ public static class PerfLog
                 "dispatches_per_s,guest_work_per_s,spirv_hits_per_s,spirv_misses_per_s," +
                 "pipelines_created_total,texture_mb_read_per_s,fence_wait_ms_per_s," +
                 "shader_eval_ms_per_s,gc0_total,gc1_total,gc2_total,managed_mb," +
-                "working_set_mb,cpu_percent");
+                "alloc_mb_per_s,working_set_mb,cpu_percent," +
+                "flip_gpu_cache_per_s,flip_draw_fallback_per_s,flip_software_per_s," +
+                "flip_guest_draw_per_s,flip_unhandled_per_s,present_skips_per_s");
             _writer.Flush();
             _stopRequested = false;
             Enabled = true;
@@ -112,6 +120,13 @@ public static class PerfLog
         var lastTextureBytes = 0L;
         var lastFenceTicks = 0L;
         var lastEvalTicks = 0L;
+        var lastAllocated = 0L;
+        var lastFlipGpuCache = 0L;
+        var lastFlipDrawFallback = 0L;
+        var lastFlipSoftware = 0L;
+        var lastFlipGuestDraw = 0L;
+        var lastFlipUnhandled = 0L;
+        var lastPresentSkips = 0L;
         while (!_stopRequested)
         {
             Thread.Sleep(1000);
@@ -135,6 +150,13 @@ public static class PerfLog
             var textureBytes = Interlocked.Read(ref GuestTextureBytesRead);
             var fenceTicks = Interlocked.Read(ref PresentFenceWaitTicks);
             var evalTicks = Interlocked.Read(ref ShaderEvalTicks);
+            var allocated = GC.GetTotalAllocatedBytes(precise: false);
+            var flipGpuCache = Interlocked.Read(ref FlipGpuCache);
+            var flipDrawFallback = Interlocked.Read(ref FlipDrawFallback);
+            var flipSoftware = Interlocked.Read(ref FlipSoftware);
+            var flipGuestDraw = Interlocked.Read(ref FlipGuestDraw);
+            var flipUnhandled = Interlocked.Read(ref FlipUnhandled);
+            var presentSkips = Interlocked.Read(ref PresentSkipsNotReady);
             var cpuPercent =
                 (cpu - lastCpu).TotalSeconds / intervalSeconds / Environment.ProcessorCount * 100.0;
 
@@ -157,8 +179,15 @@ public static class PerfLog
                 $"{GC.CollectionCount(1)}," +
                 $"{GC.CollectionCount(2)}," +
                 $"{GC.GetTotalMemory(forceFullCollection: false) / (1024.0 * 1024.0):F1}," +
+                $"{(allocated - lastAllocated) / intervalSeconds / (1024.0 * 1024.0):F1}," +
                 $"{process.WorkingSet64 / (1024.0 * 1024.0):F1}," +
-                $"{cpuPercent:F1}");
+                $"{cpuPercent:F1}," +
+                $"{(flipGpuCache - lastFlipGpuCache) / intervalSeconds:F1}," +
+                $"{(flipDrawFallback - lastFlipDrawFallback) / intervalSeconds:F1}," +
+                $"{(flipSoftware - lastFlipSoftware) / intervalSeconds:F1}," +
+                $"{(flipGuestDraw - lastFlipGuestDraw) / intervalSeconds:F1}," +
+                $"{(flipUnhandled - lastFlipUnhandled) / intervalSeconds:F1}," +
+                $"{(presentSkips - lastPresentSkips) / intervalSeconds:F1}");
             lock (Gate)
             {
                 if (_writer is null)
@@ -183,6 +212,13 @@ public static class PerfLog
             lastTextureBytes = textureBytes;
             lastFenceTicks = fenceTicks;
             lastEvalTicks = evalTicks;
+            lastAllocated = allocated;
+            lastFlipGpuCache = flipGpuCache;
+            lastFlipDrawFallback = flipDrawFallback;
+            lastFlipSoftware = flipSoftware;
+            lastFlipGuestDraw = flipGuestDraw;
+            lastFlipUnhandled = flipUnhandled;
+            lastPresentSkips = presentSkips;
         }
     }
 }

--- a/src/SharpEmu.Logging/PerfLog.cs
+++ b/src/SharpEmu.Logging/PerfLog.cs
@@ -1,0 +1,188 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
+namespace SharpEmu.Logging;
+
+/// <summary>
+/// Lightweight performance counters sampled to a CSV file once per second.
+/// Hot paths guard on <see cref="Enabled"/> so the counters cost nothing
+/// when --perf-logs is not passed.
+/// </summary>
+public static class PerfLog
+{
+    public static bool Enabled { get; private set; }
+
+    public static long FramesPresented;
+    public static long FlipsSubmitted;
+    public static long DcbSubmits;
+    public static long DrawsTranslated;
+    public static long ComputeDispatches;
+    public static long GuestWorkExecuted;
+    public static long SpirvCacheHits;
+    public static long SpirvCacheMisses;
+    public static long PipelinesCreated;
+    public static long GuestTextureBytesRead;
+    public static long PresentFenceWaitTicks;
+    public static long ShaderEvalTicks;
+
+    private static readonly object Gate = new();
+    private static StreamWriter? _writer;
+    private static Thread? _sampler;
+    private static bool _stopRequested;
+
+    public static void Start(string path)
+    {
+        lock (Gate)
+        {
+            if (_writer is not null)
+            {
+                return;
+            }
+
+            var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            _writer = new StreamWriter(
+                new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            _writer.WriteLine(
+                "time_s,fps,frames_total,flips_per_s,dcb_submits_per_s,draws_per_s," +
+                "dispatches_per_s,guest_work_per_s,spirv_hits_per_s,spirv_misses_per_s," +
+                "pipelines_created_total,texture_mb_read_per_s,fence_wait_ms_per_s," +
+                "shader_eval_ms_per_s,gc0_total,gc1_total,gc2_total,managed_mb," +
+                "working_set_mb,cpu_percent");
+            _writer.Flush();
+            _stopRequested = false;
+            Enabled = true;
+            _sampler = new Thread(SampleLoop)
+            {
+                IsBackground = true,
+                Name = "SharpEmu PerfLog",
+            };
+            _sampler.Start();
+        }
+    }
+
+    public static void Stop()
+    {
+        Thread? sampler;
+        lock (Gate)
+        {
+            if (_writer is null)
+            {
+                return;
+            }
+
+            Enabled = false;
+            _stopRequested = true;
+            sampler = _sampler;
+            _sampler = null;
+        }
+
+        sampler?.Join(TimeSpan.FromSeconds(3));
+        lock (Gate)
+        {
+            _writer?.Flush();
+            _writer?.Dispose();
+            _writer = null;
+        }
+    }
+
+    private static void SampleLoop()
+    {
+        var process = Process.GetCurrentProcess();
+        var stopwatch = Stopwatch.StartNew();
+        var lastElapsed = TimeSpan.Zero;
+        var lastCpu = process.TotalProcessorTime;
+        var lastFrames = 0L;
+        var lastFlips = 0L;
+        var lastDcb = 0L;
+        var lastDraws = 0L;
+        var lastDispatches = 0L;
+        var lastGuestWork = 0L;
+        var lastSpirvHits = 0L;
+        var lastSpirvMisses = 0L;
+        var lastTextureBytes = 0L;
+        var lastFenceTicks = 0L;
+        var lastEvalTicks = 0L;
+        while (!_stopRequested)
+        {
+            Thread.Sleep(1000);
+            var elapsed = stopwatch.Elapsed;
+            var intervalSeconds = (elapsed - lastElapsed).TotalSeconds;
+            if (intervalSeconds <= 0)
+            {
+                continue;
+            }
+
+            process.Refresh();
+            var cpu = process.TotalProcessorTime;
+            var frames = Interlocked.Read(ref FramesPresented);
+            var flips = Interlocked.Read(ref FlipsSubmitted);
+            var dcb = Interlocked.Read(ref DcbSubmits);
+            var draws = Interlocked.Read(ref DrawsTranslated);
+            var dispatches = Interlocked.Read(ref ComputeDispatches);
+            var guestWork = Interlocked.Read(ref GuestWorkExecuted);
+            var spirvHits = Interlocked.Read(ref SpirvCacheHits);
+            var spirvMisses = Interlocked.Read(ref SpirvCacheMisses);
+            var textureBytes = Interlocked.Read(ref GuestTextureBytesRead);
+            var fenceTicks = Interlocked.Read(ref PresentFenceWaitTicks);
+            var evalTicks = Interlocked.Read(ref ShaderEvalTicks);
+            var cpuPercent =
+                (cpu - lastCpu).TotalSeconds / intervalSeconds / Environment.ProcessorCount * 100.0;
+
+            var line = string.Create(CultureInfo.InvariantCulture,
+                $"{elapsed.TotalSeconds:F1}," +
+                $"{(frames - lastFrames) / intervalSeconds:F1}," +
+                $"{frames}," +
+                $"{(flips - lastFlips) / intervalSeconds:F1}," +
+                $"{(dcb - lastDcb) / intervalSeconds:F1}," +
+                $"{(draws - lastDraws) / intervalSeconds:F1}," +
+                $"{(dispatches - lastDispatches) / intervalSeconds:F1}," +
+                $"{(guestWork - lastGuestWork) / intervalSeconds:F1}," +
+                $"{(spirvHits - lastSpirvHits) / intervalSeconds:F1}," +
+                $"{(spirvMisses - lastSpirvMisses) / intervalSeconds:F1}," +
+                $"{Interlocked.Read(ref PipelinesCreated)}," +
+                $"{(textureBytes - lastTextureBytes) / intervalSeconds / (1024.0 * 1024.0):F2}," +
+                $"{(fenceTicks - lastFenceTicks) * 1000.0 / Stopwatch.Frequency / intervalSeconds:F2}," +
+                $"{(evalTicks - lastEvalTicks) * 1000.0 / Stopwatch.Frequency / intervalSeconds:F2}," +
+                $"{GC.CollectionCount(0)}," +
+                $"{GC.CollectionCount(1)}," +
+                $"{GC.CollectionCount(2)}," +
+                $"{GC.GetTotalMemory(forceFullCollection: false) / (1024.0 * 1024.0):F1}," +
+                $"{process.WorkingSet64 / (1024.0 * 1024.0):F1}," +
+                $"{cpuPercent:F1}");
+            lock (Gate)
+            {
+                if (_writer is null)
+                {
+                    return;
+                }
+
+                _writer.WriteLine(line);
+                _writer.Flush();
+            }
+
+            lastElapsed = elapsed;
+            lastCpu = cpu;
+            lastFrames = frames;
+            lastFlips = flips;
+            lastDcb = dcb;
+            lastDraws = draws;
+            lastDispatches = dispatches;
+            lastGuestWork = guestWork;
+            lastSpirvHits = spirvHits;
+            lastSpirvMisses = spirvMisses;
+            lastTextureBytes = textureBytes;
+            lastFenceTicks = fenceTicks;
+            lastEvalTicks = evalTicks;
+        }
+    }
+}

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
@@ -277,7 +277,6 @@ public sealed record Gen5VertexInputBinding(
 public sealed record Gen5ShaderEvaluation(
     IReadOnlyList<uint> InitialScalarRegisters,
     IReadOnlyList<uint> ScalarRegisters,
-    IReadOnlyDictionary<uint, IReadOnlyList<uint>> ScalarRegistersByPc,
     IReadOnlyList<Gen5ImageBinding> ImageBindings,
     IReadOnlyList<Gen5GlobalMemoryBinding> GlobalMemoryBindings,
     Gen5ComputeSystemRegisters? ComputeSystemRegisters = null,

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -37,8 +37,14 @@ public static class Gen5ShaderScalarEvaluator
 
     private const long CrossFrameReadCacheMaxBytes = 1024L * 1024 * 1024;
     private static readonly object _crossFrameReadGate = new();
-    private static readonly Dictionary<(ulong BaseAddress, int SizeBytes), byte[]> _crossFrameReadCache = new();
+    private static readonly Dictionary<(ulong BaseAddress, int SizeBytes), CachedGlobalRead> _crossFrameReadCache = new();
     private static long _crossFrameReadCacheBytes;
+
+    private sealed class CachedGlobalRead
+    {
+        public byte[] Data = [];
+        public long LastUseSequence;
+    }
     private const ulong RdnaWaveMask = 0xFFFF_FFFFUL;
 
     private readonly record struct BufferDescriptor(
@@ -575,11 +581,11 @@ public static class Gen5ShaderScalarEvaluator
     }
 
     [ThreadStatic]
-    private static Dictionary<(ulong BaseAddress, int SizeBytes), byte[]>? _globalMemoryReadCache;
+    private static Dictionary<(ulong BaseAddress, int SizeBytes), CachedGlobalRead>? _globalMemoryReadCache;
 
     public static void BeginGlobalMemoryReadScope()
     {
-        _globalMemoryReadCache = new Dictionary<(ulong, int), byte[]>();
+        _globalMemoryReadCache = new Dictionary<(ulong, int), CachedGlobalRead>();
     }
 
     public static void EndGlobalMemoryReadScope()
@@ -623,26 +629,66 @@ public static class Gen5ShaderScalarEvaluator
         if (cache is not null && cache.TryGetValue(cacheKey, out var cached))
         {
             Interlocked.Increment(ref GlobalMemoryReadCacheHits);
-            data = cached;
+            cached.LastUseSequence = VideoOut.VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1;
+            data = cached.Data;
             return true;
         }
 
-        byte[]? previous;
+        CachedGlobalRead? previous;
         lock (_crossFrameReadGate)
         {
             _crossFrameReadCache.TryGetValue(cacheKey, out previous);
         }
 
-        if (previous is not null && ctx.Memory.TryCompare(baseAddress, previous))
+        if (previous is not null && ctx.Memory.TryCompare(baseAddress, previous.Data))
         {
             Interlocked.Increment(ref GlobalMemoryReadReuses);
+            previous.LastUseSequence = VideoOut.VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1;
             if (cache is not null)
             {
                 cache[cacheKey] = previous;
             }
 
-            data = previous;
+            data = previous.Data;
             return true;
+        }
+
+        if (previous is not null &&
+            previous.Data.Length == (int)cappedSize &&
+            VideoOut.VulkanVideoPresenter.CompletedGuestWorkSequence >= previous.LastUseSequence)
+        {
+            var rewriteFromPvm = ctx.Memory.TryRead(baseAddress, previous.Data);
+            if (rewriteFromPvm ||
+                KernelMemoryCompatExports.TryReadTrackedLibcHeap(baseAddress, previous.Data))
+            {
+                Interlocked.Increment(ref GlobalMemoryReadCount);
+                Interlocked.Add(ref GlobalMemoryReadBytes, previous.Data.Length);
+                if (rewriteFromPvm)
+                {
+                    Interlocked.Add(ref GlobalMemoryReadPvmBytes, previous.Data.Length);
+                }
+                else
+                {
+                    Interlocked.Add(ref GlobalMemoryReadLibcBytes, previous.Data.Length);
+                }
+
+                previous.LastUseSequence = VideoOut.VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1;
+                if (cache is not null)
+                {
+                    cache[cacheKey] = previous;
+                }
+
+                data = previous.Data;
+                return true;
+            }
+
+            lock (_crossFrameReadGate)
+            {
+                if (_crossFrameReadCache.Remove(cacheKey))
+                {
+                    _crossFrameReadCacheBytes -= previous.Data.Length;
+                }
+            }
         }
 
         var candidateSize = (int)cappedSize;
@@ -664,16 +710,21 @@ public static class Gen5ShaderScalarEvaluator
                     Interlocked.Add(ref GlobalMemoryReadLibcBytes, data.Length);
                 }
 
+                var entry = new CachedGlobalRead
+                {
+                    Data = data,
+                    LastUseSequence = VideoOut.VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1,
+                };
                 if (cache is not null)
                 {
-                    cache[cacheKey] = data;
+                    cache[cacheKey] = entry;
                 }
 
                 lock (_crossFrameReadGate)
                 {
                     if (_crossFrameReadCache.TryGetValue(cacheKey, out var replaced))
                     {
-                        _crossFrameReadCacheBytes -= replaced.Length;
+                        _crossFrameReadCacheBytes -= replaced.Data.Length;
                     }
 
                     if (_crossFrameReadCacheBytes + data.Length > CrossFrameReadCacheMaxBytes)
@@ -682,7 +733,7 @@ public static class Gen5ShaderScalarEvaluator
                         _crossFrameReadCacheBytes = 0;
                     }
 
-                    _crossFrameReadCache[cacheKey] = data;
+                    _crossFrameReadCache[cacheKey] = entry;
                     _crossFrameReadCacheBytes += data.Length;
                 }
 

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -43,6 +43,7 @@ public static class Gen5ShaderScalarEvaluator
     private static readonly Dictionary<int, Queue<CachedGlobalRead>> _recycledReads = new();
     private static long _recycledReadBytes;
     private static readonly Dictionary<ulong, HashSet<uint>> _runtimeScalarRegisterCache = new();
+    private const int MaxEvalSkeletonEntries = 2048;
     private static readonly object _evalSkeletonGate = new();
     private static readonly Dictionary<
         (ulong Program, ulong UserData, bool ResolveVertex, uint VertexBucket),
@@ -521,6 +522,12 @@ public static class Gen5ShaderScalarEvaluator
         var ownedRuntime = new HashSet<uint>(runtimeScalarRegisters);
         lock (_evalSkeletonGate)
         {
+            if (_evalSkeletonCache.Count >= MaxEvalSkeletonEntries &&
+                !_evalSkeletonCache.ContainsKey(skeletonKey))
+            {
+                _evalSkeletonCache.Clear();
+            }
+
             _evalSkeletonCache[skeletonKey] = new EvalSkeleton
             {
                 InitialScalarRegisters = ownedInitial,

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -42,11 +42,32 @@ public static class Gen5ShaderScalarEvaluator
     private static long _crossFrameReadCacheBytes;
     private static readonly Dictionary<int, Queue<CachedGlobalRead>> _recycledReads = new();
     private static long _recycledReadBytes;
+    private static readonly Dictionary<ulong, HashSet<uint>> _runtimeScalarRegisterCache = new();
+    private static readonly object _evalSkeletonGate = new();
+    private static readonly Dictionary<
+        (ulong Program, ulong UserData, bool ResolveVertex, uint VertexBucket),
+        EvalSkeleton> _evalSkeletonCache = new();
+
+    [ThreadStatic] private static uint[]? _scalarRegisterScratch;
+    [ThreadStatic] private static uint[]? _initialScalarRegisterScratch;
+    [ThreadStatic] private static List<(ulong Address, uint Value)>? _evalLoadProbes;
+    [ThreadStatic] private static bool _recordEvalLoads;
 
     private sealed class CachedGlobalRead
     {
         public byte[] Data = [];
         public long LastUseSequence;
+    }
+
+    private sealed class EvalSkeleton
+    {
+        public required uint[] InitialScalarRegisters;
+        public required uint[] ScalarRegisters;
+        public required Gen5ImageBinding[] ImageBindings;
+        public required (uint ScalarAddress, ulong BaseAddress, int SizeBytes, uint[] Pcs)[] Globals;
+        public required (Gen5VertexInputBinding Template, int SizeBytes)[] VertexInputs;
+        public required (ulong Address, uint Value)[] Probes;
+        public required HashSet<uint> RuntimeScalarRegisters;
     }
 
     private static void RecycleReadLocked(CachedGlobalRead entry)
@@ -133,7 +154,22 @@ public static class Gen5ShaderScalarEvaluator
     {
         evaluation = default!;
         error = string.Empty;
-        var scalarRegisters = new uint[ScalarRegisterCount];
+        var userDataFingerprint = FingerprintUserData(state);
+        var vertexBucket = vertexRecordLimit is null
+            ? 0u
+            : (vertexRecordLimit.Value + 63u) / 64u;
+        var skeletonKey = (
+            state.Program.Address,
+            userDataFingerprint,
+            resolveVertexInputs,
+            vertexBucket);
+        if (TryRefreshEvalSkeleton(ctx, state, skeletonKey, out evaluation))
+        {
+            return true;
+        }
+
+        var scalarRegisters = _scalarRegisterScratch ??= new uint[ScalarRegisterCount];
+        scalarRegisters.AsSpan().Clear();
         for (var index = 0;
              index < state.UserData.Count &&
              state.UserDataScalarRegisterBase + (uint)index < scalarRegisters.Length;
@@ -151,13 +187,19 @@ public static class Gen5ShaderScalarEvaluator
         var execMask = RdnaWaveMask;
         WriteScalarPair(scalarRegisters, 106, 0, ref execMask);
         WriteScalarPair(scalarRegisters, 126, execMask, ref execMask);
-        var initialScalarRegisters = (uint[])scalarRegisters.Clone();
+        var initialScalarRegisters = _initialScalarRegisterScratch ??= new uint[ScalarRegisterCount];
+        scalarRegisters.AsSpan().CopyTo(initialScalarRegisters);
 
         var resolved = new List<Gen5ImageBinding>();
         var globalMemoryBindings = new List<Gen5GlobalMemoryBinding>();
         var globalMemoryByAddress = new Dictionary<(uint ScalarAddress, ulong BaseAddress), Gen5GlobalMemoryBinding>();
         var vertexInputBindings = new List<Gen5VertexInputBinding>();
         var runtimeScalarRegisters = CollectRuntimeScalarRegisters(state.Program);
+        var probes = _evalLoadProbes ??= new List<(ulong, uint)>(64);
+        probes.Clear();
+        _recordEvalLoads = true;
+        try
+        {
         var scalarConditionCode = false;
         uint? skipUntilPc = null;
 
@@ -472,14 +514,124 @@ public static class Gen5ShaderScalarEvaluator
                     : null));
         }
 
+        var ownedInitial = (uint[])initialScalarRegisters.Clone();
+        var ownedFinal = (uint[])scalarRegisters.Clone();
+        var ownedImages = resolved.ToArray();
+        var ownedVertices = vertexInputBindings.ToArray();
+        var ownedRuntime = new HashSet<uint>(runtimeScalarRegisters);
+        lock (_evalSkeletonGate)
+        {
+            _evalSkeletonCache[skeletonKey] = new EvalSkeleton
+            {
+                InitialScalarRegisters = ownedInitial,
+                ScalarRegisters = ownedFinal,
+                ImageBindings = ownedImages,
+                Globals = globalMemoryBindings
+                    .Select(binding => (
+                        binding.ScalarAddress,
+                        binding.BaseAddress,
+                        binding.Data.Length,
+                        binding.InstructionPcs as uint[] ?? binding.InstructionPcs.ToArray()))
+                    .ToArray(),
+                VertexInputs = ownedVertices
+                    .Select(binding => (binding with { Data = [] }, binding.Data.Length))
+                    .ToArray(),
+                Probes = probes.ToArray(),
+                RuntimeScalarRegisters = ownedRuntime,
+            };
+        }
+
         evaluation = new Gen5ShaderEvaluation(
-            initialScalarRegisters,
-            scalarRegisters,
-            resolved,
+            ownedInitial,
+            ownedFinal,
+            ownedImages,
             globalMemoryBindings,
             state.ComputeSystemRegisters,
-            runtimeScalarRegisters,
-            vertexInputBindings);
+            ownedRuntime,
+            ownedVertices);
+        return true;
+        }
+        finally
+        {
+            _recordEvalLoads = false;
+        }
+    }
+
+    private static ulong FingerprintUserData(Gen5ShaderState state)
+    {
+        const ulong offset = 14695981039346656037UL;
+        const ulong prime = 1099511628211UL;
+        var hash = offset ^ state.UserDataScalarRegisterBase;
+        hash = (hash ^ (ulong)state.UserData.Count) * prime;
+        foreach (var value in state.UserData)
+        {
+            hash = (hash ^ value) * prime;
+        }
+
+        return hash;
+    }
+
+    private static bool TryRefreshEvalSkeleton(
+        CpuContext ctx,
+        Gen5ShaderState state,
+        (ulong Program, ulong UserData, bool ResolveVertex, uint VertexBucket) key,
+        out Gen5ShaderEvaluation evaluation)
+    {
+        evaluation = default!;
+        EvalSkeleton skeleton;
+        lock (_evalSkeletonGate)
+        {
+            if (!_evalSkeletonCache.TryGetValue(key, out skeleton!))
+            {
+                return false;
+            }
+        }
+
+        foreach (var (address, value) in skeleton.Probes)
+        {
+            if (!ctx.TryReadUInt32(address, out var current) || current != value)
+            {
+                return false;
+            }
+        }
+
+        var globals = new List<Gen5GlobalMemoryBinding>(skeleton.Globals.Length);
+        foreach (var (scalarAddress, baseAddress, sizeBytes, pcs) in skeleton.Globals)
+        {
+            if (sizeBytes <= 0 ||
+                !TryReadGlobalMemory(ctx, baseAddress, (ulong)sizeBytes, out var data))
+            {
+                return false;
+            }
+
+            globals.Add(new Gen5GlobalMemoryBinding(scalarAddress, baseAddress, pcs, data));
+        }
+
+        Gen5VertexInputBinding[]? vertices = null;
+        if (key.ResolveVertex)
+        {
+            vertices = new Gen5VertexInputBinding[skeleton.VertexInputs.Length];
+            for (var index = 0; index < skeleton.VertexInputs.Length; index++)
+            {
+                var (template, sizeBytes) = skeleton.VertexInputs[index];
+                if (sizeBytes <= 0 ||
+                    !TryReadGlobalMemory(ctx, template.BaseAddress, (ulong)sizeBytes, out var data))
+                {
+                    return false;
+                }
+
+                vertices[index] = template with { Data = data };
+            }
+        }
+
+        evaluation = new Gen5ShaderEvaluation(
+            skeleton.InitialScalarRegisters,
+            skeleton.ScalarRegisters,
+            skeleton.ImageBindings,
+            globals,
+            state.ComputeSystemRegisters,
+            skeleton.RuntimeScalarRegisters,
+            vertices);
         return true;
     }
 
@@ -532,6 +684,14 @@ public static class Gen5ShaderScalarEvaluator
 
     private static HashSet<uint> CollectRuntimeScalarRegisters(Gen5ShaderProgram program)
     {
+        lock (_runtimeScalarRegisterCache)
+        {
+            if (_runtimeScalarRegisterCache.TryGetValue(program.Address, out var cached))
+            {
+                return new HashSet<uint>(cached);
+            }
+        }
+
         var registers = new HashSet<uint>();
         foreach (var instruction in program.Instructions)
         {
@@ -554,7 +714,20 @@ public static class Gen5ShaderScalarEvaluator
             }
         }
 
+        lock (_runtimeScalarRegisterCache)
+        {
+            _runtimeScalarRegisterCache[program.Address] = new HashSet<uint>(registers);
+        }
+
         return registers;
+    }
+
+    private static void RecordEvalLoad(ulong address, uint value)
+    {
+        if (_recordEvalLoads)
+        {
+            (_evalLoadProbes ??= new List<(ulong, uint)>(64)).Add((address, value));
+        }
     }
 
     private static bool TryGetSoppBranchTargetPc(
@@ -1629,16 +1802,19 @@ public static class Gen5ShaderScalarEvaluator
                 continue;
             }
 
-            if (!ctx.TryReadUInt32(
-                    address + (ulong)(index * sizeof(uint)),
-                    out var value) &&
-                !TryReadUserDataScalarLoad(
-                    state,
-                    instruction,
-                    control,
-                    byteOffset,
-                    index,
-                    out value))
+            var loadAddress = address + (ulong)(index * sizeof(uint));
+            uint value;
+            if (ctx.TryReadUInt32(loadAddress, out value))
+            {
+                RecordEvalLoad(loadAddress, value);
+            }
+            else if (!TryReadUserDataScalarLoad(
+                         state,
+                         instruction,
+                         control,
+                         byteOffset,
+                         index,
+                         out value))
             {
                 if (isBufferLoad)
                 {

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -17,6 +17,10 @@ public static class Gen5ShaderScalarEvaluator
 
     public delegate bool Gen5FallbackMemoryReader(ulong baseAddress, Span<byte> destination);
 
+    public static long EnqueuedGuestWorkSequence;
+
+    public static long CompletedGuestWorkSequence = long.MaxValue;
+
     private const int ScalarRegisterCount = 256;
     private const int ImageDescriptorDwords = 8;
     private const int SamplerDescriptorDwords = 4;
@@ -92,7 +96,7 @@ public static class Gen5ShaderScalarEvaluator
     {
         if (_recycledReads.TryGetValue(size, out var pool) &&
             pool.Count > 0 &&
-            VideoOut.VulkanVideoPresenter.CompletedGuestWorkSequence >= pool.Peek().LastUseSequence)
+            Volatile.Read(ref CompletedGuestWorkSequence) >= pool.Peek().LastUseSequence)
         {
             var entry = pool.Dequeue();
             _recycledReadBytes -= entry.Data.Length;
@@ -861,7 +865,7 @@ public static class Gen5ShaderScalarEvaluator
         if (cache is not null && cache.TryGetValue(cacheKey, out var cached))
         {
             Interlocked.Increment(ref GlobalMemoryReadCacheHits);
-            cached.LastUseSequence = VideoOut.VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1;
+            cached.LastUseSequence = Volatile.Read(ref EnqueuedGuestWorkSequence) + 1;
             data = cached.Data;
             return true;
         }
@@ -875,7 +879,7 @@ public static class Gen5ShaderScalarEvaluator
         if (previous is not null && ctx.Memory.TryCompare(baseAddress, previous.Data))
         {
             Interlocked.Increment(ref GlobalMemoryReadReuses);
-            previous.LastUseSequence = VideoOut.VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1;
+            previous.LastUseSequence = Volatile.Read(ref EnqueuedGuestWorkSequence) + 1;
             if (cache is not null)
             {
                 cache[cacheKey] = previous;
@@ -887,11 +891,11 @@ public static class Gen5ShaderScalarEvaluator
 
         if (previous is not null &&
             previous.Data.Length == (int)cappedSize &&
-            VideoOut.VulkanVideoPresenter.CompletedGuestWorkSequence >= previous.LastUseSequence)
+            Volatile.Read(ref CompletedGuestWorkSequence) >= previous.LastUseSequence)
         {
             var rewriteFromPvm = ctx.Memory.TryRead(baseAddress, previous.Data);
             if (rewriteFromPvm ||
-                KernelMemoryCompatExports.TryReadTrackedLibcHeap(baseAddress, previous.Data))
+                FallbackMemoryReader?.Invoke(baseAddress, previous.Data) == true)
             {
                 Interlocked.Increment(ref GlobalMemoryReadCount);
                 Interlocked.Add(ref GlobalMemoryReadBytes, previous.Data.Length);
@@ -904,7 +908,7 @@ public static class Gen5ShaderScalarEvaluator
                     Interlocked.Add(ref GlobalMemoryReadLibcBytes, previous.Data.Length);
                 }
 
-                previous.LastUseSequence = VideoOut.VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1;
+                previous.LastUseSequence = Volatile.Read(ref EnqueuedGuestWorkSequence) + 1;
                 if (cache is not null)
                 {
                     cache[cacheKey] = previous;
@@ -953,8 +957,7 @@ public static class Gen5ShaderScalarEvaluator
                     Interlocked.Add(ref GlobalMemoryReadLibcBytes, data.Length);
                 }
 
-                entry.LastUseSequence =
-                    VideoOut.VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1;
+                entry.LastUseSequence = Volatile.Read(ref EnqueuedGuestWorkSequence) + 1;
                 if (cache is not null)
                 {
                     cache[cacheKey] = entry;

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -35,15 +35,67 @@ public static class Gen5ShaderScalarEvaluator
     public static long GlobalMemoryReadLibcBytes;
     public static long GlobalMemoryReadReuses;
 
-    private const long CrossFrameReadCacheMaxBytes = 1024L * 1024 * 1024;
+    private const long CrossFrameReadCacheMaxBytes = 256L * 1024 * 1024;
+    private const long MaxRecycledReadBytes = 384L * 1024 * 1024;
     private static readonly object _crossFrameReadGate = new();
     private static readonly Dictionary<(ulong BaseAddress, int SizeBytes), CachedGlobalRead> _crossFrameReadCache = new();
     private static long _crossFrameReadCacheBytes;
+    private static readonly Dictionary<int, Queue<CachedGlobalRead>> _recycledReads = new();
+    private static long _recycledReadBytes;
 
     private sealed class CachedGlobalRead
     {
         public byte[] Data = [];
         public long LastUseSequence;
+    }
+
+    private static void RecycleReadLocked(CachedGlobalRead entry)
+    {
+        if (_recycledReadBytes + entry.Data.Length > MaxRecycledReadBytes)
+        {
+            return;
+        }
+
+        if (!_recycledReads.TryGetValue(entry.Data.Length, out var pool))
+        {
+            pool = new Queue<CachedGlobalRead>();
+            _recycledReads.Add(entry.Data.Length, pool);
+        }
+
+        pool.Enqueue(entry);
+        _recycledReadBytes += entry.Data.Length;
+    }
+
+    private static CachedGlobalRead? TryTakeRecycledReadLocked(int size)
+    {
+        if (_recycledReads.TryGetValue(size, out var pool) &&
+            pool.Count > 0 &&
+            VideoOut.VulkanVideoPresenter.CompletedGuestWorkSequence >= pool.Peek().LastUseSequence)
+        {
+            var entry = pool.Dequeue();
+            _recycledReadBytes -= entry.Data.Length;
+            return entry;
+        }
+
+        return null;
+    }
+
+    private static void EvictCrossFrameReadCacheLocked(
+        Dictionary<(ulong, int), CachedGlobalRead>? submitCache)
+    {
+        var inUse = submitCache is null
+            ? null
+            : new HashSet<CachedGlobalRead>(submitCache.Values);
+        foreach (var entry in _crossFrameReadCache.Values)
+        {
+            if (inUse is null || !inUse.Contains(entry))
+            {
+                RecycleReadLocked(entry);
+            }
+        }
+
+        _crossFrameReadCache.Clear();
+        _crossFrameReadCacheBytes = 0;
     }
     private const ulong RdnaWaveMask = 0xFFFF_FFFFUL;
 
@@ -300,7 +352,7 @@ public static class Gen5ShaderScalarEvaluator
                             (ulong)bufferMemory.DwordCount * sizeof(uint);
                         vertexReadSize = Math.Min(
                             bufferDescriptor.SizeBytes,
-                            Math.Max(requiredBytes, sizeof(uint)));
+                            (Math.Max(requiredBytes, sizeof(uint)) + 0xFFFFUL) & ~0xFFFFUL);
                     }
 
                     if (!TryReadGlobalMemory(
@@ -687,6 +739,7 @@ public static class Gen5ShaderScalarEvaluator
                 if (_crossFrameReadCache.Remove(cacheKey))
                 {
                     _crossFrameReadCacheBytes -= previous.Data.Length;
+                    RecycleReadLocked(previous);
                 }
             }
         }
@@ -694,7 +747,17 @@ public static class Gen5ShaderScalarEvaluator
         var candidateSize = (int)cappedSize;
         while (candidateSize >= sizeof(uint))
         {
-            data = GC.AllocateUninitializedArray<byte>(candidateSize);
+            CachedGlobalRead? entry;
+            lock (_crossFrameReadGate)
+            {
+                entry = TryTakeRecycledReadLocked(candidateSize);
+            }
+
+            entry ??= new CachedGlobalRead
+            {
+                Data = GC.AllocateUninitializedArray<byte>(candidateSize),
+            };
+            data = entry.Data;
             var readFromPvm = ctx.Memory.TryRead(baseAddress, data);
             if (readFromPvm ||
                 FallbackMemoryReader?.Invoke(baseAddress, data) == true)
@@ -710,11 +773,8 @@ public static class Gen5ShaderScalarEvaluator
                     Interlocked.Add(ref GlobalMemoryReadLibcBytes, data.Length);
                 }
 
-                var entry = new CachedGlobalRead
-                {
-                    Data = data,
-                    LastUseSequence = VideoOut.VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1,
-                };
+                entry.LastUseSequence =
+                    VideoOut.VulkanVideoPresenter.EnqueuedGuestWorkSequence + 1;
                 if (cache is not null)
                 {
                     cache[cacheKey] = entry;
@@ -722,15 +782,15 @@ public static class Gen5ShaderScalarEvaluator
 
                 lock (_crossFrameReadGate)
                 {
-                    if (_crossFrameReadCache.TryGetValue(cacheKey, out var replaced))
+                    if (_crossFrameReadCache.Remove(cacheKey, out var replaced))
                     {
                         _crossFrameReadCacheBytes -= replaced.Data.Length;
+                        RecycleReadLocked(replaced);
                     }
 
                     if (_crossFrameReadCacheBytes + data.Length > CrossFrameReadCacheMaxBytes)
                     {
-                        _crossFrameReadCache.Clear();
-                        _crossFrameReadCacheBytes = 0;
+                        EvictCrossFrameReadCacheLocked(cache);
                     }
 
                     _crossFrameReadCache[cacheKey] = entry;
@@ -738,6 +798,11 @@ public static class Gen5ShaderScalarEvaluator
                 }
 
                 return true;
+            }
+
+            lock (_crossFrameReadGate)
+            {
+                RecycleReadLocked(entry);
             }
 
             if (candidateSize == sizeof(uint))

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -100,7 +100,6 @@ public static class Gen5ShaderScalarEvaluator
         var globalMemoryByAddress = new Dictionary<(uint ScalarAddress, ulong BaseAddress), Gen5GlobalMemoryBinding>();
         var vertexInputBindings = new List<Gen5VertexInputBinding>();
         var runtimeScalarRegisters = CollectRuntimeScalarRegisters(state.Program);
-        var scalarRegisterSnapshots = new Dictionary<uint, IReadOnlyList<uint>>();
         var scalarConditionCode = false;
         uint? skipUntilPc = null;
 
@@ -115,8 +114,6 @@ public static class Gen5ShaderScalarEvaluator
 
                 skipUntilPc = null;
             }
-
-            scalarRegisterSnapshots[instruction.Pc] = (uint[])scalarRegisters.Clone();
 
             if (instruction.Opcode == "SEndpgm")
             {
@@ -420,7 +417,6 @@ public static class Gen5ShaderScalarEvaluator
         evaluation = new Gen5ShaderEvaluation(
             initialScalarRegisters,
             scalarRegisters,
-            scalarRegisterSnapshots,
             resolved,
             globalMemoryBindings,
             state.ComputeSystemRegisters,

--- a/tools/SharpEmu.Tools.ShaderDump/Program.cs
+++ b/tools/SharpEmu.Tools.ShaderDump/Program.cs
@@ -199,7 +199,6 @@ foreach (var (name, expectTranslate, words) in testPrograms)
     var evaluation = new Gen5ShaderEvaluation(
         new uint[256],
         new uint[256],
-        new Dictionary<uint, IReadOnlyList<uint>>(),
         Array.Empty<Gen5ImageBinding>(),
         globalBindings);
 


### PR DESCRIPTION
## Summary

This PR improves rendering performance by:

* batching up to 32 Vulkan draws in one command buffer;
* reusing buffers for textures, vertex data, index data, and global memory;
* recycling large arrays instead of allocating new ones every frame;
* caching scalar shader evaluation when inputs have not changed;
* adding new performance metrics.

## Performance

Tested on Dreaming Sarah

* Menu: ~36 FPS to ~75 FPS
* Scene 1: ~35 FPS to ~62 FPS
* Scene 2: ~24 FPS to ~45 FPS
* Draw throughput: about +74%
* Gen2 collections: about -99%
* CPU usage: about -40%