### PR TITLE
[VideoOut] Validate PNG chunk CRCs

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/PngSplashLoader.cs
+++ b/src/SharpEmu.Libs/VideoOut/PngSplashLoader.cs
@@ -8,6 +8,9 @@ namespace SharpEmu.Libs.VideoOut;
 
 internal static class PngSplashLoader
 {
+    private const uint CrcPolynomial = 0xEDB88320;
+    private static readonly uint[] CrcTable = BuildCrcTable();
+
     private static ReadOnlySpan<byte> PngSignature =>
     [
         0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
@@ -90,6 +93,13 @@ internal static class PngSplashLoader
 
             var chunkType = png.Slice(offset + 4, 4);
             var chunkData = png.Slice(offset + 8, (int)chunkLength);
+            var expectedCrc = BinaryPrimitives.ReadUInt32BigEndian(
+                png.Slice(offset + 8 + (int)chunkLength, 4));
+            if (CalculateCrc(chunkType, chunkData) != expectedCrc)
+            {
+                return false;
+            }
+
             if (chunkType.SequenceEqual("IHDR"u8))
             {
                 if (chunkData.Length != 13)
@@ -184,6 +194,41 @@ internal static class PngSplashLoader
         }
 
         return true;
+    }
+
+    private static uint CalculateCrc(ReadOnlySpan<byte> chunkType, ReadOnlySpan<byte> chunkData)
+    {
+        var crc = UpdateCrc(uint.MaxValue, chunkType);
+        return ~UpdateCrc(crc, chunkData);
+    }
+
+    private static uint UpdateCrc(uint crc, ReadOnlySpan<byte> bytes)
+    {
+        foreach (var value in bytes)
+        {
+            crc = CrcTable[(byte)(crc ^ value)] ^ (crc >> 8);
+        }
+
+        return crc;
+    }
+
+    private static uint[] BuildCrcTable()
+    {
+        var table = new uint[256];
+        for (var index = 0; index < table.Length; index++)
+        {
+            var value = (uint)index;
+            for (var bit = 0; bit < 8; bit++)
+            {
+                value = (value & 1) != 0
+                    ? CrcPolynomial ^ (value >> 1)
+                    : value >> 1;
+            }
+
+            table[index] = value;
+        }
+
+        return table;
     }
 
     private static bool TryUnfilter(

--- a/tests/SharpEmu.Libs.Tests/VideoOut/PngSplashLoaderTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/PngSplashLoaderTests.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class PngSplashLoaderTests
+{
+    private const int IhdrCrcOffset = 29;
+    private const int IdatCrcOffset = 53;
+    private const int IendCrcOffset = 65;
+    private const string ValidRgbPng =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGMQMgkDAAD4AJ3MaiF4AAAAAElFTkSuQmCC";
+
+    [Theory]
+    [InlineData(IhdrCrcOffset)]
+    [InlineData(IdatCrcOffset)]
+    [InlineData(IendCrcOffset)]
+    public void TryLoadRejectsInvalidChunkCrc(int crcOffset)
+    {
+        var app0Root = Path.Combine(Path.GetTempPath(), $"sharpemu-png-{Guid.NewGuid():N}");
+        var sceSysPath = Path.Combine(app0Root, "sce_sys");
+        var pngPath = Path.Combine(sceSysPath, "pic0.png");
+        var previousApp0Root = Environment.GetEnvironmentVariable("SHARPEMU_APP0_DIR");
+
+        Directory.CreateDirectory(sceSysPath);
+        try
+        {
+            Environment.SetEnvironmentVariable("SHARPEMU_APP0_DIR", app0Root);
+
+            var png = Convert.FromBase64String(ValidRgbPng);
+            File.WriteAllBytes(pngPath, png);
+
+            Assert.True(PngSplashLoader.TryLoad(out var pixels, out var width, out var height));
+            Assert.Equal(1U, width);
+            Assert.Equal(1U, height);
+            Assert.Equal([0x56, 0x34, 0x12, 0xFF], pixels);
+
+            png[crcOffset] ^= 0x01;
+            File.WriteAllBytes(pngPath, png);
+
+            Assert.False(PngSplashLoader.TryLoad(out _, out _, out _));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPEMU_APP0_DIR", previousApp0Root);
+            Directory.Delete(app0Root, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- validate each PNG chunk CRC before consuming its data
- use the standard reflected PNG CRC-32 polynomial with one process-wide lookup table
- add a fully synthetic 1x1 RGB fixture covering valid decoding and corrupted IHDR, IDAT, and IEND CRCs

## Why

`PngSplashLoader` previously skipped the four-byte CRC field while parsing chunks. A file with a corrupted chunk CRC could therefore be accepted and decoded as if it were valid. Validating type + data at the parser boundary rejects damaged splash/icon input before IHDR state changes, IDAT buffering, or IEND completion.

The implementation does not allocate per chunk; its 256-entry lookup table is initialized once.

## Verification

- RED: the new corrupted-IHDR case failed before the implementation (`Assert.False`: actual `True`)
- `dotnet restore SharpEmu.slnx --locked-mode`
- `dotnet build SharpEmu.slnx -c Release --no-restore` — 0 warnings, 0 errors
- `dotnet test SharpEmu.slnx -c Release --no-build` — 29 passed
- focused PNG tests — 3 passed
- REUSE 3.3 lint — 305/305 files compliant
- `git diff --check`

No firmware, game data, or proprietary PlayStation material is used. The PNG fixture is synthetic.

## AI assistance

This contribution was AI-assisted. The two-file patch was independently reviewed for the CRC algorithm, bounds safety, allocation behavior, test isolation, and scope; no blocking findings remained.
