### PR TITLE
[PlayGo] Fix authoritative chunk enumeration

### DIFF
--- a/src/SharpEmu.Libs/PlayGo/PlayGoExports.cs
+++ b/src/SharpEmu.Libs/PlayGo/PlayGoExports.cs
@@ -4,6 +4,7 @@
 using SharpEmu.HLE;
 using System.Buffers.Binary;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 namespace SharpEmu.Libs.PlayGo;
 
@@ -423,7 +424,10 @@ public static class PlayGoExports
                 // Titles rely on this as an enumeration terminator: Monster Truck
                 // scans ids 0,1,2,... until BAD_CHUNK_ID, and answering OK for every
                 // id makes that scan wrap the ushort range and spin forever.
-                return OrbisPlayGoErrorBadChunkId;
+                loci[i] = PlayGoLocusNotDownloaded;
+                return ctx.Memory.TryWrite(outLoci, loci)
+                    ? OrbisPlayGoErrorBadChunkId
+                    : (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
             }
 
             loci[i] = PlayGoLocusLocalFast;
@@ -669,7 +673,8 @@ public static class PlayGoExports
     {
         lock (_stateGate)
         {
-            return Array.BinarySearch(_metadata.ChunkIds, chunkId) >= 0;
+            return _metadata.ChunkIdKnowledge == PlayGoChunkIdKnowledge.Unknown ||
+                Array.BinarySearch(_metadata.ChunkIds, chunkId) >= 0;
         }
     }
 
@@ -680,7 +685,10 @@ public static class PlayGoExports
         {
             // No app0 override to probe for sidecar files: same fully-installed
             // single-chunk fallback as below, or scePlayGoOpen fails fatally.
-            return new PlayGoMetadata(true, [(ushort)0]);
+            return new PlayGoMetadata(
+                true,
+                [(ushort)0],
+                PlayGoChunkIdKnowledge.Authoritative);
         }
 
         var playGoDat = Path.Combine(app0Root, "sce_sys", "playgo-chunk.dat");
@@ -695,19 +703,19 @@ public static class PlayGoExports
             // init failure for UE titles); chunk 0 reports LocalFast and every other id
             // returns BAD_CHUNK_ID, terminating title-side chunk enumeration.
             TracePlayGo("metadata_missing; fully-installed single chunk");
-            return new PlayGoMetadata(true, [(ushort)0]);
+            return new PlayGoMetadata(
+                true,
+                [(ushort)0],
+                PlayGoChunkIdKnowledge.Authoritative);
         }
 
         var chunkIds = LoadChunkIds(chunkDefsXml);
-        if (chunkIds.Length == 0)
-        {
-            // Unreadable/empty sidecar: fall back to chunk 0, not an empty set
-            // (which IsKnownChunkId would treat as "every id valid").
-            TracePlayGo("metadata_unreadable; fully-installed single chunk");
-            return new PlayGoMetadata(true, [(ushort)0]);
-        }
-
-        return new PlayGoMetadata(true, chunkIds);
+        return new PlayGoMetadata(
+            true,
+            chunkIds,
+            chunkIds.Length == 0
+                ? PlayGoChunkIdKnowledge.Unknown
+                : PlayGoChunkIdKnowledge.Authoritative);
     }
 
     private static ushort[] LoadChunkIds(string chunkDefsXml)
@@ -720,6 +728,8 @@ public static class PlayGoExports
         try
         {
             var xml = File.ReadAllText(chunkDefsXml);
+            _ = XDocument.Parse(xml, LoadOptions.None);
+
             var chunkIds = new HashSet<ushort>();
             AddChunkIds(xml, DefaultChunkPattern, chunkIds);
             AddChunkIds(xml, ChunkIdPattern, chunkIds);
@@ -733,6 +743,10 @@ public static class PlayGoExports
             return Array.Empty<ushort>();
         }
         catch (UnauthorizedAccessException)
+        {
+            return Array.Empty<ushort>();
+        }
+        catch (System.Xml.XmlException)
         {
             return Array.Empty<ushort>();
         }
@@ -774,8 +788,35 @@ public static class PlayGoExports
         }
     }
 
-    private sealed record PlayGoMetadata(bool Available, ushort[] ChunkIds)
+    internal static void ResetForTests()
     {
-        public static readonly PlayGoMetadata Empty = new(false, Array.Empty<ushort>());
+        lock (_stateGate)
+        {
+            _initialized = false;
+            _opened = false;
+            _metadata = PlayGoMetadata.Empty;
+            _installSpeed = PlayGoInstallSpeedTrickle;
+            _languageMask = ulong.MaxValue;
+        }
+
+        Interlocked.Exchange(ref _unknownChunkDiagnostics, 0);
+        Interlocked.Exchange(ref _locusTraceDiagnostics, 0);
+    }
+
+    private enum PlayGoChunkIdKnowledge
+    {
+        Unknown,
+        Authoritative,
+    }
+
+    private sealed record PlayGoMetadata(
+        bool Available,
+        ushort[] ChunkIds,
+        PlayGoChunkIdKnowledge ChunkIdKnowledge)
+    {
+        public static readonly PlayGoMetadata Empty = new(
+            false,
+            Array.Empty<ushort>(),
+            PlayGoChunkIdKnowledge.Unknown);
     }
 }

--- a/tests/SharpEmu.Libs.Tests/PlayGo/PlayGoExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/PlayGo/PlayGoExportsTests.cs
@@ -1,0 +1,209 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.PlayGo;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.PlayGo;
+
+[CollectionDefinition("PlayGoState", DisableParallelization = true)]
+public sealed class PlayGoStateCollection
+{
+    public const string Name = "PlayGoState";
+}
+
+[Collection(PlayGoStateCollection.Name)]
+public sealed class PlayGoExportsTests : IDisposable
+{
+    private const int BadChunkId = unchecked((int)0x80B2000C);
+    private const byte LocusNotDownloaded = 0;
+    private const byte LocusLocalFast = 3;
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong InitParamsAddress = MemoryBase + 0x100;
+    private const ulong InitBufferAddress = MemoryBase + 0x1000;
+    private const ulong HandleAddress = MemoryBase + 0x200;
+    private const ulong ChunkIdsAddress = MemoryBase + 0x300;
+    private const ulong LociAddress = MemoryBase + 0x400;
+
+    private readonly string? _originalApp0Root;
+    private readonly string _app0Root;
+    private readonly FakeCpuMemory _memory = new(MemoryBase, 0x10000);
+    private readonly CpuContext _ctx;
+
+    public PlayGoExportsTests()
+    {
+        _originalApp0Root = Environment.GetEnvironmentVariable("SHARPEMU_APP0_DIR");
+        _app0Root = Path.Combine(Path.GetTempPath(), $"sharpemu-playgo-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_app0Root);
+        Environment.SetEnvironmentVariable("SHARPEMU_APP0_DIR", _app0Root);
+        PlayGoExports.ResetForTests();
+        _ctx = new CpuContext(_memory, Generation.Gen5);
+    }
+
+    [Fact]
+    public void GetLocus_MetadataFreeApp0_RejectsPastAuthoritativeDefaultChunk()
+    {
+        var handle = InitializeAndOpen();
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, GetLocus(handle, [0], 0x7F));
+        Assert.Equal(new byte[] { LocusLocalFast }, ReadLoci(1));
+
+        Assert.Equal(BadChunkId, GetLocus(handle, [1]));
+        Assert.Equal(new byte[] { LocusNotDownloaded }, ReadLoci(1));
+    }
+
+    [Fact]
+    public void GetLocus_ParsedChunkDefinitions_WritesPrefixAndRejectsFirstUnknownChunk()
+    {
+        File.WriteAllText(
+            Path.Combine(_app0Root, "playgo-chunkdefs.xml"),
+            "<playgo default_chunk=\"2\"><chunk id=\"2\"/><chunk id=\"7\"/></playgo>");
+        var handle = InitializeAndOpen();
+
+        Assert.Equal(BadChunkId, GetLocus(handle, [2, 3], 0xCC));
+        Assert.Equal(new byte[] { LocusLocalFast, LocusNotDownloaded }, ReadLoci(2));
+    }
+
+    [Theory]
+    [InlineData(UnusableMetadataKind.DatOnly)]
+    [InlineData(UnusableMetadataKind.MalformedChunkDefinitions)]
+    [InlineData(UnusableMetadataKind.UnrecognizedChunkDefinitions)]
+    public void GetLocus_UnparseableMetadata_RemainsPermissive(UnusableMetadataKind metadataKind)
+    {
+        switch (metadataKind)
+        {
+            case UnusableMetadataKind.DatOnly:
+                var sceSys = Directory.CreateDirectory(Path.Combine(_app0Root, "sce_sys"));
+                File.WriteAllBytes(Path.Combine(sceSys.FullName, "playgo-chunk.dat"), [0x70, 0x6C, 0x67, 0x6F]);
+                break;
+            case UnusableMetadataKind.MalformedChunkDefinitions:
+                File.WriteAllText(
+                    Path.Combine(_app0Root, "playgo-chunkdefs.xml"),
+                    "<playgo><chunk id=\"2\"></playgo>");
+                break;
+            case UnusableMetadataKind.UnrecognizedChunkDefinitions:
+                File.WriteAllText(Path.Combine(_app0Root, "playgo-chunkdefs.xml"), "<not-playgo/>");
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(metadataKind), metadataKind, null);
+        }
+
+        var handle = InitializeAndOpen();
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, GetLocus(handle, [42]));
+        Assert.Equal(new byte[] { LocusLocalFast }, ReadLoci(1));
+    }
+
+    [Fact]
+    public void GetLocus_FaultingChunkAndOutputPointers_ReturnMemoryFault()
+    {
+        var handle = InitializeAndOpen();
+        const ulong faultingAddress = 0xDEAD_0000_0000;
+        Assert.True(_memory.TryWrite(LociAddress, new byte[] { 0xA5 }));
+
+        SetGetLocusArguments(handle, faultingAddress, 1, LociAddress);
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            PlayGoExports.PlayGoGetLocus(_ctx));
+        Assert.Equal(new byte[] { 0xA5 }, ReadLoci(1));
+
+        WriteChunkIds([1]);
+        SetGetLocusArguments(handle, ChunkIdsAddress, 1, faultingAddress);
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            PlayGoExports.PlayGoGetLocus(_ctx));
+    }
+
+    [Fact]
+    public void GetLocus_AllEntriesSentinel_DoesNotReadChunksOrWriteLoci()
+    {
+        var handle = InitializeAndOpen();
+        Assert.True(_memory.TryWrite(LociAddress, [0xA5]));
+
+        SetGetLocusArguments(handle, 0xDEAD_0000_0000, uint.MaxValue, LociAddress);
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            PlayGoExports.PlayGoGetLocus(_ctx));
+        Assert.Equal(new byte[] { 0xA5 }, ReadLoci(1));
+    }
+
+    public void Dispose()
+    {
+        PlayGoExports.ResetForTests();
+        Environment.SetEnvironmentVariable("SHARPEMU_APP0_DIR", _originalApp0Root);
+        Directory.Delete(_app0Root, recursive: true);
+    }
+
+    private uint InitializeAndOpen()
+    {
+        Span<byte> initParams = stackalloc byte[16];
+        BinaryPrimitives.WriteUInt64LittleEndian(initParams, InitBufferAddress);
+        BinaryPrimitives.WriteUInt32LittleEndian(initParams[8..], 0x200000);
+        Assert.True(_memory.TryWrite(InitParamsAddress, initParams));
+
+        _ctx[CpuRegister.Rdi] = InitParamsAddress;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            PlayGoExports.PlayGoInitialize(_ctx));
+
+        _ctx[CpuRegister.Rdi] = HandleAddress;
+        _ctx[CpuRegister.Rsi] = 0;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            PlayGoExports.PlayGoOpen(_ctx));
+
+        Span<byte> handleBytes = stackalloc byte[sizeof(uint)];
+        Assert.True(_memory.TryRead(HandleAddress, handleBytes));
+        return BinaryPrimitives.ReadUInt32LittleEndian(handleBytes);
+    }
+
+    private int GetLocus(uint handle, ushort[] chunkIds, byte? fill = null)
+    {
+        WriteChunkIds(chunkIds);
+        if (fill is { } fillValue)
+        {
+            var initialLoci = new byte[chunkIds.Length];
+            Array.Fill(initialLoci, fillValue);
+            Assert.True(_memory.TryWrite(LociAddress, initialLoci));
+        }
+
+        SetGetLocusArguments(handle, ChunkIdsAddress, (uint)chunkIds.Length, LociAddress);
+        return PlayGoExports.PlayGoGetLocus(_ctx);
+    }
+
+    private void WriteChunkIds(ushort[] chunkIds)
+    {
+        var bytes = new byte[chunkIds.Length * sizeof(ushort)];
+        for (var i = 0; i < chunkIds.Length; i++)
+        {
+            BinaryPrimitives.WriteUInt16LittleEndian(bytes.AsSpan(i * sizeof(ushort)), chunkIds[i]);
+        }
+
+        Assert.True(_memory.TryWrite(ChunkIdsAddress, bytes));
+    }
+
+    private byte[] ReadLoci(int count)
+    {
+        var loci = new byte[count];
+        Assert.True(_memory.TryRead(LociAddress, loci));
+        return loci;
+    }
+
+    private void SetGetLocusArguments(uint handle, ulong chunkIds, uint count, ulong outLoci)
+    {
+        _ctx[CpuRegister.Rdi] = handle;
+        _ctx[CpuRegister.Rsi] = chunkIds;
+        _ctx[CpuRegister.Rdx] = count;
+        _ctx[CpuRegister.Rcx] = outLoci;
+    }
+
+    public enum UnusableMetadataKind
+    {
+        DatOnly,
+        MalformedChunkDefinitions,
+        UnrecognizedChunkDefinitions,
+    }
+}


### PR DESCRIPTION
## Summary

- distinguish authoritative PlayGo chunk sets from sidecars whose chunk IDs cannot be interpreted
- keep metadata-free full installs authoritative with the existing synthetic chunk set `[0]`
- make `scePlayGoGetLocus` write `NotDownloaded` and return `ORBIS_PLAYGO_ERROR_BAD_CHUNK_ID` for the first authoritative unknown ID
- preserve permissive behavior for dat-only, malformed, and otherwise unrecognized metadata
- reset PlayGo static state and diagnostic counters between nonparallel export tests

This restores the terminating response expected by titles that enumerate chunk IDs sequentially, while keeping strict validation scoped to `GetLocus`. Other PlayGo APIs, `ValidateChunkIds`, the import-loop guard, and `playgo-chunk.dat` parsing are unchanged.

## Verification

Using the pinned .NET SDK 10.0.103:

```text
dotnet restore SharpEmu.slnx --locked-mode
dotnet build SharpEmu.slnx -c Release --no-restore
dotnet test SharpEmu.slnx -c Release --no-build
```

Result on rebased PR head `bbf899253ae5dc6ea0a023128d961ccea97d4bcf`: Release build succeeded with 0 warnings and 0 errors; 89/89 `SharpEmu.Libs.Tests` and 33/33 `SharpEmu.SourceGenerators.Tests` passed. Scoped `dotnet format --verify-no-changes` also passed for the two changed files.

The new tests cover the metadata-free `[0]` set, parsed chunk definitions, dat-only/malformed/unrecognized metadata, mixed known/unknown output, chunk/output memory faults, and the `uint.MaxValue` sentinel.

A stacked integration build of `origin/main@864cbb0`, allocator PR #246 (`1b029b5`), and this PlayGo patch (`89d3099`; identical PlayGo source and test content to rebased commit `bbf8992`) also built with 0 warnings and 0 errors and passed 90/90 library tests plus 33/33 source-generator tests.

## GTA validation status

### San Andreas / macOS x64 with allocator PR #246

- Title: Grand Theft Auto: San Andreas - The Definitive Edition, `PPSA03525`, version `01.006.000`
- Metadata: no PlayGo sidecars, selecting the authoritative synthetic chunk set `[0]`
- Stack: `origin/main@864cbb0`, allocator PR #246 at `1b029b5`, and this PlayGo patch at integration commit `89d3099`
- Host: macOS x64 under Rosetta 2 with `SHARPEMU_LOG_PLAYGO=1` and the normal import-loop guard enabled
- The allocator reserved the main executable at the required address `0x0000000800000000`, allowing guest execution to reach PlayGo
- The sequential probe first queried chunk `0`, then queried authoritative-invalid chunk `1` from the former fixed return site `0x0000000801BA86D1`
- Chunk `1` produced `playgo.unknown_chunk_id id=1 entries=1 known=[0]` and returned `-2135818228` (`0x80B2000C`, `ORBIS_PLAYGO_ERROR_BAD_CHUNK_ID`)
- No subsequent `scePlayGoGetLocus` call occurred. Execution left the former return site and continued through import `#5453340`; no PlayGo import-loop guard fired before the next blocker
- The runtime trace does not serialize the output locus byte. The export tests explicitly verify `NotDownloaded`, and the runtime `BAD_CHUNK_ID` path is reached only after the output write succeeds
- The run ended after approximately 12 seconds with a later `FMallocBinned3` unrecognized-free error and guest access violation at RIP `0x0000000801BF82D6`, reading `0x0000000080017100` (exit 139). Because this later blocker ended the run, the strict 60-second acceptance window remains unfulfilled
- The full trace is retained locally outside the repository

This stacked run confirms that the macOS allocator fix in #246 removes the host blocker and that this PR terminates San Andreas's former PlayGo enumeration loop. The later memory/runtime failure is a distinct follow-up blocker outside this PR's PlayGo scope.

### Supplemental GTA V / allocator status

- Title: Grand Theft Auto V, `PPSA04264`, version `01.005.000`
- Metadata: no PlayGo sidecars, selecting the authoritative synthetic `[0]` path
- Allocator PR #246 maps the main image and adjacent modules at their exact addresses without the previous host crash
- On current `main`, GTA V stops before PlayGo at the separate static-TLS capacity check (`0x13570` required, `0x10000` reserved), so no GTA V PlayGo result is claimed

GTA III and Vice City dumps remain required. San Andreas also still needs either a run surviving at least 60 seconds or confirmation that the later memory/runtime failure is addressed independently.

No game dumps, extracted assets, logs containing proprietary data, or proprietary fixtures are included in this branch.

Refs #205, #230, #231.
