### PR TITLE
[Input] Map POSIX thumbstick endpoints exactly

### DIFF
--- a/src/SharpEmu.Libs/Pad/HostWindowInput.cs
+++ b/src/SharpEmu.Libs/Pad/HostWindowInput.cs
@@ -248,9 +248,9 @@ public static class HostWindowInput
         };
     }
 
-    private static byte ToStickByte(float value)
+    internal static byte ToStickByte(float value)
     {
-        return (byte)Math.Clamp((int)(128.0f + value * 127.0f), 0, 255);
+        return (byte)Math.Clamp((int)MathF.Round((value + 1.0f) * 127.5f), 0, 255);
     }
 
     private static HostGamepadButtons MapButton(ButtonName name) => name switch

--- a/tests/SharpEmu.Libs.Tests/Pad/HostWindowInputTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Pad/HostWindowInputTests.cs
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.Pad;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Pad;
+
+public sealed class HostWindowInputTests
+{
+    [Theory]
+    [InlineData(-1.0f, 0)]
+    [InlineData(0.0f, 128)]
+    [InlineData(1.0f, 255)]
+    public void ToStickByteMapsFullSilkRange(float value, int expected)
+    {
+        Assert.Equal((byte)expected, HostWindowInput.ToStickByte(value));
+    }
+}


### PR DESCRIPTION
## What

Map Silk.NET’s Linux/macOS thumbstick range `[-1, 1]` exactly onto SharpEmu’s host input byte range `[0, 255]`:

- `-1` → `0`
- `0` → `128`
- `1` → `255`

The existing clamp remains in place for unexpected out-of-range backend values. A focused xUnit theory covers all three endpoints.

## Why

The previous expression used a scale of `127`, so full negative movement mapped to `1` instead of `0`. Windows XInput and keyboard input already use `0` for full negative movement. This change makes Linux/macOS controller input cover the same complete range without changing deadzones, axis direction, buttons, triggers, or Windows backends.

## Verification

- Before the mapping change, the endpoint theory failed for `-1`: expected `0`, actual `1`.
- After the change, all 3 endpoint cases pass.
- `dotnet build SharpEmu.slnx -c Release --no-restore`
- `dotnet test SharpEmu.slnx -c Release --no-build` — 114 passed, 0 failed
- `reuse lint` — REUSE 3.3 compliant, 0 missing licenses

## AI assistance

AI assistance was used for repository research, implementation, and verification. I reviewed the focused change, understand each line, and can explain, modify, debug, and maintain it.