### PR TITLE
Fix macOS exact-address allocation without clobbering host memory

### DIFF
--- a/src/SharpEmu.HLE/Host/Posix/PosixHostMemory.cs
+++ b/src/SharpEmu.HLE/Host/Posix/PosixHostMemory.cs
@@ -163,12 +163,17 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
         private const int PROT_EXEC = 0x4;
 
         private const int MAP_PRIVATE = 0x02;
-        private const int MAP_FIXED = 0x10;
         private static readonly int MAP_ANON = OperatingSystem.IsMacOS() ? 0x1000 : 0x20;
         private static readonly int MAP_NORESERVE = OperatingSystem.IsMacOS() ? 0 : 0x4000;
 
         // Linux-only: fail instead of clobbering an existing mapping.
         private const int MAP_FIXED_NOREPLACE = 0x100000;
+
+        private const int KERN_SUCCESS = 0;
+
+        // On Darwin fixed placement is represented by the absence of
+        // VM_FLAGS_ANYWHERE. Do not add VM_FLAGS_OVERWRITE: overlap must fail.
+        private const int VM_FLAGS_FIXED = 0;
 
         private static readonly nint MAP_FAILED = -1;
 
@@ -181,6 +186,7 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
             public ulong Size;
             public uint DefaultProtect;
             public Dictionary<ulong, uint>? PageProtects;
+            public bool UsesMachAllocation;
 
             public ulong End => Base + Size;
 
@@ -251,6 +257,7 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
                 }
 
                 nint result;
+                var usesMachAllocation = false;
                 if (address != null)
                 {
                     // Win32 maps at exactly the requested address or fails
@@ -280,15 +287,17 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
                     if (result == MAP_FAILED && OperatingSystem.IsMacOS())
                     {
                         // The hint-only attempt above didn't land at the requested
-                        // address. This is routinely the case for the PS5's fixed
-                        // 32 GiB image base under Rosetta 2 on Apple Silicon, where
-                        // the kernel never honors that hint. Retry with true
-                        // MAP_FIXED: this can clobber an untracked host mapping
-                        // (dyld, the runtime's JIT heap, Rosetta) if one already
-                        // sits exactly there, but without it guest images that
-                        // require this base never load at all on macOS.
-                        Trace($"exact mmap hint failed, retrying with MAP_FIXED: addr=0x{(ulong)address:X16}");
-                        result = mmap((nint)address, (nuint)alignedSize, posixProtect, flags | MAP_FIXED, -1, 0);
+                        // address. mach_vm_allocate with fixed placement and no
+                        // overwrite flag atomically maps the requested range or
+                        // fails if any host mapping already owns it. Unlike
+                        // MAP_FIXED, it cannot clobber CLR, dyld, JIT, or Rosetta
+                        // memory that is absent from our shadow table.
+                        Trace($"exact mmap hint failed, retrying with fixed Mach allocation: addr=0x{(ulong)address:X16}");
+                        result = AllocateDarwinFixed(
+                            (nint)address,
+                            alignedSize,
+                            posixProtect);
+                        usesMachAllocation = result != MAP_FAILED;
                     }
 
                     if (result == MAP_FAILED || (ulong)result != (ulong)address)
@@ -316,7 +325,8 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
                 {
                     Base = (ulong)result,
                     Size = alignedSize,
-                    DefaultProtect = protect
+                    DefaultProtect = protect,
+                    UsesMachAllocation = usesMachAllocation,
                 };
 
                 return (void*)result;
@@ -335,8 +345,15 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
                     return false;
                 }
 
-                Regions.Remove((ulong)address);
-                return munmap((nint)address, (nuint)region.Size) == 0;
+                var released = region.UsesMachAllocation
+                    ? mach_vm_deallocate(mach_task_self(), (ulong)address, region.Size) == KERN_SUCCESS
+                    : munmap((nint)address, (nuint)region.Size) == 0;
+                if (released)
+                {
+                    Regions.Remove((ulong)address);
+                }
+
+                return released;
             }
         }
 
@@ -504,6 +521,40 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
             };
         }
 
+        private static nint AllocateDarwinFixed(nint requestedAddress, ulong size, int posixProtect)
+        {
+            var address = (ulong)requestedAddress;
+            var result = mach_vm_allocate(
+                mach_task_self(),
+                ref address,
+                size,
+                VM_FLAGS_FIXED);
+            if (result != KERN_SUCCESS || address != (ulong)requestedAddress)
+            {
+                if (result == KERN_SUCCESS)
+                {
+                    _ = mach_vm_deallocate(mach_task_self(), address, size);
+                }
+
+                Trace(
+                    $"fixed Mach allocation failed: addr=0x{(ulong)requestedAddress:X16} " +
+                    $"size=0x{size:X} kern_return={result}");
+                return MAP_FAILED;
+            }
+
+            if (mprotect((nint)address, (nuint)size, posixProtect) == 0)
+            {
+                return (nint)address;
+            }
+
+            var error = Marshal.GetLastPInvokeError();
+            _ = mach_vm_deallocate(mach_task_self(), address, size);
+            Trace(
+                $"fixed Mach allocation protection failed: addr=0x{address:X16} " +
+                $"size=0x{size:X} errno={error}");
+            return MAP_FAILED;
+        }
+
         private static void Trace(string message)
         {
             if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_VMEM"), "1", StringComparison.Ordinal))
@@ -524,5 +575,14 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
 
         [DllImport("libc", SetLastError = true)]
         private static extern int mprotect(nint addr, nuint length, int prot);
+
+        [DllImport("libSystem.B.dylib")]
+        private static extern uint mach_task_self();
+
+        [DllImport("libSystem.B.dylib")]
+        private static extern int mach_vm_allocate(uint target, ref ulong address, ulong size, int flags);
+
+        [DllImport("libSystem.B.dylib")]
+        private static extern int mach_vm_deallocate(uint target, ulong address, ulong size);
     }
 }

--- a/src/SharpEmu.HLE/SharpEmu.HLE.csproj
+++ b/src/SharpEmu.HLE/SharpEmu.HLE.csproj
@@ -14,6 +14,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
   <ItemGroup>
     <InternalsVisibleTo Include="SharpEmu.Core" />
+    <InternalsVisibleTo Include="SharpEmu.Libs.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SharpEmu.Libs.Tests/Memory/PosixHostMemoryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Memory/PosixHostMemoryTests.cs
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Runtime.InteropServices;
+using SharpEmu.HLE.Host;
+using SharpEmu.HLE.Host.Posix;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Memory;
+
+public sealed unsafe class PosixHostMemoryTests
+{
+    private const int ProtRead = 0x1;
+    private const int ProtWrite = 0x2;
+    private const int MapPrivate = 0x02;
+    private const int MapAnonymousDarwin = 0x1000;
+    private static readonly nint MapFailed = -1;
+
+    [Fact]
+    public void ExactAllocationDoesNotReplaceUntrackedDarwinMapping()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        var size = checked((nuint)Environment.SystemPageSize);
+        var externalMapping = mmap(
+            0,
+            size,
+            ProtRead | ProtWrite,
+            MapPrivate | MapAnonymousDarwin,
+            -1,
+            0);
+        Assert.NotEqual(MapFailed, externalMapping);
+
+        try
+        {
+            var sentinel = new Span<byte>((void*)externalMapping, checked((int)size));
+            sentinel.Fill(0xA5);
+
+            var hostMemory = new PosixHostMemory();
+            var result = hostMemory.Allocate(
+                (ulong)externalMapping,
+                (ulong)size,
+                HostPageProtection.ReadWrite);
+
+            Assert.Equal(0UL, result);
+            Assert.All(sentinel.ToArray(), value => Assert.Equal(0xA5, value));
+        }
+        finally
+        {
+            Assert.Equal(0, munmap(externalMapping, size));
+        }
+    }
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern nint mmap(nint addr, nuint length, int prot, int flags, int fd, long offset);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int munmap(nint addr, nuint length);
+}


### PR DESCRIPTION
## Summary

- replace Darwin's destructive `MAP_FIXED` retry with fixed `mach_vm_allocate` placement that omits `VM_FLAGS_OVERWRITE`
- track Mach-backed regions so release uses `mach_vm_deallocate`
- add a macOS regression test proving an exact guest allocation cannot replace an untracked host mapping

## Root cause

PR #214 made exact PS5 image placement possible on macOS by retrying with `MAP_FIXED` when an `mmap` hint was relocated. `MAP_FIXED` first removes anything already mapped in the requested range, including CLR, dyld, JIT, or Rosetta memory that is not represented in SharpEmu's region table. In the GTA V reproduction this allowed loading to continue temporarily, then the process segfaulted when the first adjacent module was mapped.

Darwin's Mach VM API provides the required no-replace behavior: fixed placement without `VM_FLAGS_OVERWRITE` succeeds only when the entire range is free. A collision now fails cleanly instead of corrupting the host process.

PR #216 reduces the common collision at the 32 GiB main-image base by using Workstation GC, but it does not make `MAP_FIXED` safe for other exact guest allocations. This PR keeps that configuration and focuses only on allocator safety.

## Validation

Using the pinned .NET SDK 10.0.103:

```text
dotnet restore SharpEmu.slnx --locked-mode
dotnet build SharpEmu.slnx -c Release --no-restore
dotnet test SharpEmu.slnx -c Release --no-build
```

- Release build: 0 warnings, 0 errors
- `SharpEmu.Libs.Tests`: 83/83 passed
- `SharpEmu.SourceGenerators.Tests`: 33/33 passed
- macOS collision regression: the allocator returned failure and preserved every byte of an independently mapped sentinel page

Runtime validation used GTA V, PPSA04264 v01.005.000, on the macOS x64/Rosetta path:

- baseline with #214 loaded the main image through `MAP_FIXED`, then terminated with SIGSEGV/exit 139 at the first module mapping
- the safe allocator plus Workstation GC mapped the main image at `0x0000000800000000`, mapped all three adjacent modules at their exact addresses, ran their initializers, and reached the later `BHouLQzh0X0` direct-memory-query loop without a host crash
- after rebasing onto current `main` at `864cbb0`, the main image still maps exactly without a host crash; execution now stops earlier at the newly introduced static-TLS capacity check (`0x13570` required, `0x10000` reserved), which is independent of this allocator change

No game files, extracted assets, or proprietary fixtures are included.

Follow-up to #214. Refs #194.
