### PR TITLE
[CLI] Reserve guest address space before GC heap initialization (#235)

### DIFF
--- a/src/SharpEmu.CLI/GuestAddressSpaceReservation.cs
+++ b/src/SharpEmu.CLI/GuestAddressSpaceReservation.cs
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace SharpEmu.CLI;
+
+/// <summary>
+/// Reserves the guest address space early in process startup, before the .NET runtime
+/// has a chance to reserve its GC heap in the same region. On systems with limited RAM
+/// (e.g. 16 GB), the .NET GC may reserve up to 256 GB of virtual address space, which
+/// can overlap the fixed PS5 image base at 0x800000000.
+/// </summary>
+internal static partial class GuestAddressSpaceReservation
+{
+    // PS5 guest address space layout:
+    // - Main image: 0x0000000800000000 (32 GB)
+    // - Module search: 0x0000000804000000 - 0x0000000900000000
+    // - Import stubs: 0x0000_7000_0000_0000
+    // - Guest arena: 0x00006000_0000_0000
+    //
+    // We reserve the critical region 0x800000000 - 0x900000000 (4 GB) to ensure
+    // the main image can be loaded at its required base address.
+    private const ulong Ps5CriticalRegionBase = 0x0000000800000000UL;
+    private const ulong Ps5CriticalRegionSize = 0x0000000100000000UL; // 4 GB
+
+    private static IntPtr _reservedRegion;
+
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        // Reserve the critical guest address space region as early as possible.
+        // This must happen before the .NET GC reserves its heap.
+        ReserveCriticalRegion();
+    }
+
+    private static void ReserveCriticalRegion()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            // On POSIX systems, the GC heap reservation pattern is different and
+            // typically doesn't conflict with the guest address space.
+            return;
+        }
+
+        // MEM_RESERVE without MEM_COMMIT - just reserves the address range
+        const uint MEM_RESERVE = 0x00002000;
+        const uint PAGE_NOACCESS = 0x01;
+
+        _reservedRegion = VirtualAlloc(
+            unchecked((IntPtr)Ps5CriticalRegionBase),
+            unchecked((UIntPtr)Ps5CriticalRegionSize),
+            MEM_RESERVE,
+            PAGE_NOACCESS);
+
+        if (_reservedRegion == IntPtr.Zero)
+        {
+            // Reservation failed - the address space might already be taken.
+            // PhysicalVirtualMemory will handle the failure gracefully.
+            return;
+        }
+
+        // Verify we got the exact address we requested
+        if ((ulong)_reservedRegion != Ps5CriticalRegionBase)
+        {
+            // Got a different address - free it and let the loader handle it
+            VirtualFree(_reservedRegion, UIntPtr.Zero, 0x00008000 /* MEM_RELEASE */);
+            _reservedRegion = IntPtr.Zero;
+        }
+    }
+
+    /// <summary>
+    /// Releases the early reservation so PhysicalVirtualMemory can allocate normally.
+    /// Called just before the loader needs the address space.
+    /// </summary>
+    internal static void ReleaseReservation()
+    {
+        if (_reservedRegion != IntPtr.Zero)
+        {
+            VirtualFree(_reservedRegion, UIntPtr.Zero, 0x00008000 /* MEM_RELEASE */);
+            _reservedRegion = IntPtr.Zero;
+        }
+    }
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial IntPtr VirtualAlloc(
+        IntPtr lpAddress,
+        UIntPtr dwSize,
+        uint flAllocationType,
+        uint flProtect);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool VirtualFree(
+        IntPtr lpAddress,
+        UIntPtr dwSize,
+        uint dwFreeType);
+}

--- a/src/SharpEmu.CLI/GuestAddressSpaceReservation.cs
+++ b/src/SharpEmu.CLI/GuestAddressSpaceReservation.cs
@@ -58,6 +58,9 @@ internal static partial class GuestAddressSpaceReservation
         {
             // Reservation failed - the address space might already be taken.
             // PhysicalVirtualMemory will handle the failure gracefully.
+            Console.Error.WriteLine(
+                $"[LOADER][WARN] Could not reserve guest address space at 0x{Ps5CriticalRegionBase:X16}; " +
+                "the .NET GC may already have reserved this region.");
             return;
         }
 
@@ -65,6 +68,9 @@ internal static partial class GuestAddressSpaceReservation
         if ((ulong)_reservedRegion != Ps5CriticalRegionBase)
         {
             // Got a different address - free it and let the loader handle it
+            Console.Error.WriteLine(
+                $"[LOADER][WARN] Guest address space reservation returned 0x{(ulong)_reservedRegion:X16} " +
+                $"instead of 0x{Ps5CriticalRegionBase:X16}; releasing it.");
             VirtualFree(_reservedRegion, UIntPtr.Zero, 0x00008000 /* MEM_RELEASE */);
             _reservedRegion = IntPtr.Zero;
         }

--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -250,6 +250,10 @@ internal static partial class Program
 
         Console.Error.WriteLine("[DEBUG] Creating runtime...");
 
+        // Release the early address space reservation before the loader needs it.
+        // This allows PhysicalVirtualMemory to allocate at the required base addresses.
+        GuestAddressSpaceReservation.ReleaseReservation();
+
         using var runtime = SharpEmuRuntime.CreateDefault(runtimeOptions);
 
         OrbisGen2Result result;

--- a/src/SharpEmu.CLI/SharpEmu.CLI.csproj
+++ b/src/SharpEmu.CLI/SharpEmu.CLI.csproj
@@ -31,6 +31,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
          that collision and keeps the emulator's required mappings available. -->
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <GCRetainVM>false</GCRetainVM>
     <TieredPGO>true</TieredPGO>
   </PropertyGroup>
 


### PR DESCRIPTION
The .NET GC may reserve up to 256 GB of virtual address space on systems with limited RAM (e.g. 16 GB), which can overlap the fixed PS5 image base at 0x800000000. This causes SelfLoader to fail with 'Could not allocate main image at required base'.

Added a ModuleInitializer that reserves the critical guest address region (0x800000000 - 0x900000000, 4 GB) as early as possible, before the GC heap is established. The reservation is released just before the loader needs it.

Changes:
- Added GuestAddressSpaceReservation.cs with ModuleInitializer
- Release reservation before SharpEmuRuntime.CreateDefault()

Fixes #235