### PR TITLE
[Vulkan] Validate and isolate persistent pipeline caches

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanPipelineCacheStorage.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanPipelineCacheStorage.cs
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+
+namespace SharpEmu.Libs.VideoOut;
+
+internal static class VulkanPipelineCacheStorage
+{
+    internal const int UuidSize = 16;
+    internal const long MaximumCacheSize = 256L * 1024L * 1024L;
+
+    private const int HeaderSize = 32;
+    private const uint HeaderVersionOne = 1;
+
+    internal static string GetFileName(
+        uint vendorId,
+        uint deviceId,
+        ReadOnlySpan<byte> pipelineCacheUuid)
+    {
+        ArgumentOutOfRangeException.ThrowIfNotEqual(pipelineCacheUuid.Length, UuidSize);
+        return $"vulkan-{vendorId:X8}-{deviceId:X8}-{Convert.ToHexString(pipelineCacheUuid)}.bin";
+    }
+
+    internal static bool TryReadCompatible(
+        string path,
+        uint vendorId,
+        uint deviceId,
+        ReadOnlySpan<byte> pipelineCacheUuid,
+        out byte[] data)
+    {
+        data = [];
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        if (stream.Length is < HeaderSize or > MaximumCacheSize)
+        {
+            return false;
+        }
+
+        data = new byte[checked((int)stream.Length)];
+        stream.ReadExactly(data);
+        if (HasCompatibleHeader(data, vendorId, deviceId, pipelineCacheUuid))
+        {
+            return true;
+        }
+
+        data = [];
+        return false;
+    }
+
+    internal static bool HasCompatibleHeader(
+        ReadOnlySpan<byte> data,
+        uint vendorId,
+        uint deviceId,
+        ReadOnlySpan<byte> pipelineCacheUuid)
+    {
+        return pipelineCacheUuid.Length == UuidSize &&
+               data.Length >= HeaderSize &&
+               BinaryPrimitives.ReadUInt32LittleEndian(data) == HeaderSize &&
+               BinaryPrimitives.ReadUInt32LittleEndian(data[4..]) == HeaderVersionOne &&
+               BinaryPrimitives.ReadUInt32LittleEndian(data[8..]) == vendorId &&
+               BinaryPrimitives.ReadUInt32LittleEndian(data[12..]) == deviceId &&
+               data.Slice(16, UuidSize).SequenceEqual(pipelineCacheUuid);
+    }
+}

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -3446,6 +3446,10 @@ internal static unsafe class VulkanVideoPresenter
 
         private void CreatePipelineCache()
         {
+            _vk.GetPhysicalDeviceProperties(_physicalDevice, out var properties);
+            var pipelineCacheUuid = new ReadOnlySpan<byte>(
+                properties.PipelineCacheUuid,
+                VulkanPipelineCacheStorage.UuidSize);
             var cacheMode = Environment.GetEnvironmentVariable("SHARPEMU_VK_PIPELINE_CACHE");
             // Vulkan cache blobs carry the implementation's compatibility
             // header and are rejected/rebuilt below when the device or driver
@@ -3455,13 +3459,24 @@ internal static unsafe class VulkanVideoPresenter
             // Keep an explicit opt-out for diagnostics and read-only systems.
             var persistentCacheEnabled =
                 !string.Equals(cacheMode, "0", StringComparison.Ordinal);
-            _pipelineCachePath = persistentCacheEnabled ? GetPipelineCachePath() : null;
+            _pipelineCachePath = persistentCacheEnabled
+                ? GetPipelineCachePath(properties.VendorID, properties.DeviceID, pipelineCacheUuid)
+                : null;
             byte[] initialData = [];
             try
             {
                 if (_pipelineCachePath is not null && File.Exists(_pipelineCachePath))
                 {
-                    initialData = File.ReadAllBytes(_pipelineCachePath);
+                    if (!VulkanPipelineCacheStorage.TryReadCompatible(
+                            _pipelineCachePath,
+                            properties.VendorID,
+                            properties.DeviceID,
+                            pipelineCacheUuid,
+                            out initialData))
+                    {
+                        Console.Error.WriteLine(
+                            "[LOADER][WARN] Vulkan pipeline cache has an incompatible or invalid header; rebuilding it.");
+                    }
                 }
             }
             catch (Exception exception)
@@ -3525,7 +3540,10 @@ internal static unsafe class VulkanVideoPresenter
             }
         }
 
-        private static string GetPipelineCachePath()
+        private static string GetPipelineCachePath(
+            uint vendorId,
+            uint deviceId,
+            ReadOnlySpan<byte> pipelineCacheUuid)
         {
             var configured = Environment.GetEnvironmentVariable("SHARPEMU_VK_PIPELINE_CACHE_PATH");
             if (!string.IsNullOrWhiteSpace(configured))
@@ -3540,7 +3558,10 @@ internal static unsafe class VulkanVideoPresenter
                     "Library",
                     "Caches")
                 : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            return Path.Combine(root, "SharpEmu", "vulkan-pipeline-cache.bin");
+            return Path.Combine(
+                root,
+                "SharpEmu",
+                VulkanPipelineCacheStorage.GetFileName(vendorId, deviceId, pipelineCacheUuid));
         }
 
         private void MarkPipelineCacheDirty()
@@ -3582,7 +3603,9 @@ internal static unsafe class VulkanVideoPresenter
                     _pipelineCache,
                     &size,
                     null);
-                if (result != Result.Success || size == 0 || size > 256u * 1024u * 1024u)
+                if (result != Result.Success ||
+                    size == 0 ||
+                    size > (nuint)VulkanPipelineCacheStorage.MaximumCacheSize)
                 {
                     Console.Error.WriteLine(
                         $"[LOADER][WARN] Vulkan pipeline cache query failed: result={result} size={size}");

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanPipelineCacheStorageTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanPipelineCacheStorageTests.cs
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VulkanPipelineCacheStorageTests
+{
+    private const uint VendorId = 0x10DE;
+    private const uint DeviceId = 0x2C02;
+
+    private static readonly byte[] CacheUuid = Enumerable.Range(0, 16).Select(static value => (byte)value).ToArray();
+
+    [Fact]
+    public void CompatibleCacheIsDeviceKeyedAndLoaded()
+    {
+        var directory = CreateTemporaryDirectory();
+        try
+        {
+            var fileName = VulkanPipelineCacheStorage.GetFileName(VendorId, DeviceId, CacheUuid);
+            var path = Path.Combine(directory, fileName);
+            var expected = CreateCacheData(CacheUuid);
+            File.WriteAllBytes(path, expected);
+
+            Assert.Contains(Convert.ToHexString(CacheUuid), fileName, StringComparison.Ordinal);
+            Assert.True(VulkanPipelineCacheStorage.TryReadCompatible(
+                path,
+                VendorId,
+                DeviceId,
+                CacheUuid,
+                out var actual));
+            Assert.Equal(expected, actual);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CacheFromAnotherDriverIsRejected()
+    {
+        var directory = CreateTemporaryDirectory();
+        try
+        {
+            var path = Path.Combine(directory, "cache.bin");
+            File.WriteAllBytes(path, CreateCacheData(new byte[16]));
+
+            Assert.False(VulkanPipelineCacheStorage.TryReadCompatible(
+                path,
+                VendorId,
+                DeviceId,
+                CacheUuid,
+                out var data));
+            Assert.Empty(data);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void OversizedCacheIsRejectedBeforeReading()
+    {
+        var directory = CreateTemporaryDirectory();
+        try
+        {
+            var path = Path.Combine(directory, "cache.bin");
+            using (var stream = File.Create(path))
+            {
+                stream.SetLength(VulkanPipelineCacheStorage.MaximumCacheSize + 1);
+            }
+
+            Assert.False(VulkanPipelineCacheStorage.TryReadCompatible(
+                path,
+                VendorId,
+                DeviceId,
+                CacheUuid,
+                out var data));
+            Assert.Empty(data);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static byte[] CreateCacheData(ReadOnlySpan<byte> uuid)
+    {
+        var data = new byte[36];
+        BinaryPrimitives.WriteUInt32LittleEndian(data, 32);
+        BinaryPrimitives.WriteUInt32LittleEndian(data.AsSpan(4), 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(data.AsSpan(8), VendorId);
+        BinaryPrimitives.WriteUInt32LittleEndian(data.AsSpan(12), DeviceId);
+        uuid.CopyTo(data.AsSpan(16, 16));
+        data[32..].AsSpan().Fill(0xA5);
+        return data;
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sharpemu-pipeline-cache-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}


### PR DESCRIPTION
## What changed

This makes the persistent Vulkan pipeline cache device-aware instead of treating one blob as valid for every Vulkan implementation:

- default cache files are keyed by vendor ID, device ID, and `pipelineCacheUUID`
- the 32-byte `VkPipelineCacheHeaderVersionOne` header is checked before any blob reaches `vkCreatePipelineCache`
- files smaller than the header or larger than the existing 256 MiB export limit are rejected before allocation
- an explicitly configured `SHARPEMU_VK_PIPELINE_CACHE_PATH` still works, but its contents now receive the same compatibility check

## Why

#216 made pipeline-cache persistence useful, especially for expensive MoltenVK shader compilation. The default path is currently shared by all GPUs and drivers, though. On a hybrid system, switching between the integrated and discrete GPU can therefore turn the cache into a ping-pong: each implementation rejects and later overwrites the other implementation's blob.

Vulkan already exposes the exact identity required for this through `pipelineCacheUUID`, and places that UUID together with the vendor and device IDs in the cache header. Using both sides of that contract keeps warm caches independent and avoids passing truncated or unrelated files into Vulkan.

This does not change pipeline keys, shader compilation, rendering state, synchronization, or when snapshots are saved.

## User impact

- cached pipeline work survives switching between Vulkan devices or driver implementations
- corrupt/truncated cache files fall back to a clean cache without relying on driver behavior
- an unexpectedly large cache file cannot cause an equally large managed allocation during startup

The previous unqualified `vulkan-pipeline-cache.bin` is intentionally not migrated because it cannot be attributed to a device without validating it first. The first launch after this change may rebuild that one old cache; subsequent launches use the device-specific file.

## Validation

- Release solution build: 0 warnings, 0 errors
- `SharpEmu.Libs.Tests`: 86/86 passed
- `SharpEmu.SourceGenerators.Tests`: 33/33 passed
- focused pipeline-cache tests: 3/3 passed
- `git diff --check`

The focused tests cover a compatible cache, a cache from a different driver UUID, and a sparse file above the size limit.

Reference: [VkPipelineCacheHeaderVersionOne](https://registry.khronos.org/vulkan/specs/latest/man/html/VkPipelineCacheHeaderVersionOne.html)