### PR TITLE
[HLE/Net] Fix sceNetHtonl/Htons/Ntohl/Ntohs returning 0

### DIFF
--- a/src/SharpEmu.Libs/Network/NetExports.cs
+++ b/src/SharpEmu.Libs/Network/NetExports.cs
@@ -345,7 +345,7 @@ public static class NetExports
     {
         var value = unchecked((uint)ctx[CpuRegister.Rdi]);
         ctx[CpuRegister.Rax] = BinaryPrimitives.ReverseEndianness(value);
-        return ctx.SetReturn(0);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     [SysAbiExport(
@@ -357,7 +357,7 @@ public static class NetExports
     {
         var value = unchecked((ushort)ctx[CpuRegister.Rdi]);
         ctx[CpuRegister.Rax] = BinaryPrimitives.ReverseEndianness(value);
-        return ctx.SetReturn(0);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     [SysAbiExport(
@@ -369,7 +369,7 @@ public static class NetExports
     {
         var value = unchecked((uint)ctx[CpuRegister.Rdi]);
         ctx[CpuRegister.Rax] = BinaryPrimitives.ReverseEndianness(value);
-        return ctx.SetReturn(0);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     [SysAbiExport(
@@ -381,7 +381,7 @@ public static class NetExports
     {
         var value = unchecked((ushort)ctx[CpuRegister.Rdi]);
         ctx[CpuRegister.Rax] = BinaryPrimitives.ReverseEndianness(value);
-        return ctx.SetReturn(0);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     [SysAbiExport(

--- a/tests/SharpEmu.Libs.Tests/Network/NetExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Network/NetExportsTests.cs
@@ -1,0 +1,168 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Network;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Network;
+
+public sealed class NetExportsTests
+{
+    [Fact]
+    public void Htonl_SwapsBytesAndPreservesRax()
+    {
+        var context = NewContext();
+        context[CpuRegister.Rdi] = 0x12345678UL;
+
+        var result = NetExports.NetHtonl(context);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(0x78563412UL, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void Htons_SwapsBytesAndPreservesRax()
+    {
+        var context = NewContext();
+        context[CpuRegister.Rdi] = 0x1234UL;
+
+        var result = NetExports.NetHtons(context);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(0x3412UL, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void Ntohl_RoundTripsHtonl()
+    {
+        var first = NewContext();
+        first[CpuRegister.Rdi] = 0xCAFEBABEU;
+        NetExports.NetHtonl(first);
+        var swapped = first[CpuRegister.Rax];
+
+        var second = NewContext();
+        second[CpuRegister.Rdi] = swapped;
+        NetExports.NetNtohl(second);
+
+        Assert.Equal(0xCAFEBABEUL, second[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void Ntohs_RoundTripsHtons()
+    {
+        var first = NewContext();
+        first[CpuRegister.Rdi] = 0xBEEFUL;
+        NetExports.NetHtons(first);
+        var swapped = first[CpuRegister.Rax];
+
+        var second = NewContext();
+        second[CpuRegister.Rdi] = swapped;
+        NetExports.NetNtohs(second);
+
+        Assert.Equal(0xBEEFUL, second[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void Htonl_ZeroInputReturnsZero()
+    {
+        // The one case where the broken implementation happened to return the
+        // correct value: swapping 0 yields 0. Guards against accidentally
+        // changing the dispatch status from OK on the zero path.
+        var context = NewContext();
+        context[CpuRegister.Rdi] = 0UL;
+
+        var result = NetExports.NetHtonl(context);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void Htonl_NonZeroInputNeverReturnsZero()
+    {
+        // Regression guard for the original bug: with the bug present, every
+        // call returned 0 to the guest. This test would have failed before
+        // the fix.
+        var rng = new Random(0x4E54_5400);
+        for (var i = 0; i < 1000; i++)
+        {
+            var input = unchecked((uint)rng.Next(int.MinValue, int.MaxValue));
+            var context = NewContext();
+            context[CpuRegister.Rdi] = input;
+
+            NetExports.NetHtonl(context);
+
+            Assert.NotEqual(0UL, context[CpuRegister.Rax]);
+        }
+    }
+
+    [Fact]
+    public void Htons_NonZeroInputNeverReturnsZero()
+    {
+        var rng = new Random(0x4E54_5401);
+        for (var i = 0; i < 1000; i++)
+        {
+            var input = unchecked((ushort)rng.Next(1, 65536));
+            var context = NewContext();
+            context[CpuRegister.Rdi] = input;
+
+            NetExports.NetHtons(context);
+
+            Assert.NotEqual(0UL, context[CpuRegister.Rax]);
+        }
+    }
+
+    [Fact]
+    public void Htons_OnlyTouchesLowTwoBytes()
+    {
+        // The cast `unchecked((ushort)ctx[CpuRegister.Rdi])` masks the input
+        // to its low 16 bits, so bits above 0xFFFF never reach the swap.
+        // Verify that: a 32-bit input where the high half differs swaps only
+        // the masked low half, leaving Rax a 16-bit-only value.
+        var context = NewContext();
+        context[CpuRegister.Rdi] = 0xCAFE_1234UL;
+
+        NetExports.NetHtons(context);
+
+        Assert.Equal(0x3412UL, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void Ntohl_NonZeroInputNeverReturnsZero()
+    {
+        var rng = new Random(0x4E54_5402);
+        for (var i = 0; i < 1000; i++)
+        {
+            var input = unchecked((uint)rng.Next(int.MinValue, int.MaxValue));
+            var context = NewContext();
+            context[CpuRegister.Rdi] = input;
+
+            NetExports.NetNtohl(context);
+
+            Assert.NotEqual(0UL, context[CpuRegister.Rax]);
+        }
+    }
+
+    [Fact]
+    public void Ntohs_NonZeroInputNeverReturnsZero()
+    {
+        var rng = new Random(0x4E54_5403);
+        for (var i = 0; i < 1000; i++)
+        {
+            var input = unchecked((ushort)rng.Next(1, 65536));
+            var context = NewContext();
+            context[CpuRegister.Rdi] = input;
+
+            NetExports.NetNtohs(context);
+
+            Assert.NotEqual(0UL, context[CpuRegister.Rax]);
+        }
+    }
+
+    private static CpuContext NewContext()
+    {
+        var memory = new FakeCpuMemory(0x1_0000_0000, 0x1000);
+        return new CpuContext(memory, Generation.Gen5);
+    }
+}


### PR DESCRIPTION
## What This PR Does

Fixes a silent correctness bug in four PS5 network exports where the byte-swapped result was being overwritten with `0` before being returned to the guest.

## Why

`sceNetHtonl`, `sceNetHtons`, `sceNetNtohl`, and `sceNetNtohs` correctly compute the byte swap into `Rax` but finish with `return ctx.SetReturn(0);`. `SetReturn` writes its argument into `Rax`, overwriting the swapped value with `0`. Every one of the four exports returned `0` to the guest regardless of input.

This silently corrupts anything that byte-swaps ports or addresses — for example filling in a `sockaddr_in` structure — even though the calling code looks correct.

## Change

`src/SharpEmu.Libs/Network/NetExports.cs` — for each of the four exports, replace the last line `return ctx.SetReturn(0);` with `return (int)OrbisGen2Result.ORBIS_GEN2_OK;`. This is the same pattern already used 8 times in the same file (e.g. `sceNetPoolCreate` at lines 318-319, `sceNetSocket` at lines 108-109, `sceNetAccept` at lines 264-265).

Diff: 4 lines changed across one file.

## Tests

New `tests/SharpEmu.Libs.Tests/Network/NetExportsTests.cs` (REUSE SPDX header included) with 10 xUnit `[Fact]`s modeled on the existing `KernelMemoryCompatExportsTests` pattern (FakeCpuMemory + CpuContext):

1. `Htonl_SwapsBytesAndPreservesRax` — `0x12345678 -> 0x78563412`
2. `Htons_SwapsBytesAndPreservesRax` — `0x1234 -> 0x3412`
3. `Ntohl_RoundTripsHtonl` — `Htonl(Ntohl(x)) == x`
4. `Ntohs_RoundTripsHtons` — same for 16-bit
5. `Htonl_ZeroInputReturnsZero` — guards the dispatch status on the zero path
6. `Htonl_NonZeroInputNeverReturnsZero` — fuzz 1000 inputs, regression guard
7. `Htons_NonZeroInputNeverReturnsZero` — fuzz 1000 inputs, regression guard
8. `Htons_OnlyTouchesLowTwoBytes` — verifies the ushort cast
9. `Ntohl_NonZeroInputNeverReturnsZero` — fuzz 1000 inputs, regression guard
10. `Ntohs_NonZeroInputNeverReturnsZero` — fuzz 1000 inputs, regression guard

The four `NonZeroInputNeverReturnsZero` tests are the regression guards that would have failed before the fix.

## Verification

```
$ dotnet build SharpEmu.slnx -c Release --no-restore
Build succeeded. 0 Warning(s). 0 Error(s).

$ dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~NetExports"
Passed!  - Failed:     0, Passed:    10, Skipped:     0, Total:    10

$ dotnet test SharpEmu.slnx -c Release --no-build
Passed: 95 / Failed: 0 (full test suite, no regressions)
```

## Risk

Minimal. Behavior change is local to four leaf-level exports that previously returned a constant `0`. Callers that depended on the (broken) `0` return value would have been silently broken already. The new behavior matches the documented semantics of `htonl`/`htons`/`ntohl`/`ntohs` on every Unix system.

## Reference

Closes #211.