### PR TITLE
[VideoOut] Implement sceVideoOutIsOutputSupported stub (fixes #257)

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -260,6 +260,22 @@ public static class VideoOutExports
     }
 
     [SysAbiExport(
+        Nid = "Nv8c-Kb+DUM",
+        ExportName = "sceVideoOutIsOutputSupported",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceVideoOut")]
+    public static int VideoOutIsOutputSupported(CpuContext ctx)
+    {
+        var busType = unchecked((int)ctx[CpuRegister.Rdi]);
+        _ = ctx[CpuRegister.Rsi]; // pixelFormat
+        _ = ctx[CpuRegister.Rdx]; // aspectRatio
+
+        // The emulator supports any output configuration on the main bus.
+        // Return 1 (supported) for SceVideoOutBusTypeMain, 0 otherwise.
+        return busType == SceVideoOutBusTypeMain ? 1 : 0;
+    }
+
+    [SysAbiExport(
         Nid = "uquVH4-Du78",
         ExportName = "sceVideoOutClose",
         Target = Generation.Gen4 | Generation.Gen5,


### PR DESCRIPTION
## What

Quake (PPSA01880, Kex Engine) crashes at startup because `sceVideoOutIsOutputSupported` (NID `Nv8c-Kb+DUM`) is unimplemented. The game calls it to check video output capabilities before initializing rendering.

## Fix

Add HLE export stub in `VideoOutExports.cs`:

```csharp
[SysAbiExport(
    Nid = "Nv8c-Kb+DUM",
    ExportName = "sceVideoOutIsOutputSupported",
    Target = Generation.Gen4 | Generation.Gen5,
    LibraryName = "libSceVideoOut")]
public static int VideoOutIsOutputSupported(CpuContext ctx)
{
    var busType = unchecked((int)ctx[CpuRegister.Rdi]);
    _ = ctx[CpuRegister.Rsi]; // pixelFormat
    _ = ctx[CpuRegister.Rdx]; // aspectRatio

    return busType == SceVideoOutBusTypeMain ? 1 : 0;
}
```

Returns 1 (supported) for `SceVideoOutBusTypeMain`, 0 otherwise. The emulator renders via Vulkan and supports any pixel format or aspect ratio on the main bus.

## Verification

- NID verified via `Ps5Nid.Compute` SHA1 algorithm (cross-checked against `sceVideoOutOpen → Up36PTk687E` and `sceVideoOutClose → uquVH4-Du78`)
- Export name confirmed in `scripts/ps5_names.txt` (line 142865)
- `dotnet build` — 0 errors, 0 warnings
- `dotnet test --filter VideoOut` — 3/3 passed

## Scope

1 file changed, 16 insertions. No other files modified. No tests added (trivial stub, 3-line body).

Fixes #257