### PR TITLE
[HLE] Make guest printf formatting locale-invariant

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -4033,7 +4033,7 @@ public static partial class KernelMemoryCompatExports
                             _ => unchecked((int)argumentSource.NextGpArg())
                         };
 
-                        var formatted = value.ToString();
+                        var formatted = value.ToString(CultureInfo.InvariantCulture);
                         if (showSign && value >= 0)
                             formatted = "+" + formatted;
                         else if (spaceForSign && value >= 0)
@@ -4053,7 +4053,7 @@ public static partial class KernelMemoryCompatExports
                             _ => (uint)argumentSource.NextGpArg()
                         };
 
-                        var formatted = value.ToString();
+                        var formatted = value.ToString(CultureInfo.InvariantCulture);
                         sb.Append(PadString(formatted, width, leftAlign, padWithZero && !leftAlign));
                     }
                     break;
@@ -4070,8 +4070,8 @@ public static partial class KernelMemoryCompatExports
                         };
 
                         var formatted = specifier == 'x'
-                            ? value.ToString("x")
-                            : value.ToString("X");
+                            ? value.ToString("x", CultureInfo.InvariantCulture)
+                            : value.ToString("X", CultureInfo.InvariantCulture);
 
                         if (alternateForm && value != 0)
                             formatted = specifier == 'x' ? "0x" + formatted : "0X" + formatted;
@@ -4175,7 +4175,10 @@ public static partial class KernelMemoryCompatExports
                         var formatStr = precision >= 0
                             ? $"{{0:{specifier}{precision}}}"
                             : $"{{0:{specifier}}}";
-                        var formatted = string.Format(formatStr, value);
+                        var formatted = string.Format(
+                            CultureInfo.InvariantCulture,
+                            formatStr,
+                            value);
 
                         if (showSign && value >= 0)
                             formatted = "+" + formatted;

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelMemoryCompatExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelMemoryCompatExportsTests.cs
@@ -3,6 +3,7 @@
 
 using SharpEmu.HLE;
 using SharpEmu.Libs.Kernel;
+using System.Globalization;
 using System.Text;
 using Xunit;
 
@@ -44,12 +45,22 @@ public sealed class KernelMemoryCompatExportsTests
             unchecked((ulong)BitConverter.DoubleToInt64Bits(0.5576)),
             0);
 
-        var result = KernelMemoryCompatExports.Sprintf(context);
+        var previousCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("es-ES");
 
-        Assert.Equal(0, result);
-        Assert.Equal(6UL, context[CpuRegister.Rax]);
-        Span<byte> output = stackalloc byte[7];
-        Assert.True(memory.TryRead(destinationAddress, output));
-        Assert.Equal("0.5576\0", Encoding.UTF8.GetString(output));
+            var result = KernelMemoryCompatExports.Sprintf(context);
+
+            Assert.Equal(0, result);
+            Assert.Equal(6UL, context[CpuRegister.Rax]);
+            Span<byte> output = stackalloc byte[7];
+            Assert.True(memory.TryRead(destinationAddress, output));
+            Assert.Equal("0.5576\0", Encoding.UTF8.GetString(output));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
     }
 }


### PR DESCRIPTION
Split from #208.

## Summary

- Format guest `printf` signed, unsigned, hexadecimal, and floating-point values with `InvariantCulture`.
- Make the floating-point regression test explicitly run under `es-ES`.
- Keep guest C ABI output stable regardless of the host locale.

## Why

Guest formatting currently inherits the host process culture. On hosts using a decimal comma, that changes the bytes written to guest memory and makes behavior platform/locale dependent.

## Impact

Guest `printf` output now follows the locale-independent formatting expected by the emulated ABI on macOS, Windows, and Linux.

## Validation

- Focused `KernelMemoryCompatExports` tests.
- Full solution: 118 tests passed on a Spanish-locale macOS host.
- Self-contained publishes: `osx-x64`, `win-x64`, and `linux-x64`.
- `ShaderDump` synthetic decode/emission suite.
