### PR TITLE
[CPU] Reject context transfers to unmapped guest addresses

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -1760,14 +1760,16 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		frameAddress = 0;
 		transferStub = 0;
 		error = null;
-		if (target.Rip < 65536 || target.Rsp == 0)
+		if (ActiveCpuContext is not { } activeContext)
 		{
-			error = $"invalid guest context transfer target rip=0x{target.Rip:X16} rsp=0x{target.Rsp:X16}";
+			error = "guest context transfer without an active CPU context";
 			return false;
 		}
-		if (target.Rsp < sizeof(ulong) ||
-			ActiveCpuContext is not { } activeContext ||
-			!activeContext.TryWriteUInt64(target.Rsp - sizeof(ulong), target.Rip))
+		if (!TryValidateGuestContextTransferTarget(activeContext.Memory, target, out error))
+		{
+			return false;
+		}
+		if (!activeContext.TryWriteUInt64(target.Rsp - sizeof(ulong), target.Rip))
 		{
 			error = $"guest context transfer slot is not writable at 0x{target.Rsp - sizeof(ulong):X16}";
 			return false;
@@ -1808,6 +1810,30 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		frame[17] = target.Mxcsr == 0 ? 0x1F80u : target.Mxcsr;
 		frame[18] = target.FpuControlWord == 0 ? 0x037Fu : target.FpuControlWord;
 		frame[19] = target.RestoreFullFpuState ? 1u : 0u;
+		return true;
+	}
+
+	internal static bool TryValidateGuestContextTransferTarget(
+		ICpuMemory memory,
+		in GuestCpuContinuation target,
+		out string? error)
+	{
+		if (target.Rip < 65536 || target.Rsp < sizeof(ulong))
+		{
+			error = $"invalid guest context transfer target rip=0x{target.Rip:X16} rsp=0x{target.Rsp:X16}";
+			return false;
+		}
+
+		Span<byte> ripProbe = stackalloc byte[1];
+		if (!memory.TryRead(target.Rip, ripProbe))
+		{
+			error =
+				$"guest context transfer target rip=0x{target.Rip:X16} is not mapped guest memory " +
+				$"(rsp=0x{target.Rsp:X16})";
+			return false;
+		}
+
+		error = null;
 		return true;
 	}
 

--- a/src/SharpEmu.Core/SharpEmu.Core.csproj
+++ b/src/SharpEmu.Core/SharpEmu.Core.csproj
@@ -14,6 +14,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <PackageReference Include="Iced" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SharpEmu.Libs.Tests" />
+  </ItemGroup>
+
   <PropertyGroup>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/tests/SharpEmu.Libs.Tests/Cpu/GuestContextTransferValidationTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/GuestContextTransferValidationTests.cs
@@ -1,0 +1,61 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Native;
+using SharpEmu.HLE;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+public sealed class GuestContextTransferValidationTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+
+    [Fact]
+    public void MappedGuestInstructionPointer_IsAccepted()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var continuation = CreateContinuation(MemoryBase + 0x100, MemoryBase + 0x800);
+
+        Assert.True(DirectExecutionBackend.TryValidateGuestContextTransferTarget(
+            memory,
+            continuation,
+            out var error));
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void UnmappedGuestInstructionPointer_IsRejected()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var continuation = CreateContinuation(MemoryBase + 0x2000, MemoryBase + 0x800);
+
+        Assert.False(DirectExecutionBackend.TryValidateGuestContextTransferTarget(
+            memory,
+            continuation,
+            out var error));
+        Assert.Contains("not mapped guest memory", error);
+    }
+
+    [Theory]
+    [InlineData(0UL, MemoryBase + 0x800)]
+    [InlineData(MemoryBase + 0x100, 0UL)]
+    public void InvalidInstructionOrStackPointer_IsRejected(ulong rip, ulong rsp)
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var continuation = CreateContinuation(rip, rsp);
+
+        Assert.False(DirectExecutionBackend.TryValidateGuestContextTransferTarget(
+            memory,
+            continuation,
+            out var error));
+        Assert.Contains("invalid guest context transfer target", error);
+    }
+
+    private static GuestCpuContinuation CreateContinuation(ulong rip, ulong rsp) =>
+        new()
+        {
+            Rip = rip,
+            Rsp = rsp,
+        };
+}


### PR DESCRIPTION
Split from #208.

## Summary

- Validate guest context-transfer RIP and RSP before preparing a native transfer frame.
- Reject targets whose instruction pointer is not mapped in guest memory.
- Route a corrupt continuation through the existing controlled guest-thread failure path instead of attempting a native host jump.
- Add mapped, unmapped, and invalid-pointer tests.

## Why

The native backend previously accepted an unvalidated guest continuation target. A corrupt or stale RIP could therefore escape the normal guest-memory checks and become an unsafe native transfer.

## Impact

Invalid continuations fail predictably while valid mapped targets retain the existing behavior.

## Validation

- Focused validation cases: 4 passed.
- Full solution: 122 tests passed with invariant globalization.
- Self-contained publishes: `osx-x64`, `win-x64`, and `linux-x64`.
- Void Terrarium macOS x64/Rosetta smoke: Vulkan ready, splash, first frame, and guest frame; no context-transfer rejection or fatal fault.
