### PR TITLE
[Kernel] Format printf numeric conversions with invariant culture

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -4033,7 +4033,7 @@ public static partial class KernelMemoryCompatExports
                             _ => unchecked((int)argumentSource.NextGpArg())
                         };
 
-                        var formatted = value.ToString();
+                        var formatted = value.ToString(CultureInfo.InvariantCulture);
                         if (showSign && value >= 0)
                             formatted = "+" + formatted;
                         else if (spaceForSign && value >= 0)
@@ -4053,7 +4053,7 @@ public static partial class KernelMemoryCompatExports
                             _ => (uint)argumentSource.NextGpArg()
                         };
 
-                        var formatted = value.ToString();
+                        var formatted = value.ToString(CultureInfo.InvariantCulture);
                         sb.Append(PadString(formatted, width, leftAlign, padWithZero && !leftAlign));
                     }
                     break;
@@ -4175,7 +4175,7 @@ public static partial class KernelMemoryCompatExports
                         var formatStr = precision >= 0
                             ? $"{{0:{specifier}{precision}}}"
                             : $"{{0:{specifier}}}";
-                        var formatted = string.Format(formatStr, value);
+                        var formatted = string.Format(CultureInfo.InvariantCulture, formatStr, value);
 
                         if (showSign && value >= 0)
                             formatted = "+" + formatted;


### PR DESCRIPTION
## What this changes

The HLE `printf`/`sprintf` implementation in `KernelMemoryCompatExports` now formats **numeric conversions using `CultureInfo.InvariantCulture`** instead of the host's current culture. Three call sites are touched:

- `%f/%e/%g` (and uppercase `%F/%E/%G`): `string.Format(...)` → `string.Format(CultureInfo.InvariantCulture, ...)`
- `%d/%i`: `value.ToString()` → `value.ToString(CultureInfo.InvariantCulture)`
- `%u`: `value.ToString()` → `value.ToString(CultureInfo.InvariantCulture)`

The `%x/%X` and `%o` paths already produced culture-independent output, so they were left as-is.

## Why it's needed / the problem it solves

C's `printf` is locale-independent for these conversions: `%f` always uses `.` as the decimal separator. The current code relies on the host thread's culture, so on any machine whose OS locale uses a comma as the decimal separator (es-ES, fr-FR, de-DE, pt-BR, and many others) a guest call like `printf("%f", 0.5576)` produces `"0,5576"` instead of the correct `"0.5576"`. Any PS5 title that formats floats through this path — and later parses that text, hashes it, or renders it — would receive corrupted output purely because of the host's regional settings. This is host-environment-dependent behaviour, not a game-specific issue, which is why it's worth fixing generically.

I hit this while building the project on a Spanish (es-ES) Windows machine: the repository's own unit test failed for exactly this reason.

## How I verified it

- **Before**: on an es-ES host, the existing test `SharpEmu.Libs.Tests.Kernel.KernelMemoryCompatExportsTests.Sprintf_ReadsVariadicDoubleFromXmmRegister` fails — `Expected: "0.5576"`, `Actual: "0,5576"`.
- **After**: the same test passes, and the full suite is green: **118/118** (`85` in `SharpEmu.Libs.Tests`, `33` in `SharpEmu.SourceGenerators.Tests`).
- Build is clean with `dotnet build SharpEmu.slnx -c Release` (0 warnings, 0 errors) using the SDK pinned in `global.json` (10.0.103).

Command used: `dotnet test SharpEmu.slnx -c Release`.

## Scope / follow-up

I intentionally kept this PR to the locale bug only, to stay small and focused. While investigating I also noticed that the **default precision** of `%f/%e/%g` doesn't match C semantics (`%f` with no precision yields .NET's 2 fraction digits rather than C's 6, and `%e` emits a 3-digit exponent instead of the minimum 2). That's a separate conformance topic and I'd rather address it in its own PR/issue than mix it in here.

## Note on AI assistance

This change was developed with AI assistance (per the project's AI-assisted contributions policy). The diff is three one-line edits adding `CultureInfo.InvariantCulture`; I understand the change fully and can explain, modify, and maintain it. Happy to answer any review questions.
