### PR TITLE
core: report what occupies a fixed-address allocation on failure

### DIFF
--- a/src/SharpEmu.Core/Loader/SelfLoader.cs
+++ b/src/SharpEmu.Core/Loader/SelfLoader.cs
@@ -197,8 +197,9 @@ public sealed class SelfLoader : ISelfLoader
             {
                 if (!physicalVm.TryAllocateAtExact(imageBase, totalImageSize, executable: true, out var allocatedBase))
                 {
+                    var reason = physicalVm.DescribeAddressForDiagnostics(imageBase);
                     throw new InvalidOperationException(
-                        $"Could not allocate main image at required base 0x{imageBase:X16} (size=0x{totalImageSize:X}).");
+                        $"Could not allocate main image at required base 0x{imageBase:X16} (size=0x{totalImageSize:X}): {reason}.");
                 }
 
                 imageBase = allocatedBase;

--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -198,6 +198,24 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         return true;
     }
 
+    public string DescribeAddressForDiagnostics(ulong address)
+    {
+        if (!_hostMemory.Query(address, out var info))
+        {
+            return "unable to query host memory at this address";
+        }
+
+        return info.State switch
+        {
+            HostRegionState.Free => "address reports free, but the exact-address reservation still failed",
+            HostRegionState.Reserved =>
+                $"already reserved by another host allocation (base=0x{info.AllocationBase:X16}, size=0x{info.RegionSize:X})",
+            HostRegionState.Committed =>
+                $"already committed by another host allocation (base=0x{info.AllocationBase:X16}, size=0x{info.RegionSize:X}, protect=0x{info.RawProtection:X})",
+            _ => $"in an unexpected host state (raw=0x{info.RawState:X})",
+        };
+    }
+
     public ulong AllocateAt(ulong desiredAddress, ulong size, bool executable = true, bool allowAlternative = true)
     {
         if (size == 0)


### PR DESCRIPTION
## What this change does

Adds `PhysicalVirtualMemory.DescribeAddressForDiagnostics(ulong address)`, a small diagnostic helper that calls the existing `IHostMemory.Query` to inspect whatever the host OS already has mapped at a given guest address. It returns a string describing the region state (free, reserved, committed) along with base, size, and protection info.

`SelfLoader.LoadCore` now calls this helper when `TryAllocateAtExact` fails to place the PS5 main image at its required base, and includes the result in the `InvalidOperationException` message.

## Why it is needed

Issue #235 reports `InvalidOperationException: Could not allocate main image at required base 0x0000000800000000` with no further context. `TryAllocateAtExact` currently returns `false` without explaining *why* the OS refused the mapping. This change gives the next person hitting the bug enough information to tell whether the problem is a host-side reservation or something else.

## How I verified it

- Confirmed `IHostMemory.Query(ulong, out HostRegionInfo)` matches the call signature used in the new helper.
- Confirmed `_hostMemory` in `PhysicalVirtualMemory` is typed `IHostMemory` and that `HostRegionState`/`HostRegionInfo` are already imported via `using SharpEmu.HLE.Host;`.
- Confirmed the change does not alter the allocation logic: `TryAllocateAtExact` still returns `false` on failure; only the exception message is enriched.
- Not yet runtime-tested; this is a hand-reviewed change.

## Checklist

- [x] Focused on a single topic (diagnostics only, no behavior change).
- [x] Follows existing coding style (4-space indentation, no tabs).
- [x] Uses existing project APIs (`IHostMemory.Query`) rather than introducing new abstractions.
- [x] No generated code submitted without understanding.
- [x] No Sony proprietary code, firmware, keys, or decrypted assets introduced.
- [x] No game-specific hacks; this is a generic diagnostic improvement.