### PR TITLE
[GUI] Link version pill to exact build commit

### DIFF
--- a/src/SharpEmu.GUI/App.axaml
+++ b/src/SharpEmu.GUI/App.axaml
@@ -55,6 +55,21 @@ SPDX-License-Identifier: GPL-2.0-or-later
       <Setter Property="Padding" Value="10,3" />
     </Style>
 
+    <Style Selector="Button.pill">
+      <Setter Property="Background" Value="{StaticResource ElevatedBrush}" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="CornerRadius" Value="999" />
+      <Setter Property="Padding" Value="10,3" />
+      <Setter Property="MinWidth" Value="0" />
+      <Setter Property="MinHeight" Value="0" />
+    </Style>
+    <Style Selector="Button.pill:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{StaticResource CardBorderBrush}" />
+    </Style>
+    <Style Selector="Button.pill:disabled">
+      <Setter Property="Opacity" Value="1" />
+    </Style>
+
     <Style Selector="TextBlock.sectionTitle">
       <Setter Property="FontSize" Value="11" />
       <Setter Property="FontWeight" Value="SemiBold" />

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -49,9 +49,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
         <Image Source="avares://SharpEmu.GUI/Assets/SharpEmu.ico" Width="20" Height="20"
                RenderOptions.BitmapInterpolationMode="HighQuality" />
         <TextBlock Text="SharpEmu" FontSize="14" FontWeight="SemiBold" VerticalAlignment="Center" />
-        <Border Classes="pill">
+        <Button x:Name="VersionButton" Classes="pill" IsEnabled="False">
           <TextBlock x:Name="VersionText" Text="v0.0.1" FontSize="11" Foreground="{StaticResource MutedBrush}" />
-        </Border>
+        </Button>
       </StackPanel>
     </Grid>
 

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -155,6 +155,17 @@ public partial class MainWindow : Window
         EnvLogNpToggle.IsCheckedChanged += (_, _) =>
             SetEnvironmentToggle("SHARPEMU_LOG_NP", EnvLogNpToggle.IsChecked == true);
         LanguageBox.SelectionChanged += (_, _) => OnLanguageChanged();
+        VersionButton.Click += (_, _) =>
+        {
+            if (BuildInfo.CommitUrl is not null)
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = BuildInfo.CommitUrl,
+                    UseShellExecute = true,
+                });
+            }
+        };
 
         GameList.AddHandler(ContextRequestedEvent, OnGameContextRequested, RoutingStrategies.Tunnel);
         CtxLaunch.Click += (_, _) => LaunchSelected();
@@ -372,7 +383,8 @@ public partial class MainWindow : Window
                 : $" · UNOFFICIAL {BuildInfo.CommitSha}";
         VersionText.Text = display;
         Title = $"SharpEmu {display}";
-        ToolTip.SetTip(VersionText, BuildInfo.Banner);
+        VersionButton.IsEnabled = BuildInfo.CommitUrl is not null;
+        ToolTip.SetTip(VersionButton, BuildInfo.Banner);
 
         _settings = GuiSettings.Load();
         Localization.Instance.Load(_settings.Language);
@@ -606,6 +618,12 @@ public partial class MainWindow : Window
 
     private void OnTitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
     {
+        if (e.Source is Visual source &&
+            (source is Button || source.FindAncestorOfType<Button>() is not null))
+        {
+            return;
+        }
+
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
             BeginMoveDrag(e);

--- a/src/SharpEmu.Logging/BuildInfo.cs
+++ b/src/SharpEmu.Logging/BuildInfo.cs
@@ -27,6 +27,9 @@ public static class BuildInfo
     /// <summary>URL of the GitHub Actions workflow run that produced the build, or <c>null</c>.</summary>
     public static string? WorkflowRunUrl { get; }
 
+    /// <summary>URL of the exact commit used to produce the build, or <c>null</c>.</summary>
+    public static string? CommitUrl { get; }
+
     /// <summary>Build configuration (e.g. <c>Debug</c> or <c>Release</c>), or <c>null</c>.</summary>
     public static string? Configuration { get; }
 
@@ -43,7 +46,8 @@ public static class BuildInfo
     {
         var metadata = ReadMetadata();
 
-        CommitSha = Normalize(metadata.GetValueOrDefault("SharpEmu.BuildSha"));
+        var fullCommitSha = Normalize(metadata.GetValueOrDefault("SharpEmu.BuildSha"));
+        CommitSha = fullCommitSha;
         if (CommitSha is { Length: > 7 })
         {
             CommitSha = CommitSha[..7];
@@ -55,6 +59,11 @@ public static class BuildInfo
 
         var serverUrl = Normalize(metadata.GetValueOrDefault("SharpEmu.BuildServerUrl"));
         var runId = Normalize(metadata.GetValueOrDefault("SharpEmu.BuildRunId"));
+        if (serverUrl is not null && Repository is not null && fullCommitSha is not null)
+        {
+            CommitUrl = $"{serverUrl.TrimEnd('/')}/{Repository}/commit/{fullCommitSha}";
+        }
+
         if (serverUrl is not null && Repository is not null && runId is not null)
         {
             WorkflowRunUrl = $"{serverUrl.TrimEnd('/')}/{Repository}/actions/runs/{runId}";


### PR DESCRIPTION
## What changed

- derive a commit URL from the build's existing GitHub Actions provenance metadata
- turn the version pill into a keyboard-accessible button that opens the exact commit used to build the running binary
- keep the full SHA in the URL while continuing to show the short SHA in the launcher
- prevent title-bar drag handling from swallowing button clicks

## Why

This preserves the useful commit-link affordance discussed in #279 without querying the live tip of `main` on every startup. The link describes the code the user is actually running, works for canonical, fork, and GitHub Enterprise builds, and stays disabled for local builds without provenance metadata.

## Impact

No runtime GitHub request, rate-limit usage, or new offline/error state is introduced. Existing build banners and update behavior are unchanged.

## Validation

- `dotnet build SharpEmu.slnx -c Release` — 0 warnings, 0 errors
- `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 dotnet test SharpEmu.slnx -c Release --no-build` — 179 passed
- `git diff --check`

The unmodified suite currently has one locale-dependent `sprintf` failure on this Norwegian host; open PR #276 addresses that pre-existing main-branch issue.
