### PR TITLE
savedata: unblock Dreaming Sarah new-game flow

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -214,6 +214,22 @@ public static partial class KernelMemoryCompatExports
         }
     }
 
+    public static bool UnregisterGuestPathMount(string guestMountPoint)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(guestMountPoint);
+
+        var normalizedMountPoint = NormalizeGuestStatCachePath(guestMountPoint);
+        if (normalizedMountPoint is null || normalizedMountPoint == "/")
+        {
+            throw new ArgumentException("Guest mount point must name a directory.", nameof(guestMountPoint));
+        }
+
+        lock (_guestMountGate)
+        {
+            return _guestMounts.Remove(normalizedMountPoint);
+        }
+    }
+
     internal static bool TryAllocateHleData(
         CpuContext ctx,
         ulong length,

--- a/src/SharpEmu.Libs/Np/NpUniversalDataSystemExports.cs
+++ b/src/SharpEmu.Libs/Np/NpUniversalDataSystemExports.cs
@@ -169,6 +169,27 @@ public static class NpUniversalDataSystemExports
     }
 
     [SysAbiExport(
+        Nid = "4llLk7YJRTE",
+        ExportName = "sceNpUniversalDataSystemEventPropertyArraySetString",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceNpUniversalDataSystem")]
+    public static int NpUniversalDataSystemEventPropertyArraySetString(CpuContext ctx)
+    {
+        // Telemetry is optional for local emulation. Dreaming Sarah passes a
+        // null destination while constructing its new-game event, so preserve
+        // the value-pointer validation without making telemetry block gameplay.
+        var valueAddress = ctx[CpuRegister.Rsi];
+        if (valueAddress == 0)
+        {
+            return ctx.SetReturn(NpUniversalDataSystemErrorInvalidArgument, typeof(long));
+        }
+
+        return ctx.TryReadNullTerminatedUtf8(valueAddress, 4096, out _)
+            ? ctx.SetReturn(0, typeof(long))
+            : ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT, typeof(long));
+    }
+
+    [SysAbiExport(
         Nid = "CzkKf7ahIyU",
         ExportName = "sceNpUniversalDataSystemPostEvent",
         Target = Generation.Gen4 | Generation.Gen5,

--- a/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
@@ -11,12 +11,19 @@ namespace SharpEmu.Libs.SaveData;
 public static class SaveDataExports
 {
     private const int OrbisSaveDataErrorParameter = unchecked((int)0x809F0000);
+    private const int OrbisSaveDataErrorBusy = unchecked((int)0x809F0003);
+    private const int OrbisSaveDataErrorNotMounted = unchecked((int)0x809F0004);
     private const int OrbisSaveDataErrorExists = unchecked((int)0x809F0007);
     private const int OrbisSaveDataErrorNotFound = unchecked((int)0x809F0008);
     private const int OrbisSaveDataErrorInternal = unchecked((int)0x809F000B);
     private const int SaveDataTitleIdSize = 10;
     private const int SaveDataDirNameSize = 32;
     private const int SaveDataParamSize = 0x530;
+    private const int SaveDataParamTitleOffset = 0x00;
+    private const int SaveDataParamSubTitleOffset = 0x80;
+    private const int SaveDataParamDetailOffset = 0x100;
+    private const int SaveDataParamUserParamOffset = 0x500;
+    private const int SaveDataParamMtimeOffset = 0x508;
     private const int SaveDataSearchInfoSize = 0x30;
     private const ulong ResultHitNumOffset = 0x00;
     private const ulong ResultDirNamesOffset = 0x08;
@@ -31,14 +38,24 @@ public static class SaveDataExports
     private const int MountResultSize = 0x40;
     private static readonly object _stateGate = new();
     private static readonly HashSet<int> _preparedTransactionResources = [];
+    private static readonly Dictionary<string, string> _mountedSavePaths = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly StringComparison _hostPathComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
     private static string? _titleId;
 
     public static void ConfigureApplicationInfo(string? titleId)
     {
         lock (_stateGate)
         {
+            foreach (var mountPoint in _mountedSavePaths.Keys)
+            {
+                KernelMemoryCompatExports.UnregisterGuestPathMount(mountPoint);
+            }
+
             _titleId = string.IsNullOrWhiteSpace(titleId) ? null : SanitizePathSegment(titleId.Trim());
             _preparedTransactionResources.Clear();
+            _mountedSavePaths.Clear();
         }
     }
 
@@ -191,46 +208,52 @@ public static class SaveDataExports
 
         try
         {
-            var titleId = ResolveConfiguredTitleId();
-            var savePath = Path.Combine(
-                ResolveTitleSaveRoot(userId, titleId),
-                SanitizePathSegment(dirName));
-            var existed = Directory.Exists(savePath);
-            var create = (mountMode & MountModeCreate) != 0;
-            var createIfMissing = (mountMode & MountModeCreate2) != 0;
-
-            if (!existed && !create && !createIfMissing)
+            lock (_stateGate)
             {
-                return SetReturn(ctx, OrbisSaveDataErrorNotFound);
+                var titleId = ResolveConfiguredTitleId();
+                if (!TryResolveSavePath(userId, titleId, dirName, out var savePath))
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorParameter);
+                }
+
+                const string mountPoint = "/savedata0";
+                var existed = Directory.Exists(savePath);
+                var create = (mountMode & MountModeCreate) != 0;
+                var createIfMissing = (mountMode & MountModeCreate2) != 0;
+
+                if (!existed && !create && !createIfMissing)
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorNotFound);
+                }
+
+                if (existed && create)
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorExists);
+                }
+
+                if (!existed)
+                {
+                    Directory.CreateDirectory(savePath);
+                }
+
+                Span<byte> result = stackalloc byte[MountResultSize];
+                result.Clear();
+                WriteAscii(result[..16], mountPoint);
+                BinaryPrimitives.WriteUInt32LittleEndian(result[0x1C..], createIfMissing && !existed ? 1u : 0u);
+                if (!ctx.Memory.TryWrite(resultAddress, result))
+                {
+                    return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+                }
+
+                KernelMemoryCompatExports.RegisterGuestPathMount(mountPoint, savePath);
+                _mountedSavePaths[mountPoint] = savePath;
+
+                TraceSaveData(
+                    $"mount3 user={userId} title={titleId} dir={dirName} blocks={blocks} " +
+                    $"system_blocks={systemBlocks} mount_mode=0x{mountMode:X} resource={resource} mode={mode} " +
+                    $"mount_point={mountPoint} created={!existed} root='{savePath}'");
+                return SetReturn(ctx, 0);
             }
-
-            if (existed && create)
-            {
-                return SetReturn(ctx, OrbisSaveDataErrorExists);
-            }
-
-            if (!existed)
-            {
-                Directory.CreateDirectory(savePath);
-            }
-
-            const string mountPoint = "/savedata0";
-            KernelMemoryCompatExports.RegisterGuestPathMount(mountPoint, savePath);
-
-            Span<byte> result = stackalloc byte[MountResultSize];
-            result.Clear();
-            WriteAscii(result[..16], mountPoint);
-            BinaryPrimitives.WriteUInt32LittleEndian(result[0x1C..], createIfMissing && !existed ? 1u : 0u);
-            if (!ctx.Memory.TryWrite(resultAddress, result))
-            {
-                return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
-            }
-
-            TraceSaveData(
-                $"mount3 user={userId} title={titleId} dir={dirName} blocks={blocks} " +
-                $"system_blocks={systemBlocks} mount_mode=0x{mountMode:X} resource={resource} mode={mode} " +
-                $"mount_point={mountPoint} created={!existed} root='{savePath}'");
-            return SetReturn(ctx, 0);
         }
         catch (IOException)
         {
@@ -243,6 +266,183 @@ public static class SaveDataExports
         catch (ArgumentException)
         {
             return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+    }
+
+    [SysAbiExport(
+        Nid = "85zul--eGXs",
+        ExportName = "sceSaveDataSetParam",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceSaveData")]
+    public static int SaveDataSetParam(CpuContext ctx)
+    {
+        var mountPointAddress = ctx[CpuRegister.Rdi];
+        var paramType = unchecked((uint)ctx[CpuRegister.Rsi]);
+        var paramAddress = ctx[CpuRegister.Rdx];
+        var paramSize = ctx[CpuRegister.Rcx];
+        if (mountPointAddress == 0 || paramAddress == 0 || paramType > 4)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+
+        if (!TryReadFixedAscii(ctx, mountPointAddress, 16, out var mountPoint))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        var fieldCapacity = paramType switch
+        {
+            0 => SaveDataParamSize,
+            1 or 2 => 128,
+            3 => 1024,
+            4 => sizeof(uint),
+            _ => 0,
+        };
+        var inputSize = paramType is 1 or 2 or 3
+            ? checked((int)Math.Min(paramSize, (ulong)fieldCapacity))
+            : fieldCapacity;
+        if (paramSize < (ulong)inputSize ||
+            inputSize == 0 ||
+            (paramType is 0 or 4 && paramSize < (ulong)fieldCapacity))
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+
+        var input = new byte[inputSize];
+        if (!ctx.Memory.TryRead(paramAddress, input))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+        if (paramType is 1 or 2 or 3 && !input.Contains((byte)0))
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+
+        try
+        {
+            lock (_stateGate)
+            {
+                if (!_mountedSavePaths.TryGetValue(mountPoint, out var savePath))
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorNotMounted);
+                }
+
+                var param = LoadSavedParam(savePath) ?? CreateDefaultParam(savePath);
+                switch (paramType)
+                {
+                    case 0:
+                        input.CopyTo(param, 0);
+                        break;
+                    case 1:
+                        ReplaceParamField(param, SaveDataParamTitleOffset, 128, input);
+                        break;
+                    case 2:
+                        ReplaceParamField(param, SaveDataParamSubTitleOffset, 128, input);
+                        break;
+                    case 3:
+                        ReplaceParamField(param, SaveDataParamDetailOffset, 1024, input);
+                        break;
+                    case 4:
+                        input.CopyTo(param, SaveDataParamUserParamOffset);
+                        break;
+                }
+
+                WriteSavedParam(savePath, param);
+                TraceSaveData(
+                    $"set_param mount_point={mountPoint} type={paramType} size={inputSize} root='{savePath}'");
+                return SetReturn(ctx, 0);
+            }
+        }
+        catch (IOException)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorInternal);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorInternal);
+        }
+    }
+
+    [SysAbiExport(
+        Nid = "S1GkePI17zQ",
+        ExportName = "sceSaveDataDelete",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceSaveData")]
+    public static int SaveDataDelete(CpuContext ctx)
+    {
+        var deleteAddress = ctx[CpuRegister.Rdi];
+        if (deleteAddress == 0)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+
+        if (!TryReadInt32(ctx, deleteAddress, out var userId) ||
+            !ctx.TryReadUInt64(deleteAddress + 0x08, out var titleIdAddress) ||
+            !ctx.TryReadUInt64(deleteAddress + 0x10, out var dirNameAddress))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        if (userId < 0 || dirNameAddress == 0)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+
+        if (!TryReadFixedAscii(ctx, dirNameAddress, SaveDataDirNameSize, out var dirName))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        var useConfiguredTitleId = titleIdAddress == 0;
+        var titleId = string.Empty;
+        if (!useConfiguredTitleId &&
+            !TryReadFixedAscii(ctx, titleIdAddress, SaveDataTitleIdSize, out titleId))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        try
+        {
+            lock (_stateGate)
+            {
+                if (useConfiguredTitleId)
+                {
+                    titleId = ResolveConfiguredTitleId();
+                }
+
+                if (!TryResolveSavePath(userId, titleId, dirName, out var savePath))
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorParameter);
+                }
+
+                if (_mountedSavePaths.Values.Any(path =>
+                        string.Equals(path, savePath, _hostPathComparison)))
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorBusy);
+                }
+
+                if (Directory.Exists(savePath))
+                {
+                    Directory.Delete(savePath, recursive: true);
+                }
+
+                var metadataPath = ResolveParamMetadataPath(savePath);
+                if (File.Exists(metadataPath))
+                {
+                    File.Delete(metadataPath);
+                }
+
+                TraceSaveData($"delete user={userId} title={titleId} dir={dirName} root='{savePath}'");
+                return SetReturn(ctx, 0);
+            }
+        }
+        catch (IOException)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorInternal);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorInternal);
         }
     }
 
@@ -316,7 +516,21 @@ public static class SaveDataExports
         // Unmounting a save directory always succeeds in the stub filesystem;
         // returning an error here makes the game's save flow stall before it
         // hands control to the title/gameplay state.
-        TraceSaveData($"umount2 user={unchecked((int)ctx[CpuRegister.Rdi])}");
+        var mountPointAddress = ctx[CpuRegister.Rdi];
+        var mountPoint = string.Empty;
+        if (mountPointAddress != 0 &&
+            TryReadFixedAscii(ctx, mountPointAddress, 16, out mountPoint))
+        {
+            lock (_stateGate)
+            {
+                if (_mountedSavePaths.Remove(mountPoint))
+                {
+                    KernelMemoryCompatExports.UnregisterGuestPathMount(mountPoint);
+                }
+            }
+        }
+
+        TraceSaveData($"umount2 mount_point={mountPoint}");
         return SetReturn(ctx, 0);
     }
 
@@ -375,7 +589,7 @@ public static class SaveDataExports
             }
 
             var info = new DirectoryInfo(directory);
-            entries.Add(new SaveEntry(name, directory, info.LastWriteTimeUtc));
+            entries.Add(new SaveEntry(name, directory, ResolveSaveMtimeUtc(directory, info.LastWriteTimeUtc)));
         }
 
         return entries;
@@ -400,13 +614,104 @@ public static class SaveDataExports
 
     private static bool TryWriteParam(CpuContext ctx, ulong address, SaveEntry entry)
     {
-        var param = new byte[SaveDataParamSize];
-        WriteAscii(param.AsSpan(0x00, 128), "Saved Data");
-        WriteAscii(param.AsSpan(0x100, 1024), entry.Name);
-        BinaryPrimitives.WriteInt64LittleEndian(
-            param.AsSpan(0x508, sizeof(long)),
-            new DateTimeOffset(entry.LastWriteUtc).ToUnixTimeSeconds());
+        var param = LoadSavedParam(entry.Path);
+        if (param is null)
+        {
+            param = new byte[SaveDataParamSize];
+            WriteAscii(param.AsSpan(SaveDataParamTitleOffset, 128), "Saved Data");
+            WriteAscii(param.AsSpan(SaveDataParamDetailOffset, 1024), entry.Name);
+            BinaryPrimitives.WriteInt64LittleEndian(
+                param.AsSpan(SaveDataParamMtimeOffset, sizeof(long)),
+                new DateTimeOffset(entry.LastWriteUtc).ToUnixTimeSeconds());
+        }
+
         return ctx.Memory.TryWrite(address, param);
+    }
+
+    private static byte[]? LoadSavedParam(string savePath)
+    {
+        var metadataPath = ResolveParamMetadataPath(savePath);
+        if (!File.Exists(metadataPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var param = File.ReadAllBytes(metadataPath);
+            return param.Length == SaveDataParamSize ? param : null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    private static byte[] CreateDefaultParam(string savePath)
+    {
+        var param = new byte[SaveDataParamSize];
+        var mtime = Directory.Exists(savePath)
+            ? Directory.GetLastWriteTimeUtc(savePath)
+            : DateTime.UtcNow;
+        BinaryPrimitives.WriteInt64LittleEndian(
+            param.AsSpan(SaveDataParamMtimeOffset, sizeof(long)),
+            new DateTimeOffset(mtime).ToUnixTimeSeconds());
+        return param;
+    }
+
+    private static string ResolveParamMetadataPath(string savePath)
+    {
+        var titleRoot = Directory.GetParent(savePath)?.FullName ?? ResolveSaveDataRoot();
+        var dirName = Path.GetFileName(Path.TrimEndingDirectorySeparator(savePath));
+        return Path.Combine(titleRoot, "sce_params", $"{dirName}.bin");
+    }
+
+    private static void WriteSavedParam(string savePath, byte[] param)
+    {
+        var metadataPath = ResolveParamMetadataPath(savePath);
+        var metadataRoot = Path.GetDirectoryName(metadataPath)!;
+        Directory.CreateDirectory(metadataRoot);
+        var temporaryPath = Path.Combine(metadataRoot, $".{Path.GetFileName(metadataPath)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            File.WriteAllBytes(temporaryPath, param);
+            File.Move(temporaryPath, metadataPath, overwrite: true);
+        }
+        finally
+        {
+            File.Delete(temporaryPath);
+        }
+    }
+
+    private static DateTime ResolveSaveMtimeUtc(string savePath, DateTime fallback)
+    {
+        var param = LoadSavedParam(savePath);
+        if (param is null)
+        {
+            return fallback;
+        }
+
+        var seconds = BinaryPrimitives.ReadInt64LittleEndian(
+            param.AsSpan(SaveDataParamMtimeOffset, sizeof(long)));
+        try
+        {
+            return DateTimeOffset.FromUnixTimeSeconds(seconds).UtcDateTime;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return fallback;
+        }
+    }
+
+    private static void ReplaceParamField(byte[] param, int offset, int length, byte[] value)
+    {
+        var field = param.AsSpan(offset, length);
+        field.Clear();
+        value.AsSpan(0, Math.Min(value.Length, field.Length)).CopyTo(field);
     }
 
     private static bool TryWriteSearchInfo(CpuContext ctx, ulong address, SaveEntry entry)
@@ -470,7 +775,34 @@ public static class SaveDataExports
     }
 
     private static string ResolveTitleSaveRoot(int userId, string titleId) =>
-        Path.Combine(ResolveSaveDataRoot(), userId.ToString(), SanitizePathSegment(titleId));
+        Path.GetFullPath(Path.Combine(ResolveSaveDataRoot(), userId.ToString(), SanitizePathSegment(titleId)));
+
+    private static bool TryResolveSavePath(int userId, string titleId, string dirName, out string savePath)
+    {
+        savePath = string.Empty;
+        if (!IsGuestPathSegment(titleId) || !IsGuestPathSegment(dirName))
+        {
+            return false;
+        }
+
+        var titleRoot = ResolveTitleSaveRoot(userId, titleId);
+        var candidate = Path.GetFullPath(Path.Combine(titleRoot, SanitizePathSegment(dirName)));
+        var rootWithSeparator = Path.TrimEndingDirectorySeparator(titleRoot) + Path.DirectorySeparatorChar;
+        if (!candidate.StartsWith(rootWithSeparator, _hostPathComparison))
+        {
+            return false;
+        }
+
+        savePath = candidate;
+        return true;
+    }
+
+    private static bool IsGuestPathSegment(string value) =>
+        !string.IsNullOrWhiteSpace(value) &&
+        !string.Equals(value, ".", StringComparison.Ordinal) &&
+        !string.Equals(value, "..", StringComparison.Ordinal) &&
+        !value.Contains('/') &&
+        !value.Contains('\\');
 
     private static string ResolveSaveDataRoot()
     {
@@ -511,7 +843,7 @@ public static class SaveDataExports
     {
         var invalid = Path.GetInvalidFileNameChars();
         var sanitized = new string(value.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray());
-        return string.IsNullOrWhiteSpace(sanitized) ? "default" : sanitized;
+        return string.IsNullOrWhiteSpace(sanitized) || sanitized is "." or ".." ? "default" : sanitized;
     }
 
     private static bool TryReadFixedAscii(CpuContext ctx, ulong address, int length, out string value)

--- a/tests/SharpEmu.Libs.Tests/Np/NpUniversalDataSystemExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Np/NpUniversalDataSystemExportsTests.cs
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Np;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Np;
+
+public sealed class NpUniversalDataSystemExportsTests
+{
+    [Fact]
+    public void EventPropertyArraySetString_AllowsNullTelemetryDestination()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong valueAddress = memoryBase + 0x100;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        memory.WriteCString(valueAddress, "new_game");
+        context[CpuRegister.Rdi] = 0;
+        context[CpuRegister.Rsi] = valueAddress;
+
+        Assert.Equal(0, NpUniversalDataSystemExports.NpUniversalDataSystemEventPropertyArraySetString(context));
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(0x1_0000_2000)]
+    public void EventPropertyArraySetString_RejectsInvalidValuePointer(ulong valueAddress)
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rsi] = valueAddress;
+
+        Assert.NotEqual(0, NpUniversalDataSystemExports.NpUniversalDataSystemEventPropertyArraySetString(context));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/SaveData/SaveDataExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/SaveData/SaveDataExportsTests.cs
@@ -1,0 +1,295 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using SharpEmu.Libs.SaveData;
+using System.Buffers.Binary;
+using System.Text;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.SaveData;
+
+[CollectionDefinition("SaveData", DisableParallelization = true)]
+public sealed class SaveDataCollectionDefinition;
+
+[Collection("SaveData")]
+public sealed class SaveDataExportsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong MountAddress = MemoryBase + 0x100;
+    private const ulong DirNameAddress = MemoryBase + 0x200;
+    private const ulong MountResultAddress = MemoryBase + 0x300;
+    private const ulong ParamAddress = MemoryBase + 0x1000;
+    private const ulong SearchCondAddress = MemoryBase + 0x2000;
+    private const ulong SearchResultAddress = MemoryBase + 0x2100;
+    private const ulong SearchDirNamesAddress = MemoryBase + 0x2200;
+    private const ulong SearchParamsAddress = MemoryBase + 0x2300;
+    private const ulong DeleteAddress = MemoryBase + 0x3000;
+
+    [Fact]
+    public void MountSetParamSearchAndDelete_RoundTripsSaveMetadata()
+    {
+        var saveRoot = Path.Combine(Path.GetTempPath(), $"sharpemu-savedata-{Guid.NewGuid():N}");
+        var previousSaveRoot = Environment.GetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR");
+        var memory = new FakeCpuMemory(MemoryBase, 0x10000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        try
+        {
+            Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", saveRoot);
+            SaveDataExports.ConfigureApplicationInfo("PPSA02929");
+            memory.WriteCString(DirNameAddress, "slot0");
+
+            Span<byte> mount = stackalloc byte[0x30];
+            mount.Clear();
+            BinaryPrimitives.WriteInt32LittleEndian(mount, 1);
+            BinaryPrimitives.WriteUInt64LittleEndian(mount[0x08..], DirNameAddress);
+            BinaryPrimitives.WriteUInt64LittleEndian(mount[0x10..], 96);
+            BinaryPrimitives.WriteUInt32LittleEndian(mount[0x20..], 1u << 5);
+            Assert.True(memory.TryWrite(MountAddress, mount));
+
+            context[CpuRegister.Rdi] = MountAddress;
+            context[CpuRegister.Rsi] = MountResultAddress;
+            Assert.Equal(0, SaveDataExports.SaveDataMount3(context));
+            Assert.EndsWith(
+                Path.Combine("PPSA02929", "slot0", "data.bin"),
+                KernelMemoryCompatExports.ResolveGuestPath("/savedata0/data.bin"));
+
+            var expectedParam = new byte[0x530];
+            WriteAscii(expectedParam.AsSpan(0x00, 128), "Dreaming Sarah");
+            WriteAscii(expectedParam.AsSpan(0x80, 128), "slot0");
+            WriteAscii(expectedParam.AsSpan(0x100, 1024), "New game");
+            BinaryPrimitives.WriteUInt32LittleEndian(expectedParam.AsSpan(0x500), 42);
+            BinaryPrimitives.WriteInt64LittleEndian(expectedParam.AsSpan(0x508), 1_784_000_000);
+            Assert.True(memory.TryWrite(ParamAddress, expectedParam));
+
+            context[CpuRegister.Rdi] = MountResultAddress;
+            context[CpuRegister.Rsi] = 0;
+            context[CpuRegister.Rdx] = ParamAddress;
+            context[CpuRegister.Rcx] = (ulong)expectedParam.Length;
+            Assert.Equal(0, SaveDataExports.SaveDataSetParam(context));
+
+            var shortTitle = Encoding.ASCII.GetBytes("Sarah\0");
+            Assert.True(memory.TryWrite(ParamAddress, shortTitle));
+            context[CpuRegister.Rdi] = MountResultAddress;
+            context[CpuRegister.Rsi] = 1;
+            context[CpuRegister.Rdx] = ParamAddress;
+            context[CpuRegister.Rcx] = (ulong)shortTitle.Length;
+            Assert.Equal(0, SaveDataExports.SaveDataSetParam(context));
+            WriteAscii(expectedParam.AsSpan(0x00, 128), "Sarah");
+
+            Span<byte> searchCond = stackalloc byte[0x20];
+            searchCond.Clear();
+            BinaryPrimitives.WriteInt32LittleEndian(searchCond, 1);
+            Assert.True(memory.TryWrite(SearchCondAddress, searchCond));
+
+            Span<byte> searchResult = stackalloc byte[0x28];
+            searchResult.Clear();
+            BinaryPrimitives.WriteUInt64LittleEndian(searchResult[0x08..], SearchDirNamesAddress);
+            BinaryPrimitives.WriteUInt32LittleEndian(searchResult[0x10..], 1);
+            BinaryPrimitives.WriteUInt64LittleEndian(searchResult[0x18..], SearchParamsAddress);
+            Assert.True(memory.TryWrite(SearchResultAddress, searchResult));
+
+            context[CpuRegister.Rdi] = SearchCondAddress;
+            context[CpuRegister.Rsi] = SearchResultAddress;
+            Assert.Equal(0, SaveDataExports.SaveDataDirNameSearch(context));
+
+            var actualParam = new byte[expectedParam.Length];
+            Assert.True(memory.TryRead(SearchParamsAddress, actualParam));
+            Assert.Equal(expectedParam, actualParam);
+
+            WriteDeleteRequest(memory, 1, DirNameAddress, DeleteAddress);
+            context[CpuRegister.Rdi] = DeleteAddress;
+            Assert.Equal(unchecked((int)0x809F0003), SaveDataExports.SaveDataDelete(context));
+            Assert.True(Directory.Exists(Path.Combine(saveRoot, "1", "PPSA02929", "slot0")));
+
+            context[CpuRegister.Rdi] = MountResultAddress;
+            Assert.Equal(0, SaveDataExports.SaveDataUmount2(context));
+            Assert.Equal("/savedata0/data.bin", KernelMemoryCompatExports.ResolveGuestPath("/savedata0/data.bin"));
+
+            WriteDeleteRequest(memory, 1, DirNameAddress, DeleteAddress);
+            context[CpuRegister.Rdi] = DeleteAddress;
+            Assert.Equal(0, SaveDataExports.SaveDataDelete(context));
+            Assert.False(Directory.Exists(Path.Combine(saveRoot, "1", "PPSA02929", "slot0")));
+        }
+        finally
+        {
+            SaveDataExports.ConfigureApplicationInfo(null);
+            Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", previousSaveRoot);
+            if (Directory.Exists(saveRoot))
+            {
+                Directory.Delete(saveRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void Delete_RejectsParentDirectoryTraversal()
+    {
+        var saveRoot = Path.Combine(Path.GetTempPath(), $"sharpemu-savedata-{Guid.NewGuid():N}");
+        var previousSaveRoot = Environment.GetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR");
+        var memory = new FakeCpuMemory(MemoryBase, 0x10000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        try
+        {
+            Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", saveRoot);
+            SaveDataExports.ConfigureApplicationInfo("PPSA02929");
+            var sentinelPath = Path.Combine(saveRoot, "1", "sentinel.txt");
+            Directory.CreateDirectory(Path.GetDirectoryName(sentinelPath)!);
+            File.WriteAllText(sentinelPath, "must survive");
+            memory.WriteCString(DirNameAddress, "..");
+            WriteDeleteRequest(memory, 1, DirNameAddress, DeleteAddress);
+
+            context[CpuRegister.Rdi] = DeleteAddress;
+            Assert.Equal(unchecked((int)0x809F0000), SaveDataExports.SaveDataDelete(context));
+            Assert.True(File.Exists(sentinelPath));
+        }
+        finally
+        {
+            SaveDataExports.ConfigureApplicationInfo(null);
+            Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", previousSaveRoot);
+            if (Directory.Exists(saveRoot))
+            {
+                Directory.Delete(saveRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void FirstPartialSetParam_PreservesDirectoryMtime()
+    {
+        var saveRoot = Path.Combine(Path.GetTempPath(), $"sharpemu-savedata-{Guid.NewGuid():N}");
+        var previousSaveRoot = Environment.GetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR");
+        var memory = new FakeCpuMemory(MemoryBase, 0x10000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        try
+        {
+            Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", saveRoot);
+            SaveDataExports.ConfigureApplicationInfo("PPSA02929");
+            memory.WriteCString(DirNameAddress, "slot0");
+
+            Span<byte> mount = stackalloc byte[0x30];
+            mount.Clear();
+            BinaryPrimitives.WriteInt32LittleEndian(mount, 1);
+            BinaryPrimitives.WriteUInt64LittleEndian(mount[0x08..], DirNameAddress);
+            BinaryPrimitives.WriteUInt32LittleEndian(mount[0x20..], 1u << 5);
+            Assert.True(memory.TryWrite(MountAddress, mount));
+            context[CpuRegister.Rdi] = MountAddress;
+            context[CpuRegister.Rsi] = MountResultAddress;
+            Assert.Equal(0, SaveDataExports.SaveDataMount3(context));
+
+            var savePath = Path.Combine(saveRoot, "1", "PPSA02929", "slot0");
+            var expectedMtime = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+            Directory.SetLastWriteTimeUtc(savePath, expectedMtime);
+            var shortTitle = Encoding.ASCII.GetBytes("Sarah\0");
+            Assert.True(memory.TryWrite(ParamAddress, shortTitle));
+            context[CpuRegister.Rdi] = MountResultAddress;
+            context[CpuRegister.Rsi] = 1;
+            context[CpuRegister.Rdx] = ParamAddress;
+            context[CpuRegister.Rcx] = (ulong)shortTitle.Length;
+            Assert.Equal(0, SaveDataExports.SaveDataSetParam(context));
+
+            var storedParam = File.ReadAllBytes(Path.Combine(saveRoot, "1", "PPSA02929", "sce_params", "slot0.bin"));
+            var actualMtime = BinaryPrimitives.ReadInt64LittleEndian(storedParam.AsSpan(0x508));
+            Assert.Equal(new DateTimeOffset(expectedMtime).ToUnixTimeSeconds(), actualMtime);
+        }
+        finally
+        {
+            SaveDataExports.ConfigureApplicationInfo(null);
+            Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", previousSaveRoot);
+            if (Directory.Exists(saveRoot))
+            {
+                Directory.Delete(saveRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void DirNameSearch_SortsByStoredSaveMtime()
+    {
+        var saveRoot = Path.Combine(Path.GetTempPath(), $"sharpemu-savedata-{Guid.NewGuid():N}");
+        var previousSaveRoot = Environment.GetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR");
+        var memory = new FakeCpuMemory(MemoryBase, 0x10000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        try
+        {
+            Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", saveRoot);
+            SaveDataExports.ConfigureApplicationInfo("PPSA02929");
+            var titleRoot = Path.Combine(saveRoot, "1", "PPSA02929");
+            var newerHostPath = Directory.CreateDirectory(Path.Combine(titleRoot, "stored-oldest")).FullName;
+            var olderHostPath = Directory.CreateDirectory(Path.Combine(titleRoot, "stored-newest")).FullName;
+            Directory.SetLastWriteTimeUtc(newerHostPath, new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+            Directory.SetLastWriteTimeUtc(olderHostPath, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+            var metadataRoot = Directory.CreateDirectory(Path.Combine(titleRoot, "sce_params")).FullName;
+            WriteStoredMtime(Path.Combine(metadataRoot, "stored-oldest.bin"), 100);
+            WriteStoredMtime(Path.Combine(metadataRoot, "stored-newest.bin"), 200);
+
+            Span<byte> searchCond = stackalloc byte[0x20];
+            searchCond.Clear();
+            BinaryPrimitives.WriteInt32LittleEndian(searchCond, 1);
+            BinaryPrimitives.WriteUInt32LittleEndian(searchCond[0x18..], 3);
+            Assert.True(memory.TryWrite(SearchCondAddress, searchCond));
+
+            Span<byte> searchResult = stackalloc byte[0x28];
+            searchResult.Clear();
+            BinaryPrimitives.WriteUInt64LittleEndian(searchResult[0x08..], SearchDirNamesAddress);
+            BinaryPrimitives.WriteUInt32LittleEndian(searchResult[0x10..], 2);
+            Assert.True(memory.TryWrite(SearchResultAddress, searchResult));
+
+            context[CpuRegister.Rdi] = SearchCondAddress;
+            context[CpuRegister.Rsi] = SearchResultAddress;
+            Assert.Equal(0, SaveDataExports.SaveDataDirNameSearch(context));
+            Assert.Equal("stored-oldest", ReadFixedAscii(memory, SearchDirNamesAddress, 32));
+            Assert.Equal("stored-newest", ReadFixedAscii(memory, SearchDirNamesAddress + 32, 32));
+        }
+        finally
+        {
+            SaveDataExports.ConfigureApplicationInfo(null);
+            Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", previousSaveRoot);
+            if (Directory.Exists(saveRoot))
+            {
+                Directory.Delete(saveRoot, recursive: true);
+            }
+        }
+    }
+
+    private static void WriteDeleteRequest(
+        FakeCpuMemory memory,
+        int userId,
+        ulong dirNameAddress,
+        ulong deleteAddress)
+    {
+        Span<byte> delete = stackalloc byte[0x40];
+        delete.Clear();
+        BinaryPrimitives.WriteInt32LittleEndian(delete, userId);
+        BinaryPrimitives.WriteUInt64LittleEndian(delete[0x10..], dirNameAddress);
+        Assert.True(memory.TryWrite(deleteAddress, delete));
+    }
+
+    private static void WriteStoredMtime(string path, long seconds)
+    {
+        var param = new byte[0x530];
+        BinaryPrimitives.WriteInt64LittleEndian(param.AsSpan(0x508), seconds);
+        File.WriteAllBytes(path, param);
+    }
+
+    private static string ReadFixedAscii(FakeCpuMemory memory, ulong address, int length)
+    {
+        var bytes = new byte[length];
+        Assert.True(memory.TryRead(address, bytes));
+        var end = Array.IndexOf(bytes, (byte)0);
+        return Encoding.ASCII.GetString(bytes, 0, end < 0 ? bytes.Length : end);
+    }
+
+    private static void WriteAscii(Span<byte> destination, string value)
+    {
+        destination.Clear();
+        var encoded = Encoding.ASCII.GetBytes(value);
+        encoded.AsSpan(0, Math.Min(encoded.Length, destination.Length - 1)).CopyTo(destination);
+    }
+}


### PR DESCRIPTION
## Summary

- implement `sceSaveDataSetParam` with persistent metadata and partial-field updates
- implement contained, mount-aware `sceSaveDataDelete`
- unregister guest save mounts during unmount and application reset
- tolerate Dreaming Sarah's optional null telemetry destination while validating its value string

## Why

Dreaming Sarah reaches its menu but stops when starting a new game because these save-data and NP Universal Data System imports are unresolved. This gives that path real local save semantics instead of success-only stubs.

The save metadata sidecar is deliberately kept outside the guest-visible mounted directory. Recursive deletion rejects dot/path segments and is serialized with mount, set-param, and unmount transitions.

Fixes #256.

## Validation

- Release solution build: 0 warnings, 0 errors
- full automated suite: 186 passed
- focused save-data/NP regressions: 7 passed
- targeted `dotnet format --verify-no-changes`
- `git diff --check`

Tests use synthetic guest memory and temporary directories; no proprietary game data is included. Runtime validation with a legally dumped copy of Dreaming Sarah is still needed.
