### PR TITLE
[Logging] Collapse repeated log lines centrally over Console

### DIFF
--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -56,6 +56,7 @@ internal static partial class Program
         }
         finally
         {
+            DrainConsoleCollapsing();
             DropConsoleFileMirror();
             SharpEmuLog.Shutdown();
         }
@@ -84,6 +85,12 @@ internal static partial class Program
         {
             TryEnableConsoleFileMirror(earlyLogFilePath);
         }
+
+        // Funnel all console output through one collapser so repeated log lines
+        // (guest printf floods, per-call import-result warnings) fold to a single
+        // line plus a summary instead of drowning the log. Installed last, over
+        // any file mirror, so the log file is collapsed too.
+        InstallConsoleCollapsing();
 
         if (!CheckHostArchitecture())
         {
@@ -1201,6 +1208,28 @@ internal static partial class Program
         public nuint JobMemoryLimit;
         public nuint PeakProcessMemoryUsed;
         public nuint PeakJobMemoryUsed;
+    }
+
+    private static CollapsingTextWriter? _outCollapser;
+    private static CollapsingTextWriter? _errCollapser;
+
+    // Wrap Console.Out/Console.Error so every write funnels through one collapser.
+    // References are kept so the collapsers can be drained at shutdown even after
+    // a file mirror later wraps Console.Out in a TeeTextWriter.
+    private static void InstallConsoleCollapsing()
+    {
+        _outCollapser = new CollapsingTextWriter(Console.Out);
+        _errCollapser = new CollapsingTextWriter(Console.Error);
+        Console.SetOut(_outCollapser);
+        Console.SetError(_errCollapser);
+    }
+
+    // Emit any pending "(previous message repeated N more times)" summary before
+    // the process exits, so a trailing run of duplicates is not lost.
+    private static void DrainConsoleCollapsing()
+    {
+        _outCollapser?.Drain();
+        _errCollapser?.Drain();
     }
 
     private sealed class TeeTextWriter : TextWriter

--- a/src/SharpEmu.Logging/CollapsingTextWriter.cs
+++ b/src/SharpEmu.Logging/CollapsingTextWriter.cs
@@ -1,0 +1,199 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace SharpEmu.Logging;
+
+// A TextWriter decorator that collapses runs of repeated log lines into a single
+// line plus a "(previous message repeated N more times)" summary. It is installed
+// over Console.Out / Console.Error so every write in the process funnels through
+// one collapser, instead of each spammy call site needing its own.
+//
+// Two lines count as "the same" after volatile tokens are masked: hex addresses
+// (0x...) and #counters. That lets structurally identical spam that differs only
+// by a pointer or an incrementing id still fold (e.g. the import-result warnings
+// logged per-call during shutdown). The trade-off is deliberate: two genuinely
+// different lines that differ only by such a token collapse together. The first
+// occurrence of a run is always printed verbatim; only the repeats are dropped.
+//
+// The summary is emitted when a different line arrives, once per flush interval
+// while a run is outstanding (so an ongoing flood still shows progress and a run
+// that falls quiet still gets summarised), or on Drain at shutdown. Crucially it
+// is NOT emitted from Flush(): Console.Error auto-flushes after every write, so
+// summarising there would print a summary line after every single repeat.
+public sealed partial class CollapsingTextWriter : TextWriter
+{
+    [GeneratedRegex("0x[0-9A-Fa-f]+")]
+    private static partial Regex HexRegex();
+
+    [GeneratedRegex("#[0-9]+")]
+    private static partial Regex CounterRegex();
+
+    private static readonly TimeSpan DefaultFlushInterval = TimeSpan.FromSeconds(2);
+
+    private readonly TextWriter _inner;
+    private readonly Lock _gate = new();
+    private readonly StringBuilder _lineBuffer = new();
+    private readonly TimeProvider _time;
+    private readonly TimeSpan _flushInterval;
+    private readonly ITimer _flushTimer;
+
+    private string? _lastKey;
+    private long _repeatCount;
+    private long _lastEmitTimestamp;
+
+    public CollapsingTextWriter(
+        TextWriter inner,
+        TimeProvider? timeProvider = null,
+        TimeSpan? flushInterval = null)
+    {
+        _inner = inner;
+        _time = timeProvider ?? TimeProvider.System;
+        _flushInterval = flushInterval ?? DefaultFlushInterval;
+        _flushTimer = _time.CreateTimer(
+            _ => FlushStaleSummary(), state: null, _flushInterval, _flushInterval);
+    }
+
+    public override Encoding Encoding => _inner.Encoding;
+
+    public override void Write(char value) => Append([value]);
+
+    public override void Write(string? value) => Append(value.AsSpan());
+
+    public override void Write(char[] buffer, int index, int count) =>
+        Append(buffer.AsSpan(index, count));
+
+    public override void Write(ReadOnlySpan<char> buffer) => Append(buffer);
+
+    public override void WriteLine() => Append(_inner.NewLine.AsSpan());
+
+    public override void WriteLine(string? value)
+    {
+        lock (_gate)
+        {
+            AppendLocked(value.AsSpan());
+            AppendLocked(_inner.NewLine.AsSpan());
+        }
+    }
+
+    // Do NOT summarise here. Console.Error auto-flushes after every write, so a
+    // summary from Flush would print once per repeat. Just push the inner writer.
+    public override void Flush()
+    {
+        lock (_gate)
+        {
+            _inner.Flush();
+        }
+    }
+
+    // Emit any pending summary and buffered partial line. Call at shutdown so a
+    // trailing run of repeats (or an unterminated line) is never lost.
+    public void Drain()
+    {
+        lock (_gate)
+        {
+            FlushSummaryLocked();
+            if (_lineBuffer.Length > 0)
+            {
+                _inner.Write(_lineBuffer.ToString());
+                _lineBuffer.Clear();
+                _lastKey = null;
+            }
+
+            _inner.Flush();
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _flushTimer.Dispose();
+            Drain();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void Append(ReadOnlySpan<char> text)
+    {
+        lock (_gate)
+        {
+            AppendLocked(text);
+        }
+    }
+
+    private void AppendLocked(ReadOnlySpan<char> text)
+    {
+        foreach (var c in text)
+        {
+            _lineBuffer.Append(c);
+            if (c == '\n')
+            {
+                FinalizeLineLocked();
+            }
+        }
+    }
+
+    private void FinalizeLineLocked()
+    {
+        var line = _lineBuffer.ToString();
+        _lineBuffer.Clear();
+
+        var content = line.AsSpan().TrimEnd('\n').TrimEnd('\r');
+        var key = Normalize(content);
+
+        if (key == _lastKey)
+        {
+            _repeatCount++;
+            return;
+        }
+
+        FlushSummaryLocked();
+        _inner.Write(line);
+        _lastKey = key;
+        _lastEmitTimestamp = _time.GetTimestamp();
+    }
+
+    // Timer path: surface an outstanding run once the interval has elapsed, so an
+    // ongoing flood shows progress and a run that fell quiet is still summarised.
+    private void FlushStaleSummary()
+    {
+        lock (_gate)
+        {
+            if (_repeatCount > 0 &&
+                _time.GetElapsedTime(_lastEmitTimestamp) >= _flushInterval)
+            {
+                FlushSummaryLocked();
+            }
+        }
+    }
+
+    private void FlushSummaryLocked()
+    {
+        if (_repeatCount == 0)
+        {
+            return;
+        }
+
+        _inner.WriteLine(
+            $"(previous message repeated {_repeatCount} more times)");
+        _repeatCount = 0;
+        _lastEmitTimestamp = _time.GetTimestamp();
+    }
+
+    private static string Normalize(ReadOnlySpan<char> content)
+    {
+        // Fast path: nothing volatile to mask, the line is its own key.
+        if (content.IndexOf("0x", StringComparison.Ordinal) < 0 &&
+            content.IndexOf('#') < 0)
+        {
+            return content.ToString();
+        }
+
+        var masked = HexRegex().Replace(content.ToString(), "0x#");
+        return CounterRegex().Replace(masked, "#N");
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Logging/CollapsingTextWriterTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Logging/CollapsingTextWriterTests.cs
@@ -1,0 +1,258 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Logging;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Logging;
+
+// CollapsingTextWriter decorates Console.Out/Console.Error and folds runs of
+// repeated log lines. Two lines are "the same" after hex addresses (0x...) and
+// #counters are masked, so structurally identical spam that differs only by a
+// pointer or an incrementing id still collapses. Unique output is never dropped.
+public sealed class CollapsingTextWriterTests : IDisposable
+{
+    private readonly List<CollapsingTextWriter> _created = [];
+
+    private (CollapsingTextWriter Writer, StringWriter Sink, ManualTimeProvider Clock) New()
+    {
+        var clock = new ManualTimeProvider();
+        var sink = new StringWriter { NewLine = "\n" };
+        var writer = new CollapsingTextWriter(
+            sink, clock, flushInterval: TimeSpan.FromSeconds(2));
+        _created.Add(writer);
+        return (writer, sink, clock);
+    }
+
+    // Stop the background timers; Dispose also drains, but the asserts run first.
+    public void Dispose()
+    {
+        foreach (var writer in _created)
+        {
+            writer.Dispose();
+        }
+    }
+
+    [Fact]
+    public void DistinctLines_PassThroughVerbatim()
+    {
+        var (writer, sink, _) = New();
+
+        writer.WriteLine("a");
+        writer.WriteLine("b");
+        writer.WriteLine("c");
+
+        Assert.Equal("a\nb\nc\n", sink.ToString());
+    }
+
+    [Fact]
+    public void IdenticalRun_PrintsOnce_ThenSummarisesWhenADifferentLineArrives()
+    {
+        var (writer, sink, _) = New();
+
+        for (var i = 0; i < 5; i++)
+        {
+            writer.WriteLine("same");
+        }
+        writer.WriteLine("different");
+
+        Assert.Equal(
+            "same\n" +
+            "(previous message repeated 4 more times)\n" +
+            "different\n",
+            sink.ToString());
+    }
+
+    [Fact]
+    public void Normalisation_FoldsLinesDifferingOnlyByAddressesAndCounters()
+    {
+        var (writer, sink, _) = New();
+
+        // The shutdown import-result spam: every line differs by the Import#
+        // counter and an rsi address that alternates between two values, yet they
+        // are the same event and must collapse to one line plus a summary.
+        writer.WriteLine("Import#100 result: INVALID (QOQtbeDqsT4) rsi=0x00007FFFDF1FF790 ret=0x800");
+        writer.WriteLine("Import#131 result: INVALID (QOQtbeDqsT4) rsi=0x00007FFFDF1FEF90 ret=0x800");
+        writer.WriteLine("Import#162 result: INVALID (QOQtbeDqsT4) rsi=0x00007FFFDF1FF790 ret=0x800");
+        writer.WriteLine("[DEBUG] done");
+
+        Assert.Equal(
+            "Import#100 result: INVALID (QOQtbeDqsT4) rsi=0x00007FFFDF1FF790 ret=0x800\n" +
+            "(previous message repeated 2 more times)\n" +
+            "[DEBUG] done\n",
+            sink.ToString());
+    }
+
+    [Fact]
+    public void Normalisation_KeepsGenuinelyDifferentLinesApart()
+    {
+        var (writer, sink, _) = New();
+
+        // Same shape, different NID in the un-masked part: must NOT fold.
+        writer.WriteLine("Import#1 result: INVALID (AAAAAAAAAAA) rsi=0x10");
+        writer.WriteLine("Import#2 result: INVALID (BBBBBBBBBBB) rsi=0x20");
+
+        Assert.Equal(
+            "Import#1 result: INVALID (AAAAAAAAAAA) rsi=0x10\n" +
+            "Import#2 result: INVALID (BBBBBBBBBBB) rsi=0x20\n",
+            sink.ToString());
+    }
+
+    [Fact]
+    public void IdleRun_IsSummarisedByTheBackgroundTimer()
+    {
+        var (writer, sink, clock) = New();
+
+        writer.WriteLine("spam");
+        writer.WriteLine("spam");            // one outstanding repeat, then quiet
+
+        clock.Advance(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(
+            "spam\n" +
+            "(previous message repeated 1 more times)\n",
+            sink.ToString());
+    }
+
+    [Fact]
+    public void Flush_DoesNotEmitTheSummary_SoAutoFlushDoesNotSpamIt()
+    {
+        var (writer, sink, _) = New();
+
+        writer.WriteLine("spam");
+        writer.WriteLine("spam");
+        writer.Flush();                       // Console.Error auto-flushes like this
+        writer.Flush();
+
+        // The repeat is still pending; Flush must stay silent about it.
+        Assert.Equal("spam\n", sink.ToString());
+    }
+
+    [Fact]
+    public void Drain_EmitsTrailingSummary_AtShutdown()
+    {
+        var (writer, sink, _) = New();
+
+        writer.WriteLine("spam");
+        writer.WriteLine("spam");
+        writer.WriteLine("spam");
+        writer.Drain();
+
+        Assert.Equal(
+            "spam\n" +
+            "(previous message repeated 2 more times)\n",
+            sink.ToString());
+    }
+
+    [Fact]
+    public void Drain_FlushesAnUnterminatedPartialLine()
+    {
+        var (writer, sink, _) = New();
+
+        writer.Write("partial with no newline");
+        writer.Drain();
+
+        Assert.Equal("partial with no newline", sink.ToString());
+    }
+
+    // A TimeProvider whose clock only moves when the test advances it; advancing
+    // also fires any due timers, so the background summary can be driven
+    // deterministically.
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private readonly List<FakeTimer> _timers = [];
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override ITimer CreateTimer(
+            TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = new FakeTimer(this, callback, state, dueTime, period);
+            lock (_timers)
+            {
+                _timers.Add(timer);
+            }
+            return timer;
+        }
+
+        public void Advance(TimeSpan delta)
+        {
+            _timestamp += delta.Ticks;
+
+            FakeTimer[] snapshot;
+            lock (_timers)
+            {
+                snapshot = [.. _timers];
+            }
+            foreach (var timer in snapshot)
+            {
+                timer.Advance(delta);
+            }
+        }
+
+        private void Remove(FakeTimer timer)
+        {
+            lock (_timers)
+            {
+                _timers.Remove(timer);
+            }
+        }
+
+        private sealed class FakeTimer(
+            ManualTimeProvider owner,
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period) : ITimer
+        {
+            private TimeSpan _remaining = dueTime;
+            private TimeSpan _period = period;
+            private bool _active = dueTime != Timeout.InfiniteTimeSpan;
+
+            public bool Change(TimeSpan dueTime, TimeSpan period)
+            {
+                _period = period;
+                _remaining = dueTime;
+                _active = dueTime != Timeout.InfiniteTimeSpan;
+                return true;
+            }
+
+            public void Advance(TimeSpan delta)
+            {
+                if (!_active)
+                {
+                    return;
+                }
+
+                _remaining -= delta;
+                while (_active && _remaining <= TimeSpan.Zero)
+                {
+                    callback(state);
+                    if (_period <= TimeSpan.Zero)
+                    {
+                        _active = false;
+                    }
+                    else
+                    {
+                        _remaining += _period;
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                _active = false;
+                owner.Remove(this);
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                Dispose();
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What this changes

Adds a central log-collapsing layer so repeated console output folds to a single line plus a summary, instead of each spammy call site needing its own throttling. Three things:

- New src/SharpEmu.Logging/CollapsingTextWriter.cs — a TextWriter installed over Console.Out/Console.Error. It assembles complete lines and compares them by a normalised key (hex addresses 0x… and #counters masked, via source-generated regex), so structurally identical spam that differs only by a pointer or an incrementing id still folds. The first occurrence of a run is printed verbatim; repeats are counted and a (previous message repeated N more times) summary is emitted when a different line arrives, on an idle timer, or at shutdown via Drain(). Flush() deliberately stays silent so Console.Error's auto-flush doesn't print a summary after every repeat.
- src/SharpEmu.CLI/Program.cs — InstallConsoleCollapsing() wraps the console after the file-mirror setup (outermost, so the log file is collapsed too); DrainConsoleCollapsing() runs in Main's finally so a trailing run isn't lost.
- tests/SharpEmu.Libs.Tests/Logging/CollapsingTextWriterTests.cs — 8 tests.

Purely additive: 3 files, +486 lines, no existing behaviour paths modified.

### Why it's needed / the problem it solves

Two real sources flood the log. A chatty guest can printf the same line every frame, and the HLE import tracer emits one [LOADER][WARN] per call — e.g. on shutdown sceAudioOutOutput returns INVALID_ARGUMENT once per audio-thread iteration after the port is closed, producing hundreds of near-identical lines. Those import lines are never byte-identical (each carries an incrementing Import#N and an rsi=0x… address that alternates between two buffers), so a plain "fold identical consecutive lines" approach can't catch them.

About 90% of the emulator's output goes straight to Console rather than through the logger, so a collapser at the log-sink level would miss nearly everything. The one place that can fold all of it is the Console stream itself — hence a TextWriter decorator, with token normalisation so the varying counter/address lines collapse too.

### How I verified it

- New unit tests: 8/8 pass, including the real import-line format collapsing to one line + summary, genuinely-different NIDs staying apart, the Flush()-emits-nothing guarantee, the idle-timer summary (driven deterministically via a manual TimeProvider), and drain-at-shutdown.
- Build is clean with dotnet build SharpEmu.slnx -c Release (0 warnings, 0 errors) using the SDK pinned in global.json (10.0.103).
- Full suite with dotnet test SharpEmu.slnx -c Release: SharpEmu.SourceGenerators.Tests 33/33 pass; SharpEmu.Libs.Tests 92/93 pass.
  - The single failure — KernelMemoryCompatExportsTests.Sprintf_ReadsVariadicDoubleFromXmmRegister (Expected "0.5576", Actual "0,5576") — is a pre-existing locale bug on main, not introduced by this PR. It reproduces on a host whose OS locale uses a comma decimal separator (I'm on es-ES Windows) and lives in KernelMemoryCompatExports, a file this PR does not touch. It is unrelated to this change.

### Scope / follow-up

I kept this PR to the central collapser only. One deliberate trade-off: because comparison is on the normalised form, two genuinely different lines that differ only by a masked token (an address or counter) will collapse together — the first is always shown verbatim, so one real sample is preserved, but per-address detail within a repeated run is lost. If a subsystem ever needs every address kept, that call site can bypass the writer.

Separately, while verifying I confirmed the pre-existing es-ES Sprintf locale failure noted above. That's a distinct conformance fix (CultureInfo.InvariantCulture in the printf numeric paths) and I'd rather address it in its own PR than mix it in here.

### Note on AI assistance

This change was developed with AI assistance (per the project's AI-assisted contributions policy). I understand the change fully and can explain, modify, and maintain it. Happy to answer any review questions.