### PR TITLE
[Perf] Cache pixel shader export masks

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -5936,13 +5936,14 @@ public static partial class AgcExports
         // Every bound color target the shader exports to. Deferred renderers
         // draw a multi-render-target G-buffer (up to eight slots) in one pass.
         // Fall back to slot 0 if we cannot match any export to a bound target.
+        var pixelColorExportMasks = pixelState.Program.PixelColorExportMasks;
         var allBoundTargets = GetRenderTargets(state.CxRegisters);
         // At most 8 slots; a manual filter avoids the per-draw LINQ iterator/
         // closure allocations. Slots are distinct, so sorting by slot is stable.
         var selectedTargets = new List<RenderTargetDescriptor>(allBoundTargets.Count);
         foreach (var target in allBoundTargets)
         {
-            if (HasPixelColorExport(pixelState, target.Slot))
+            if (GetPixelColorExportMask(pixelColorExportMasks, target.Slot) != 0)
             {
                 selectedTargets.Add(target);
             }
@@ -5965,7 +5966,7 @@ public static partial class AgcExports
         {
             TraceAgcShader(
                 $"agc.mrt_filter ps=0x{pixelShaderAddress:X16} " +
-                $"bound=[{string.Join(",", allBoundTargets.Select(t => $"s{t.Slot}:0x{t.Address:X}:exp{(HasPixelColorExport(pixelState, t.Slot) ? 1 : 0)}"))}] " +
+                $"bound=[{string.Join(",", allBoundTargets.Select(t => $"s{t.Slot}:0x{t.Address:X}:exp{(GetPixelColorExportMask(pixelColorExportMasks, t.Slot) != 0 ? 1 : 0)}"))}] " +
                  $"kept={renderTargets.Length}");
         }
 
@@ -6165,7 +6166,7 @@ public static partial class AgcExports
             DecodeDepthTarget(state.CxRegisters),
             guestTargets,
             ApplyTransparentPremultipliedFillClear(
-                CreateRenderState(state.CxRegisters, renderTargets, pixelState),
+                CreateRenderState(state.CxRegisters, renderTargets, pixelColorExportMasks),
                 textures,
                 vertexInputs,
                 pixelEvaluation.InitialScalarRegisters),
@@ -6409,26 +6410,10 @@ public static partial class AgcExports
         return true;
     }
 
-    private static bool HasPixelColorExport(Gen5ShaderState state, uint target) =>
-        GetPixelColorExportMask(state, target) != 0;
-
-    private static uint GetPixelColorExportMask(Gen5ShaderState state, uint target)
-    {
-        // Called per render target (twice per draw via CreateRenderState +
-        // HasPixelColorExport); a manual scan avoids the per-call LINQ iterator
-        // and closure allocations. Same result as the previous
-        // Select/OfType/Where/Aggregate chain.
-        var mask = 0u;
-        foreach (var instruction in state.Program.Instructions)
-        {
-            if (instruction.Control is Gen5ExportControl export && export.Target == target)
-            {
-                mask |= export.EnableMask & 0xFu;
-            }
-        }
-
-        return mask;
-    }
+    private static uint GetPixelColorExportMask(uint packedMasks, uint target) =>
+        target < ColorTargetCount
+            ? (packedMasks >> (int)(target * 4)) & 0xFu
+            : 0;
 
     private static uint GetInterpolatedAttributeCount(Gen5ShaderState state)
     {
@@ -6626,7 +6611,7 @@ public static partial class AgcExports
     private static GuestRenderState CreateRenderState(
         IReadOnlyDictionary<uint, uint> registers,
         IReadOnlyList<RenderTargetDescriptor> targets,
-        Gen5ShaderState pixelState)
+        uint pixelColorExportMasks)
     {
         if (targets.Count == 0)
         {
@@ -6641,7 +6626,8 @@ public static partial class AgcExports
                 var blend = DecodeBlendState(registers, target.Slot);
                 return blend with
                 {
-                    WriteMask = blend.WriteMask & GetPixelColorExportMask(pixelState, target.Slot),
+                    WriteMask = blend.WriteMask &
+                        GetPixelColorExportMask(pixelColorExportMasks, target.Slot),
                 };
             }).ToArray(),
             scissor,

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
@@ -325,8 +325,30 @@ public sealed record Gen5ShaderProgram(
     ulong Address,
     IReadOnlyList<Gen5ShaderInstruction> Instructions)
 {
+    private const uint PixelColorTargetCount = 8;
+    private const int PixelColorMaskBits = 4;
+    private readonly uint _pixelColorExportMasks = ComputePixelColorExportMasks(Instructions);
     private const int ScalarRegisterCount = 256;
     private IReadOnlySet<uint>? _runtimeScalarRegisters;
+
+    public uint PixelColorExportMasks => _pixelColorExportMasks;
+
+    private static uint ComputePixelColorExportMasks(
+        IReadOnlyList<Gen5ShaderInstruction> instructions)
+    {
+        var masks = 0u;
+        foreach (var instruction in instructions)
+        {
+            if (instruction.Control is Gen5ExportControl export &&
+                export.Target < PixelColorTargetCount)
+            {
+                masks |= (export.EnableMask & 0xFu) <<
+                    (int)(export.Target * PixelColorMaskBits);
+            }
+        }
+
+        return masks;
+    }
 
     public IEnumerable<Gen5ImageControl> ImageResources =>
         Instructions

--- a/tests/SharpEmu.Libs.Tests/Agc/Gen5ShaderProgramTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/Gen5ShaderProgramTests.cs
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.ShaderCompiler;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class Gen5ShaderProgramTests
+{
+    [Fact]
+    public void PixelColorExportMasksPackAllColorTargets()
+    {
+        var program = new Gen5ShaderProgram(
+            0,
+            [
+                Export(0, 0x1),
+                Export(0, 0x4),
+                Export(1, 0x2),
+                Export(2, 0x3),
+                Export(3, 0x4),
+                Export(4, 0x5),
+                Export(5, 0x6),
+                Export(6, 0x7),
+                Export(7, 0x8),
+                Export(8, 0xF),
+            ]);
+
+        Assert.Equal(0x8765_4325u, program.PixelColorExportMasks);
+        Assert.Equal(0x8765_4325u, program.PixelColorExportMasks);
+    }
+
+    private static Gen5ShaderInstruction Export(uint target, uint enableMask) => new(
+        0,
+        Gen5ShaderEncoding.Exp,
+        "exp",
+        [],
+        [],
+        [],
+        new Gen5ExportControl(target, enableMask, false, false, false));
+}


### PR DESCRIPTION
## What

Cache the eight four-bit pixel color export masks on each immutable decoded `Gen5ShaderProgram`.

`AgcExports` now reads that packed `uint` once per draw and uses constant-time nibble lookups for:

- render-target filtering;
- shader trace output;
- blend write masks.

Repeated exports to one target still combine with bitwise OR, non-color targets are ignored, and the existing slot-0 fallback is unchanged. A focused xUnit test covers all eight slots, repeated exports, and an out-of-range target.

## Why

The previous helper scanned the pixel shader’s complete decoded instruction list for each render target while filtering and then scanned it again while creating blend state. With eight exported targets, that is roughly 16 scans of the same immutable program per draw. Decoded programs are already cached and reused, so the export masks can be computed once when the program is constructed.

## Measurement

Uncommitted .NET microbenchmark:

- synthetic 256-instruction shader;
- 8 color targets;
- 25,000 draw iterations;
- 5 samples, median reported;
- identical checksum (`1,800,000`) for both algorithms.

| Path | Median |
| --- | ---: |
| Existing repeated scans, before the change | 304.974 ms |
| Existing repeated scans, committed comparison run | 310.944 ms |
| Cached packed-mask lookups | 0.246 ms |

The committed comparison run reports a **1,264.51× isolated algorithm speedup**. This is a microbenchmark of the removed CPU work, not a claim of a 1,264× frame-rate improvement.

## Verification

- Red test: `CS1061` before `PixelColorExportMasks` existed
- Focused packed-mask test: 1 passed, 0 failed
- `dotnet build SharpEmu.slnx -c Release --no-restore`
- `dotnet test SharpEmu.slnx -c Release --no-build` — 193 passed, 0 failed
- `reuse lint` — REUSE 3.3 compliant, 0 missing licenses

## AI assistance

AI assistance was used for repository research, benchmarking, implementation, and verification. I reviewed the focused change, understand each line, and can explain, modify, debug, and maintain it.