### PR TITLE
[CI] Make versioned releases immutable

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - "**"
+    tags:
+      - "v*"
     paths-ignore:
       - "**/*.md"
       - "**/*.png"
@@ -52,6 +54,11 @@ jobs:
           version="$(python3 -c 'import sys, xml.etree.ElementTree as ET; version = ET.parse("Directory.Build.props").getroot().findtext(".//SharpEmuVersion"); sys.exit("Directory.Build.props is missing SharpEmuVersion") if not version or not version.strip() else print(version.strip())')"
           release_tag="v${version}"
           release_name="SharpEmu v${version}"
+
+          if [ "${GITHUB_REF_TYPE}" = "tag" ] && [ "${GITHUB_REF_NAME}" != "${release_tag}" ]; then
+            echo "Release tag ${GITHUB_REF_NAME} does not match project version ${release_tag}." >&2
+            exit 1
+          fi
 
           {
             echo "short-sha=${short_sha}"
@@ -203,7 +210,9 @@ jobs:
       - init
       - build
       - build-posix
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    # Versioned releases are immutable and tag-driven. Branch and manual runs
+    # still produce Actions artifacts without modifying a published release.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -213,7 +222,7 @@ jobs:
         with:
           path: release
 
-      - name: Create or update release
+      - name: Create release
         shell: bash
         env:
           GH_REPO: ${{ github.repository }}
@@ -231,26 +240,11 @@ jobs:
           notes="Automated SharpEmu v${VERSION} build for commit ${GITHUB_SHA}."
 
           if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
-            gh release upload "${RELEASE_TAG}" "${assets[@]}" --clobber
-            gh release edit "${RELEASE_TAG}" --title "${RELEASE_NAME}" --notes "${notes}"
-          else
-            gh release create "${RELEASE_TAG}" "${assets[@]}" \
-              --title "${RELEASE_NAME}" \
-              --notes "${notes}" \
-              --target "${GITHUB_SHA}"
+            echo "Release ${RELEASE_TAG} already exists and will not be modified." >&2
+            exit 1
           fi
 
-          keep=()
-          for asset_path in "${assets[@]}"; do
-            keep+=("$(basename "${asset_path}")")
-          done
-          mapfile -t release_assets < <(gh release view "${RELEASE_TAG}" --json assets --jq '.assets[].name' | sort)
-          for asset in "${release_assets[@]}"; do
-            case "${asset}" in
-              sharpemu-${VERSION}-*.zip|sharpemu-${VERSION}-*.tar.gz)
-                if ! printf '%s\n' "${keep[@]}" | grep -Fxq "${asset}"; then
-                  gh release delete-asset "${RELEASE_TAG}" "${asset}" --yes
-                fi
-                ;;
-            esac
-          done
+          gh release create "${RELEASE_TAG}" "${assets[@]}" \
+            --verify-tag \
+            --title "${RELEASE_NAME}" \
+            --notes "${notes}"


### PR DESCRIPTION
## Summary

- publish versioned releases only from `v*` tag pushes
- require the pushed tag to match `SharpEmuVersion`
- keep branch, pull request, and manual runs as Actions artifacts without changing a release
- refuse to overwrite an existing versioned release

## Root cause

The release job ran for every push to `main` and for manual dispatches while always targeting `v${version}`. A later build could therefore replace or append binaries under a tag that still identified an older commit.

## Behavior after this change

| Event | Build artifacts | GitHub release |
| --- | --- | --- |
| Branch or pull request push | Yes | No |
| Manual dispatch | Yes | No |
| Matching `vX.Y.Z` tag push | Yes | Created once |
| Mismatched version tag | No | Rejected during init |
| Existing versioned release | N/A | Left unchanged; the job fails |

This keeps one source revision behind each semantic-version tag and its platform archives.

## Validation

- `actionlint` 1.7.12 on both workflow files
- `git diff --check`
- event matrix check for branch, matching-tag, and mismatched-tag inputs

## Follow-up

The existing `v0.0.1` release still needs a one-time maintainer cleanup. That state change is intentionally not automated here.

Addresses #240.