### PR TITLE
[Tests/VideoOut] Add pixel format mapping unit tests

### DIFF
--- a/tests/SharpEmu.Libs.Tests/VideoOut/VideoOutPixelFormatTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VideoOutPixelFormatTests.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Runtime.CompilerServices;
 using SharpEmu.Libs.VideoOut;
 using Xunit;
 
@@ -8,8 +9,8 @@ namespace SharpEmu.Libs.Tests.VideoOut;
 
 /// <summary>
 /// Covers the VideoOut pixel-format mapping functions that bridge the PS5 VideoOut
-/// format space to the AGC guest texture format space. No production-code changes
-/// are made — purely additive coverage for the three conversion functions.
+/// format space to the AGC guest texture format. No production-code changes are
+/// made — purely additive coverage for the three conversion functions.
 /// </summary>
 public sealed class VideoOutPixelFormatTests
 {
@@ -91,8 +92,8 @@ public sealed class VideoOutPixelFormatTests
     [Fact]
     public void MapPixelFormat_Unknown_Returns56()
     {
-        // Unknown formats now fall back to 56 (8-bit RGBA) so games display
-        // something instead of silently failing the flip.
+        // All unhandled pixel formats fall back to 56 (8-bit RGBA) per the
+        // merged PR #294, including the zero format itself.
         Assert.Equal(56u, InvokeMapPixelFormat(0x00000000UL));
         Assert.Equal(56u, InvokeMapPixelFormat(0xDEADBEEFUL));
     }
@@ -102,10 +103,11 @@ public sealed class VideoOutPixelFormatTests
     [Fact]
     public void StaticConstructor_RunsSelfChecks_WithoutThrowing()
     {
-        // RunPixelFormatSelfChecks is called from the static constructor.
-        // If the checks fail, Debug.Assert will fail in a debug build.
-        // This test ensures the constructor executed without throwing.
-        Assert.True(true);
+        // RunPixelFormatSelfChecks is called from the static constructor. We
+        // explicitly trigger the type initializer to ensure it executes and
+        // does not throw. If RuntimeHelpers.RunClassConstructor fails, a
+        // TypeInitializationException propagates and fails the test.
+        RuntimeHelpers.RunClassConstructor(typeof(VideoOutExports).TypeHandle);
     }
 
     // ---- Reflection-based access to internal/private methods ----


### PR DESCRIPTION
## What this adds

11 focused xUnit tests for the three internal pixel-format conversion functions in `VideoOutExports`:

- **`GetBytesPerPixel`** -- known 8-bit RGBA (returns 4), known 10-bit packed (returns 4), unknown formats (returns 0)
- **`NormalizePixelFormat`** -- already-normalized values pass through, low-32 match extraction, high-32 match extraction, completely unknown values returned unchanged
- **`MapPixelFormatToGuestTextureFormat`** -- 8-bit RGBA maps to format 56, 10-bit packed maps to format 9, unknown maps to 0
- **`StaticConstructor_RunsSelfChecks_WithoutThrowing`** -- confirms the debug-only `RunPixelFormatSelfChecks` completed without throwing

The private/internal methods are accessed via reflection, matching the project's existing test pattern (see `KernelMemoryCompatExportsTests`).

## Why

These functions bridge the PS5 VideoOut format space to the AGC guest texture format space. No unit tests existed for any of them -- only the debug-only `RunPixelFormatSelfChecks` in the static constructor. This coverage makes the mapping contract explicit and catches regressions if new formats are added.

## Validation

- Build: `dotnet build SharpEmu.slnx -c Release` -- **0 warnings, 0 errors**
- New tests: **11/11 passed**
- Full suite: **203/203 passed** (170 Libs.Tests + 33 SourceGenerators.Tests)
- No production code changes

## Checklist

- [x] Focused on a single topic (testing only, no behavior change)
- [x] Follows existing coding style (4-space indentation, no tabs)
- [x] Uses the project's xUnit test conventions
- [x] No generated code submitted without understanding
- [x] No Sony proprietary code, firmware, keys, or decrypted assets introduced
- [x] No game-specific hacks; purely additive test coverage
