### PR TITLE
[Pad] Add device class extended information export

### DIFF
--- a/src/SharpEmu.Libs/Pad/PadExports.cs
+++ b/src/SharpEmu.Libs/Pad/PadExports.cs
@@ -10,6 +10,7 @@ namespace SharpEmu.Libs.Pad;
 
 public static class PadExports
 {
+    private const int OrbisPadErrorInvalidArgument = unchecked((int)0x80920001);
     private const int OrbisPadErrorInvalidHandle = unchecked((int)0x80920003);
     private const int OrbisPadErrorNotInitialized = unchecked((int)0x80920005);
     private const int OrbisPadErrorDeviceNotConnected = unchecked((int)0x80920007);
@@ -22,6 +23,7 @@ public static class PadExports
     private const int StandardPortType = 0;
     private const int PrimaryPadHandle = 1;
     private const int ControllerInformationSize = 0x1C;
+    private const int DeviceClassExtendedInformationSize = 0x14;
     private const int PadDataSize = 0x78;
 
     // Real firmware hands out small non-negative handles; 0 is valid. Some titles
@@ -112,6 +114,32 @@ public static class PadExports
         return IsPrimaryPadHandle(handle)
             ? ctx.SetReturn(0)
             : ctx.SetReturn(OrbisPadErrorInvalidHandle);
+    }
+
+    [SysAbiExport(
+        Nid = "AcslpN1jHR8",
+        ExportName = "scePadDeviceClassGetExtendedInformation",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libScePad")]
+    public static int PadDeviceClassGetExtendedInformation(CpuContext ctx)
+    {
+        var handle = unchecked((int)ctx[CpuRegister.Rdi]);
+        var informationAddress = ctx[CpuRegister.Rsi];
+        if (!IsPrimaryPadHandle(handle))
+        {
+            return ctx.SetReturn(OrbisPadErrorInvalidHandle);
+        }
+
+        if (informationAddress == 0)
+        {
+            return ctx.SetReturn(OrbisPadErrorInvalidArgument);
+        }
+
+        Span<byte> information = stackalloc byte[DeviceClassExtendedInformationSize];
+        information.Clear();
+        return ctx.Memory.TryWrite(informationAddress, information)
+            ? ctx.SetReturn(0)
+            : ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
     }
 
     [SysAbiExport(

--- a/tests/SharpEmu.Libs.Tests/Pad/PadExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Pad/PadExportsTests.cs
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Pad;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Pad;
+
+public sealed class PadExportsTests
+{
+    private const int PadErrorInvalidArgument = unchecked((int)0x80920001);
+    private const int PadErrorInvalidHandle = unchecked((int)0x80920003);
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong InformationAddress = MemoryBase + 0x100;
+    private const int ExtendedInformationSize = 0x14;
+
+    private readonly FakeCpuMemory _memory = new(MemoryBase, 0x1000);
+    private readonly CpuContext _ctx;
+
+    public PadExportsTests()
+    {
+        _ctx = new CpuContext(_memory, Generation.Gen5);
+    }
+
+    [Fact]
+    public void DeviceClassGetExtendedInformation_ValidHandleWritesStandardControllerInformation()
+    {
+        Assert.True(_memory.TryWrite(InformationAddress, Enumerable.Repeat((byte)0xA5, ExtendedInformationSize).ToArray()));
+        SetArguments(handle: 1, InformationAddress);
+
+        Assert.Equal(0, PadExports.PadDeviceClassGetExtendedInformation(_ctx));
+
+        var information = new byte[ExtendedInformationSize];
+        Assert.True(_memory.TryRead(InformationAddress, information));
+        Assert.Equal(new byte[ExtendedInformationSize], information);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void DeviceClassGetExtendedInformation_AcceptsPrimaryCompatibilityHandles(int handle)
+    {
+        SetArguments(handle, InformationAddress);
+
+        Assert.Equal(0, PadExports.PadDeviceClassGetExtendedInformation(_ctx));
+    }
+
+    [Fact]
+    public void DeviceClassGetExtendedInformation_InvalidHandleReturnsPadError()
+    {
+        SetArguments(handle: 2, InformationAddress);
+
+        Assert.Equal(PadErrorInvalidHandle, PadExports.PadDeviceClassGetExtendedInformation(_ctx));
+    }
+
+    [Fact]
+    public void DeviceClassGetExtendedInformation_NullOutputReturnsPadError()
+    {
+        SetArguments(handle: 1, informationAddress: 0);
+
+        Assert.Equal(PadErrorInvalidArgument, PadExports.PadDeviceClassGetExtendedInformation(_ctx));
+    }
+
+    [Fact]
+    public void DeviceClassGetExtendedInformation_UnmappedOutputReturnsMemoryFault()
+    {
+        SetArguments(handle: 1, informationAddress: 0xDEAD_0000_0000);
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            PadExports.PadDeviceClassGetExtendedInformation(_ctx));
+    }
+
+    private void SetArguments(int handle, ulong informationAddress)
+    {
+        _ctx[CpuRegister.Rdi] = unchecked((ulong)(long)handle);
+        _ctx[CpuRegister.Rsi] = informationAddress;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `scePadDeviceClassGetExtendedInformation` for Gen4 and Gen5
- return pad-specific argument and handle errors while preserving guest memory faults
- initialize the complete 20-byte standard-controller result
- add focused coverage for valid, compatibility, and error paths

## Root cause
The NID `AcslpN1jHR8` was not registered, so titles querying device-class information reached the unresolved-import path after opening the primary controller.

## Compatibility validation
`PPSA15929` on upstream commit `2db1fae` reproduced the missing import with handle `1`. With this change, that import resolves and the title continues through the same controller initialization path. A later native access violation still remains and is outside the scope of this change.

Related to #116.

## Validation
- focused pad export tests: 6 passed
- full test suite: 198 passed
- Release build: 0 warnings, 0 errors
- REUSE 3.3 lint
- `git diff --check`
- bounded `PPSA15929` compatibility run