### PR TITLE
[Diagnostics] Preserve import library metadata

### DIFF
--- a/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
+++ b/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
@@ -85,14 +85,15 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
         IReadOnlyDictionary<ulong, string>? importStubs = null,
         IReadOnlyDictionary<string, ulong>? runtimeSymbols = null,
         string processImageName = "eboot.bin",
-        CpuExecutionOptions executionOptions = default)
+        CpuExecutionOptions executionOptions = default,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata>? importMetadata = null)
     {
         Console.Error.WriteLine("[DISPATCHER] === DispatchEntry START ===");
         Console.Error.WriteLine($"[DISPATCHER] entryPoint=0x{entryPoint:X16}, generation={generation}");
 
         try
         {
-            return DispatchEntryCore(entryPoint, generation, importStubs, runtimeSymbols, processImageName, executionOptions);
+            return DispatchEntryCore(entryPoint, generation, importStubs, importMetadata, runtimeSymbols, processImageName, executionOptions);
         }
         catch (Exception ex)
         {
@@ -108,7 +109,8 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
         IReadOnlyDictionary<ulong, string>? importStubs = null,
         IReadOnlyDictionary<string, ulong>? runtimeSymbols = null,
         string moduleName = "module",
-        CpuExecutionOptions executionOptions = default)
+        CpuExecutionOptions executionOptions = default,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata>? importMetadata = null)
     {
         Console.Error.WriteLine("[DISPATCHER] === DispatchModuleInitializer START ===");
         Console.Error.WriteLine($"[DISPATCHER] moduleInit=0x{entryPoint:X16}, generation={generation}, module={moduleName}");
@@ -119,6 +121,7 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
                 entryPoint,
                 generation,
                 importStubs,
+                importMetadata,
                 runtimeSymbols,
                 moduleName,
                 executionOptions,
@@ -136,6 +139,7 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
         ulong entryPoint,
         Generation generation,
         IReadOnlyDictionary<ulong, string>? importStubs = null,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata>? importMetadata = null,
         IReadOnlyDictionary<string, ulong>? runtimeSymbols = null,
         string processImageName = "eboot.bin",
         CpuExecutionOptions executionOptions = default,
@@ -214,6 +218,9 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
         var effectiveImportStubs = importStubs is null
             ? new Dictionary<ulong, string>()
             : new Dictionary<ulong, string>(importStubs);
+        var effectiveImportMetadata = importMetadata is null
+            ? new Dictionary<string, ImportedSymbolMetadata>(StringComparer.Ordinal)
+            : new Dictionary<string, ImportedSymbolMetadata>(importMetadata, StringComparer.Ordinal);
         var entryParamsConfigured = false;
         if (frameKind == EntryFrameKind.ProcessEntry)
         {
@@ -278,6 +285,7 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
                 entryPoint,
                 generation,
                 effectiveImportStubs,
+                effectiveImportMetadata,
                 runtimeSymbols ?? new Dictionary<string, ulong>(StringComparer.Ordinal),
                 executionOptions,
                 out var nativeResult))

--- a/src/SharpEmu.Core/Cpu/ICpuDispatcher.cs
+++ b/src/SharpEmu.Core/Cpu/ICpuDispatcher.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
+using SharpEmu.Core.Loader;
 
 namespace SharpEmu.Core.Cpu;
 
@@ -33,7 +34,8 @@ public interface ICpuDispatcher
         IReadOnlyDictionary<ulong, string>? importStubs = null,
         IReadOnlyDictionary<string, ulong>? runtimeSymbols = null,
         string processImageName = "eboot.bin",
-        CpuExecutionOptions executionOptions = default);
+        CpuExecutionOptions executionOptions = default,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata>? importMetadata = null);
 
     OrbisGen2Result DispatchModuleInitializer(
         ulong entryPoint,
@@ -41,5 +43,6 @@ public interface ICpuDispatcher
         IReadOnlyDictionary<ulong, string>? importStubs = null,
         IReadOnlyDictionary<string, ulong>? runtimeSymbols = null,
         string moduleName = "module",
-        CpuExecutionOptions executionOptions = default);
+        CpuExecutionOptions executionOptions = default,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata>? importMetadata = null);
 }

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -548,7 +548,7 @@ public sealed partial class DirectExecutionBackend
 					DumpIl2CppExceptionDiagnostic(cpuContext, value, num7);
 				}
 				Console.Error.WriteLine(
-					$"[LOADER][WARN] Import#{num} unresolved: nid={importStubEntry.Nid} ret=0x{num7:X16} " +
+					$"[LOADER][WARN] Import#{num} unresolved: nid={importStubEntry.Nid}{importStubEntry.Metadata.DiagnosticSuffix} ret=0x{num7:X16} " +
 					$"rdi=0x{value:X16} rsi=0x{value2:X16} rdx=0x{num3:X16} rcx=0x{num4:X16} r8=0x{num5:X16} r9=0x{num6:X16}");
 				if (importStubEntry.Nid == "L-Q3LEjIbgA")
 				{

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -41,6 +41,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 		public string Nid { get; }
 
+		public ImportedSymbolMetadata Metadata { get; }
+
 		public ExportedFunction? Export { get; }
 
 		// Precomputed per-import classification: DispatchImport runs for
@@ -59,6 +61,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		public ImportStubEntry(
 			ulong address,
 			string nid,
+			ImportedSymbolMetadata metadata,
 			ExportedFunction? export,
 			bool isLeaf,
 			bool isNoBlockLeaf,
@@ -68,6 +71,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		{
 			Address = address;
 			Nid = nid;
+			Metadata = metadata;
 			Export = export;
 			IsLeaf = isLeaf;
 			IsNoBlockLeaf = isNoBlockLeaf;
@@ -1043,7 +1047,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		SetupExceptionHandler();
 	}
 
-	public bool TryExecute(CpuContext context, ulong entryPoint, Generation generation, IReadOnlyDictionary<ulong, string> importStubs, IReadOnlyDictionary<string, ulong> runtimeSymbols, CpuExecutionOptions executionOptions, out OrbisGen2Result result)
+	public bool TryExecute(CpuContext context, ulong entryPoint, Generation generation, IReadOnlyDictionary<ulong, string> importStubs, IReadOnlyDictionary<string, ImportedSymbolMetadata> importMetadata, IReadOnlyDictionary<string, ulong> runtimeSymbols, CpuExecutionOptions executionOptions, out OrbisGen2Result result)
 	{
 		Console.Error.WriteLine("[LOADER][INFO] === Execute START ===");
 		Console.Error.WriteLine($"[LOADER][INFO] EntryPoint: 0x{entryPoint:X16}, ImportStubs: {importStubs.Count}");
@@ -1116,7 +1120,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		GuestThreadExecution.Scheduler = this;
 		try
 		{
-			if (!SetupImportStubs(importStubs))
+			if (!SetupImportStubs(importStubs, importMetadata))
 			{
 				if (string.IsNullOrEmpty(LastError))
 				{
@@ -1154,7 +1158,9 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		Console.Error.WriteLine($"[LOADER][INFO] {LastError}");
 	}
 
-	private bool SetupImportStubs(IReadOnlyDictionary<ulong, string> importStubs)
+	private bool SetupImportStubs(
+		IReadOnlyDictionary<ulong, string> importStubs,
+		IReadOnlyDictionary<string, ImportedSymbolMetadata> importMetadata)
 	{
 		Console.Error.WriteLine($"[LOADER][INFO] Setting up {importStubs.Count} import stubs...");
 		ClearImportHandlerTrampolines();
@@ -1166,9 +1172,11 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		foreach (var (num4, text2) in importStubs)
 		{
 			_ = _moduleManager.TryGetExport(text2, out var resolvedExport);
+			importMetadata.TryGetValue(text2, out var metadata);
 			_importEntries[num] = new ImportStubEntry(
 				num4,
 				text2,
+				metadata,
 				resolvedExport,
 				IsLeafImport(text2),
 				IsNoBlockLeafImport(text2),

--- a/src/SharpEmu.Core/Cpu/Native/INativeCpuBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/INativeCpuBackend.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
+using SharpEmu.Core.Loader;
 
 namespace SharpEmu.Core.Cpu.Native;
 
@@ -16,6 +17,7 @@ public interface INativeCpuBackend
         ulong entryPoint,
         Generation generation,
         IReadOnlyDictionary<ulong, string> importStubs,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata> importMetadata,
         IReadOnlyDictionary<string, ulong> runtimeSymbols,
         CpuExecutionOptions executionOptions,
         out OrbisGen2Result result);

--- a/src/SharpEmu.Core/Loader/ImportedSymbolMetadata.cs
+++ b/src/SharpEmu.Core/Loader/ImportedSymbolMetadata.cs
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Core.Loader;
+
+public readonly record struct ImportedSymbolMetadata(
+    string? LibraryName,
+    string? ModuleName)
+{
+    public string DiagnosticSuffix
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(LibraryName) && string.IsNullOrWhiteSpace(ModuleName))
+            {
+                return string.Empty;
+            }
+
+            var library = string.IsNullOrWhiteSpace(LibraryName) ? "?" : LibraryName;
+            var module = string.IsNullOrWhiteSpace(ModuleName) ? "?" : ModuleName;
+            return $" library={library} module={module}";
+        }
+    }
+}

--- a/src/SharpEmu.Core/Loader/SceImportMetadataParser.cs
+++ b/src/SharpEmu.Core/Loader/SceImportMetadataParser.cs
@@ -1,0 +1,155 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Text;
+
+namespace SharpEmu.Core.Loader;
+
+internal static class SceImportMetadataParser
+{
+    private const int DynamicEntrySize = 16;
+    private const long DtNull = 0;
+    private const long DtSceNeededModule = 0x6100000F;
+    private const long DtSceImportLibrary = 0x61000015;
+    private const long DtSceNeededModuleGen5 = 0x61000045;
+    private const long DtSceImportLibraryGen5 = 0x61000049;
+    private const string IdAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-";
+
+    internal static SceImportNameTables Parse(
+        ReadOnlySpan<byte> dynamicTable,
+        ReadOnlySpan<byte> stringTable)
+    {
+        var libraries = new Dictionary<string, string>(StringComparer.Ordinal);
+        var modules = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        for (var offset = 0; offset + DynamicEntrySize <= dynamicTable.Length; offset += DynamicEntrySize)
+        {
+            var entry = dynamicTable[offset..];
+            var tag = BinaryPrimitives.ReadInt64LittleEndian(entry);
+            if (tag == DtNull)
+            {
+                break;
+            }
+
+            if (tag is not (DtSceNeededModule or DtSceImportLibrary or
+                DtSceNeededModuleGen5 or DtSceImportLibraryGen5))
+            {
+                continue;
+            }
+
+            var value = BinaryPrimitives.ReadUInt64LittleEndian(entry[sizeof(long)..]);
+            var nameOffset = (uint)value;
+            var id = (ushort)(value >> 48);
+            if (!TryReadNullTerminatedAscii(stringTable, nameOffset, out var name))
+            {
+                continue;
+            }
+
+            var encodedId = EncodeId(id);
+            var destination = tag is DtSceImportLibrary or DtSceImportLibraryGen5
+                ? libraries
+                : modules;
+            destination.TryAdd(encodedId, name);
+        }
+
+        return new SceImportNameTables(libraries, modules);
+    }
+
+    internal static bool TryResolve(
+        string symbolName,
+        SceImportNameTables names,
+        out string nid,
+        out ImportedSymbolMetadata metadata)
+    {
+        nid = string.Empty;
+        metadata = default;
+        if (string.IsNullOrWhiteSpace(symbolName))
+        {
+            return false;
+        }
+
+        var firstSeparator = symbolName.IndexOf('#');
+        if (firstSeparator <= 0)
+        {
+            nid = symbolName;
+            return false;
+        }
+
+        nid = symbolName[..firstSeparator];
+        var secondSeparator = symbolName.IndexOf('#', firstSeparator + 1);
+        if (secondSeparator <= firstSeparator + 1 || secondSeparator == symbolName.Length - 1)
+        {
+            return false;
+        }
+
+        var libraryId = symbolName[(firstSeparator + 1)..secondSeparator];
+        var moduleId = symbolName[(secondSeparator + 1)..];
+        names.Libraries.TryGetValue(libraryId, out var libraryName);
+        names.Modules.TryGetValue(moduleId, out var moduleName);
+        metadata = new ImportedSymbolMetadata(libraryName, moduleName);
+        return libraryName is not null || moduleName is not null;
+    }
+
+    internal static string ExtractNid(string symbolName)
+    {
+        if (string.IsNullOrWhiteSpace(symbolName))
+        {
+            return string.Empty;
+        }
+
+        var separator = symbolName.IndexOf('#');
+        return separator <= 0 ? symbolName : symbolName[..separator];
+    }
+
+    private static string EncodeId(ushort value)
+    {
+        Span<char> encoded = stackalloc char[3];
+        var length = value switch
+        {
+            < 0x40 => 1,
+            < 0x1000 => 2,
+            _ => 3,
+        };
+
+        for (var index = length - 1; index >= 0; index--)
+        {
+            encoded[index] = IdAlphabet[value & 0x3F];
+            value >>= 6;
+        }
+
+        return new string(encoded[..length]);
+    }
+
+    private static bool TryReadNullTerminatedAscii(
+        ReadOnlySpan<byte> source,
+        uint offset,
+        out string value)
+    {
+        if (offset >= (uint)source.Length)
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        var slice = source[(int)offset..];
+        var terminatorIndex = slice.IndexOf((byte)0);
+        if (terminatorIndex < 0)
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        value = Encoding.ASCII.GetString(slice[..terminatorIndex]);
+        return true;
+    }
+}
+
+internal sealed record SceImportNameTables(
+    IReadOnlyDictionary<string, string> Libraries,
+    IReadOnlyDictionary<string, string> Modules)
+{
+    internal static readonly SceImportNameTables Empty = new(
+        new Dictionary<string, string>(StringComparer.Ordinal),
+        new Dictionary<string, string>(StringComparer.Ordinal));
+}

--- a/src/SharpEmu.Core/Loader/SelfImage.cs
+++ b/src/SharpEmu.Core/Loader/SelfImage.cs
@@ -27,7 +27,8 @@ public sealed class SelfImage
         string? version = null,
         uint tlsModuleId = 0,
         ulong tlsMemorySize = 0,
-        ulong tlsStaticOffset = 0)
+        ulong tlsStaticOffset = 0,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata>? importMetadata = null)
     {
         ArgumentNullException.ThrowIfNull(programHeaders);
         ArgumentNullException.ThrowIfNull(mappedRegions);
@@ -37,6 +38,7 @@ public sealed class SelfImage
         ProgramHeaders = programHeaders;
         MappedRegions = mappedRegions;
         ImportStubs = importStubs ?? new Dictionary<ulong, string>();
+        ImportMetadata = importMetadata ?? new Dictionary<string, ImportedSymbolMetadata>(StringComparer.Ordinal);
         RuntimeSymbols = runtimeSymbols ?? new Dictionary<string, ulong>(StringComparer.Ordinal);
         ImportedRelocations = importedRelocations ?? Array.Empty<ImportedSymbolRelocation>();
         PreInitializerFunctions = preInitializerFunctions ?? Array.Empty<ulong>();
@@ -61,6 +63,8 @@ public sealed class SelfImage
     public IReadOnlyList<VirtualMemoryRegion> MappedRegions { get; }
 
     public IReadOnlyDictionary<ulong, string> ImportStubs { get; }
+
+    public IReadOnlyDictionary<string, ImportedSymbolMetadata> ImportMetadata { get; }
 
     public IReadOnlyDictionary<string, ulong> RuntimeSymbols { get; }
 

--- a/src/SharpEmu.Core/Loader/SelfLoader.cs
+++ b/src/SharpEmu.Core/Loader/SelfLoader.cs
@@ -234,7 +234,8 @@ public sealed class SelfLoader : ISelfLoader
             imageBase,
             _moduleManager,
             tlsModuleId,
-            out var importedRelocations);
+            out var importedRelocations,
+            out var importMetadata);
         var effectiveImportStubs = importStubs.Count == 0
             ? new Dictionary<ulong, string>()
             : new Dictionary<ulong, string>(importStubs);
@@ -306,7 +307,8 @@ public sealed class SelfLoader : ISelfLoader
             applicationInfo.Version,
             tlsModuleId,
             tlsInfo.MemorySize,
-            tlsInfo.StaticOffset);
+            tlsInfo.StaticOffset,
+            importMetadata);
     }
 
     private static (string? Title, string? TitleId, string? Version) TryLoadParamJson(
@@ -549,9 +551,11 @@ public sealed class SelfLoader : ISelfLoader
         ulong imageBase,
         IModuleManager? moduleManager,
         uint tlsModuleId,
-        out IReadOnlyList<ImportedSymbolRelocation> importedRelocations)
+        out IReadOnlyList<ImportedSymbolRelocation> importedRelocations,
+        out IReadOnlyDictionary<string, ImportedSymbolMetadata> importMetadata)
     {
         importedRelocations = Array.Empty<ImportedSymbolRelocation>();
+        importMetadata = new Dictionary<string, ImportedSymbolMetadata>(StringComparer.Ordinal);
         if (!TryGetProgramHeader(programHeaders, ProgramHeaderType.Dynamic, out var dynamicHeader, out var dynamicHeaderIndex))
         {
             return EmptyImportStubs;
@@ -673,6 +677,10 @@ public sealed class SelfLoader : ISelfLoader
         var descriptors = new List<RelocationDescriptor>(256);
         var orderedImportNids = new List<string>(128);
         var seenImportNids = new HashSet<string>(StringComparer.Ordinal);
+        var importNames = stringTable.Length == 0
+            ? SceImportNameTables.Empty
+            : SceImportMetadataParser.Parse(dynamicTable, stringTable);
+        var discoveredImportMetadata = new Dictionary<string, ImportedSymbolMetadata>(StringComparer.Ordinal);
         AppendRelocationDescriptors(
             relocations,
             symbolTable,
@@ -682,7 +690,9 @@ public sealed class SelfLoader : ISelfLoader
             tlsModuleId,
             descriptors,
             orderedImportNids,
-            seenImportNids);
+            seenImportNids,
+            importNames,
+            discoveredImportMetadata);
 
         if (descriptors.Count == 0)
         {
@@ -695,7 +705,9 @@ public sealed class SelfLoader : ISelfLoader
                 tlsModuleId,
                 descriptors,
                 orderedImportNids,
-                seenImportNids);
+                seenImportNids,
+                importNames,
+                discoveredImportMetadata);
             if (sectionFallbackRelocCount != 0)
             {
                 Console.WriteLine(
@@ -712,6 +724,7 @@ public sealed class SelfLoader : ISelfLoader
         }
 
         importedRelocations = BuildImportedRelocations(descriptors);
+        importMetadata = discoveredImportMetadata;
 
         var stubImportNids = orderedImportNids
             .Where(nid => ShouldCreateImportStub(nid, descriptors, moduleManager))
@@ -820,7 +833,9 @@ public sealed class SelfLoader : ISelfLoader
         uint tlsModuleId,
         ICollection<RelocationDescriptor> descriptors,
         IList<string> orderedImportNids,
-        ISet<string> seenImportNids)
+        ISet<string> seenImportNids,
+        SceImportNameTables importNames,
+        IDictionary<string, ImportedSymbolMetadata> importMetadata)
     {
         if (elfHeader.SectionHeaderOffset == 0 ||
             elfHeader.SectionHeaderCount == 0 ||
@@ -875,7 +890,9 @@ public sealed class SelfLoader : ISelfLoader
                 tlsModuleId,
                 descriptors,
                 orderedImportNids,
-                seenImportNids);
+                seenImportNids,
+                importNames,
+                importMetadata);
             appendedRelocations += relocations.Count;
         }
 
@@ -891,7 +908,9 @@ public sealed class SelfLoader : ISelfLoader
         uint tlsModuleId,
         ICollection<RelocationDescriptor> descriptors,
         IList<string> orderedImportNids,
-        ISet<string> seenImportNids)
+        ISet<string> seenImportNids,
+        SceImportNameTables importNames,
+        IDictionary<string, ImportedSymbolMetadata> importMetadata)
     {
         foreach (var relocation in relocations)
         {
@@ -1091,7 +1110,7 @@ public sealed class SelfLoader : ISelfLoader
                 continue;
             }
 
-            var nid = ExtractNid(symbolName);
+            var nid = SceImportMetadataParser.ExtractNid(symbolName);
             if (string.IsNullOrWhiteSpace(nid))
             {
                 if (symbolBind == SymbolBindWeak)
@@ -1110,6 +1129,12 @@ public sealed class SelfLoader : ISelfLoader
             if (seenImportNids.Add(nid))
             {
                 orderedImportNids.Add(nid);
+            }
+
+            if (!importMetadata.ContainsKey(nid) &&
+                SceImportMetadataParser.TryResolve(symbolName, importNames, out _, out var metadata))
+            {
+                importMetadata[nid] = metadata;
             }
 
             descriptors.Add(CreateSymbolRelocationDescriptor(

--- a/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
+++ b/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
@@ -148,6 +148,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
         Console.Error.WriteLine($"[RUNTIME] Entry: 0x{image.EntryPoint:X16}");
         var generation = image.ElfHeader.AbiVersion == 2 ? Generation.Gen5 : Generation.Gen4;
         var activeImportStubs = new Dictionary<ulong, string>(image.ImportStubs);
+        var activeImportMetadata = new Dictionary<string, ImportedSymbolMetadata>(image.ImportMetadata, StringComparer.Ordinal);
         var activeRuntimeSymbols = new Dictionary<string, ulong>(image.RuntimeSymbols, StringComparer.Ordinal);
         var processImageName = Path.GetFileName(ebootPath);
         if (string.IsNullOrWhiteSpace(processImageName))
@@ -157,13 +158,18 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
 
         HleDataSymbols.ConfigureProcessImageName(processImageName);
         MergeKnownHleDataSymbols(activeRuntimeSymbols);
-        var loadedModuleImages = LoadAdjacentSceModules(ebootPath, activeImportStubs, activeRuntimeSymbols);
+        var loadedModuleImages = LoadAdjacentSceModules(
+            ebootPath,
+            activeImportStubs,
+            activeImportMetadata,
+            activeRuntimeSymbols);
         RebindImportedDataSymbols(image, loadedModuleImages, activeRuntimeSymbols);
         var initializerResult = RunAllInitializers(
             image,
             loadedModuleImages,
             generation,
             activeImportStubs,
+            activeImportMetadata,
             activeRuntimeSymbols,
             processImageName);
         if (initializerResult is { } failedInitializerResult)
@@ -185,7 +191,8 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
             activeImportStubs,
             activeRuntimeSymbols,
             processImageName,
-            _cpuExecutionOptions);
+            _cpuExecutionOptions,
+            activeImportMetadata);
 
         Console.Error.WriteLine($"[RUNTIME] DispatchEntry returned: {result}");
         Console.Error.WriteLine($"[RUNTIME] Dispatch result: {result}");
@@ -413,6 +420,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
         IReadOnlyList<LoadedModuleImage> loadedModuleImages,
         Generation generation,
         IReadOnlyDictionary<ulong, string> activeImportStubs,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata> activeImportMetadata,
         IReadOnlyDictionary<string, ulong> activeRuntimeSymbols,
         string processImageName)
     {
@@ -420,6 +428,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
             loadedModuleImages,
             generation,
             activeImportStubs,
+            activeImportMetadata,
             activeRuntimeSymbols);
         if (moduleStartResult is not null)
         {
@@ -486,6 +495,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
         IReadOnlyList<LoadedModuleImage> loadedModuleImages,
         Generation generation,
         IReadOnlyDictionary<ulong, string> activeImportStubs,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata> activeImportMetadata,
         IReadOnlyDictionary<string, ulong> activeRuntimeSymbols)
     {
         for (var i = 0; i < loadedModuleImages.Count; i++)
@@ -522,7 +532,8 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
                 activeImportStubs,
                 activeRuntimeSymbols,
                 moduleName,
-                _cpuExecutionOptions);
+                _cpuExecutionOptions,
+                activeImportMetadata);
             KernelModuleRegistry.CompleteModuleStart(
                 loadedModule.Handle,
                 result == OrbisGen2Result.ORBIS_GEN2_OK);
@@ -542,6 +553,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
         SelfImage image,
         Generation generation,
         IReadOnlyDictionary<ulong, string> activeImportStubs,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata> activeImportMetadata,
         IReadOnlyDictionary<string, ulong> activeRuntimeSymbols,
         string processImageName)
     {
@@ -558,6 +570,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
             image.PreInitializerFunctions,
             generation,
             activeImportStubs,
+            activeImportMetadata,
             activeRuntimeSymbols,
             processImageName);
         if (result is not null)
@@ -570,6 +583,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
             image.InitializerFunctions,
             generation,
             activeImportStubs,
+            activeImportMetadata,
             activeRuntimeSymbols,
             processImageName);
     }
@@ -579,6 +593,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
         IReadOnlyList<ulong> initializerFunctions,
         Generation generation,
         IReadOnlyDictionary<ulong, string> activeImportStubs,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata> activeImportMetadata,
         IReadOnlyDictionary<string, ulong> activeRuntimeSymbols,
         string processImageName)
     {
@@ -599,7 +614,8 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
                 activeImportStubs,
                 activeRuntimeSymbols,
                 processImageName,
-                _cpuExecutionOptions);
+                _cpuExecutionOptions,
+                activeImportMetadata);
             if (result != OrbisGen2Result.ORBIS_GEN2_OK)
             {
                 return result;
@@ -612,6 +628,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
     private List<LoadedModuleImage> LoadAdjacentSceModules(
         string ebootPath,
         IDictionary<ulong, string> importStubs,
+        IDictionary<string, ImportedSymbolMetadata> importMetadata,
         IDictionary<string, ulong> runtimeSymbols)
     {
         var loadedImages = new List<LoadedModuleImage>();
@@ -706,6 +723,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
                     Path.GetDirectoryName(modulePath));
 
                 mergedImportCount += MergeImportStubs(importStubs, moduleImage.ImportStubs, modulePath);
+                MergeImportMetadata(importMetadata, moduleImage.ImportMetadata, modulePath);
                 mergedSymbolCount += MergeRuntimeSymbols(runtimeSymbols, moduleImage.RuntimeSymbols);
                 InstallNativePluginCompatibilityHooks(importStubs, moduleImage, modulePath);
                 var moduleHandle = RegisterLoadedModule(modulePath, moduleImage, isMain: false, isSystemModule: false);
@@ -874,6 +892,29 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
         }
 
         return added;
+    }
+
+    private static void MergeImportMetadata(
+        IDictionary<string, ImportedSymbolMetadata> destination,
+        IReadOnlyDictionary<string, ImportedSymbolMetadata> source,
+        string modulePath)
+    {
+        foreach (var (nid, metadata) in source)
+        {
+            if (destination.TryGetValue(nid, out var existing))
+            {
+                if (existing != metadata)
+                {
+                    Console.Error.WriteLine(
+                        $"[RUNTIME] Import metadata conflict for {nid}: keep={existing.LibraryName}/{existing.ModuleName}, " +
+                        $"skip={metadata.LibraryName}/{metadata.ModuleName} ({Path.GetFileName(modulePath)})");
+                }
+
+                continue;
+            }
+
+            destination[nid] = metadata;
+        }
     }
 
     private static int MergeRuntimeSymbols(

--- a/tests/SharpEmu.Libs.Tests/Loader/SceImportMetadataParserTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Loader/SceImportMetadataParserTests.cs
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Text;
+using SharpEmu.Core.Loader;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Loader;
+
+public sealed class SceImportMetadataParserTests
+{
+    private const long NeededModuleTag = 0x6100000F;
+    private const long ImportLibraryTag = 0x61000015;
+    private const long NeededModuleGen5Tag = 0x61000045;
+    private const long ImportLibraryGen5Tag = 0x61000049;
+
+    [Fact]
+    public void Parse_ResolvesLibraryAndModuleFromEncodedSymbolSuffix()
+    {
+        var stringTable = Encoding.ASCII.GetBytes("\0libScePad\0libScePad.prx\0");
+        Span<byte> dynamicTable = stackalloc byte[48];
+        WriteDynamicEntry(dynamicTable, 0, ImportLibraryTag, PackReference(nameOffset: 1, id: 10));
+        WriteDynamicEntry(dynamicTable, 16, NeededModuleTag, PackReference(nameOffset: 11, id: 10));
+
+        var names = SceImportMetadataParser.Parse(dynamicTable, stringTable);
+
+        Assert.True(SceImportMetadataParser.TryResolve(
+            "AcslpN1jHR8#K#K",
+            names,
+            out var nid,
+            out var metadata));
+        Assert.Equal("AcslpN1jHR8", nid);
+        Assert.Equal("libScePad", metadata.LibraryName);
+        Assert.Equal("libScePad.prx", metadata.ModuleName);
+        Assert.Equal(" library=libScePad module=libScePad.prx", metadata.DiagnosticSuffix);
+    }
+
+    [Fact]
+    public void Parse_ResolvesGen5DynamicTags()
+    {
+        const int nameOffset = 0x2727;
+        var stringTable = new byte[nameOffset + 10];
+        Encoding.ASCII.GetBytes("libScePad\0").CopyTo(stringTable, nameOffset);
+        Span<byte> dynamicTable = stackalloc byte[48];
+        // Values observed in a Gen5 ELF: module version 1.1 and library version 1,
+        // both with encoded id K (numeric id 10) and the same string-table offset.
+        WriteDynamicEntry(dynamicTable, 0, NeededModuleGen5Tag, 0x000A_0101_0000_2727);
+        WriteDynamicEntry(dynamicTable, 16, ImportLibraryGen5Tag, 0x000A_0001_0000_2727);
+
+        var names = SceImportMetadataParser.Parse(dynamicTable, stringTable);
+
+        Assert.True(SceImportMetadataParser.TryResolve(
+            "AcslpN1jHR8#K#K",
+            names,
+            out _,
+            out var metadata));
+        Assert.Equal("libScePad", metadata.LibraryName);
+        Assert.Equal("libScePad", metadata.ModuleName);
+    }
+
+    [Fact]
+    public void Parse_KeepsDistinctLibraryAndModuleIdsInSymbolOrder()
+    {
+        var stringTable = Encoding.ASCII.GetBytes("\0libkernel\0libkernel.prx\0");
+        Span<byte> dynamicTable = stackalloc byte[48];
+        WriteDynamicEntry(dynamicTable, 0, NeededModuleGen5Tag, PackReference(nameOffset: 11, id: 13));
+        WriteDynamicEntry(dynamicTable, 16, ImportLibraryGen5Tag, PackReference(nameOffset: 1, id: 36));
+
+        var names = SceImportMetadataParser.Parse(dynamicTable, stringTable);
+
+        Assert.True(SceImportMetadataParser.TryResolve(
+            "12wOHk8ywb0#k#N",
+            names,
+            out _,
+            out var metadata));
+        Assert.Equal("libkernel", metadata.LibraryName);
+        Assert.Equal("libkernel.prx", metadata.ModuleName);
+    }
+
+    [Theory]
+    [InlineData("MjQ5oH6b620", "MjQ5oH6b620")]
+    [InlineData("MjQ5oH6b620#K", "MjQ5oH6b620")]
+    [InlineData("MjQ5oH6b620##K", "MjQ5oH6b620")]
+    public void TryResolve_IncompleteMetadata_PreservesNidWithoutInventingNames(
+        string symbolName,
+        string expectedNid)
+    {
+        Assert.False(SceImportMetadataParser.TryResolve(
+            symbolName,
+            SceImportNameTables.Empty,
+            out var nid,
+            out var metadata));
+        Assert.Equal(expectedNid, nid);
+        Assert.Equal(string.Empty, metadata.DiagnosticSuffix);
+    }
+
+    private static ulong PackReference(uint nameOffset, ushort id) =>
+        nameOffset | ((ulong)id << 48);
+
+    private static void WriteDynamicEntry(
+        Span<byte> table,
+        int offset,
+        long tag,
+        ulong value)
+    {
+        BinaryPrimitives.WriteInt64LittleEndian(table[offset..], tag);
+        BinaryPrimitives.WriteUInt64LittleEndian(table[(offset + sizeof(long))..], value);
+    }
+}


### PR DESCRIPTION
## Summary

- parse legacy Gen4 and PS5 Gen5 SCE dynamic import tags and their encoded library/module IDs
- retain resolved import provenance while loading the main image and adjacent modules
- include library and module names in unresolved-import warnings when metadata is available
- preserve the existing NID-only output for malformed or metadata-free symbols

## Motivation

Unknown NIDs currently lose the `#library#module` provenance stored in the ELF symbol and dynamic tables. Once a NID is absent from Aerolib, compatibility reports contain no reliable way to tell which system library owns it.

With this change an unresolved call can report:

```text
nid=<unknown> library=libSce... module=libSce....prx
```

This narrows future symbol research without guessing function names or changing dispatch behavior. It helps diagnose the unmapped networking imports reported in #258.

## Compatibility

- supports the legacy Gen4 `DT_SCE_NEEDED_MODULE` / `DT_SCE_IMPORT_LIB` tags and the PS5 Gen5 `0x61000045` / `0x61000049` variants
- keeps library and module IDs in the symbol-defined `NID#library#module` order
- adds optional metadata parameters at the end of existing dispatcher APIs so current call sites remain source-compatible
- does not change export resolution or guest execution

## Validation

- `dotnet build SharpEmu.slnx -c Release`: 0 warnings, 0 errors
- `SharpEmu.Libs.Tests`: 216 passed
- `SharpEmu.SourceGenerators.Tests`: 33 passed
- 6 focused parser and fallback tests, including PS5 Gen5 dynamic-tag values and distinct library/module IDs
- `git diff --check`
