### PR TITLE
[Perf] Reduce Vulkan guest buffer upload allocations

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -4399,11 +4399,14 @@ internal static unsafe class VulkanVideoPresenter
             CollectCompletedGuestSubmissions(waitForOldest: false);
             var waitedMs = (System.Diagnostics.Stopwatch.GetTimestamp() - waitStart) *
                 1000.0 / System.Diagnostics.Stopwatch.Frequency;
-            TraceVulkanShader(
-                $"vk.queue_visibility queue={_activeGuestQueue.Name} " +
-                $"submission={_activeGuestQueue.SubmissionId} " +
-                $"target_timeline={targetTimeline} completed_timeline={_completedTimeline} " +
-                $"waited_ms={waitedMs:F3}");
+            if (_traceVulkanShaderEnabled)
+            {
+                TraceVulkanShader(
+                    $"vk.queue_visibility queue={_activeGuestQueue.Name} " +
+                    $"submission={_activeGuestQueue.SubmissionId} " +
+                    $"target_timeline={targetTimeline} completed_timeline={_completedTimeline} " +
+                    $"waited_ms={waitedMs:F3}");
+            }
         }
 
         private void ExecuteOrderedGuestAction(VulkanOrderedGuestAction work)
@@ -4411,10 +4414,13 @@ internal static unsafe class VulkanVideoPresenter
             WaitForActiveGuestQueueSubmissionsForCpuVisibility();
             WriteBackAllDirtyGuestBuffers(_activeGuestQueue.Name);
             work.Action();
-            TraceVulkanShader(
-                $"vk.ordered_action queue={_activeGuestQueue.Name} " +
-                $"submission={_activeGuestQueue.SubmissionId} " +
-                $"work_sequence={_activeGuestWorkSequence} name='{work.DebugName}'");
+            if (_traceVulkanShaderEnabled)
+            {
+                TraceVulkanShader(
+                    $"vk.ordered_action queue={_activeGuestQueue.Name} " +
+                    $"submission={_activeGuestQueue.SubmissionId} " +
+                    $"work_sequence={_activeGuestWorkSequence} name='{work.DebugName}'");
+            }
         }
 
         private void ExecuteOrderedGuestFlip(VulkanOrderedGuestFlip work)
@@ -7523,21 +7529,43 @@ internal static unsafe class VulkanVideoPresenter
 
             var size = (ulong)Math.Max(guestBuffer.Length, sizeof(uint));
             var endAddress = checked(guestBuffer.BaseAddress + size);
-            var allocation = _guestBufferAllocations
-                .Where(candidate =>
-                    candidate.BaseAddress <= guestBuffer.BaseAddress &&
-                    candidate.BaseAddress + candidate.Size >= endAddress)
-                .OrderByDescending(candidate =>
-                    string.Equals(
+            GuestBufferAllocation? allocation = null;
+            var allocationPriority = -1;
+            // This runs for every bound global buffer. Preserve the previous
+            // stable queue preference without allocating LINQ sort state.
+            foreach (var candidate in _guestBufferAllocations)
+            {
+                if (candidate.BaseAddress > guestBuffer.BaseAddress ||
+                    candidate.BaseAddress + candidate.Size < endAddress)
+                {
+                    continue;
+                }
+
+                var candidatePriority = string.Equals(
                         candidate.QueueName,
                         _activeGuestQueue.Name,
-                        StringComparison.Ordinal))
-                .ThenByDescending(candidate =>
-                    string.Equals(
+                        StringComparison.Ordinal)
+                    ? 2
+                    : string.Equals(
                         candidate.QueueName,
                         SharedReadOnlyGuestBufferQueue,
-                        StringComparison.Ordinal))
-                .First();
+                        StringComparison.Ordinal)
+                        ? 1
+                        : 0;
+                if (candidatePriority > allocationPriority)
+                {
+                    allocation = candidate;
+                    allocationPriority = candidatePriority;
+                }
+            }
+
+            if (allocation is null)
+            {
+                throw new InvalidOperationException(
+                    $"no Vulkan guest buffer allocation covers " +
+                    $"0x{guestBuffer.BaseAddress:X16}-0x{endAddress:X16}");
+            }
+
             var guestOffset = guestBuffer.BaseAddress - allocation.BaseAddress;
             var descriptorOffset = guestOffset &
                 ~(GuestStorageBufferOffsetAlignment - 1);
@@ -7586,16 +7614,15 @@ internal static unsafe class VulkanVideoPresenter
                     WaitForActiveGuestQueueSubmissionsForCpuVisibility();
                     WriteBackAllDirtyGuestBuffers(_activeGuestQueue.Name);
                 }
-                var live = new byte[guestBuffer.Length];
-                if (_guestMemory?.TryRead(guestBuffer.BaseAddress, live) == true)
+                var mapped = new Span<byte>(
+                    (void*)(allocation.Mapped + checked((nint)guestOffset)),
+                    guestBuffer.Length);
+                if (_guestMemory?.TryRead(guestBuffer.BaseAddress, mapped) != true)
                 {
-                    source = live;
+                    source.CopyTo(mapped);
                 }
 
-                source.CopyTo(new Span<byte>(
-                    (void*)(allocation.Mapped + checked((nint)guestOffset)),
-                    source.Length));
-                source.CopyTo(shadow);
+                mapped.CopyTo(shadow);
             }
 
             if (ShouldTraceVulkanResources() &&
@@ -7605,14 +7632,6 @@ internal static unsafe class VulkanVideoPresenter
                     $"[LOADER][TRACE] vk.global_buffer base=0x{guestBuffer.BaseAddress:X16} " +
                     $"bytes={guestBuffer.Length}");
             }
-            if (_setDebugUtilsObjectName is not null)
-            {
-                SetDebugName(
-                    ObjectType.Buffer,
-                    allocation.Buffer.Handle,
-                    $"SharpEmu global 0x{guestBuffer.BaseAddress:X16} {guestBuffer.Length}b");
-            }
-
             if (guestBuffer.Pooled)
             {
                 GuestDataPool.Return(guestBuffer.Data);
@@ -9853,10 +9872,13 @@ internal static unsafe class VulkanVideoPresenter
                         }
                     }
                 }
-                TraceVulkanShader(
-                    $"vk.offscreen_draw mrt={targets.Length} " +
-                    $"size={firstTarget.Width}x{firstTarget.Height} " +
-                    $"textures={work.Draw.Textures.Count}");
+                if (_traceVulkanShaderEnabled)
+                {
+                    TraceVulkanShader(
+                        $"vk.offscreen_draw mrt={targets.Length} " +
+                        $"size={firstTarget.Width}x{firstTarget.Height} " +
+                        $"textures={work.Draw.Textures.Count}");
+                }
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
## Summary

- read current guest buffer bytes directly into the synchronized mapped Vulkan allocation instead of allocating a temporary managed array for every changed binding
- preserve guest-queue allocation preference with an allocation-free stable scan
- avoid renaming persistent Vulkan buffers on every access and skip formatting disabled hot-path trace messages

Synchronization, dirty-buffer writeback, and the parser-data fallback are unchanged.

## Performance

Measured in Void Terrarium gameplay on an Apple M4 through Rosetta 2 + MoltenVK. This commit was stacked on #290 only for the runtime benchmark so the game could reach its correctly rendered scene; this PR itself remains independent and is based directly on `main`.

| Counter | main | this change | delta |
| --- | ---: | ---: | ---: |
| managed allocation rate | 127.0 MB/s | 64.6 MB/s | -49% |
| GC pause time | 13.9 ms/s | 10.0 ms/s | -28% |
| `CreateGlobalBufferResource` allocation-trace weight | 1.27% | 0.22% | -83% |

Terrarium continued to render the full gameplay scene. FPS varied between roughly 10 and 15 on both runs, so this PR does not claim a stable FPS uplift; its demonstrated benefit is substantially lower allocation and GC pressure in the per-draw path.

## Validation

- `dotnet build SharpEmu.slnx -c Release --no-restore`
- `dotnet test SharpEmu.slnx -c Release --no-build --no-restore` (192 passed)
- self-contained publish: `win-x64`, `linux-x64`, `osx-x64`
