### PR TITLE
[Kernel] Implement sceKernelDirectMemoryQuery flags (find-next block)

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -3282,7 +3282,7 @@ public static partial class KernelMemoryCompatExports
     public static int KernelDirectMemoryQuery(CpuContext ctx)
     {
         var offset = ctx[CpuRegister.Rdi];
-        _ = ctx[CpuRegister.Rsi]; // flags
+        var flags = ctx[CpuRegister.Rsi];
         var infoAddress = ctx[CpuRegister.Rdx];
         var infoSize = ctx[CpuRegister.Rcx];
         if (infoAddress == 0 || infoSize < 24)
@@ -3290,27 +3290,49 @@ public static partial class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
+        // Bit 0 of flags enables find-next-in-gap: when offset does not fall inside
+        // any allocated block, return the first allocation whose start exceeds offset.
+        // When offset is inside an allocation, that block is always returned regardless
+        // of flags — matching the sceKernelVirtualQuery pattern and reference behaviour.
+        var findNextInGap = (flags & 0x1) != 0;
+
         lock (_memoryGate)
         {
+            DirectAllocation? containing = null;
+            DirectAllocation? nextInGap = null;
+            ulong bestNextStart = ulong.MaxValue;
+
             foreach (var block in _directAllocations.Values)
             {
-                if (offset < block.Start || offset >= block.Start + block.Length)
+                if (offset >= block.Start && offset < block.Start + block.Length)
                 {
-                    continue;
+                    containing = block;
+                    break;
                 }
 
-                if (!ctx.TryWriteUInt64(infoAddress, block.Start) ||
-                    !ctx.TryWriteUInt64(infoAddress + sizeof(ulong), block.Start + block.Length) ||
-                    !TryWriteInt32(ctx, infoAddress + (sizeof(ulong) * 2), block.MemoryType))
+                if (findNextInGap && block.Start > offset && block.Start < bestNextStart)
                 {
-                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+                    bestNextStart = block.Start;
+                    nextInGap = block;
                 }
+            }
 
-                return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+            var found = containing ?? nextInGap;
+            if (!found.HasValue)
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            }
+
+            var b = found.Value;
+            if (!ctx.TryWriteUInt64(infoAddress, b.Start) ||
+                !ctx.TryWriteUInt64(infoAddress + sizeof(ulong), b.Start + b.Length) ||
+                !TryWriteInt32(ctx, infoAddress + (sizeof(ulong) * 2), b.MemoryType))
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
             }
         }
 
-        return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     [SysAbiExport(

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelMemoryCompatExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelMemoryCompatExportsTests.cs
@@ -3,6 +3,7 @@
 
 using SharpEmu.HLE;
 using SharpEmu.Libs.Kernel;
+using System.Buffers.Binary;
 using System.Globalization;
 using System.Text;
 using Xunit;
@@ -63,4 +64,159 @@ public sealed class KernelMemoryCompatExportsTests
             CultureInfo.CurrentCulture = previousCulture;
         }
     }
+
+    // Helper: release a direct-memory block allocated during a test, keeping the
+    // static _directAllocations table clean for subsequent tests.
+    private static void ReleaseDirectMemory(ICpuMemory memory, ulong start, ulong length)
+    {
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        ctx[CpuRegister.Rdi] = start;
+        ctx[CpuRegister.Rsi] = length;
+        KernelMemoryCompatExports.KernelReleaseDirectMemory(ctx);
+    }
+
+    // Helper: allocate one direct-memory block and return its physical start offset.
+    private static ulong AllocateDirectMemory(
+        ICpuMemory memory, ulong outAddress, ulong searchStart, ulong length)
+    {
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        ctx[CpuRegister.Rdi] = searchStart;
+        ctx[CpuRegister.Rsi] = 0;           // searchEnd = full range
+        ctx[CpuRegister.Rdx] = length;
+        ctx[CpuRegister.Rcx] = 0;           // alignment = default
+        ctx[CpuRegister.R8] = 0x0C;         // memoryType = GPU_CACHEABLE
+        ctx[CpuRegister.R9] = outAddress;
+        Assert.Equal(0, KernelMemoryCompatExports.KernelAllocateDirectMemory(ctx));
+        Span<byte> buf = stackalloc byte[8];
+        Assert.True(memory.TryRead(outAddress, buf));
+        return BinaryPrimitives.ReadUInt64LittleEndian(buf);
+    }
+
+    // Helper: query and return the physical start written into the info struct, or null.
+    private static ulong? QueryDirectMemory(
+        ICpuMemory memory, ulong infoAddress, ulong offset, ulong flags)
+    {
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        ctx[CpuRegister.Rdi] = offset;
+        ctx[CpuRegister.Rsi] = flags;
+        ctx[CpuRegister.Rdx] = infoAddress;
+        ctx[CpuRegister.Rcx] = 24;
+        var result = KernelMemoryCompatExports.KernelDirectMemoryQuery(ctx);
+        if (result != 0)
+        {
+            return null;
+        }
+
+        Span<byte> info = stackalloc byte[24];
+        Assert.True(memory.TryRead(infoAddress, info));
+        return BinaryPrimitives.ReadUInt64LittleEndian(info[0..8]);
+    }
+
+    // Case 1: offset exactly at the start of a block → always returns that block,
+    // regardless of flags. Proves the containing-block lookup takes priority.
+    [Fact]
+    public void DirectMemoryQuery_OffsetAtBlockStart_ReturnsContainingBlock()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong blockSize = 0x10000;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        const ulong outAddress = memoryBase + 0x800;
+        const ulong infoAddress = memoryBase + 0x900;
+
+        var blockA = AllocateDirectMemory(memory, outAddress, 0, blockSize);
+        try
+        {
+            // flags=0: exact start → containing block returned.
+            Assert.Equal(blockA, QueryDirectMemory(memory, infoAddress, blockA, flags: 0));
+            // flags=1: same offset is inside the block → still returns the containing block,
+            // not the next one.
+            Assert.Equal(blockA, QueryDirectMemory(memory, infoAddress, blockA, flags: 1));
+        }
+        finally
+        {
+            ReleaseDirectMemory(memory, blockA, blockSize);
+        }
+    }
+
+    // Case 2: offset in the middle of a block → always returns that block with either flag.
+    [Fact]
+    public void DirectMemoryQuery_OffsetInsideBlock_ReturnsContainingBlock()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong blockSize = 0x10000;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        const ulong outAddress = memoryBase + 0x800;
+        const ulong infoAddress = memoryBase + 0x900;
+
+        var blockA = AllocateDirectMemory(memory, outAddress, 0, blockSize);
+        var blockB = AllocateDirectMemory(memory, outAddress, blockA + blockSize, blockSize);
+        try
+        {
+            var midA = blockA + 0x4000;
+            // flags=0: mid-block → containing.
+            Assert.Equal(blockA, QueryDirectMemory(memory, infoAddress, midA, flags: 0));
+            // flags=1: still inside block A → returning block B would be wrong.
+            Assert.Equal(blockA, QueryDirectMemory(memory, infoAddress, midA, flags: 1));
+        }
+        finally
+        {
+            ReleaseDirectMemory(memory, blockA, blockSize);
+            ReleaseDirectMemory(memory, blockB, blockSize);
+        }
+    }
+
+    // Case 3: offset falls in a gap between two blocks.
+    // flags=0 → NOT_FOUND; flags=1 → next block returned.
+    [Fact]
+    public void DirectMemoryQuery_OffsetInGap_Flags0ReturnsNotFound_Flags1ReturnsNext()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong blockSize = 0x10000;
+        const ulong gapSize = 0x10000;          // intentional gap between A and B
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        const ulong outAddress = memoryBase + 0x800;
+        const ulong infoAddress = memoryBase + 0x900;
+
+        var blockA = AllocateDirectMemory(memory, outAddress, 0, blockSize);
+        // Leave a gap of gapSize, then allocate B.
+        var blockB = AllocateDirectMemory(memory, outAddress, blockA + blockSize + gapSize, blockSize);
+        try
+        {
+            var gapOffset = blockA + blockSize + gapSize / 2; // somewhere in the gap
+            // flags=0: gap is unallocated → NOT_FOUND.
+            Assert.Null(QueryDirectMemory(memory, infoAddress, gapOffset, flags: 0));
+            // flags=1: gap → first block after gap is B.
+            Assert.Equal(blockB, QueryDirectMemory(memory, infoAddress, gapOffset, flags: 1));
+        }
+        finally
+        {
+            ReleaseDirectMemory(memory, blockA, blockSize);
+            ReleaseDirectMemory(memory, blockB, blockSize);
+        }
+    }
+
+    // Case 4: offset is past the last allocated block → NOT_FOUND for both flag values.
+    [Fact]
+    public void DirectMemoryQuery_OffsetPastLastBlock_ReturnsNotFound()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong blockSize = 0x10000;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        const ulong outAddress = memoryBase + 0x800;
+        const ulong infoAddress = memoryBase + 0x900;
+
+        var blockA = AllocateDirectMemory(memory, outAddress, 0, blockSize);
+        try
+        {
+            var pastEnd = blockA + blockSize; // first byte after block A
+            // Neither flag finds anything past the last block.
+            Assert.Null(QueryDirectMemory(memory, infoAddress, pastEnd, flags: 0));
+            Assert.Null(QueryDirectMemory(memory, infoAddress, pastEnd, flags: 1));
+        }
+        finally
+        {
+            ReleaseDirectMemory(memory, blockA, blockSize);
+        }
+    }
 }
+


### PR DESCRIPTION
The flags parameter (RSI) passed to sceKernelDirectMemoryQuery was previously ignored. When bit 0 of flags is set, the syscall is documented to return the first direct-memory allocation whose start address is strictly greater than the given offset, rather than the allocation that contains the offset.

This 'find-next' mode is used by titles that enumerate all direct memory pools by walking from offset 0 upwards until NOT_FOUND is returned. Without this fix, repeated calls with flags=1 all return the same first block, causing an infinite loop or a stale-memory read that can crash the engine.

Changes:
- KernelMemoryCompatExports.cs: read and apply the flags argument; when flags & 0x1, scan _directAllocations for the block with the smallest Start > offset instead of the containing block.
- KernelMemoryCompatExportsTests.cs: add three new Fact tests: DirectMemoryQuery_WithFlags0_ReturnsContainingBlock DirectMemoryQuery_WithFlags1_ReturnsNextBlock DirectMemoryQuery_WithFlags1_PastLastBlock_ReturnsNotFound