### PR TITLE
[Perf] Reduce runtime and Vulkan draw overhead

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -5127,64 +5127,51 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			BindTlsBase(context);
 			byte* ptr2 = (byte*)ptr;
 			ulong hostRspSlot = (ulong)hostRspStorage;
-			int offset = 0;
+			var emitter = new NativeCodeEmitter(ptr2);
 
-			void Emit(byte value) => ptr2[offset++] = value;
-			void EmitU64(ulong value)
-			{
-				*(ulong*)(ptr2 + offset) = value;
-				offset += sizeof(ulong);
-			}
-			void EmitMovR64Imm(byte rex, byte opcode, ulong value)
-			{
-				Emit(rex);
-				Emit(opcode);
-				EmitU64(value);
-			}
-
-			Emit(0x53); // push rbx
-			Emit(0x55); // push rbp
-			Emit(0x57); // push rdi
-			Emit(0x56); // push rsi
-			Emit(0x41); Emit(0x54); // push r12
-			Emit(0x41); Emit(0x55); // push r13
-			Emit(0x41); Emit(0x56); // push r14
-			Emit(0x41); Emit(0x57); // push r15
-			EmitHostNonvolatileXmmSave(ptr2, ref offset);
+			emitter.Emit(0x53); // push rbx
+			emitter.Emit(0x55); // push rbp
+			emitter.Emit(0x57); // push rdi
+			emitter.Emit(0x56); // push rsi
+			emitter.Emit(0x41); emitter.Emit(0x54); // push r12
+			emitter.Emit(0x41); emitter.Emit(0x55); // push r13
+			emitter.Emit(0x41); emitter.Emit(0x56); // push r14
+			emitter.Emit(0x41); emitter.Emit(0x57); // push r15
+			EmitHostNonvolatileXmmSave(ptr2, ref emitter.Offset);
 			// Restore the fiber's floating-point control environment before
 			// abandoning the host stack. This path is used when a blocked guest
 			// continuation migrates to another managed worker.
-			Emit(0x48); Emit(0x83); Emit(0xEC); Emit(0x08); // sub rsp,8
-			Emit(0xC7); Emit(0x04); Emit(0x24);             // mov dword [rsp],imm32
-			*(uint*)(ptr2 + offset) = context.Mxcsr; offset += sizeof(uint);
-			Emit(0x0F); Emit(0xAE); Emit(0x14); Emit(0x24); // ldmxcsr [rsp]
-			Emit(0x66); Emit(0xC7); Emit(0x04); Emit(0x24); // mov word [rsp],imm16
-			*(ushort*)(ptr2 + offset) = context.FpuControlWord; offset += sizeof(ushort);
-			Emit(0xD9); Emit(0x2C); Emit(0x24);             // fldcw [rsp]
-			Emit(0x48); Emit(0x83); Emit(0xC4); Emit(0x08); // add rsp,8
-			EmitMovR64Imm(0x49, 0xBA, hostRspSlot); // mov r10, hostRspSlot
-			Emit(0x49); Emit(0x89); Emit(0x22); // mov [r10], rsp
-			EmitMovR64Imm(0x48, 0xB8, context[CpuRegister.Rsp]); // mov rax, guest rsp
-			Emit(0x48); Emit(0x89); Emit(0xC4); // mov rsp, rax
-			Emit(0x48); Emit(0x83); Emit(0xEC); Emit(0x08); // reserve transfer slot
-			EmitMovR64Imm(0x48, 0xB8, entryPoint); // mov rax, entryPoint
-			Emit(0x48); Emit(0x89); Emit(0x04); Emit(0x24); // mov [rsp],rax
-			EmitMovR64Imm(0x48, 0xBB, context[CpuRegister.Rbx]); // mov rbx, imm64
-			EmitMovR64Imm(0x48, 0xBD, context[CpuRegister.Rbp]); // mov rbp, imm64
-			EmitMovR64Imm(0x48, 0xBF, context[CpuRegister.Rdi]); // mov rdi, imm64
-			EmitMovR64Imm(0x48, 0xBE, context[CpuRegister.Rsi]); // mov rsi, imm64
-			EmitMovR64Imm(0x48, 0xBA, context[CpuRegister.Rdx]); // mov rdx, imm64
-			EmitMovR64Imm(0x48, 0xB9, context[CpuRegister.Rcx]); // mov rcx, imm64
-			EmitMovR64Imm(0x49, 0xB8, context[CpuRegister.R8]); // mov r8, imm64
-			EmitMovR64Imm(0x49, 0xB9, context[CpuRegister.R9]); // mov r9, imm64
-			EmitMovR64Imm(0x49, 0xBA, context[CpuRegister.R10]); // mov r10, imm64
-			EmitMovR64Imm(0x49, 0xBC, context[CpuRegister.R12]); // mov r12, imm64
-			EmitMovR64Imm(0x49, 0xBD, context[CpuRegister.R13]); // mov r13, imm64
-			EmitMovR64Imm(0x49, 0xBE, context[CpuRegister.R14]); // mov r14, imm64
-			EmitMovR64Imm(0x49, 0xBF, context[CpuRegister.R15]); // mov r15, imm64
-			EmitMovR64Imm(0x49, 0xBB, context[CpuRegister.R11]); // mov r11, imm64
-			EmitMovR64Imm(0x48, 0xB8, context[CpuRegister.Rax]); // mov rax, imm64
-			Emit(0xC3); // ret through the synthetic transfer slot
+			emitter.Emit(0x48); emitter.Emit(0x83); emitter.Emit(0xEC); emitter.Emit(0x08); // sub rsp,8
+			emitter.Emit(0xC7); emitter.Emit(0x04); emitter.Emit(0x24); // mov dword [rsp],imm32
+			emitter.Emit(context.Mxcsr);
+			emitter.Emit(0x0F); emitter.Emit(0xAE); emitter.Emit(0x14); emitter.Emit(0x24); // ldmxcsr [rsp]
+			emitter.Emit(0x66); emitter.Emit(0xC7); emitter.Emit(0x04); emitter.Emit(0x24); // mov word [rsp],imm16
+			emitter.Emit(context.FpuControlWord);
+			emitter.Emit(0xD9); emitter.Emit(0x2C); emitter.Emit(0x24); // fldcw [rsp]
+			emitter.Emit(0x48); emitter.Emit(0x83); emitter.Emit(0xC4); emitter.Emit(0x08); // add rsp,8
+			emitter.EmitMovR64Immediate(0x49, 0xBA, hostRspSlot); // mov r10, hostRspSlot
+			emitter.Emit(0x49); emitter.Emit(0x89); emitter.Emit(0x22); // mov [r10], rsp
+			emitter.EmitMovR64Immediate(0x48, 0xB8, context[CpuRegister.Rsp]); // mov rax, guest rsp
+			emitter.Emit(0x48); emitter.Emit(0x89); emitter.Emit(0xC4); // mov rsp, rax
+			emitter.Emit(0x48); emitter.Emit(0x83); emitter.Emit(0xEC); emitter.Emit(0x08); // reserve transfer slot
+			emitter.EmitMovR64Immediate(0x48, 0xB8, entryPoint); // mov rax, entryPoint
+			emitter.Emit(0x48); emitter.Emit(0x89); emitter.Emit(0x04); emitter.Emit(0x24); // mov [rsp],rax
+			emitter.EmitMovR64Immediate(0x48, 0xBB, context[CpuRegister.Rbx]); // mov rbx, imm64
+			emitter.EmitMovR64Immediate(0x48, 0xBD, context[CpuRegister.Rbp]); // mov rbp, imm64
+			emitter.EmitMovR64Immediate(0x48, 0xBF, context[CpuRegister.Rdi]); // mov rdi, imm64
+			emitter.EmitMovR64Immediate(0x48, 0xBE, context[CpuRegister.Rsi]); // mov rsi, imm64
+			emitter.EmitMovR64Immediate(0x48, 0xBA, context[CpuRegister.Rdx]); // mov rdx, imm64
+			emitter.EmitMovR64Immediate(0x48, 0xB9, context[CpuRegister.Rcx]); // mov rcx, imm64
+			emitter.EmitMovR64Immediate(0x49, 0xB8, context[CpuRegister.R8]); // mov r8, imm64
+			emitter.EmitMovR64Immediate(0x49, 0xB9, context[CpuRegister.R9]); // mov r9, imm64
+			emitter.EmitMovR64Immediate(0x49, 0xBA, context[CpuRegister.R10]); // mov r10, imm64
+			emitter.EmitMovR64Immediate(0x49, 0xBC, context[CpuRegister.R12]); // mov r12, imm64
+			emitter.EmitMovR64Immediate(0x49, 0xBD, context[CpuRegister.R13]); // mov r13, imm64
+			emitter.EmitMovR64Immediate(0x49, 0xBE, context[CpuRegister.R14]); // mov r14, imm64
+			emitter.EmitMovR64Immediate(0x49, 0xBF, context[CpuRegister.R15]); // mov r15, imm64
+			emitter.EmitMovR64Immediate(0x49, 0xBB, context[CpuRegister.R11]); // mov r11, imm64
+			emitter.EmitMovR64Immediate(0x48, 0xB8, context[CpuRegister.Rax]); // mov rax, imm64
+			emitter.Emit(0xC3); // ret through the synthetic transfer slot
 			ActiveEntryReturnSentinelRip = (ulong)_guestReturnStub;
 			if (returnSlotAddress == 0 || !context.TryWriteUInt64(returnSlotAddress, (ulong)_guestReturnStub))
 			{
@@ -5245,6 +5232,45 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				previousYieldReason);
 			NativeMemory.Free(hostRspStorage);
 			VirtualFree(ptr, 0u, 32768u);
+		}
+	}
+
+	// The continuation trampoline is rebuilt on every blocked-thread resume.
+	// Keep its tiny writer on the stack: capturing local emit functions create a
+	// managed display-class allocation on this extremely hot path.
+	private unsafe ref struct NativeCodeEmitter(byte* code)
+	{
+		private readonly byte* _code = code;
+		public int Offset;
+
+		public void Emit(byte value)
+		{
+			_code[Offset++] = value;
+		}
+
+		public void Emit(ushort value)
+		{
+			*(ushort*)(_code + Offset) = value;
+			Offset += sizeof(ushort);
+		}
+
+		public void Emit(uint value)
+		{
+			*(uint*)(_code + Offset) = value;
+			Offset += sizeof(uint);
+		}
+
+		private void Emit(ulong value)
+		{
+			*(ulong*)(_code + Offset) = value;
+			Offset += sizeof(ulong);
+		}
+
+		public void EmitMovR64Immediate(byte rex, byte opcode, ulong value)
+		{
+			Emit(rex);
+			Emit(opcode);
+			Emit(value);
 		}
 	}
 

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -3729,13 +3729,16 @@ public static partial class AgcExports
             _labelProducers.Add(producer);
         }
 
-        foreach (var waiting in GpuWaitRegistry.SnapshotInRange(memory, address, length))
+        if (_traceAgc)
         {
-            TraceAgc(
-                $"agc.wait_producer_scheduled label=0x{waiting.Address:X16} " +
-                $"waiters={waiting.Count} producer_seq={producer.Sequence} " +
-                $"queue={producer.QueueName} submission={producer.SubmissionId} " +
-                $"packet=0x{packetAddress:X16} action='{debugName}'");
+            foreach (var waiting in GpuWaitRegistry.SnapshotInRange(memory, address, length))
+            {
+                TraceAgc(
+                    $"agc.wait_producer_scheduled label=0x{waiting.Address:X16} " +
+                    $"waiters={waiting.Count} producer_seq={producer.Sequence} " +
+                    $"queue={producer.QueueName} submission={producer.SubmissionId} " +
+                    $"packet=0x{packetAddress:X16} action='{debugName}'");
+            }
         }
 
         return producer;
@@ -3753,16 +3756,19 @@ public static partial class AgcExports
             producer.Completed = true;
         }
 
-        foreach (var waiting in GpuWaitRegistry.SnapshotInRange(
-                     producer.Memory,
-                     producer.Address,
-                     producer.Length))
+        if (_traceAgc)
         {
-            TraceAgc(
-                $"agc.wait_producer_completed label=0x{waiting.Address:X16} " +
-                $"waiters={waiting.Count} producer_seq={producer.Sequence} " +
-                $"queue={producer.QueueName} submission={producer.SubmissionId} " +
-                $"action='{producer.DebugName}'");
+            foreach (var waiting in GpuWaitRegistry.SnapshotInRange(
+                         producer.Memory,
+                         producer.Address,
+                         producer.Length))
+            {
+                TraceAgc(
+                    $"agc.wait_producer_completed label=0x{waiting.Address:X16} " +
+                    $"waiters={waiting.Count} producer_seq={producer.Sequence} " +
+                    $"queue={producer.QueueName} submission={producer.SubmissionId} " +
+                    $"action='{producer.DebugName}'");
+            }
         }
     }
 
@@ -3805,6 +3811,14 @@ public static partial class AgcExports
             {
                 return;
             }
+        }
+
+        // Producer-backed waits are trace-only. Keep the producer lookup above
+        // because producerless waits are always warned, but do not build the
+        // detailed condition strings when AGC tracing is disabled.
+        if (producer is not null && !_traceAgc)
+        {
+            return;
         }
 
         var prefix = stale ? "agc.wait_stale" : "agc.wait_suspended";
@@ -6087,54 +6101,39 @@ public static partial class AgcExports
             _graphicsShaderCache.TryAdd(shaderKey, compiled);
         }
 
-        var imageBindings = pixelEvaluation.ImageBindings
-            .Concat(exportEvaluation.ImageBindings);
         var textures = new List<TranslatedImageBinding>(
             pixelEvaluation.ImageBindings.Count +
             exportEvaluation.ImageBindings.Count);
-        foreach (var binding in imageBindings)
+        if (!TryAppendTranslatedImageBindings(
+                pixelEvaluation.ImageBindings,
+                textures,
+                pixelShaderAddress,
+                exportShaderAddress,
+                out error) ||
+            !TryAppendTranslatedImageBindings(
+                exportEvaluation.ImageBindings,
+                textures,
+                pixelShaderAddress,
+                exportShaderAddress,
+                out error))
         {
-            if (!TryDecodeTextureDescriptor(binding.ResourceDescriptor, out var texture))
-            {
-                // A garbage/zeroed texture descriptor (from a per-draw descriptor
-                // setup race — the same root as scalar-load-failed) would drop
-                // the whole draw, so Demon's Souls' deferred-lighting/composite
-                // passes that produce the composite's feeder targets never run
-                // and the frame stays black. Substitute a 1x1 fallback binding so
-                // the pass still renders (that one sampled texture reads black)
-                // rather than dropping it entirely. STRICT reverts.
-                if (_strictShaderDescriptors)
-                {
-                    error = $"invalid texture descriptor at pc=0x{binding.Pc:X}";
-                    ReturnPooledEvaluationArrays(exportEvaluation);
-                    ReturnPooledEvaluationArrays(pixelEvaluation);
-                    return false;
-                }
-
-                texture = new TextureDescriptor(
-                    0, 1, 1, Gen5TextureFormatR8G8B8A8Unorm, 0, 0, 0, 0, 0, 1, 0xFAC);
-            }
-
-            if (_traceAgcShader || _tracePixelShaderAddress == pixelShaderAddress)
-            {
-                Console.Error.WriteLine(
-                    "[LOADER][TRACE] " +
-                    $"agc.texture_binding ps=0x{pixelShaderAddress:X16} es=0x{exportShaderAddress:X16} " +
-                    $"pc=0x{binding.Pc:X} op={binding.Opcode} storage={(Gen5ShaderTranslator.IsStorageImageOperation(binding.Opcode) ? 1 : 0)} " +
-                    $"decoded={FormatTextureDescriptor(texture)} " +
-                    $"raw={FormatShaderDwords(binding.ResourceDescriptor)} sampler={FormatShaderDwords(binding.SamplerDescriptor)}");
-            }
-            textures.Add(
-                new TranslatedImageBinding(
-                    texture,
-                    Gen5ShaderTranslator.IsStorageImageOperation(binding.Opcode),
-                    binding.MipLevel ?? 0,
-                    binding.SamplerDescriptor));
+            ReturnPooledEvaluationArrays(exportEvaluation);
+            ReturnPooledEvaluationArrays(pixelEvaluation);
+            return false;
         }
 
-        var globalMemoryBindings = pixelEvaluation.GlobalMemoryBindings
-            .Concat(exportEvaluation.GlobalMemoryBindings)
-            .ToArray();
+        var globalMemoryBindings = new Gen5GlobalMemoryBinding[
+            pixelEvaluation.GlobalMemoryBindings.Count +
+            exportEvaluation.GlobalMemoryBindings.Count];
+        for (var index = 0; index < pixelEvaluation.GlobalMemoryBindings.Count; index++)
+        {
+            globalMemoryBindings[index] = pixelEvaluation.GlobalMemoryBindings[index];
+        }
+        for (var index = 0; index < exportEvaluation.GlobalMemoryBindings.Count; index++)
+        {
+            globalMemoryBindings[pixelEvaluation.GlobalMemoryBindings.Count + index] =
+                exportEvaluation.GlobalMemoryBindings[index];
+        }
         IReadOnlyList<Gen5VertexInputBinding> vertexInputs =
             exportEvaluation.VertexInputs ?? [];
         state.UcRegisters.TryGetValue(VgtPrimitiveType, out var primitiveType);
@@ -6147,6 +6146,13 @@ public static partial class AgcExports
                 renderTargets[index].Height,
                 renderTargets[index].Format,
                 renderTargets[index].NumberType);
+        }
+
+        var pixelUserDataCount = Math.Min(pixelEvaluation.InitialScalarRegisters.Count, 8);
+        var pixelUserData = new uint[pixelUserDataCount];
+        for (var index = 0; index < pixelUserDataCount; index++)
+        {
+            pixelUserData[index] = pixelEvaluation.InitialScalarRegisters[index];
         }
 
         draw = new TranslatedGuestDraw(
@@ -6170,7 +6176,7 @@ public static partial class AgcExports
                 textures,
                 vertexInputs,
                 pixelEvaluation.InitialScalarRegisters),
-            pixelEvaluation.InitialScalarRegisters.Take(8).ToArray(),
+            pixelUserData,
             state.CxRegisters.TryGetValue(CbBlend0Control, out var rawBlend) ? rawBlend : 0,
             state.CxRegisters.TryGetValue(
                 CbColor0Info + renderTargets.FirstOrDefault().Slot * CbColorRegisterStride,
@@ -6179,6 +6185,55 @@ public static partial class AgcExports
                 : 0,
             pixelEvaluation.InitialScalarRegisters,
             exportEvaluation.InitialScalarRegisters);
+        return true;
+    }
+
+    private static bool TryAppendTranslatedImageBindings(
+        IReadOnlyList<Gen5ImageBinding> bindings,
+        List<TranslatedImageBinding> textures,
+        ulong pixelShaderAddress,
+        ulong exportShaderAddress,
+        out string error)
+    {
+        foreach (var binding in bindings)
+        {
+            if (!TryDecodeTextureDescriptor(binding.ResourceDescriptor, out var texture))
+            {
+                // A garbage/zeroed texture descriptor (from a per-draw descriptor
+                // setup race — the same root as scalar-load-failed) would drop
+                // the whole draw, so deferred-lighting/composite passes that
+                // produce the composite's feeder targets never run. Keep the
+                // existing 1x1 fallback unless strict diagnostics are requested.
+                if (_strictShaderDescriptors)
+                {
+                    error = $"invalid texture descriptor at pc=0x{binding.Pc:X}";
+                    return false;
+                }
+
+                texture = new TextureDescriptor(
+                    0, 1, 1, Gen5TextureFormatR8G8B8A8Unorm, 0, 0, 0, 0, 0, 1, 0xFAC);
+            }
+
+            var isStorage =
+                Gen5ShaderTranslator.IsStorageImageOperation(binding.Opcode);
+            if (_traceAgcShader || _tracePixelShaderAddress == pixelShaderAddress)
+            {
+                Console.Error.WriteLine(
+                    "[LOADER][TRACE] " +
+                    $"agc.texture_binding ps=0x{pixelShaderAddress:X16} es=0x{exportShaderAddress:X16} " +
+                    $"pc=0x{binding.Pc:X} op={binding.Opcode} storage={(isStorage ? 1 : 0)} " +
+                    $"decoded={FormatTextureDescriptor(texture)} " +
+                    $"raw={FormatShaderDwords(binding.ResourceDescriptor)} sampler={FormatShaderDwords(binding.SamplerDescriptor)}");
+            }
+            textures.Add(
+                new TranslatedImageBinding(
+                    texture,
+                    isStorage,
+                    binding.MipLevel ?? 0,
+                    binding.SamplerDescriptor));
+        }
+
+        error = string.Empty;
         return true;
     }
 
@@ -6636,15 +6691,19 @@ public static partial class AgcExports
 
         var target = targets[0];
         var scissor = DecodeScissor(registers, target.Width, target.Height);
-        return new GuestRenderState(
-            targets.Select(target =>
+        var blends = new GuestBlendState[targets.Count];
+        for (var index = 0; index < targets.Count; index++)
+        {
+            var blend = DecodeBlendState(registers, targets[index].Slot);
+            blends[index] = blend with
             {
-                var blend = DecodeBlendState(registers, target.Slot);
-                return blend with
-                {
-                    WriteMask = blend.WriteMask & GetPixelColorExportMask(pixelState, target.Slot),
-                };
-            }).ToArray(),
+                WriteMask = blend.WriteMask &
+                    GetPixelColorExportMask(pixelState, targets[index].Slot),
+            };
+        }
+
+        return new GuestRenderState(
+            blends,
             scissor,
             DecodeViewport(registers, target.Width, target.Height, scissor),
             DecodeRasterState(registers),

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -2775,6 +2775,11 @@ internal static unsafe class VulkanVideoPresenter
 
         private void LoadDebugUtilsCommands()
         {
+            if (!_vulkanDebugUtilsEnabled)
+            {
+                return;
+            }
+
             var setObjectName = _vk.GetDeviceProcAddr(_device, "vkSetDebugUtilsObjectNameEXT");
             var beginLabel = _vk.GetDeviceProcAddr(_device, "vkCmdBeginDebugUtilsLabelEXT");
             var endLabel = _vk.GetDeviceProcAddr(_device, "vkCmdEndDebugUtilsLabelEXT");
@@ -2877,10 +2882,48 @@ internal static unsafe class VulkanVideoPresenter
             $"SharpEmu texture 0x{texture.Address:X16} {texture.Width}x{texture.Height} " +
             $"fmt{texture.Format}/{format}";
 
+        private static bool IsTitleDraw(IReadOnlyList<GuestVertexBuffer> vertexBuffers)
+        {
+            foreach (var buffer in vertexBuffers)
+            {
+                if (buffer.Location == 0 &&
+                    buffer.ComponentCount == 4 &&
+                    buffer.DataFormat == 10 &&
+                    buffer.NumberFormat == 0 &&
+                    buffer.Stride == 16 &&
+                    buffer.OffsetBytes == 12 &&
+                    buffer.Length == 67568)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool AnyTargetAddressMatches(
+            IReadOnlyList<GuestImageResource>? targets,
+            string environmentVariable)
+        {
+            if (targets is null)
+            {
+                return false;
+            }
+
+            foreach (var target in targets)
+            {
+                if (AddressListContains(environmentVariable, target.Address))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private void CreateInstance()
         {
             var applicationName = (byte*)SilkMarshal.StringToPtr("SharpEmu");
-            var enableValidation = Environment.GetEnvironmentVariable("SHARPEMU_VK_VALIDATION") == "1";
             byte* validationLayerName = null;
 
             try
@@ -2906,7 +2949,8 @@ internal static unsafe class VulkanVideoPresenter
                     enabledExtensions[index] = extensions[index];
                 }
 
-                if (IsInstanceExtensionAvailable(DebugUtilsExtensionName))
+                if (_vulkanDebugUtilsEnabled &&
+                    IsInstanceExtensionAvailable(DebugUtilsExtensionName))
                 {
                     debugUtilsExtension = (byte*)SilkMarshal.StringToPtr(DebugUtilsExtensionName);
                     enabledExtensions[enabledExtensionCount++] = debugUtilsExtension;
@@ -2921,11 +2965,12 @@ internal static unsafe class VulkanVideoPresenter
                     instanceCreateFlags |= InstanceCreateFlags.EnumeratePortabilityBitKhr;
                 }
 
-                if (enableValidation && IsInstanceLayerAvailable("VK_LAYER_KHRONOS_validation"))
+                if (_vulkanValidationEnabled &&
+                    IsInstanceLayerAvailable("VK_LAYER_KHRONOS_validation"))
                 {
                     validationLayerName = (byte*)SilkMarshal.StringToPtr("VK_LAYER_KHRONOS_validation");
                 }
-                else if (enableValidation)
+                else if (_vulkanValidationEnabled)
                 {
                     Console.Error.WriteLine("[LOADER][WARN] SHARPEMU_VK_VALIDATION=1 but VK_LAYER_KHRONOS_validation not found (Vulkan SDK installed?).");
                 }
@@ -4898,6 +4943,13 @@ internal static unsafe class VulkanVideoPresenter
             IReadOnlyList<GuestImageResource>? renderTargets = null,
             ulong shaderAddress = 0)
         {
+            if (!_traceGuestImagesEnabled &&
+                !_traceGuestImageAddressFilterEnabled &&
+                GuestImageTraceInterval() is null)
+            {
+                return Array.Empty<GuestImageResource>();
+            }
+
             var candidates = new HashSet<GuestImageResource>();
             foreach (var renderTarget in renderTargets ?? [])
             {
@@ -5140,47 +5192,35 @@ internal static unsafe class VulkanVideoPresenter
             bool hasDepthAttachment = false,
             GuestDepthResource? feedbackDepth = null)
         {
-            var isTitleDraw = draw.VertexBuffers.Any(buffer =>
-                buffer.Location == 0 &&
-                buffer.ComponentCount == 4 &&
-                buffer.DataFormat == 10 &&
-                buffer.NumberFormat == 0 &&
-                buffer.Stride == 16 &&
-                buffer.OffsetBytes == 12 &&
-                buffer.Length == 67568);
-            var forceFullscreenPipeline = Environment.GetEnvironmentVariable(
-                "SHARPEMU_FORCE_FULLSCREEN_PIPELINE") == "1";
-            var forceFullscreenVertex = forceFullscreenPipeline ||
-                Environment.GetEnvironmentVariable(
-                    "SHARPEMU_FORCE_FULLSCREEN_VERTEX") == "1" ||
-                isTitleDraw && Environment.GetEnvironmentVariable(
-                    "SHARPEMU_FORCE_TITLE_FULLSCREEN_VERTEX") == "1" ||
-                feedbackTargets?.Any(target => AddressListContains(
-                    "SHARPEMU_FORCE_FULLSCREEN_VERTEX_TARGETS",
-                    target.Address)) == true;
-            var forceRasterState = forceFullscreenPipeline ||
-                Environment.GetEnvironmentVariable(
-                    "SHARPEMU_FORCE_DEFAULT_RASTER_STATE") == "1" ||
-                isTitleDraw && Environment.GetEnvironmentVariable(
-                    "SHARPEMU_FORCE_TITLE_DEFAULT_RASTER_STATE") == "1" ||
-                feedbackTargets?.Any(target => AddressListContains(
-                    "SHARPEMU_FORCE_DEFAULT_RASTER_STATE_TARGETS",
-                    target.Address)) == true;
+            var isTitleDraw = IsTitleDraw(draw.VertexBuffers);
+            var forceFullscreenVertex = _forceFullscreenPipeline ||
+                _forceFullscreenVertex ||
+                isTitleDraw && _forceTitleFullscreenVertex ||
+                AnyTargetAddressMatches(
+                    feedbackTargets,
+                    "SHARPEMU_FORCE_FULLSCREEN_VERTEX_TARGETS");
+            var forceRasterState = _forceFullscreenPipeline ||
+                _forceDefaultRasterState ||
+                isTitleDraw && _forceTitleDefaultRasterState ||
+                AnyTargetAddressMatches(
+                    feedbackTargets,
+                    "SHARPEMU_FORCE_DEFAULT_RASTER_STATE_TARGETS");
             var forceTitleSolidFragment =
-                Environment.GetEnvironmentVariable(
-                    "SHARPEMU_FORCE_TITLE_SOLID_FRAGMENT") == "1" &&
+                _forceTitleSolidFragment &&
                 isTitleDraw;
-            var forceSolidFragment = forceTitleSolidFragment || forceFullscreenPipeline ||
-                Environment.GetEnvironmentVariable("SHARPEMU_FORCE_SOLID_FRAGMENT") == "1" ||
-                feedbackTargets?.Any(target => AddressListContains(
-                    "SHARPEMU_FORCE_SOLID_FRAGMENT_TARGETS",
-                    target.Address)) == true;
-            var forceAttributeFragment = uint.TryParse(
-                Environment.GetEnvironmentVariable("SHARPEMU_FORCE_ATTRIBUTE_FRAGMENT"),
-                out var attributeFragmentLocation) &&
-                feedbackTargets?.Any(target => AddressListContains(
-                    "SHARPEMU_FORCE_ATTRIBUTE_FRAGMENT_TARGETS",
-                    target.Address)) == true;
+            var forceSolidFragment = forceTitleSolidFragment ||
+                _forceFullscreenPipeline ||
+                _forceSolidFragment ||
+                AnyTargetAddressMatches(
+                    feedbackTargets,
+                    "SHARPEMU_FORCE_SOLID_FRAGMENT_TARGETS");
+            var attributeFragmentLocation =
+                _forceAttributeFragmentLocation.GetValueOrDefault();
+            var forceAttributeFragment =
+                _forceAttributeFragmentLocation.HasValue &&
+                AnyTargetAddressMatches(
+                    feedbackTargets,
+                    "SHARPEMU_FORCE_ATTRIBUTE_FRAGMENT_TARGETS");
             var vertexSpirv = forceFullscreenVertex
                 ? SpirvFixedShaders.CreateFullscreenVertex(0)
                 : draw.VertexSpirv;
@@ -5189,11 +5229,9 @@ internal static unsafe class VulkanVideoPresenter
                 : forceAttributeFragment
                     ? SpirvFixedShaders.CreateAttributeFragment(attributeFragmentLocation)
                 : draw.PixelSpirv;
-            var fixedFragmentDumpPath = Environment.GetEnvironmentVariable(
-                "SHARPEMU_DUMP_FIXED_SOLID_FRAGMENT");
-            if (forceSolidFragment && !string.IsNullOrWhiteSpace(fixedFragmentDumpPath))
+            if (forceSolidFragment && !string.IsNullOrWhiteSpace(_fixedFragmentDumpPath))
             {
-                File.WriteAllBytes(fixedFragmentDumpPath, fragmentSpirv);
+                File.WriteAllBytes(_fixedFragmentDumpPath, fragmentSpirv);
             }
             if (draw.RenderState.Blends.Count != renderTargetFormats.Count)
             {
@@ -5243,21 +5281,18 @@ internal static unsafe class VulkanVideoPresenter
                 resources.Raster = GuestRasterState.Default;
                 resources.Depth = GuestDepthState.Default;
             }
-            if (isTitleDraw && Environment.GetEnvironmentVariable(
-                    "SHARPEMU_FORCE_TITLE_DEFAULT_BLEND") == "1")
+            if (isTitleDraw && _forceTitleDefaultBlend)
             {
                 resources.Blends = Enumerable.Repeat(
                     GuestBlendState.Default,
                     renderTargetFormats.Count).ToArray();
             }
-            if (isTitleDraw && Environment.GetEnvironmentVariable(
-                    "SHARPEMU_FORCE_TITLE_DEFAULT_VIEWPORT_SCISSOR") == "1")
+            if (isTitleDraw && _forceTitleDefaultViewportScissor)
             {
                 resources.Scissor = null;
                 resources.Viewport = null;
             }
-            if (isTitleDraw && Environment.GetEnvironmentVariable(
-                    "SHARPEMU_FORCE_TITLE_DISABLE_CULL") == "1")
+            if (isTitleDraw && _forceTitleDisableCull)
             {
                 resources.Raster = resources.Raster with
                 {
@@ -5265,13 +5300,11 @@ internal static unsafe class VulkanVideoPresenter
                     CullBack = false,
                 };
             }
-            if (isTitleDraw && Environment.GetEnvironmentVariable(
-                    "SHARPEMU_FORCE_TITLE_DISABLE_DEPTH") == "1")
+            if (isTitleDraw && _forceTitleDisableDepth)
             {
                 resources.Depth = GuestDepthState.Default;
             }
-            if (isTitleDraw && Environment.GetEnvironmentVariable(
-                    "SHARPEMU_TRACE_TITLE_STATE") == "1")
+            if (isTitleDraw && _traceTitleState)
             {
                 Console.Error.WriteLine(
                     $"[LOADER][TRACE] vk.title_state " +
@@ -7874,7 +7907,7 @@ internal static unsafe class VulkanVideoPresenter
         {
             ReadOnlySpan<byte> source = guestBuffer.Data.AsSpan(0, guestBuffer.Length);
             byte[]? forcedVertexColors = null;
-            if (Environment.GetEnvironmentVariable("SHARPEMU_FORCE_TITLE_VERTEX_COLOR_WHITE") == "1" &&
+            if (_forceTitleVertexColorWhite &&
                 guestBuffer.Location == 0 &&
                 guestBuffer.ComponentCount == 4 &&
                 guestBuffer.DataFormat == 10 &&
@@ -9400,37 +9433,67 @@ internal static unsafe class VulkanVideoPresenter
                 return;
             }
 
-            if (targetFormats
-                .Select((format, index) => format.IsInteger && work.Draw.RenderState.Blends[index].Enable)
-                .Any(invalid => invalid))
+            for (var index = 0; index < targetFormats.Length; index++)
             {
-                Console.Error.WriteLine(
-                    "[LOADER][WARN] Vulkan skipped MRT draw with blending enabled for an integer attachment.");
-                ReturnPooledGuestData(work.Draw);
-                return;
+                if (targetFormats[index].IsInteger &&
+                    work.Draw.RenderState.Blends[index].Enable)
+                {
+                    Console.Error.WriteLine(
+                        "[LOADER][WARN] Vulkan skipped MRT draw with blending enabled for an integer attachment.");
+                    ReturnPooledGuestData(work.Draw);
+                    return;
+                }
             }
 
-            if (!_supportsIndependentBlend &&
-                work.Draw.RenderState.Blends.Skip(1).Any(blend => blend != work.Draw.RenderState.Blends[0]))
+            if (!_supportsIndependentBlend)
             {
-                Console.Error.WriteLine(
-                    "[LOADER][WARN] Vulkan skipped MRT draw requiring unsupported independentBlend.");
-                ReturnPooledGuestData(work.Draw);
-                return;
+                for (var index = 1; index < work.Draw.RenderState.Blends.Count; index++)
+                {
+                    if (work.Draw.RenderState.Blends[index] !=
+                        work.Draw.RenderState.Blends[0])
+                    {
+                        Console.Error.WriteLine(
+                            "[LOADER][WARN] Vulkan skipped MRT draw requiring unsupported independentBlend.");
+                        ReturnPooledGuestData(work.Draw);
+                        return;
+                    }
+                }
             }
 
-            var formats = targetFormats.Select(target => target.Format).ToArray();
+            var formats = new Format[targetFormats.Length];
+            for (var index = 0; index < targetFormats.Length; index++)
+            {
+                formats[index] = targetFormats[index].Format;
+            }
 
-            var targetAddresses = work.Targets
-                .Where(target => target.Address != 0)
-                .Select(target => target.Address)
-                .ToHashSet();
-            if (work.Draw.Textures.Any(texture =>
-                    texture.IsStorage && targetAddresses.Contains(texture.Address)))
+            var hasStorageFeedback = false;
+            foreach (var texture in work.Draw.Textures)
+            {
+                if (!texture.IsStorage || texture.Address == 0)
+                {
+                    continue;
+                }
+
+                foreach (var target in work.Targets)
+                {
+                    if (target.Address != 0 && target.Address == texture.Address)
+                    {
+                        hasStorageFeedback = true;
+                        break;
+                    }
+                }
+
+                if (hasStorageFeedback)
+                {
+                    break;
+                }
+            }
+
+            if (hasStorageFeedback)
             {
                 Console.Error.WriteLine(
                     $"[LOADER][WARN] Vulkan skipped storage render-target feedback loop " +
-                    $"targets={string.Join(',', targetAddresses.Select(address => $"0x{address:X16}"))}; " +
+                    $"targets={string.Join(',', work.Targets.Where(target => target.Address != 0).Select(target => $"0x{target.Address:X16}"))}; " +
                     "sampled aliases use ordered snapshots");
                 ReturnPooledGuestData(work.Draw);
                 return;
@@ -9802,64 +9865,34 @@ internal static unsafe class VulkanVideoPresenter
                     }
                 }
 
-                var guestWritesMode = Environment.GetEnvironmentVariable(
-                    "SHARPEMU_TRACE_GUEST_WRITES");
-                var traceAddressWriteOrdinal = 0L;
-                _ = long.TryParse(
-                    Environment.GetEnvironmentVariable("SHARPEMU_TRACE_GUEST_WRITE_ORDINAL"),
-                    out traceAddressWriteOrdinal);
-                var traceLargeWriteOrdinal = 0L;
-                if (guestWritesMode is not null &&
-                    guestWritesMode.StartsWith("large@", StringComparison.Ordinal) &&
-                    long.TryParse(
-                        guestWritesMode.AsSpan("large@".Length),
-                        out var parsedTraceLargeWriteOrdinal) &&
-                    parsedTraceLargeWriteOrdinal > 0)
-                {
-                    traceLargeWriteOrdinal = parsedTraceLargeWriteOrdinal;
-                }
-
                 var tracePixelSpirv = false;
-                if (int.TryParse(
-                        Environment.GetEnvironmentVariable("SHARPEMU_TRACE_PIXEL_SPIRV_BYTES"),
-                        out var tracePixelSpirvBytes) &&
-                    tracePixelSpirvBytes == work.Draw.PixelSpirv.Length)
+                if (_tracePixelSpirvBytes > 0 &&
+                    _tracePixelSpirvBytes == work.Draw.PixelSpirv.Length)
                 {
                     var pixelWriteCount = _pixelSpirvWriteCounts.TryGetValue(
-                        tracePixelSpirvBytes,
+                        _tracePixelSpirvBytes,
                         out var previousPixelWriteCount)
                             ? previousPixelWriteCount + 1
                             : 1;
-                    _pixelSpirvWriteCounts[tracePixelSpirvBytes] = pixelWriteCount;
-                    var tracePixelSpirvOccurrence = 1;
-                    _ = int.TryParse(
-                        Environment.GetEnvironmentVariable(
-                            "SHARPEMU_TRACE_PIXEL_SPIRV_OCCURRENCE"),
-                        out tracePixelSpirvOccurrence);
+                    _pixelSpirvWriteCounts[_tracePixelSpirvBytes] = pixelWriteCount;
                     tracePixelSpirv =
-                        pixelWriteCount == Math.Max(tracePixelSpirvOccurrence, 1);
+                        pixelWriteCount == _tracePixelSpirvOccurrence;
                 }
                 var traceTitleDraw =
                     !_tracedTitleDraw &&
-                    Environment.GetEnvironmentVariable("SHARPEMU_TRACE_TITLE_DRAW") == "1" &&
-                    work.Draw.VertexBuffers.Any(buffer =>
-                        buffer.Location == 0 &&
-                        buffer.ComponentCount == 4 &&
-                        buffer.DataFormat == 10 &&
-                        buffer.NumberFormat == 0 &&
-                        buffer.Stride == 16 &&
-                        buffer.OffsetBytes == 12 &&
-                        buffer.Length == 67568);
+                    _traceTitleDrawEnabled &&
+                    IsTitleDraw(work.Draw.VertexBuffers);
                 _tracedTitleDraw |= traceTitleDraw;
 
                 foreach (var target in targets)
                 {
                     var traceAddressWrite =
                         ShouldTraceGuestImageWriteForDiagnostics(target.Address);
-                    var traceSmallWrites = guestWritesMode == "small" &&
+                    var traceSmallWrites = _traceGuestWritesMode == "small" &&
                         target.Width <= 512 && target.Height <= 256;
                     var traceLargeWrites =
-                        (guestWritesMode == "large" || traceLargeWriteOrdinal != 0) &&
+                        (_traceGuestWritesMode == "large" ||
+                         _traceLargeGuestWriteOrdinal != 0) &&
                         target.Width >= 2560 && target.Height >= 1440;
                     if (traceAddressWrite || traceSmallWrites ||
                         traceLargeWrites || tracePixelSpirv || traceTitleDraw)
@@ -9872,10 +9905,10 @@ internal static unsafe class VulkanVideoPresenter
                         _tracedGuestWriteCounts[target.Address] = writeCount;
                         var shouldTraceWrite = tracePixelSpirv || traceTitleDraw
                             ? true
-                            : traceAddressWrite && traceAddressWriteOrdinal > 0
-                                ? writeCount == traceAddressWriteOrdinal
-                            : traceLargeWriteOrdinal != 0
-                                ? writeCount == traceLargeWriteOrdinal
+                            : traceAddressWrite && _traceGuestWriteOrdinal > 0
+                                ? writeCount == _traceGuestWriteOrdinal
+                            : _traceLargeGuestWriteOrdinal != 0
+                                ? writeCount == _traceLargeGuestWriteOrdinal
                             : writeCount <=
                                 (traceLargeWrites ? 2 : traceSmallWrites ? 48 : 3);
                         if (traceAddressWrite || shouldTraceWrite)
@@ -12849,6 +12882,20 @@ internal static unsafe class VulkanVideoPresenter
         // Diagnostics toggles are read once: these run per draw / per cached
         // texture hit, and env lookups plus string parsing are far too
         // expensive there (and non-trivially so under Rosetta 2).
+        private static readonly bool _vulkanValidationEnabled =
+            string.Equals(
+                Environment.GetEnvironmentVariable("SHARPEMU_VK_VALIDATION"),
+                "1",
+                StringComparison.Ordinal);
+        // Object names and command labels are useful in RenderDoc and validation
+        // captures, but formatting them and calling the debug-utils driver hooks
+        // for every draw is measurable overhead in normal gameplay.
+        private static readonly bool _vulkanDebugUtilsEnabled =
+            _vulkanValidationEnabled ||
+            string.Equals(
+                Environment.GetEnvironmentVariable("SHARPEMU_VK_DEBUG_LABELS"),
+                "1",
+                StringComparison.Ordinal);
         private static readonly string? _traceGuestImagesMode =
             Environment.GetEnvironmentVariable("SHARPEMU_TRACE_GUEST_IMAGES");
         private static readonly bool _traceGuestImagesEnabled =
@@ -12912,9 +12959,79 @@ internal static unsafe class VulkanVideoPresenter
             !string.IsNullOrWhiteSpace(
                 Environment.GetEnvironmentVariable(
                     "SHARPEMU_TRACE_GUEST_IMAGE_ADDRS"));
+        private static readonly bool _forceFullscreenPipeline =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_FULLSCREEN_PIPELINE") == "1";
+        private static readonly bool _forceFullscreenVertex =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_FULLSCREEN_VERTEX") == "1";
+        private static readonly bool _forceTitleFullscreenVertex =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_TITLE_FULLSCREEN_VERTEX") == "1";
+        private static readonly bool _forceDefaultRasterState =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_DEFAULT_RASTER_STATE") == "1";
+        private static readonly bool _forceTitleDefaultRasterState =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_TITLE_DEFAULT_RASTER_STATE") == "1";
+        private static readonly bool _forceTitleSolidFragment =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_TITLE_SOLID_FRAGMENT") == "1";
+        private static readonly bool _forceSolidFragment =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_SOLID_FRAGMENT") == "1";
+        private static readonly uint? _forceAttributeFragmentLocation =
+            uint.TryParse(
+                Environment.GetEnvironmentVariable("SHARPEMU_FORCE_ATTRIBUTE_FRAGMENT"),
+                out var forceAttributeFragmentLocation)
+                    ? forceAttributeFragmentLocation
+                    : null;
+        private static readonly string? _fixedFragmentDumpPath =
+            Environment.GetEnvironmentVariable("SHARPEMU_DUMP_FIXED_SOLID_FRAGMENT");
+        private static readonly bool _forceTitleDefaultBlend =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_TITLE_DEFAULT_BLEND") == "1";
+        private static readonly bool _forceTitleDefaultViewportScissor =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_TITLE_DEFAULT_VIEWPORT_SCISSOR") == "1";
+        private static readonly bool _forceTitleDisableCull =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_TITLE_DISABLE_CULL") == "1";
+        private static readonly bool _forceTitleDisableDepth =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_TITLE_DISABLE_DEPTH") == "1";
+        private static readonly bool _traceTitleState =
+            Environment.GetEnvironmentVariable("SHARPEMU_TRACE_TITLE_STATE") == "1";
+        private static readonly bool _forceTitleVertexColorWhite =
+            Environment.GetEnvironmentVariable("SHARPEMU_FORCE_TITLE_VERTEX_COLOR_WHITE") == "1";
+        private static readonly bool _chunkedDrawsEnabled =
+            Environment.GetEnvironmentVariable("SHARPEMU_ENABLE_CHUNKED_DRAWS") == "1";
+        private static readonly string? _traceGuestWritesMode =
+            Environment.GetEnvironmentVariable("SHARPEMU_TRACE_GUEST_WRITES");
+        private static readonly long _traceGuestWriteOrdinal =
+            long.TryParse(
+                Environment.GetEnvironmentVariable("SHARPEMU_TRACE_GUEST_WRITE_ORDINAL"),
+                out var traceGuestWriteOrdinal)
+                    ? traceGuestWriteOrdinal
+                    : 0;
+        private static readonly long _traceLargeGuestWriteOrdinal =
+            ParseTraceLargeGuestWriteOrdinal(_traceGuestWritesMode);
+        private static readonly int _tracePixelSpirvBytes =
+            int.TryParse(
+                Environment.GetEnvironmentVariable("SHARPEMU_TRACE_PIXEL_SPIRV_BYTES"),
+                out var tracePixelSpirvBytes)
+                    ? tracePixelSpirvBytes
+                    : 0;
+        private static readonly int _tracePixelSpirvOccurrence =
+            int.TryParse(
+                Environment.GetEnvironmentVariable("SHARPEMU_TRACE_PIXEL_SPIRV_OCCURRENCE"),
+                out var tracePixelSpirvOccurrence)
+                    ? Math.Max(tracePixelSpirvOccurrence, 1)
+                    : 1;
+        private static readonly bool _traceTitleDrawEnabled =
+            Environment.GetEnvironmentVariable("SHARPEMU_TRACE_TITLE_DRAW") == "1";
         private static readonly System.Collections.Concurrent.ConcurrentDictionary<
             string,
             (bool Wildcard, ulong[] Addresses)> _cachedAddressLists = new();
+
+        private static long ParseTraceLargeGuestWriteOrdinal(string? mode)
+        {
+            return mode is not null &&
+                mode.StartsWith("large@", StringComparison.Ordinal) &&
+                long.TryParse(mode.AsSpan("large@".Length), out var ordinal) &&
+                ordinal > 0
+                    ? ordinal
+                    : 0;
+        }
 
         private static bool ShouldTraceGuestImageContentsForDiagnostics() =>
             _traceGuestImagesEnabled;
@@ -13113,8 +13230,7 @@ internal static unsafe class VulkanVideoPresenter
             // MoltenVK this starves the render thread and makes the guest fall
             // behind its own flip queue. Vulkan clips a normal fullscreen draw
             // efficiently; keep tiling only as an explicit driver diagnostic.
-            var maxPixelsPerDraw = Environment.GetEnvironmentVariable(
-                "SHARPEMU_ENABLE_CHUNKED_DRAWS") == "1"
+            var maxPixelsPerDraw = _chunkedDrawsEnabled
                 ? 512u * 512u
                 : uint.MaxValue;
             var rowsPerDraw = Math.Max(


### PR DESCRIPTION
## Summary

- replace the per-continuation capturing emitter helpers with a stack-only writer, removing a compiler-generated display-class allocation from every blocked guest-thread resume
- skip AGC wait-registry snapshots and detailed producer strings when AGC tracing is disabled, and remove several per-draw LINQ intermediates
- keep Vulkan debug-utils names and command labels off during normal gameplay; validation still enables them automatically and `SHARPEMU_VK_DEBUG_LABELS=1` enables them explicitly
- cache startup-only Vulkan diagnostic settings and avoid inactive trace-image/hash-set work and per-draw validation collections

## Relationship to existing work

This branch is based on current `main`, which includes #301 and #290. It does not duplicate the open shader, pipeline, render-pass, guest-image, scheduler, or synchronization PRs.

## Measurement

Terrarium was profiled in the same rendered gameplay scene on an Apple M4 through the macOS x64/Rosetta build:

- managed allocation rate: **70.6 -> 48.8 MB/s** (about **31% lower**)
- gen0 collections: **7.64 -> 5.63/s** (about **26% lower**)
- FPS remained scene/noise sensitive in the 10-16 range, so this PR does not claim a reproducible frame-rate uplift from one machine; it removes measured runtime overhead and GC pressure that affects frame consistency and other games as well

A more aggressive guest-runner scheduling experiment was discarded after it failed runtime validation.

## Validation

- Release solution build: zero warnings/errors
- tests: 199 passed
- publishes: macOS x64, Linux x64, Windows x64
- Terrarium: reaches and renders gameplay on Apple M4 with the merged #301/#290 path