### PR TITLE
[Agc] Report base console from the Trinity mode query

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -632,6 +632,18 @@ public static partial class AgcExports
     public static int GetRegisterDefaults2Internal(CpuContext ctx) =>
         ReturnRegisterDefaults(ctx, internalDefaults: true);
 
+    // The emulator models the base console; Trinity is the PS5 Pro hardware mode.
+    [SysAbiExport(
+        Nid = "BfBDZGbti7A",
+        ExportName = "sceAgcGetIsTrinityMode",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int GetIsTrinityMode(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
     [SysAbiExport(
         Nid = "f3dg2CSgRKY",
         ExportName = "sceAgcCreateShader",


### PR DESCRIPTION
## What this adds

`sceAgcGetIsTrinityMode` (`BfBDZGbti7A`, real catalog name): returns 0.

## Why

The emulator models the base console; Trinity is the PS5 Pro hardware mode,
so the accurate answer is a constant. Titles probe this to select quality
modes and Pro-only register paths, and with the export missing every such
probe surfaced as an unresolved import. Astro Bot's boot-time query (#11)
surfaced it first.

## Verification

- The query resolves and callers take the base-console path (verified with
  Astro Bot's boot). No memory is written, so there is nothing beyond the
  constant to test; `SharpEmu.Libs.Tests` passes unchanged (210 tests).