### PR TITLE
ci: rebuild the website when a release is published

### DIFF
--- a/.github/workflows/notify-site.yml
+++ b/.github/workflows/notify-site.yml
@@ -1,0 +1,28 @@
+# Tells the website repo to rebuild when a release is published, so
+# sharpemu.app/downloads lists the new build within a minute.
+name: Notify website
+
+on:
+  release:
+    types: [published, released, edited, deleted]
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sharpemu-site rebuild
+        env:
+          TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "SITE_DISPATCH_TOKEN is not set — skipping website rebuild."
+            exit 0
+          fi
+          curl -fsS -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/sharpemu/sharpemu-site/dispatches \
+            -d '{"event_type":"release-published"}'
+          echo "Website rebuild requested."

--- a/.github/workflows/notify-site.yml
+++ b/.github/workflows/notify-site.yml
@@ -1,3 +1,6 @@
+# Copyright (C) 2026 SharpEmu Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 # Tells the website repo to rebuild when a release is published, so
 # sharpemu.app/downloads lists the new build within a minute.
 name: Notify website


### PR DESCRIPTION
Publishing a release now also refreshes https://sharpemu.app/downloads, which reads the release list at build time.

On `release: published` (and edited/deleted), this workflow sends a `repository_dispatch` to `sharpemu/sharpemu-site`, whose deploy workflow rebuilds and ships to Cloudflare Pages — the new build shows up within about a minute instead of waiting for the next site commit.

**One-time setup:** add a repository secret `SITE_DISPATCH_TOKEN` — a fine-grained PAT scoped to `sharpemu/sharpemu-site` with **Contents: read and write**. Without it, the job logs a notice and exits 0, so releases never fail because of the website.

No emulator code, build, or release artifacts are touched. The site repo also rebuilds daily as a safety net.