### PR TITLE
[CI] Validate release helper inputs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Test release helper
+        run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+
       - name: Run REUSE lint
         uses: fsfe/reuse-action@v6
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ packages/
 .nuget/
 .dotnet-home/
 .cache/
+__pycache__/
+*.py[cod]
 
 .DS_Store
 Thumbs.db

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -12,7 +12,13 @@ import sys
 from pathlib import Path
 
 
-VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
+VERSION_PATTERN = re.compile(
+    r"^(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)"
+    r"(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?$"
+)
 VERSION_ELEMENT_PATTERN = re.compile(
     r"(<SharpEmuVersion>)([^<]+)(</SharpEmuVersion>)"
 )
@@ -162,14 +168,20 @@ def read_version(props_path: Path) -> str:
         raise ReleaseError(f"Version file not found: {props_path}")
 
     content = props_path.read_text(encoding="utf-8")
-    match = VERSION_ELEMENT_PATTERN.search(content)
+    matches = list(VERSION_ELEMENT_PATTERN.finditer(content))
 
-    if match is None:
+    if not matches:
         raise ReleaseError(
             f"SharpEmuVersion was not found in {props_path.name}."
         )
 
-    return match.group(2).strip()
+    if len(matches) != 1:
+        raise ReleaseError(
+            f"Expected exactly one SharpEmuVersion element in "
+            f"{props_path.name}, found {len(matches)}."
+        )
+
+    return matches[0].group(2).strip()
 
 
 def update_version(props_path: Path, version: str) -> str:

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -1,0 +1,113 @@
+# Copyright (C) 2026 SharpEmu Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.release import (
+    ReleaseError,
+    VERSION_PATTERN,
+    read_version,
+    update_version,
+)
+
+
+class VersionPatternTests(unittest.TestCase):
+    def test_accepts_supported_versions(self) -> None:
+        versions = (
+            "0.0.2",
+            "1.2.3-alpha",
+            "1.2.3-beta.2",
+            "1.2.3-rc.1",
+            "10.20.30-preview-1",
+        )
+
+        for version in versions:
+            with self.subTest(version=version):
+                self.assertIsNotNone(VERSION_PATTERN.fullmatch(version))
+
+    def test_rejects_malformed_versions(self) -> None:
+        versions = (
+            "v1.2.3",
+            "1.2",
+            "01.2.3",
+            "1.02.3",
+            "1.2.03",
+            "1.2.3-",
+            "1.2.3-.",
+            "1.2.3-alpha..1",
+            "1.2.3-01",
+            "1.2.3-alpha_1",
+        )
+
+        for version in versions:
+            with self.subTest(version=version):
+                self.assertIsNone(VERSION_PATTERN.fullmatch(version))
+
+
+class VersionFileTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.props_path = Path(self.temporary_directory.name) / "Directory.Build.props"
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def write_props(self, content: str) -> None:
+        self.props_path.write_text(content, encoding="utf-8")
+
+    def test_reads_exactly_one_version(self) -> None:
+        self.write_props(
+            "<Project><PropertyGroup>"
+            "<SharpEmuVersion>1.2.3-beta.2</SharpEmuVersion>"
+            "</PropertyGroup></Project>"
+        )
+
+        self.assertEqual("1.2.3-beta.2", read_version(self.props_path))
+
+    def test_rejects_missing_version(self) -> None:
+        self.write_props("<Project><PropertyGroup /></Project>")
+
+        with self.assertRaisesRegex(ReleaseError, "was not found"):
+            read_version(self.props_path)
+
+    def test_rejects_duplicate_versions(self) -> None:
+        self.write_props(
+            "<Project><PropertyGroup>"
+            "<SharpEmuVersion>1.2.3</SharpEmuVersion>"
+            "<SharpEmuVersion>2.0.0</SharpEmuVersion>"
+            "</PropertyGroup></Project>"
+        )
+
+        with self.assertRaisesRegex(ReleaseError, "found 2"):
+            read_version(self.props_path)
+
+    def test_updates_the_version_without_changing_other_properties(self) -> None:
+        self.write_props(
+            "<Project>\n"
+            "  <PropertyGroup>\n"
+            "    <SharpEmuVersion>1.2.3</SharpEmuVersion>\n"
+            "    <Version>$(SharpEmuVersion)</Version>\n"
+            "  </PropertyGroup>\n"
+            "</Project>\n"
+        )
+
+        previous_version = update_version(self.props_path, "1.2.4-rc.1")
+
+        self.assertEqual("1.2.3", previous_version)
+        self.assertEqual(
+            "<Project>\n"
+            "  <PropertyGroup>\n"
+            "    <SharpEmuVersion>1.2.4-rc.1</SharpEmuVersion>\n"
+            "    <Version>$(SharpEmuVersion)</Version>\n"
+            "  </PropertyGroup>\n"
+            "</Project>\n",
+            self.props_path.read_text(encoding="utf-8"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add standard-library unit tests for release version parsing and `Directory.Build.props` updates
- enforce the supported SemVer core and prerelease rules before creating release branches or tags
- reject ambiguous files containing more than one `SharpEmuVersion` element
- run the release helper tests in CI and ignore generated Python bytecode

## Motivation

The release helper creates branches, commits, and annotated tags, but currently has no automated coverage. Its prerelease expression accepts malformed values such as `1.2.3-...`, and a duplicated `SharpEmuVersion` element is silently read and partially updated.

Failing these cases before any Git mutation keeps release tags compatible with the tag-driven immutable release workflow and makes configuration mistakes deterministic.

## Validation

- `python -m unittest discover -s scripts/tests -p 'test_*.py' -v` (6 passed)
- `python -m py_compile scripts/release.py scripts/tests/test_release.py`
- verified all existing release tags and documented version examples remain accepted
- `git diff --check`