### PR TITLE
[VideoOut] Correct flip and vblank status ABI layouts

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -34,6 +34,8 @@ public static class VideoOutExports
     private const int VideoOutBufferAttributeSize = 0x28;
     private const int VideoOutBufferAttribute2Size = 0x50;
     private const int VideoOutBuffersEntrySize = 0x20;
+    private const int VideoOutFlipStatusGen4Size = 0x40;
+    private const int VideoOutFlipStatusGen5Size = 0x80;
     private const int VideoOutOutputStatusSize = 0x30;
     private const int VideoOutVblankStatusSize = 0x28;
     private const ulong SceVideoOutPixelFormatA8R8G8B8Srgb = 0x80000000;
@@ -173,6 +175,7 @@ public static class VideoOutExports
         public int FlipRate { get; set; }
         public ulong VblankCount { get; set; }
         public ulong FlipCount { get; set; }
+        public long FlipArg { get; set; } = -1;
         public int CurrentBuffer { get; set; } = -1;
         public uint OutputWidth { get; set; } = 1920;
         public uint OutputHeight { get; set; } = 1080;
@@ -645,19 +648,26 @@ public static class VideoOutExports
         }
 
         ulong count;
-        uint currentBuffer;
+        long flipArg;
+        int currentBuffer;
         lock (_stateGate)
         {
             count = port.FlipCount;
-            currentBuffer = unchecked((uint)port.CurrentBuffer);
+            flipArg = port.FlipArg;
+            currentBuffer = port.CurrentBuffer;
         }
 
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x00, count);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x08, 0);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x10, 0);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x18, 0);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x20, currentBuffer);
-        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        var statusSize = ctx.TargetGeneration == Generation.Gen5
+            ? VideoOutFlipStatusGen5Size
+            : VideoOutFlipStatusGen4Size;
+        Span<byte> status = stackalloc byte[statusSize];
+        status.Clear();
+        BinaryPrimitives.WriteUInt64LittleEndian(status[0x00..], count);
+        BinaryPrimitives.WriteInt64LittleEndian(status[0x18..], flipArg);
+        BinaryPrimitives.WriteInt32LittleEndian(status[0x38..], currentBuffer);
+        return ctx.Memory.TryWrite(statusAddress, status)
+            ? (int)OrbisGen2Result.ORBIS_GEN2_OK
+            : (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
     }
 
     [SysAbiExport(
@@ -1089,6 +1099,7 @@ public static class VideoOutExports
 
             port.CurrentBuffer = bufferIndex;
             port.FlipCount++;
+            port.FlipArg = flipArg;
             eventHint = SceVideoOutInternalEventFlip |
                 ((unchecked((ulong)flipArg) & 0x0000_FFFF_FFFF_FFFFUL) << 16);
             flipEventCount = port.FlipEvents.Count;

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -504,7 +504,8 @@ public static class VideoOutExports
         status.Clear();
         BinaryPrimitives.WriteUInt64LittleEndian(status, count);
         BinaryPrimitives.WriteUInt64LittleEndian(status[0x08..], elapsedMicroseconds);
-        BinaryPrimitives.WriteUInt64LittleEndian(status[0x10..], unchecked((ulong)now));
+        var counterOffset = ctx.TargetGeneration == Generation.Gen5 ? 0x18 : 0x10;
+        BinaryPrimitives.WriteUInt64LittleEndian(status[counterOffset..], unchecked((ulong)now));
         status[0x20] = 0;
         return ctx.Memory.TryWrite(statusAddress, status)
             ? (int)OrbisGen2Result.ORBIS_GEN2_OK

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VideoOutFlipStatusTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VideoOutFlipStatusTests.cs
@@ -1,0 +1,101 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.VideoOut;
+using System.Buffers.Binary;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VideoOutFlipStatusTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong StatusAddress = MemoryBase + 0x100;
+    private const long FlipArg = 0x1122_3344_5566_7788;
+
+    [Theory]
+    [InlineData(Generation.Gen4, 0x40)]
+    [InlineData(Generation.Gen5, 0x80)]
+    public void GetFlipStatus_WritesGenerationLayout(Generation generation, int statusSize)
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, generation);
+        var handle = OpenPort(context);
+
+        try
+        {
+            context[CpuRegister.Rdi] = unchecked((ulong)handle);
+            context[CpuRegister.Rsi] = ulong.MaxValue;
+            context[CpuRegister.Rdx] = 1;
+            context[CpuRegister.Rcx] = unchecked((ulong)FlipArg);
+            Assert.Equal(0, VideoOutExports.VideoOutSubmitFlip(context));
+
+            var sentinel = new byte[0x81];
+            Array.Fill(sentinel, (byte)0xCC);
+            Assert.True(memory.TryWrite(StatusAddress, sentinel));
+
+            context[CpuRegister.Rdi] = unchecked((ulong)handle);
+            context[CpuRegister.Rsi] = StatusAddress;
+            Assert.Equal(0, VideoOutExports.VideoOutGetFlipStatus(context));
+
+            var status = new byte[statusSize + 1];
+            Assert.True(memory.TryRead(StatusAddress, status));
+            Assert.Equal(1UL, BinaryPrimitives.ReadUInt64LittleEndian(status));
+            Assert.Equal(FlipArg, BinaryPrimitives.ReadInt64LittleEndian(status.AsSpan(0x18)));
+            Assert.Equal(-1, BinaryPrimitives.ReadInt32LittleEndian(status.AsSpan(0x38)));
+
+            Assert.All(status.AsSpan(0x08, 0x10).ToArray(), value => Assert.Equal(0, value));
+            Assert.All(status.AsSpan(0x20, 0x18).ToArray(), value => Assert.Equal(0, value));
+            Assert.All(status.AsSpan(0x3C, statusSize - 0x3C).ToArray(), value => Assert.Equal(0, value));
+            Assert.Equal(0xCC, status[statusSize]);
+        }
+        finally
+        {
+            ClosePort(context, handle);
+        }
+    }
+
+    [Theory]
+    [InlineData(Generation.Gen4, 0x40)]
+    [InlineData(Generation.Gen5, 0x80)]
+    public void GetFlipStatus_UnwritableLayoutReturnsMemoryFault(
+        Generation generation,
+        int statusSize)
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x100);
+        var context = new CpuContext(memory, generation);
+        var handle = OpenPort(context);
+
+        try
+        {
+            context[CpuRegister.Rdi] = unchecked((ulong)handle);
+            context[CpuRegister.Rsi] = MemoryBase + 0x100 - (ulong)statusSize + 1;
+
+            Assert.Equal(
+                (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+                VideoOutExports.VideoOutGetFlipStatus(context));
+        }
+        finally
+        {
+            ClosePort(context, handle);
+        }
+    }
+
+    private static int OpenPort(CpuContext context)
+    {
+        context[CpuRegister.Rdi] = 0;
+        context[CpuRegister.Rsi] = 0;
+        context[CpuRegister.Rdx] = 0;
+        context[CpuRegister.Rcx] = 0;
+        var handle = VideoOutExports.VideoOutOpen(context);
+        Assert.True(handle > 0);
+        return handle;
+    }
+
+    private static void ClosePort(CpuContext context, int handle)
+    {
+        context[CpuRegister.Rdi] = unchecked((ulong)handle);
+        Assert.Equal(0, VideoOutExports.VideoOutClose(context));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VideoOutVblankStatusTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VideoOutVblankStatusTests.cs
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.VideoOut;
+using System.Buffers.Binary;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VideoOutVblankStatusTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong StatusAddress = MemoryBase + 0x100;
+    private const int StatusSize = 0x28;
+
+    [Theory]
+    [InlineData(Generation.Gen4, 0x10, 0x18)]
+    [InlineData(Generation.Gen5, 0x18, 0x10)]
+    public void GetVblankStatus_WritesGenerationCounterOffset(
+        Generation generation,
+        int counterOffset,
+        int reservedOffset)
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, generation);
+        var handle = OpenPort(context);
+
+        try
+        {
+            var sentinel = new byte[StatusSize + 1];
+            Array.Fill(sentinel, (byte)0xCC);
+            Assert.True(memory.TryWrite(StatusAddress, sentinel));
+
+            context[CpuRegister.Rdi] = unchecked((ulong)handle);
+            context[CpuRegister.Rsi] = StatusAddress;
+            Assert.Equal(0, VideoOutExports.VideoOutGetVblankStatus(context));
+
+            var status = new byte[StatusSize + 1];
+            Assert.True(memory.TryRead(StatusAddress, status));
+            Assert.True(BinaryPrimitives.ReadUInt64LittleEndian(status.AsSpan(counterOffset)) > 0);
+            Assert.Equal(0UL, BinaryPrimitives.ReadUInt64LittleEndian(status.AsSpan(reservedOffset)));
+            Assert.All(status.AsSpan(0x20, 0x08).ToArray(), value => Assert.Equal(0, value));
+            Assert.Equal(0xCC, status[StatusSize]);
+        }
+        finally
+        {
+            ClosePort(context, handle);
+        }
+    }
+
+    private static int OpenPort(CpuContext context)
+    {
+        context[CpuRegister.Rdi] = 0;
+        context[CpuRegister.Rsi] = 0;
+        context[CpuRegister.Rdx] = 0;
+        context[CpuRegister.Rcx] = 0;
+        var handle = VideoOutExports.VideoOutOpen(context);
+        Assert.True(handle > 0);
+        return handle;
+    }
+
+    private static void ClosePort(CpuContext context, int handle)
+    {
+        context[CpuRegister.Rdi] = unchecked((ulong)handle);
+        Assert.Equal(0, VideoOutExports.VideoOutClose(context));
+    }
+}


### PR DESCRIPTION
## Summary

- write the complete Gen4 (`0x40`) and Gen5 (`0x80`) flip-status structures
- place `flipArg` and `currentBuffer` at their ABI offsets (`0x18` and `0x38`)
- retain the last submitted flip argument alongside the existing count and buffer state
- write the vblank counter at `0x10` for Gen4 and `0x18` for Gen5
- return a memory fault when the complete flip-status structure cannot be written

## Motivation

`sceVideoOutGetFlipStatus` currently writes five 64-bit values through offset `0x20`. That places `currentBuffer` in a timestamp/reserved field, while both supported ABI layouts place it at `0x38`. The function also discards the submitted `flipArg` and reports success even if one or more field writes fail.

`sceVideoOutGetVblankStatus` also uses the Gen4 counter offset for every generation. In the Gen5 layout, `0x10` is reserved and `processTimeCounter` is at `0x18`, so Gen5 guests receive a timestamp in a reserved field and observe a zero counter.

Games polling these real status fields can therefore continue to observe stale guest memory. The flip-status correction is relevant to the repeated `sceVideoOutGetFlipStatus` polling reported in #287, although title-level validation is still required before treating that loop as resolved.

## Compatibility

- Gen4 flip status writes the `0x40` PS4 layout; Gen5 writes the extended `0x80` PS5 layout.
- The common flip fields keep identical offsets through `0x3f`; generation-specific trailing fields are currently zeroed.
- Vblank status remains `0x28` bytes for both generations, with only the counter offset selected per ABI.

## Validation

- focused flip/vblank status tests: 6 passed
- `SharpEmu.Libs.Tests`: 216 passed
- `SharpEmu.SourceGenerators.Tests`: 33 passed
- `dotnet build SharpEmu.slnx -c Release`: 0 warnings, 0 errors
- `git diff --check`