### PR TITLE
[VideoOut] Initialize output options storage

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -34,7 +34,6 @@ public static class VideoOutExports
     private const int VideoOutBufferAttributeSize = 0x28;
     private const int VideoOutBufferAttribute2Size = 0x50;
     private const int VideoOutBuffersEntrySize = 0x20;
-    private const int VideoOutOutputOptionsSize = 0x40;
     private const int VideoOutOutputStatusSize = 0x30;
     private const int VideoOutVblankStatusSize = 0x28;
     private const ulong SceVideoOutPixelFormatA8R8G8B8Srgb = 0x80000000;
@@ -335,13 +334,14 @@ public static class VideoOutExports
         LibraryName = "libSceVideoOut")]
     public static int VideoOutInitializeOutputOptions(CpuContext ctx)
     {
+        const int outputOptionsSize = 0x40;
         var optionsAddress = ctx[CpuRegister.Rdi];
         if (optionsAddress == 0)
         {
             return OrbisVideoOutErrorInvalidAddress;
         }
 
-        Span<byte> options = stackalloc byte[VideoOutOutputOptionsSize];
+        Span<byte> options = stackalloc byte[outputOptionsSize];
         options.Clear();
         return ctx.Memory.TryWrite(optionsAddress, options)
             ? (int)OrbisGen2Result.ORBIS_GEN2_OK

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -34,6 +34,7 @@ public static class VideoOutExports
     private const int VideoOutBufferAttributeSize = 0x28;
     private const int VideoOutBufferAttribute2Size = 0x50;
     private const int VideoOutBuffersEntrySize = 0x20;
+    private const int VideoOutOutputOptionsSize = 0x40;
     private const int VideoOutOutputStatusSize = 0x30;
     private const int VideoOutVblankStatusSize = 0x28;
     private const ulong SceVideoOutPixelFormatA8R8G8B8Srgb = 0x80000000;
@@ -334,7 +335,17 @@ public static class VideoOutExports
         LibraryName = "libSceVideoOut")]
     public static int VideoOutInitializeOutputOptions(CpuContext ctx)
     {
-        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        var optionsAddress = ctx[CpuRegister.Rdi];
+        if (optionsAddress == 0)
+        {
+            return OrbisVideoOutErrorInvalidAddress;
+        }
+
+        Span<byte> options = stackalloc byte[VideoOutOutputOptionsSize];
+        options.Clear();
+        return ctx.Memory.TryWrite(optionsAddress, options)
+            ? (int)OrbisGen2Result.ORBIS_GEN2_OK
+            : (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
     }
 
     [SysAbiExport(

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VideoOutOutputOptionsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VideoOutOutputOptionsTests.cs
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VideoOutOutputOptionsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong OptionsAddress = MemoryBase + 0x40;
+    private const int OptionsSize = 0x40;
+    private const int InvalidAddress = unchecked((int)0x80290002);
+
+    [Theory]
+    [InlineData(Generation.Gen4)]
+    [InlineData(Generation.Gen5)]
+    public void InitializeOutputOptions_ClearsExactlyOneStructure(Generation generation)
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, generation);
+        var sentinel = new byte[OptionsSize + 1];
+        Array.Fill(sentinel, (byte)0xCC);
+        Assert.True(memory.TryWrite(OptionsAddress, sentinel));
+        context[CpuRegister.Rdi] = OptionsAddress;
+
+        Assert.Equal(0, VideoOutExports.VideoOutInitializeOutputOptions(context));
+
+        var result = new byte[OptionsSize + 1];
+        Assert.True(memory.TryRead(OptionsAddress, result));
+        Assert.All(result.AsSpan(0, OptionsSize).ToArray(), value => Assert.Equal(0, value));
+        Assert.Equal(0xCC, result[OptionsSize]);
+    }
+
+    [Fact]
+    public void InitializeOutputOptions_NullAddressReturnsInvalidAddress()
+    {
+        var context = new CpuContext(new FakeCpuMemory(MemoryBase, 0x100), Generation.Gen5);
+        context[CpuRegister.Rdi] = 0;
+
+        Assert.Equal(InvalidAddress, VideoOutExports.VideoOutInitializeOutputOptions(context));
+    }
+
+    [Fact]
+    public void InitializeOutputOptions_UnwritableStructureReturnsMemoryFault()
+    {
+        var context = new CpuContext(new FakeCpuMemory(MemoryBase, 0x100), Generation.Gen5);
+        context[CpuRegister.Rdi] = MemoryBase + 0xC1;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            VideoOutExports.VideoOutInitializeOutputOptions(context));
+    }
+}


### PR DESCRIPTION
## Summary

- initialize the 0x40-byte video output options structure to zero
- reject null option pointers and report guest-memory write failures
- cover Gen4 and Gen5 calls, structure bounds, and error paths with focused tests

## Motivation

`sceVideoOutInitializeOutputOptions` currently returns success without touching caller storage. Callers therefore retain stale bytes even though the initialized options structure is expected to contain only default zero values. This also makes subsequent validation of reserved fields depend on whatever was previously in guest memory.

The implementation writes exactly one output-options structure and leaves adjacent guest memory unchanged.

## Validation

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release -m:1 --no-restore` (214 passed)
- `dotnet test tests/SharpEmu.SourceGenerators.Tests/SharpEmu.SourceGenerators.Tests.csproj -c Release -m:1 --no-restore` (33 passed)
- `dotnet build SharpEmu.slnx -c Release -m:1 --no-restore` (0 warnings, 0 errors)
- `git diff --check`