### PR TITLE
[Shader/Vulkan] Improve guest shader execution and frame presentation

### DIFF
--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -17,6 +17,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj" />
+    <Project Path="tests/SharpEmu.ShaderCompiler.Tests/SharpEmu.ShaderCompiler.Tests.csproj" />
     <Project Path="tests/SharpEmu.SourceGenerators.Tests/SharpEmu.SourceGenerators.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/SharpEmu.Core/Cpu/TrackedCpuMemory.cs
+++ b/src/SharpEmu.Core/Cpu/TrackedCpuMemory.cs
@@ -31,6 +31,7 @@ public sealed class TrackedCpuMemory : ICpuMemory, ITrackedCpuMemory, IGuestMemo
 
     public bool TryWrite(ulong virtualAddress, ReadOnlySpan<byte> source)
     {
+        GuestImageWriteTracker.NotifyManagedWrite(virtualAddress, (ulong)source.Length);
         var result = _inner.TryWrite(virtualAddress, source);
         if (!result)
         {

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -44,6 +44,7 @@ public static partial class AgcExports
     private const uint ItDispatchIndirect = 0x16;
     private const uint ItWaitRegMem = 0x3C;
     private const uint ItIndirectBuffer = 0x3F;
+    private const uint ItCopyData = 0x40;
     private const uint ItEventWrite = 0x46;
     private const uint ItReleaseMem = 0x49;
     private const uint ItDmaData = 0x50;
@@ -78,6 +79,10 @@ public static partial class AgcExports
     private const uint SpiShaderPgmHiLs = 0x149;
     private const uint SpiShaderPgmLoGs = 0x8A;
     private const uint SpiShaderPgmHiGs = 0x8B;
+    // On GFX10 these two SH offsets are the NGG/GS resource registers.  The
+    // NGG program address itself remains in SPI_SHADER_PGM_LO/HI_ES.
+    private const uint SpiShaderPgmRsrc1Gs = 0x8A;
+    private const uint SpiShaderPgmRsrc2Gs = 0x8B;
     private const uint SpiPsInputEna = 0x1B3;
     private const uint SpiPsInputAddr = 0x1B4;
     private const uint ComputePgmLo = 0x20C;
@@ -91,6 +96,12 @@ public static partial class AgcExports
     private const uint ComputeNumThreadZ = 0x209;
     private const uint SpiPsInputCntl0 = 0x191;
     private const uint VgtPrimitiveType = 0x242;
+    private const uint VgtShaderStagesEn = 0x2D5;
+    private const uint GeCntl = 0x25B;
+    private const uint GeUserVgpr1 = 0x25C;
+    private const uint GeUserVgpr2 = 0x25D;
+    private const uint GeUserVgpr3 = 0x25E;
+    private const uint GeUserVgprEn = 0x262;
     private const uint PaScScreenScissorTl = 0x0C;
     private const uint PaScScreenScissorBr = 0x0D;
     private const uint CbTargetMask = 0x8E;
@@ -166,6 +177,7 @@ public static partial class AgcExports
     private const ulong ShaderSpecialsOffset = 0x28;
     private const ulong ShaderInputSemanticsOffset = 0x30;
     private const ulong ShaderOutputSemanticsOffset = 0x38;
+    private const ulong ShaderSizeOffset = 0x44;
     private const ulong ResourceRegistrationBytesPerResource = 0x118;
     private const ulong ResourceRegistrationBytesPerOwner = 0x1E0;
     private const int ResourceRegistrationMaxNameLength = 256;
@@ -189,6 +201,9 @@ public static partial class AgcExports
     private static readonly HashSet<(ulong Es, ulong Ps)> _tracedShaderDecodePairs = new();
     private static readonly HashSet<(ulong Es, ulong Ps, ulong Target, ulong Texture, uint VertexCount)> _tracedShaderDraws = new();
     private static readonly HashSet<(ulong Ps, string Error)> _tracedShaderFailures = new();
+    private static readonly ConcurrentDictionary<
+        (ulong Ps, ulong Address, uint Width, uint Height, uint Format, uint NumberType,
+         uint TileMode, uint Pitch, uint DstSelect), byte> _tracedAddressedTextureBindings = new();
     private static readonly HashSet<(int Handle, int Index, ulong Address, string Path)> _tracedDisplayBuffers = new();
     private static readonly HashSet<ulong> _tracedComputeShaders = new();
     private static readonly HashSet<(ulong Address, uint X, uint Y, uint Z)>
@@ -199,16 +214,16 @@ public static partial class AgcExports
     // Concurrent so the per-draw/per-dispatch hit path is lock-free (and no longer
     // shares _submitTraceGate with tracing).
     private static readonly ConcurrentDictionary<
-        (ulong Es, ulong EsState, ulong Ps, ulong PsState, ulong OutputLayout,
-         uint OutputCount, uint Attributes, uint PsInputEna, uint PsInputAddr,
-         ulong AliasAlignment),
+        (ulong Es, ulong EsState, uint EsRsrc1, ulong Ps, ulong PsState,
+         uint PsRsrc1, ulong OutputLayout, uint OutputMasks, uint OutputCount, uint Attributes,
+         uint PsInputEna, uint PsInputAddr, ulong InputControls, ulong AliasAlignment),
         (IGuestCompiledShader Vertex, IGuestCompiledShader Pixel)> _graphicsShaderCache = new();
     private static readonly ConcurrentDictionary<
-        (ulong Cs, ulong State, uint LocalX, uint LocalY, uint LocalZ,
+        (ulong Cs, ulong State, uint Rsrc1, uint LocalX, uint LocalY, uint LocalZ,
          uint WaveLanes, ulong AliasAlignment),
         IGuestCompiledShader> _computeShaderCache = new();
     private static readonly ConcurrentDictionary<
-        (ulong Es, ulong State, ulong AliasAlignment),
+        (ulong Es, ulong State, uint Rsrc1, ulong AliasAlignment),
         IGuestCompiledShader> _depthOnlyVertexShaderCache = new();
     private static readonly Dictionary<ulong, ulong> _shaderHeadersByCode = new();
     private static readonly bool _traceAgc = string.Equals(
@@ -232,6 +247,8 @@ public static partial class AgcExports
         Environment.GetEnvironmentVariable("SHARPEMU_TRACE_COMPUTE_SHADER_ADDRESS"));
     private static readonly ulong? _tracePixelShaderAddress = ParseOptionalHexAddress(
         Environment.GetEnvironmentVariable("SHARPEMU_TRACE_PIXEL_SHADER_ADDRESS"));
+    private static readonly ulong[] _traceGuestImageAddresses = ParseHexAddresses(
+        Environment.GetEnvironmentVariable("SHARPEMU_TRACE_GUEST_IMAGE_ADDRS"));
     private static readonly ulong? _traceRenderTargetAddress = ParseOptionalHexAddress(
         Environment.GetEnvironmentVariable("SHARPEMU_TRACE_RENDER_TARGET_ADDRESS"));
     private static readonly bool _traceDraws = string.Equals(
@@ -402,6 +419,7 @@ public static partial class AgcExports
         uint Height,
         uint Format,
         uint NumberType,
+        uint ComponentSwap,
         uint TileMode);
 
     private sealed record TranslatedGuestDraw(
@@ -807,51 +825,190 @@ public static partial class AgcExports
         var geometryShaderAddress = ctx[CpuRegister.Rsi];
         var pixelShaderAddress = ctx[CpuRegister.Rdx];
 
-        if (registersAddress == 0 || geometryShaderAddress == 0)
+        if (registersAddress == 0)
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryReadUInt64(ctx, geometryShaderAddress + ShaderOutputSemanticsOffset, out var outputSemanticsAddress) ||
-            !TryReadUInt32(ctx, geometryShaderAddress + ShaderNumOutputSemanticsOffset, out var outputSemanticsCount))
+        if (pixelShaderAddress == 0)
+        {
+            return WriteIdentityInterpolantMapping(ctx, registersAddress, 0);
+        }
+
+        if (!TryReadUInt64(
+                ctx,
+                pixelShaderAddress + ShaderInputSemanticsOffset,
+                out var inputSemanticsAddress) ||
+            !TryReadUInt32(
+                ctx,
+                pixelShaderAddress + ShaderNumInputSemanticsOffset,
+                out var inputSemanticsCount))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
-        ulong inputSemanticsAddress = 0;
-        if (pixelShaderAddress != 0 &&
-            (!TryReadUInt64(ctx, pixelShaderAddress + ShaderInputSemanticsOffset, out inputSemanticsAddress) ||
-             !TryReadUInt32(ctx, pixelShaderAddress + ShaderNumInputSemanticsOffset, out _)))
+        if (inputSemanticsCount == 0)
         {
-            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            return WriteIdentityInterpolantMapping(ctx, registersAddress, 0);
         }
 
-        for (uint i = 0; i < 32; i++)
+        if (geometryShaderAddress == 0 || inputSemanticsAddress == 0 ||
+            !TryReadUInt64(
+                ctx,
+                geometryShaderAddress + ShaderOutputSemanticsOffset,
+                out var outputSemanticsAddress) ||
+            !TryReadUInt32(
+                ctx,
+                geometryShaderAddress + ShaderNumOutputSemanticsOffset,
+                out var packedOutputSemanticsCount))
         {
-            uint value = 0;
-            if (i < outputSemanticsCount && outputSemanticsAddress != 0)
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        // num_output_semantics is a uint16 followed by other packed header
+        // fields. Reading the enclosing dword is safe, but only the low half
+        // belongs to the count.
+        var outputSemanticsCount = packedOutputSemanticsCount & 0xFFFFu;
+        var mappedCount = Math.Min(inputSemanticsCount, 32u);
+        for (uint pixelIndex = 0; pixelIndex < mappedCount; pixelIndex++)
+        {
+            if (!TryReadUInt32(
+                    ctx,
+                    inputSemanticsAddress + (pixelIndex * sizeof(uint)),
+                    out var pixelSemantic))
             {
-                var flat = false;
-                if (pixelShaderAddress != 0 && inputSemanticsAddress != 0 &&
-                    TryReadUInt32(ctx, inputSemanticsAddress + (i * sizeof(uint)), out var inputSemantic))
-                {
-                    flat = ((inputSemantic >> 22) & 0x1) != 0;
-                }
-
-                value = i | (flat ? 0x400u : 0u);
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             }
 
-            var destination = registersAddress + (i * 8);
-            if (!TryWriteUInt32(ctx, destination, SpiPsInputCntl0 + i) ||
-                !TryWriteUInt32(ctx, destination + sizeof(uint), value))
+            uint? geometrySemantic = null;
+            if (outputSemanticsAddress != 0)
+            {
+                for (uint geometryIndex = 0;
+                     geometryIndex < outputSemanticsCount;
+                     geometryIndex++)
+                {
+                    if (!TryReadUInt32(
+                            ctx,
+                            outputSemanticsAddress + (geometryIndex * sizeof(uint)),
+                            out var candidate))
+                    {
+                        return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+                    }
+
+                    if ((candidate & 0xFFu) == (pixelSemantic & 0xFFu))
+                    {
+                        geometrySemantic = candidate;
+                        break;
+                    }
+                }
+            }
+
+            var value = CreateInterpolantMappingValue(
+                pixelSemantic,
+                geometrySemantic);
+            if (!WriteInterpolantMappingRegister(
+                    ctx,
+                    registersAddress,
+                    pixelIndex,
+                    value))
             {
                 return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             }
         }
 
+        var identityResult = WriteIdentityInterpolantMapping(
+            ctx,
+            registersAddress,
+            mappedCount);
+        if (identityResult != (int)OrbisGen2Result.ORBIS_GEN2_OK)
+        {
+            return identityResult;
+        }
+
         TraceAgc($"agc.create_interpolant_mapping regs=0x{registersAddress:X16} gs=0x{geometryShaderAddress:X16} ps=0x{pixelShaderAddress:X16}");
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    private static uint CreateInterpolantMappingValue(
+        uint pixelSemantic,
+        uint? geometrySemantic)
+    {
+        uint value;
+        if ((pixelSemantic & 0x0030_0000u) != 0)
+        {
+            value = (pixelSemantic << 4) & 0x0300_0000u;
+            if (geometrySemantic is { } geometry)
+            {
+                var common = pixelSemantic & geometry;
+                value &= 0xFFF7_FFDFu;
+                value |= (common >> 15) & 0x20u;
+                value ^= 0x0008_0020u;
+                value &= ~0x0010_0000u;
+                value |= (~common >> 1) & 0x0010_0000u;
+            }
+            else
+            {
+                value |= 0x0018_0020u;
+            }
+
+            value &= ~0x0060_0000u;
+            value |= ((pixelSemantic >> 30) & 0x3u) << 21;
+        }
+        else
+        {
+            value = (pixelSemantic & 0x0100_0000u) != 0 ||
+                geometrySemantic is null
+                    ? 0x20u
+                    : 0u;
+        }
+
+        value &= ~0x1Fu;
+        value |= geometrySemantic is { } mapped
+            ? (mapped >> 8) & 0x1Fu
+            : 0u;
+        value &= ~0x400u;
+        if (geometrySemantic is not null &&
+            (pixelSemantic & 0x0140_0000u) != 0)
+        {
+            value |= 0x400u;
+        }
+
+        value &= ~0x300u;
+        value |= ((pixelSemantic >> 28) & 0x3u) << 8;
+        return value;
+    }
+
+    private static int WriteIdentityInterpolantMapping(
+        CpuContext ctx,
+        ulong registersAddress,
+        uint firstIndex)
+    {
+        for (var index = firstIndex; index < 32u; index++)
+        {
+            if (!WriteInterpolantMappingRegister(
+                    ctx,
+                    registersAddress,
+                    index,
+                    index))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    private static bool WriteInterpolantMappingRegister(
+        CpuContext ctx,
+        ulong registersAddress,
+        uint index,
+        uint value)
+    {
+        var destination = registersAddress + (index * 8);
+        return TryWriteUInt32(ctx, destination, SpiPsInputCntl0 + index) &&
+            TryWriteUInt32(ctx, destination + sizeof(uint), value);
     }
     #pragma warning restore SHEM004
 
@@ -2681,7 +2838,6 @@ public static partial class AgcExports
                 tracePackets);
             DrainResumableDcbs(ctx, gpuState, tracePackets);
         }
-
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
@@ -2739,10 +2895,10 @@ public static partial class AgcExports
                 tracePackets);
             DrainResumableDcbs(ctx, gpuState, tracePackets);
         }
-
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
+
 
     [SysAbiExport(
     Nid = "uJziRsODk1c",
@@ -3371,7 +3527,8 @@ public static partial class AgcExports
                             pendingDisplayTarget.Width,
                             pendingDisplayTarget.Height,
                             pendingDisplayTarget.Format,
-                            pendingDisplayTarget.NumberType)],
+                            pendingDisplayTarget.NumberType,
+                            ComponentSwap: pendingDisplayTarget.ComponentSwap)],
                         pendingComposite.VertexShader,
                         pendingComposite.VertexCount,
                         pendingComposite.InstanceCount,
@@ -4306,6 +4463,9 @@ public static partial class AgcExports
             }
         }
 
+        var writeLength = incrementAddress
+            ? (ulong)dwordCount * sizeof(uint)
+            : (ulong)sizeof(uint);
         SubmitOrderedGpuSideEffect(
             ctx,
             gpuState,
@@ -5047,6 +5207,7 @@ public static partial class AgcExports
             writesGuestMemory ? writeLength : 0);
     }
 
+
     private static (uint Destination, uint DataSelection)
         DecodeStandardReleaseMemControl(uint control) =>
         (
@@ -5283,14 +5444,38 @@ public static partial class AgcExports
                 _tracePixelShaderAddress == pixelShaderAddress ||
                 _traceRenderTargetAddress == target.Address)
             {
+                var pixelInputControls = string.Join(
+                    ',',
+                    Enumerable.Range(0, 4).Select(index =>
+                        state.CxRegisters.TryGetValue(
+                            SpiPsInputCntl0 + (uint)index,
+                            out var inputControl)
+                                ? $"0x{inputControl:X8}"
+                                : "missing"));
+                var targetBaseRegister = CbColor0Base + target.Slot * CbColorRegisterStride;
+                state.CxRegisters.TryGetValue(targetBaseRegister + 3, out var rawView);
+                state.CxRegisters.TryGetValue(
+                    CbColor0Info + target.Slot * CbColorRegisterStride,
+                    out var rawInfo);
+                state.CxRegisters.TryGetValue(CbBlend0Control + target.Slot, out var rawBlend);
+                var blend = DecodeBlendState(state.CxRegisters, target.Slot);
                 Console.Error.WriteLine(
                     "[LOADER][TRACE] " +
                     $"agc.rt_writer seq={drawSequence} target=0x{target.Address:X16} " +
-                    $"fmt={target.Format} tile={target.TileMode} " +
-                    $"size={target.Width}x{target.Height} vertices={vertexCount} " +
+                    $"fmt={target.Format} num={target.NumberType} " +
+                    $"swap={target.ComponentSwap} info=0x{rawInfo:X8} " +
+                    $"tile={target.TileMode} " +
+                    $"size={target.Width}x{target.Height} slot={target.Slot} " +
+                    $"view=0x{rawView:X8} blend=0x{rawBlend:X8}:" +
+                    $"{(blend.Enable ? 1 : 0)}:{blend.ColorSrcFactor}/" +
+                    $"{blend.ColorDstFactor}/{blend.ColorFunc}:" +
+                    $"a{blend.AlphaSrcFactor}/{blend.AlphaDstFactor}/{blend.AlphaFunc}:" +
+                    $"s{(blend.SeparateAlphaBlend ? 1 : 0)}:m{blend.WriteMask:X} " +
+                    $"vertices={vertexCount} " +
                     $"prim=0x{primitiveType:X} indexed={indexed} " +
                     $"es=0x{(hasExportShader ? exportShaderAddress : 0):X16} " +
                     $"ps=0x{(hasPixelShader ? pixelShaderAddress : 0):X16} " +
+                    $"ps_inputs=[{pixelInputControls}] " +
                     $"color_write={(hasPixelShader ? 1 : 0)}");
             }
         }
@@ -5690,7 +5875,6 @@ public static partial class AgcExports
                 exportState,
                 out var exportEvaluation,
                 out error,
-                resolveVertexInputs: true,
                 requiredVertexRecordCount: TryGetRequiredVertexRecordCount(
                     ctx,
                     state,
@@ -5709,6 +5893,7 @@ public static partial class AgcExports
         var cacheKey = (
             exportShaderAddress,
             exportFingerprint,
+            exportState.ProgramResource1,
             VulkanVideoPresenter.GuestStorageBufferOffsetAlignment);
         _depthOnlyVertexShaderCache.TryGetValue(cacheKey, out var vertexShader);
 
@@ -5794,6 +5979,7 @@ public static partial class AgcExports
             depthTarget.Height,
             Format: 0,
             NumberType: 0,
+            ComponentSwap: 0,
             TileMode: 0);
         var renderState = CreateRenderState(state.CxRegisters, syntheticTarget) with
         {
@@ -5900,7 +6086,6 @@ public static partial class AgcExports
                 exportState,
                 out var exportEvaluation,
                 out error,
-                resolveVertexInputs: true,
                 requiredVertexRecordCount: TryGetRequiredVertexRecordCount(
                     ctx,
                     state,
@@ -6002,18 +6187,40 @@ public static partial class AgcExports
             }
         }
 
-        // Exact packed encoding of the output layout — guest slot (6 bits, CB targets are
-        // 0-7) plus output kind (2 bits) per target, host locations being the sequential
-        // byte positions. Replaces a per-draw LINQ + string build that allocated on every
-        // draw, cache hit or not; the target count disambiguates trailing zero bytes.
+        var guestRenderState = CreateRenderState(
+            state.CxRegisters,
+            renderTargets,
+            pixelColorExportMasks);
+        var hostRenderTargets = BuildHostRenderTargets(
+            renderTargets,
+            guestRenderState,
+            out var hostOutputLocations);
+
+        // Exact packed encoding of the output layout: guest slot (3 bits), host
+        // location (3 bits), and output kind (2 bits) per guest export. The
+        // separate nibble-packed masks are part of the shader key because
+        // aliased guest MRT slots can merge disjoint channels into one Vulkan
+        // attachment.
         var outputLayout = 0UL;
+        var outputMasks = 0u;
         for (var index = 0; index < renderTargets.Length; index++)
         {
-            outputLayout |= (ulong)(((renderTargets[index].Slot & 0x3Fu) << 2) |
+            outputLayout |= (ulong)(
+                ((renderTargets[index].Slot & 0x7u) << 5) |
+                ((hostOutputLocations[index] & 0x7u) << 2) |
                 (uint)renderTargetOutputKinds[index]) << (index * 8);
+            outputMasks |=
+                (guestRenderState.Blends[index].WriteMask & 0xFu) << (index * 4);
         }
 
         var attributeCount = GetInterpolatedAttributeCount(pixelState);
+        var pixelInputControls = GetPixelInputControls(
+            state.CxRegisters,
+            attributeCount);
+        var inputControlsFingerprint = ComputePixelInputControlsFingerprint(
+            pixelInputControls);
+        var requiredVertexOutputCount = GetRequiredVertexOutputCount(
+            pixelInputControls);
         var exportStateFingerprint = _bakeScalars
             ? ComputeShaderStateFingerprint(exportEvaluation)
             : ComputeShaderStructuralFingerprint(exportEvaluation);
@@ -6023,13 +6230,17 @@ public static partial class AgcExports
         var shaderKey = (
             exportShaderAddress,
             exportStateFingerprint,
+            exportState.ProgramResource1,
             pixelShaderAddress,
             pixelStateFingerprint,
+            pixelState.ProgramResource1,
             outputLayout,
+            outputMasks,
             (uint)renderTargets.Length,
             attributeCount,
             psInputEna,
             psInputAddr,
+            inputControlsFingerprint,
             VulkanVideoPresenter.GuestStorageBufferOffsetAlignment);
 
         var guestGlobalBuffers =
@@ -6049,8 +6260,9 @@ public static partial class AgcExports
             {
                 pixelOutputs[location] = new Gen5PixelOutputBinding(
                     renderTargets[location].Slot,
-                    (uint)location,
-                    renderTargetOutputKinds[location]);
+                    hostOutputLocations[location],
+                    renderTargetOutputKinds[location],
+                    guestRenderState.Blends[location].WriteMask);
             }
 
             if (!GuestGpu.Current.TryCompilePixelShader(
@@ -6066,7 +6278,8 @@ public static partial class AgcExports
                     pixelInputEnable: psInputEna,
                     pixelInputAddress: psInputAddr,
                     storageBufferOffsetAlignment:
-                        VulkanVideoPresenter.GuestStorageBufferOffsetAlignment) ||
+                        VulkanVideoPresenter.GuestStorageBufferOffsetAlignment,
+                    pixelInputControls: pixelInputControls) ||
                 !GuestGpu.Current.TryCompileVertexShader(
                     exportState,
                     exportEvaluation,
@@ -6076,9 +6289,10 @@ public static partial class AgcExports
                     totalGlobalBufferCount: totalGlobalBuffers,
                     imageBindingBase: pixelEvaluation.ImageBindings.Count,
                     scalarRegisterBufferIndex: _bakeScalars ? -1 : guestGlobalBuffers + 1,
-                    requiredVertexOutputCount: (int)GetInterpolatedAttributeCount(pixelState),
+                    requiredVertexOutputCount: requiredVertexOutputCount,
                     storageBufferOffsetAlignment:
-                        VulkanVideoPresenter.GuestStorageBufferOffsetAlignment))
+                        VulkanVideoPresenter.GuestStorageBufferOffsetAlignment,
+                    pixelInputControls: pixelInputControls))
             {
                 ReturnPooledEvaluationArrays(exportEvaluation);
                 ReturnPooledEvaluationArrays(pixelEvaluation);
@@ -6138,17 +6352,27 @@ public static partial class AgcExports
         IReadOnlyList<Gen5VertexInputBinding> vertexInputs =
             exportEvaluation.VertexInputs ?? [];
         state.UcRegisters.TryGetValue(VgtPrimitiveType, out var primitiveType);
-        var guestTargets = new GuestRenderTarget[renderTargets.Length];
-        for (var index = 0; index < renderTargets.Length; index++)
+        var guestTargets = new GuestRenderTarget[hostRenderTargets.Length];
+        for (var index = 0; index < hostRenderTargets.Length; index++)
         {
             guestTargets[index] = new GuestRenderTarget(
-                renderTargets[index].Address,
-                renderTargets[index].Width,
-                renderTargets[index].Height,
-                renderTargets[index].Format,
-                renderTargets[index].NumberType);
+                hostRenderTargets[index].Address,
+                hostRenderTargets[index].Width,
+                hostRenderTargets[index].Height,
+                hostRenderTargets[index].Format,
+                hostRenderTargets[index].NumberType,
+                ComponentSwap: hostRenderTargets[index].ComponentSwap);
         }
 
+        var adjustedGuestRenderState = ApplyTransparentPremultipliedFillClear(
+            guestRenderState,
+            textures,
+            vertexInputs,
+            pixelEvaluation.InitialScalarRegisters);
+        var hostRenderState = CollapseGuestRenderState(
+            adjustedGuestRenderState,
+            hostOutputLocations,
+            hostRenderTargets.Length);
         var pixelUserDataCount = Math.Min(pixelEvaluation.InitialScalarRegisters.Count, 8);
         var pixelUserData = new uint[pixelUserDataCount];
         for (var index = 0; index < pixelUserDataCount; index++)
@@ -6172,11 +6396,7 @@ public static partial class AgcExports
             renderTargets,
             DecodeDepthTarget(state.CxRegisters),
             guestTargets,
-            ApplyTransparentPremultipliedFillClear(
-                CreateRenderState(state.CxRegisters, renderTargets, pixelColorExportMasks),
-                textures,
-                vertexInputs,
-                pixelEvaluation.InitialScalarRegisters),
+            hostRenderState,
             pixelUserData,
             state.CxRegisters.TryGetValue(CbBlend0Control, out var rawBlend) ? rawBlend : 0,
             state.CxRegisters.TryGetValue(
@@ -6217,11 +6437,28 @@ public static partial class AgcExports
 
             var isStorage =
                 Gen5ShaderTranslator.IsStorageImageOperation(binding.Opcode);
-            if (_traceAgcShader || _tracePixelShaderAddress == pixelShaderAddress)
+            var traceAddressedTextureBinding =
+                texture.Address != 0 &&
+                Array.IndexOf(_traceGuestImageAddresses, texture.Address) >= 0 &&
+                _tracedAddressedTextureBindings.TryAdd(
+                    (pixelShaderAddress,
+                     texture.Address,
+                     texture.Width,
+                     texture.Height,
+                     texture.Format,
+                     texture.NumberType,
+                     texture.TileMode,
+                     texture.Pitch,
+                     texture.DstSelect),
+                    0);
+            if (_traceAgcShader ||
+                _tracePixelShaderAddress == pixelShaderAddress ||
+                traceAddressedTextureBinding)
             {
                 Console.Error.WriteLine(
                     "[LOADER][TRACE] " +
-                    $"agc.texture_binding ps=0x{pixelShaderAddress:X16} es=0x{exportShaderAddress:X16} " +
+                    $"{(traceAddressedTextureBinding ? "agc.addressed_texture_binding" : "agc.texture_binding")} " +
+                    $"ps=0x{pixelShaderAddress:X16} es=0x{exportShaderAddress:X16} " +
                     $"pc=0x{binding.Pc:X} op={binding.Opcode} storage={(isStorage ? 1 : 0)} " +
                     $"decoded={FormatTextureDescriptor(texture)} " +
                     $"raw={FormatShaderDwords(binding.ResourceDescriptor)} sampler={FormatShaderDwords(binding.SamplerDescriptor)}");
@@ -6485,6 +6722,48 @@ public static partial class AgcExports
         return (uint)(maxAttribute + 1);
     }
 
+    private static uint[] GetPixelInputControls(
+        IReadOnlyDictionary<uint, uint> contextRegisters,
+        uint attributeCount)
+    {
+        var controls = new uint[attributeCount];
+        for (uint attribute = 0; attribute < attributeCount; attribute++)
+        {
+            controls[attribute] = contextRegisters.TryGetValue(
+                SpiPsInputCntl0 + attribute,
+                out var control)
+                    ? control
+                    : attribute;
+        }
+
+        return controls;
+    }
+
+    private static ulong ComputePixelInputControlsFingerprint(
+        IReadOnlyList<uint> controls)
+    {
+        const ulong prime = 1099511628211UL;
+        var hash = 14695981039346656037UL;
+        foreach (var control in controls)
+        {
+            hash = (hash ^ control) * prime;
+        }
+
+        return hash;
+    }
+
+    private static int GetRequiredVertexOutputCount(
+        IReadOnlyList<uint> controls)
+    {
+        var maxLocation = -1;
+        foreach (var control in controls)
+        {
+            maxLocation = Math.Max(maxLocation, (int)(control & 0x1Fu));
+        }
+
+        return maxLocation + 1;
+    }
+
     private static readonly bool _bakeScalars = string.Equals(
         Environment.GetEnvironmentVariable("SHARPEMU_BAKE_SGPRS"),
         "1",
@@ -6645,10 +6924,116 @@ public static partial class AgcExports
                 (attrib2 & 0x3FFFu) + 1,
                 (info >> 2) & 0x1Fu,
                 (info >> 8) & 0x7u,
+                (info >> 11) & 0x3u,
                 (attrib3 >> 14) & 0x1Fu));
         }
 
         return targets;
+    }
+
+    private static RenderTargetDescriptor[] BuildHostRenderTargets(
+        IReadOnlyList<RenderTargetDescriptor> guestTargets,
+        GuestRenderState guestRenderState,
+        out uint[] hostOutputLocations)
+    {
+        hostOutputLocations = new uint[guestTargets.Count];
+        var hostTargets = new List<RenderTargetDescriptor>(guestTargets.Count);
+        for (var guestIndex = 0; guestIndex < guestTargets.Count; guestIndex++)
+        {
+            var guestTarget = guestTargets[guestIndex];
+            var hostIndex = -1;
+            if (CanMergeAliasedRenderTarget(
+                    guestTargets,
+                    guestRenderState.Blends,
+                    guestIndex))
+            {
+                hostIndex = hostTargets.FindIndex(
+                    target => RenderTargetsShareSurface(target, guestTarget));
+            }
+
+            if (hostIndex < 0)
+            {
+                hostIndex = hostTargets.Count;
+                hostTargets.Add(guestTarget);
+            }
+
+            hostOutputLocations[guestIndex] = (uint)hostIndex;
+        }
+
+        return hostTargets.ToArray();
+    }
+
+    private static bool CanMergeAliasedRenderTarget(
+        IReadOnlyList<RenderTargetDescriptor> targets,
+        IReadOnlyList<GuestBlendState> blends,
+        int targetIndex)
+    {
+        var target = targets[targetIndex];
+        var matchingTargets = 0;
+        var combinedMask = 0u;
+        GuestBlendState? commonBlend = null;
+        for (var index = 0; index < targets.Count; index++)
+        {
+            if (!RenderTargetsShareSurface(targets[index], target))
+            {
+                continue;
+            }
+
+            matchingTargets++;
+            var blend = blends[index];
+            var blendWithoutMask = blend with { WriteMask = 0 };
+            if (commonBlend is { } expectedBlend && expectedBlend != blendWithoutMask)
+            {
+                return false;
+            }
+
+            commonBlend ??= blendWithoutMask;
+            if ((combinedMask & blend.WriteMask) != 0)
+            {
+                return false;
+            }
+
+            combinedMask |= blend.WriteMask;
+        }
+
+        return matchingTargets > 1;
+    }
+
+    private static bool RenderTargetsShareSurface(
+        RenderTargetDescriptor left,
+        RenderTargetDescriptor right) =>
+        left.Address == right.Address &&
+        left.Width == right.Width &&
+        left.Height == right.Height &&
+        left.Format == right.Format &&
+        left.NumberType == right.NumberType &&
+        left.TileMode == right.TileMode;
+
+    private static GuestRenderState CollapseGuestRenderState(
+        GuestRenderState guestRenderState,
+        IReadOnlyList<uint> hostOutputLocations,
+        int hostTargetCount)
+    {
+        var hostBlends = new GuestBlendState[hostTargetCount];
+        var initialized = new bool[hostTargetCount];
+        for (var guestIndex = 0; guestIndex < hostOutputLocations.Count; guestIndex++)
+        {
+            var hostIndex = checked((int)hostOutputLocations[guestIndex]);
+            var guestBlend = guestRenderState.Blends[guestIndex];
+            if (!initialized[hostIndex])
+            {
+                hostBlends[hostIndex] = guestBlend;
+                initialized[hostIndex] = true;
+                continue;
+            }
+
+            hostBlends[hostIndex] = hostBlends[hostIndex] with
+            {
+                WriteMask = hostBlends[hostIndex].WriteMask | guestBlend.WriteMask,
+            };
+        }
+
+        return guestRenderState with { Blends = hostBlends };
     }
 
     private static GuestRenderState CreateRenderState(
@@ -7305,7 +7690,7 @@ public static partial class AgcExports
     }
 
     private static int GetRuntimeScalarBufferLength(int bindingCount) =>
-        checked((256 + bindingCount) * sizeof(uint));
+        checked(Gen5RuntimeScalarLayout.GetDwordLength(bindingCount) * sizeof(uint));
 
     private static byte[] PackRuntimeScalarState(
         IReadOnlyList<uint> registers,
@@ -7326,21 +7711,40 @@ public static partial class AgcExports
         return bytes;
     }
 
-    private static void PackRuntimeScalarStateInto(
+    internal static void PackRuntimeScalarStateInto(
         byte[] bytes,
         IReadOnlyList<uint> registers,
         IReadOnlyList<Gen5GlobalMemoryBinding> bindings)
     {
         PackScalarRegistersInto(bytes, registers);
-        var biasOffset = 256 * sizeof(uint);
         for (var index = 0; index < bindings.Count; index++)
         {
             var byteBias = checked((uint)(
                 bindings[index].BaseAddress &
                 (VulkanVideoPresenter.GuestStorageBufferOffsetAlignment - 1)));
+            var biasOffset = checked(
+                Gen5RuntimeScalarLayout.GetByteBiasDwordIndex(index) *
+                sizeof(uint));
             BinaryPrimitives.WriteUInt32LittleEndian(
-                bytes.AsSpan(biasOffset + index * sizeof(uint), sizeof(uint)),
+                bytes.AsSpan(biasOffset, sizeof(uint)),
                 byteBias);
+            // The presenter rounds the descriptor offset down to the portable
+            // storage-buffer alignment and exposes the discarded low address
+            // bits as byteBias. Shader addresses include that bias, so the
+            // explicit bounds metadata must describe the same descriptor range
+            // as Vulkan: max(data length, one dword) + byteBias, dword-aligned.
+            var descriptorBytes = checked(
+                (long)Math.Max(bindings[index].DataLength, sizeof(uint)) +
+                byteBias);
+            var dwordCount = checked((uint)(
+                (descriptorBytes + sizeof(uint) - 1) /
+                sizeof(uint)));
+            var dwordCountOffset = checked(
+                Gen5RuntimeScalarLayout.GetBufferDwordCountDwordIndex(index) *
+                sizeof(uint));
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                bytes.AsSpan(dwordCountOffset, sizeof(uint)),
+                dwordCount);
         }
     }
 
@@ -7685,12 +8089,17 @@ public static partial class AgcExports
             return true;
         }
 
-        if (!isStorage &&
+        var guestImageAvailable =
+            !isStorage &&
             descriptor.Address != 0 &&
             VulkanVideoPresenter.IsGuestImageAvailable(
                 descriptor.Address,
                 descriptor.Format,
-                descriptor.NumberType))
+                descriptor.NumberType);
+        if (TryUseAvailableGuestImageWithoutSnapshot(
+                descriptor.Address,
+                guestImageAvailable,
+                out var dirtyGuestImageSnapshotClaimed))
         {
             texture = new GuestDrawTexture(
                 descriptor.Address,
@@ -7712,112 +8121,176 @@ public static partial class AgcExports
             return true;
         }
 
-        if (isStorage)
+        var dirtyGuestImageSnapshotSucceeded = false;
+        try
         {
-            var initialPixels = Array.Empty<byte>();
-            var uploadKnown = descriptor.Address != 0 &&
-                VulkanVideoPresenter.IsGuestImageUploadKnown(
-                    descriptor.Address,
-                    descriptor.Format,
-                    descriptor.NumberType);
-            var readSucceeded = false;
-            var linearNonzero = false;
-            if (descriptor.Address != 0 && !uploadKnown)
+            if (isStorage)
             {
-                // Storage images can be pre-populated in tiled guest memory
-                // just like sampled images. Reading only the logical linear
-                // byte count both truncates 64 KiB swizzle blocks and uploads
-                // tiled bytes as scanlines. Read the full physical footprint
-                // and run the same AddrLib-derived detile path used below for
-                // sampled textures before seeding the Vulkan image.
-                var storageSource = new byte[(int)physicalSourceByteCount];
-                if (ctx.Memory.TryRead(descriptor.Address, storageSource))
+                var initialPixels = Array.Empty<byte>();
+                var uploadKnown = descriptor.Address != 0 &&
+                    VulkanVideoPresenter.IsGuestImageUploadKnown(
+                        descriptor.Address,
+                        descriptor.Format,
+                        descriptor.NumberType);
+                var readSucceeded = false;
+                var linearNonzero = false;
+                if (descriptor.Address != 0 && !uploadKnown)
                 {
-                    readSucceeded = true;
-                    var linearStorage = TryDetileTextureSource(
-                        descriptor,
-                        sourceWidth,
-                        checked((int)sourceByteCount),
-                        storageSource) ?? storageSource
-                            .AsSpan(0, checked((int)sourceByteCount))
-                            .ToArray();
-                    if (linearStorage.AsSpan().IndexOfAnyExcept((byte)0) >= 0)
+                    // Storage images can be pre-populated in tiled guest memory
+                    // just like sampled images. Reading only the logical linear
+                    // byte count both truncates 64 KiB swizzle blocks and uploads
+                    // tiled bytes as scanlines. Read the full physical footprint
+                    // and run the same AddrLib-derived detile path used below for
+                    // sampled textures before seeding the Vulkan image.
+                    var storageSource = new byte[(int)physicalSourceByteCount];
+                    if (ctx.Memory.TryRead(descriptor.Address, storageSource))
                     {
-                        linearNonzero = true;
-                        initialPixels = linearStorage;
+                        readSucceeded = true;
+                        var linearStorage = TryDetileTextureSource(
+                            descriptor,
+                            sourceWidth,
+                            checked((int)sourceByteCount),
+                            storageSource) ?? storageSource
+                                .AsSpan(0, checked((int)sourceByteCount))
+                                .ToArray();
+                        if (linearStorage.AsSpan().IndexOfAnyExcept((byte)0) >= 0)
+                        {
+                            linearNonzero = true;
+                            initialPixels = linearStorage;
+                        }
                     }
                 }
-            }
 
-            if (ParseOptionalHexAddress(
-                    Environment.GetEnvironmentVariable(
-                        "SHARPEMU_TRACE_STORAGE_IMAGE_INIT_ADDRESS")) ==
-                descriptor.Address)
-            {
-                Console.Error.WriteLine(
-                    $"[LOADER][TRACE] agc.storage_initial_data " +
-                    $"addr=0x{descriptor.Address:X16} op_storage={isStorage} " +
-                    $"upload_known={uploadKnown} read={readSucceeded} " +
-                    $"nonzero={linearNonzero} initial_bytes={initialPixels.Length} " +
-                    $"logical_bytes={sourceByteCount} physical_bytes={physicalSourceByteCount} " +
-                    $"size={descriptor.Width}x{descriptor.Height} pitch={sourceWidth} " +
-                    $"fmt={descriptor.Format} num={descriptor.NumberType} " +
-                    $"tile={descriptor.TileMode} mip={mipLevel}");
-            }
+                if (ParseOptionalHexAddress(
+                        Environment.GetEnvironmentVariable(
+                            "SHARPEMU_TRACE_STORAGE_IMAGE_INIT_ADDRESS")) ==
+                    descriptor.Address)
+                {
+                    Console.Error.WriteLine(
+                        $"[LOADER][TRACE] agc.storage_initial_data " +
+                        $"addr=0x{descriptor.Address:X16} op_storage={isStorage} " +
+                        $"upload_known={uploadKnown} read={readSucceeded} " +
+                        $"nonzero={linearNonzero} initial_bytes={initialPixels.Length} " +
+                        $"logical_bytes={sourceByteCount} physical_bytes={physicalSourceByteCount} " +
+                        $"size={descriptor.Width}x{descriptor.Height} pitch={sourceWidth} " +
+                        $"fmt={descriptor.Format} num={descriptor.NumberType} " +
+                        $"tile={descriptor.TileMode} mip={mipLevel}");
+                }
 
-            texture = new GuestDrawTexture(
-                descriptor.Address,
-                descriptor.Width,
-                descriptor.Height,
-                descriptor.Format,
-                descriptor.NumberType,
-                initialPixels,
-                IsFallback: descriptor.Address == 0,
-                IsStorage: true,
-                MipLevels: descriptor.MipLevels,
-                MipLevel: mipLevel,
-                BaseMipLevel: descriptor.ViewBaseLevel,
-                ResourceMipLevels: descriptor.ResourceMipLevels,
-                Pitch: sourceWidth,
-                TileMode: descriptor.TileMode,
-                DstSelect: descriptor.DstSelect,
-                Sampler: ToGuestSampler(samplerDescriptor));
-            return true;
-        }
-
-        // When the presenter already holds this exact texture identity in
-        // its cache, the texel copy below would be discarded on arrival; for
-        // scenes that sample large textures every draw this copy dominated
-        // CPU time. The dirty peek closes the race with eviction: a texture
-        // the guest rewrote must ship fresh texels with this draw, because
-        // the render thread evicts the stale cache entry before executing it
-        // (skipping would leave the draw with no pixels and a fallback
-        // texture for the frame — visible flicker on animated textures).
-        var sampler = ToGuestSampler(samplerDescriptor);
-        if (!_textureCopySkipDisabled &&
-            descriptor.Address != 0 &&
-            !SharpEmu.HLE.GuestImageWriteTracker.PeekDirty(descriptor.Address) &&
-            VulkanVideoPresenter.IsTextureContentCached(
-                new VulkanVideoPresenter.TextureContentIdentity(
+                texture = new GuestDrawTexture(
                     descriptor.Address,
                     descriptor.Width,
                     descriptor.Height,
                     descriptor.Format,
                     descriptor.NumberType,
-                    descriptor.DstSelect,
-                    descriptor.TileMode,
-                    sourceWidth,
-                    sampler)))
-        {
+                    initialPixels,
+                    IsFallback: descriptor.Address == 0,
+                    IsStorage: true,
+                    MipLevels: descriptor.MipLevels,
+                    MipLevel: mipLevel,
+                    BaseMipLevel: descriptor.ViewBaseLevel,
+                    ResourceMipLevels: descriptor.ResourceMipLevels,
+                    Pitch: sourceWidth,
+                    TileMode: descriptor.TileMode,
+                    DstSelect: descriptor.DstSelect,
+                    Sampler: ToGuestSampler(samplerDescriptor));
+                return true;
+            }
+
+            // When the presenter already holds this exact texture identity in
+            // its cache, the texel copy below would be discarded on arrival; for
+            // scenes that sample large textures every draw this copy dominated
+            // CPU time. The dirty peek closes the race with eviction: a texture
+            // the guest rewrote must ship fresh texels with this draw, because
+            // the render thread evicts the stale cache entry before executing it
+            // (skipping would leave the draw with no pixels and a fallback
+            // texture for the frame — visible flicker on animated textures).
+            var sampler = ToGuestSampler(samplerDescriptor);
+            if (!dirtyGuestImageSnapshotClaimed &&
+                !_textureCopySkipDisabled &&
+                descriptor.Address != 0 &&
+                !SharpEmu.HLE.GuestImageWriteTracker.PeekDirty(descriptor.Address) &&
+                VulkanVideoPresenter.IsTextureContentCached(
+                    new VulkanVideoPresenter.TextureContentIdentity(
+                        descriptor.Address,
+                        descriptor.Width,
+                        descriptor.Height,
+                        descriptor.Format,
+                        descriptor.NumberType,
+                        descriptor.DstSelect,
+                        descriptor.TileMode,
+                        sourceWidth,
+                        sampler)))
+            {
+                texture = new GuestDrawTexture(
+                    descriptor.Address,
+                    descriptor.Width,
+                    descriptor.Height,
+                    descriptor.Format,
+                    descriptor.NumberType,
+                    [],
+                    IsFallback: false,
+                    IsStorage: false,
+                    MipLevels: descriptor.MipLevels,
+                    MipLevel: mipLevel,
+                    BaseMipLevel: descriptor.ViewBaseLevel,
+                    ResourceMipLevels: descriptor.ResourceMipLevels,
+                    Pitch: sourceWidth,
+                    TileMode: descriptor.TileMode,
+                    DstSelect: descriptor.DstSelect,
+                    Sampler: sampler);
+                return true;
+            }
+
+            var source = new byte[(int)physicalSourceByteCount];
+            if (!ctx.Memory.TryRead(descriptor.Address, source))
+            {
+                TraceTextureFallback(
+                    descriptor,
+                    $"guest-read-failed:{sourceByteCount}");
+                texture = CreateFallbackGuestDrawTexture(isStorage, descriptor.Format, descriptor.NumberType);
+                return true;
+            }
+
+            if (_traceAgcShader)
+            {
+                var nonZero = 0;
+                for (var i = 0; i < source.Length; i++)
+                {
+                    if (source[i] != 0)
+                    {
+                        nonZero++;
+                        if (nonZero >= 64)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                TraceAgcShader(
+                    $"agc.texture_source addr=0x{descriptor.Address:X16} " +
+                    $"fmt={descriptor.Format} num={descriptor.NumberType} tile={descriptor.TileMode} " +
+                    $"size={descriptor.Width}x{descriptor.Height} pitch={descriptor.Pitch} " +
+                    $"dst=0x{descriptor.DstSelect:X3} " +
+                    $"bytes={source.Length} logical_bytes={sourceByteCount} nonzero64={nonZero}");
+            }
+            DumpTextureSourceIfRequested(descriptor, sourceWidth, source);
+
+            var rgba = TryDetileTextureSource(
+                descriptor,
+                sourceWidth,
+                checked((int)sourceByteCount),
+                source) ?? source.AsSpan(0, checked((int)sourceByteCount)).ToArray();
+            DumpLinearTextureIfRequested(descriptor, sourceWidth, rgba);
             texture = new GuestDrawTexture(
                 descriptor.Address,
                 descriptor.Width,
                 descriptor.Height,
                 descriptor.Format,
                 descriptor.NumberType,
-                [],
+                rgba,
                 IsFallback: false,
-                IsStorage: false,
+                IsStorage: isStorage,
                 MipLevels: descriptor.MipLevels,
                 MipLevel: mipLevel,
                 BaseMipLevel: descriptor.ViewBaseLevel,
@@ -7825,68 +8298,42 @@ public static partial class AgcExports
                 Pitch: sourceWidth,
                 TileMode: descriptor.TileMode,
                 DstSelect: descriptor.DstSelect,
-                Sampler: sampler);
+                Sampler: ToGuestSampler(samplerDescriptor));
+            dirtyGuestImageSnapshotSucceeded = true;
             return true;
         }
-
-        var source = new byte[(int)physicalSourceByteCount];
-        if (!ctx.Memory.TryRead(descriptor.Address, source))
+        finally
         {
-            TraceTextureFallback(
-                descriptor,
-                $"guest-read-failed:{sourceByteCount}");
-            texture = CreateFallbackGuestDrawTexture(isStorage, descriptor.Format, descriptor.NumberType);
-            return true;
-        }
-
-        if (_traceAgcShader)
-        {
-            var nonZero = 0;
-            for (var i = 0; i < source.Length; i++)
+            if (dirtyGuestImageSnapshotClaimed)
             {
-                if (source[i] != 0)
-                {
-                    nonZero++;
-                    if (nonZero >= 64)
-                    {
-                        break;
-                    }
-                }
+                CompleteGuestImageSnapshot(
+                    descriptor.Address,
+                    dirtyGuestImageSnapshotSucceeded);
             }
-
-            TraceAgcShader(
-                $"agc.texture_source addr=0x{descriptor.Address:X16} " +
-                $"fmt={descriptor.Format} num={descriptor.NumberType} tile={descriptor.TileMode} " +
-                $"size={descriptor.Width}x{descriptor.Height} pitch={descriptor.Pitch} " +
-                $"dst=0x{descriptor.DstSelect:X3} " +
-                $"bytes={source.Length} logical_bytes={sourceByteCount} nonzero64={nonZero}");
         }
-        DumpTextureSourceIfRequested(descriptor, sourceWidth, source);
+    }
 
-        var rgba = TryDetileTextureSource(
-            descriptor,
-            sourceWidth,
-            checked((int)sourceByteCount),
-            source) ?? source.AsSpan(0, checked((int)sourceByteCount)).ToArray();
-        DumpLinearTextureIfRequested(descriptor, sourceWidth, rgba);
-        texture = new GuestDrawTexture(
-            descriptor.Address,
-            descriptor.Width,
-            descriptor.Height,
-            descriptor.Format,
-            descriptor.NumberType,
-            rgba,
-            IsFallback: false,
-            IsStorage: isStorage,
-            MipLevels: descriptor.MipLevels,
-            MipLevel: mipLevel,
-            BaseMipLevel: descriptor.ViewBaseLevel,
-            ResourceMipLevels: descriptor.ResourceMipLevels,
-            Pitch: sourceWidth,
-            TileMode: descriptor.TileMode,
-            DstSelect: descriptor.DstSelect,
-            Sampler: ToGuestSampler(samplerDescriptor));
-        return true;
+    internal static bool TryUseAvailableGuestImageWithoutSnapshot(
+        ulong address,
+        bool guestImageAvailable,
+        out bool dirtySnapshotClaimed)
+    {
+        dirtySnapshotClaimed = guestImageAvailable &&
+            GuestImageWriteTracker.ConsumeDirty(address);
+        return guestImageAvailable && !dirtySnapshotClaimed;
+    }
+
+    internal static void CompleteGuestImageSnapshot(ulong address, bool succeeded)
+    {
+        GuestImageWriteTracker.Rearm(address);
+        if (!succeeded)
+        {
+            // Put the consumed generation back for a later attempt. Rearm first
+            // so this synthetic notification leaves the range dirty/disarmed,
+            // matching a real CPU write and preventing a failed read from
+            // making the stale host image look current.
+            GuestImageWriteTracker.NotifyManagedWrite(address, 1);
+        }
     }
 
 
@@ -8270,9 +8717,16 @@ public static partial class AgcExports
             return false;
         }
 
+        _ = TryGetShaderAddress(
+            state.ShRegisters,
+            ComputePgmLo,
+            ComputePgmHi,
+            out var shaderAddress);
+
         if (dispatchEndX == 0 || dispatchEndY == 0 || dispatchEndZ == 0)
         {
             return RejectComputeDispatch(
+                shaderAddress,
                 dimensionsAddress,
                 initiator,
                 dispatchSource,
@@ -8324,6 +8778,7 @@ public static partial class AgcExports
                 (ulong)dispatchEndZ <= startThreadZ)
             {
                 return RejectComputeDispatch(
+                    shaderAddress,
                     dimensionsAddress,
                     initiator,
                     dispatchSource,
@@ -8348,6 +8803,7 @@ public static partial class AgcExports
                 dispatchEndZ <= baseGroupZ)
             {
                 return RejectComputeDispatch(
+                    shaderAddress,
                     dimensionsAddress,
                     initiator,
                     dispatchSource,
@@ -8372,6 +8828,7 @@ public static partial class AgcExports
                 partialSizeZ == 0 || partialSizeZ > localSizeZ)
             {
                 return RejectComputeDispatch(
+                    shaderAddress,
                     dimensionsAddress,
                     initiator,
                     dispatchSource,
@@ -8387,6 +8844,7 @@ public static partial class AgcExports
                 partialSizeZ != localSizeZ)
             {
                 return RejectComputeDispatch(
+                    shaderAddress,
                     dimensionsAddress,
                     initiator,
                     dispatchSource,
@@ -8443,6 +8901,7 @@ public static partial class AgcExports
         checked((uint)((value + divisor - 1) / divisor));
 
     private static bool RejectComputeDispatch(
+        ulong shaderAddress,
         ulong dimensionsAddress,
         uint initiator,
         string source,
@@ -8458,6 +8917,7 @@ public static partial class AgcExports
             {
                 Console.Error.WriteLine(
                     $"[LOADER][WARN] agc.dispatch_reject source={source} " +
+                    $"cs=0x{shaderAddress:X16} " +
                     $"dims=0x{dimensionsAddress:X16} raw={rawX:X8}/{rawY:X8}/{rawZ:X8} " +
                     $"initiator=0x{initiator:X8} reason={reason}");
             }
@@ -8516,6 +8976,10 @@ public static partial class AgcExports
             return;
         }
 
+        var localSizeX = GetComputeLocalSize(state.ShRegisters, ComputeNumThreadX);
+        var localSizeY = GetComputeLocalSize(state.ShRegisters, ComputeNumThreadY);
+        var localSizeZ = GetComputeLocalSize(state.ShRegisters, ComputeNumThreadZ);
+
         var bindings = evaluation.ImageBindings;
         var descriptions = new List<string>(bindings.Count);
         var translatedBindings = new List<TranslatedImageBinding>(bindings.Count);
@@ -8528,6 +8992,7 @@ public static partial class AgcExports
             {
                 texture = CreateFallbackTextureDescriptor(binding.ResourceDescriptor);
             }
+
 
             translatedBindings.Add(
                 new TranslatedImageBinding(
@@ -8558,9 +9023,6 @@ public static partial class AgcExports
             }
         }
 
-        var localSizeX = GetComputeLocalSize(state.ShRegisters, ComputeNumThreadX);
-        var localSizeY = GetComputeLocalSize(state.ShRegisters, ComputeNumThreadY);
-        var localSizeZ = GetComputeLocalSize(state.ShRegisters, ComputeNumThreadZ);
         if (_traceComputeShaderAddress == shaderAddress)
         {
             Console.Error.WriteLine(
@@ -8619,6 +9081,7 @@ public static partial class AgcExports
                 _bakeScalars
                     ? ComputeShaderStateFingerprint(evaluation)
                     : ComputeShaderStructuralFingerprint(evaluation),
+                shaderState.ProgramResource1,
                 localSizeX,
                 localSizeY,
                 localSizeZ,
@@ -8731,7 +9194,7 @@ public static partial class AgcExports
                         .Select(instruction => instruction.Opcode)
                         .Distinct()
                         .Take(48));
-                TraceAgcShader(
+                var computeSummary =
                     $"agc.compute_shader cs=0x{shaderAddress:X16} " +
                     $"groups={dispatch.GroupCountX}x{dispatch.GroupCountY}x{dispatch.GroupCountZ} " +
                     $"base={dispatch.BaseGroupX}x{dispatch.BaseGroupY}x{dispatch.BaseGroupZ} " +
@@ -8746,7 +9209,12 @@ public static partial class AgcExports
                     globalProbes +
                     globalDescriptors +
                     $" opcodes=[{opcodes}]" +
-                    $" bindings=[{string.Join(',', descriptions)}]");
+                    $" bindings=[{string.Join(',', descriptions)}]";
+                TraceAgcShader(computeSummary);
+                if (_traceComputeShaderAddress == shaderAddress && !_traceAgcShader)
+                {
+                    Console.Error.WriteLine($"[AGC][COMPUTE-RESULT] {computeSummary}");
+                }
             }
         }
 
@@ -10814,6 +11282,30 @@ public static partial class AgcExports
         $"lod={descriptor.MinLod:X3}/{descriptor.MinLodWarn:X3} " +
         $"bc={descriptor.BcSwizzle} meta=0x{descriptor.MetadataAddress:X16} " +
         $"flags=0x{descriptor.DescriptorFlags:X6} dst=0x{descriptor.DstSelect:X3}";
+
+    private static int? ParseOptionalPositiveInt(string? value) =>
+        int.TryParse(value, out var parsed) && parsed > 0
+            ? parsed
+            : null;
+
+    private static ulong[] ParseHexAddresses(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return [];
+        }
+
+        return value.Split(
+                ',',
+                StringSplitOptions.RemoveEmptyEntries |
+                StringSplitOptions.TrimEntries)
+            .Select(ParseOptionalHexAddress)
+            .Where(static address => address.HasValue)
+            .Select(static address => address!.Value)
+            .Distinct()
+            .ToArray();
+    }
+
 
     private static ulong? ParseOptionalHexAddress(string? value)
     {

--- a/src/SharpEmu.Libs/AvPlayer/AvPlayerExports.cs
+++ b/src/SharpEmu.Libs/AvPlayer/AvPlayerExports.cs
@@ -19,6 +19,7 @@ public static class AvPlayerExports
     private const int FrameInfoExSize = 104;
     private const int StreamInfoSize = 40;
     private const int MaxGuestPathLength = 4096;
+    private const int VideoPitchAlignment = 256;
     private static readonly object StateGate = new();
     private static readonly Dictionary<ulong, PlayerState> Players = new();
     private static int _traceCount;
@@ -886,7 +887,9 @@ public static class AvPlayerExports
 
         var alignedWidth = AlignUp(player.Width, 16);
         var alignedHeight = AlignUp(player.Height, 16);
-        var bufferStride = checked(alignedWidth * alignedHeight * 3 / 2);
+        var pitch = extended ? CalculateNv12Pitch(player.Width) : alignedWidth;
+        var bufferHeight = extended ? player.Height : alignedHeight;
+        var bufferStride = CalculateNv12BufferSize(pitch, bufferHeight);
         if (player.GuestBuffers[0] == 0)
         {
             if (!AllocateGuestVideoBuffers(ctx, player, bufferStride))
@@ -894,12 +897,34 @@ public static class AvPlayerExports
                 return false;
             }
             player.GuestBufferStride = bufferStride;
+            Trace(
+                $"video_layout ex={extended} width={player.Width} height={player.Height} " +
+                $"pitch={pitch} uv_offset={checked(pitch * bufferHeight)} size={bufferStride}");
         }
 
         var frameData = player.RawFrame;
-        if (!extended && (alignedWidth != player.Width || alignedHeight != player.Height))
+        if (extended)
         {
-            player.PaddedFrame ??= new byte[bufferStride];
+            if (player.PaddedFrame is null || player.PaddedFrame.Length != bufferStride)
+            {
+                player.PaddedFrame = new byte[bufferStride];
+            }
+            CopyNv12ToGuestBuffer(
+                player.RawFrame,
+                player.PaddedFrame,
+                player.Width,
+                player.Height,
+                player.Width,
+                player.Width,
+                pitch);
+            frameData = player.PaddedFrame;
+        }
+        else if (alignedWidth != player.Width || alignedHeight != player.Height)
+        {
+            if (player.PaddedFrame is null || player.PaddedFrame.Length != bufferStride)
+            {
+                player.PaddedFrame = new byte[bufferStride];
+            }
             player.PaddedFrame.AsSpan().Clear();
             for (var row = 0; row < player.Height; row++)
             {
@@ -935,11 +960,43 @@ public static class AvPlayerExports
         BinaryPrimitives.WriteSingleLittleEndian(info[32..], 1.0f);
         if (extended)
         {
-            BinaryPrimitives.WriteUInt32LittleEndian(info[60..], checked((uint)player.Width));
+            BinaryPrimitives.WriteUInt32LittleEndian(info[60..], checked((uint)pitch));
             info[64] = 8;
             info[65] = 8;
         }
         return ctx.Memory.TryWrite(infoAddress, info);
+    }
+
+    internal static int CalculateNv12Pitch(int width) =>
+        AlignUp(width, VideoPitchAlignment);
+
+    internal static int CalculateNv12BufferSize(int pitch, int height) =>
+        checked(pitch * height * 3 / 2);
+
+    internal static void CopyNv12ToGuestBuffer(
+        ReadOnlySpan<byte> source,
+        Span<byte> destination,
+        int width,
+        int height,
+        int sourceLumaStride,
+        int sourceChromaStride,
+        int destinationPitch)
+    {
+        var sourceChromaOffset = checked(sourceLumaStride * height);
+        var destinationChromaOffset = checked(destinationPitch * height);
+        var destinationSize = CalculateNv12BufferSize(destinationPitch, height);
+        destination[..destinationSize].Clear();
+
+        for (var row = 0; row < height; row++)
+        {
+            source.Slice(row * sourceLumaStride, width)
+                .CopyTo(destination.Slice(row * destinationPitch, width));
+        }
+        for (var row = 0; row < height / 2; row++)
+        {
+            source.Slice(sourceChromaOffset + (row * sourceChromaStride), width)
+                .CopyTo(destination.Slice(destinationChromaOffset + (row * destinationPitch), width));
+        }
     }
 
     private static bool AllocateGuestVideoBuffers(CpuContext ctx, PlayerState player, int bufferSize)

--- a/src/SharpEmu.Libs/Gpu/GuestGpuTypes.cs
+++ b/src/SharpEmu.Libs/Gpu/GuestGpuTypes.cs
@@ -140,14 +140,15 @@ internal sealed record GuestRenderState(
         Blends.Count == 0 ? GuestBlendState.Default : Blends[0];
 }
 
-/// <summary>Format/NumberType are raw guest render-target register codes.</summary>
+/// <summary>Format/NumberType/ComponentSwap are raw guest render-target register codes.</summary>
 internal sealed record GuestRenderTarget(
     ulong Address,
     uint Width,
     uint Height,
     uint Format,
     uint NumberType,
-    uint MipLevels = 1);
+    uint MipLevels = 1,
+    uint ComponentSwap = 0);
 
 /// <summary>Guest DB surface bound alongside a color render target.</summary>
 internal sealed record GuestDepthTarget(

--- a/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
@@ -35,7 +35,8 @@ internal interface IGuestGpuBackend
         int imageBindingBase = 0,
         int scalarRegisterBufferIndex = -1,
         int requiredVertexOutputCount = 0,
-        ulong storageBufferOffsetAlignment = 1);
+        ulong storageBufferOffsetAlignment = 1,
+        IReadOnlyList<uint>? pixelInputControls = null);
 
     bool TryCompilePixelShader(
         Gen5ShaderState state,
@@ -49,7 +50,8 @@ internal interface IGuestGpuBackend
         int scalarRegisterBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
-        ulong storageBufferOffsetAlignment = 1);
+        ulong storageBufferOffsetAlignment = 1,
+        IReadOnlyList<uint>? pixelInputControls = null);
 
     bool TryCompileComputeShader(
         Gen5ShaderState state,

--- a/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
@@ -28,7 +28,8 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         int imageBindingBase = 0,
         int scalarRegisterBufferIndex = -1,
         int requiredVertexOutputCount = 0,
-        ulong storageBufferOffsetAlignment = 1)
+        ulong storageBufferOffsetAlignment = 1,
+        IReadOnlyList<uint>? pixelInputControls = null)
     {
         shader = null;
         if (!Gen5SpirvTranslator.TryCompileVertexShader(
@@ -41,7 +42,9 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
                 imageBindingBase,
                 scalarRegisterBufferIndex,
                 requiredVertexOutputCount,
-                storageBufferOffsetAlignment))
+                storageBufferOffsetAlignment,
+                VulkanVideoPresenter.SupportsVertexSubgroupOperations,
+                pixelInputControls))
         {
             return false;
         }
@@ -62,7 +65,8 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         int scalarRegisterBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
-        ulong storageBufferOffsetAlignment = 1)
+        ulong storageBufferOffsetAlignment = 1,
+        IReadOnlyList<uint>? pixelInputControls = null)
     {
         shader = null;
         if (!Gen5SpirvTranslator.TryCompilePixelShader(
@@ -77,7 +81,10 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
                 scalarRegisterBufferIndex,
                 pixelInputEnable,
                 pixelInputAddress,
-                storageBufferOffsetAlignment))
+                storageBufferOffsetAlignment,
+                VulkanVideoPresenter.SupportsFragmentSubgroupOperations,
+                VulkanVideoPresenter.SupportsFragmentShaderBarycentric,
+                pixelInputControls))
         {
             return false;
         }
@@ -111,7 +118,8 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
                 totalGlobalBufferCount,
                 initialScalarBufferIndex,
                 waveLaneCount,
-                storageBufferOffsetAlignment))
+                storageBufferOffsetAlignment,
+                VulkanVideoPresenter.SupportsComputeSubgroupOperations))
         {
             return false;
         }

--- a/src/SharpEmu.Libs/Json/JsonExports.cs
+++ b/src/SharpEmu.Libs/Json/JsonExports.cs
@@ -26,8 +26,11 @@ public static class JsonExports
         ulong GuestBufferAddress = 0,
         int GuestBufferCapacity = 0);
 
+    private readonly record struct JsonReferenceKey(ulong ValueAddress, string Key);
+
     private static readonly ConcurrentDictionary<ulong, JsonValueState> _values = new();
     private static readonly ConcurrentDictionary<ulong, JsonStringState> _strings = new();
+    private static readonly ConcurrentDictionary<JsonReferenceKey, ulong> _valueReferences = new();
     private static readonly JsonElement _nullElement = CreateNullElement();
 
     [SysAbiExport(
@@ -356,6 +359,39 @@ public static class JsonExports
     }
 
     [SysAbiExport(
+        Nid = "wLsJlmgEIaI",
+        ExportName = "_ZN3sce4Json5Value10referValueERKNS0_6StringE",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceJson")]
+    public static int ValueReferValueByString(CpuContext ctx)
+    {
+        var valueAddress = ctx[CpuRegister.Rdi];
+        var stringAddress = ctx[CpuRegister.Rsi];
+        if (!TryGetStringValue(ctx, stringAddress, out var key))
+        {
+            ctx[CpuRegister.Rax] = 0;
+            TraceJsonReference(valueAddress, string.Empty, 0, 0);
+            return 0;
+        }
+
+        var parent = GetValue(valueAddress);
+        if (parent.ValueKind != System.Text.Json.JsonValueKind.Object ||
+            !parent.TryGetProperty(key, out var property) ||
+            !TryGetOrAllocateValueReference(ctx, new JsonReferenceKey(valueAddress, key), out var childAddress))
+        {
+            ctx[CpuRegister.Rax] = 0;
+            TraceJsonReference(valueAddress, key, 0, 0);
+            return 0;
+        }
+
+        var child = property.Clone();
+        StoreValue(ctx, childAddress, child);
+        ctx[CpuRegister.Rax] = childAddress;
+        TraceJsonReference(valueAddress, key, childAddress, GetValueType(child));
+        return 0;
+    }
+
+    [SysAbiExport(
         Nid = "XlWbvieLj2M",
         ExportName = "_ZNK3sce4Json5ValueixEm",
         Target = Generation.Gen4 | Generation.Gen5,
@@ -517,7 +553,7 @@ public static class JsonExports
     private static int DestroyValue(CpuContext ctx)
     {
         var thisAddress = ctx[CpuRegister.Rdi];
-        _values.TryRemove(thisAddress, out _);
+        RemoveCompleteValueShadow(ctx, thisAddress);
         if (thisAddress != 0)
         {
             Span<byte> empty = stackalloc byte[ValueObjectSize];
@@ -546,7 +582,7 @@ public static class JsonExports
     private static int DestroyString(CpuContext ctx)
     {
         var thisAddress = ctx[CpuRegister.Rdi];
-        _strings.TryRemove(thisAddress, out _);
+        RemoveCompleteStringShadow(ctx, thisAddress);
         if (thisAddress != 0)
         {
             ctx.TryWriteUInt64(thisAddress, 0);
@@ -580,7 +616,8 @@ public static class JsonExports
         Span<byte> mirror = stackalloc byte[ValueObjectSize];
         mirror.Clear();
         var type = GetValueType(clone);
-        BinaryPrimitives.WriteInt32LittleEndian(mirror[0x1C..], type);
+        var typeOffset = ctx.TargetGeneration == Generation.Gen4 ? 0x18 : 0x1C;
+        BinaryPrimitives.WriteInt32LittleEndian(mirror[typeOffset..], type);
         switch (clone.ValueKind)
         {
             case System.Text.Json.JsonValueKind.True:
@@ -622,6 +659,68 @@ public static class JsonExports
             allocator.TryAllocateGuestMemory((ulong)size, 0x10, out address);
     }
 
+    private static bool TryGetOrAllocateValueReference(
+        CpuContext ctx,
+        JsonReferenceKey key,
+        out ulong address)
+    {
+        if (_valueReferences.TryGetValue(key, out address))
+        {
+            return true;
+        }
+
+        if (!TryAllocateGuestObject(ctx, ValueObjectSize, out var allocatedAddress))
+        {
+            address = 0;
+            return false;
+        }
+
+        address = _valueReferences.GetOrAdd(key, allocatedAddress);
+        if (address != allocatedAddress && ctx.Memory is IGuestMemoryAllocator allocator)
+        {
+            allocator.TryFreeGuestMemory(allocatedAddress);
+        }
+
+        return true;
+    }
+
+    internal static void RemoveCompleteValueShadow(CpuContext ctx, ulong address)
+    {
+        _values.TryRemove(address, out _);
+        foreach (var reference in _valueReferences.Where(entry => entry.Key.ValueAddress == address).ToArray())
+        {
+            if (!_valueReferences.TryRemove(reference.Key, out var childAddress))
+            {
+                continue;
+            }
+
+            _values.TryRemove(childAddress, out _);
+            if (ctx.Memory is IGuestMemoryAllocator allocator)
+            {
+                allocator.TryFreeGuestMemory(childAddress);
+            }
+        }
+    }
+
+    internal static void RemoveCompleteStringShadow(CpuContext ctx, ulong address)
+    {
+        if (!_strings.TryRemove(address, out var state) ||
+            state.GuestBufferAddress == 0 ||
+            ctx.Memory is not IGuestMemoryAllocator allocator)
+        {
+            return;
+        }
+
+        allocator.TryFreeGuestMemory(state.GuestBufferAddress);
+    }
+
+    internal static void ResetForTests()
+    {
+        _values.Clear();
+        _strings.Clear();
+        _valueReferences.Clear();
+    }
+
     private static bool TryReadUtf8CString(
         CpuContext ctx,
         ulong address,
@@ -655,6 +754,30 @@ public static class JsonExports
         return false;
     }
 
+    private static bool TryGetStringValue(CpuContext ctx, ulong address, out string value)
+    {
+        value = string.Empty;
+        if (address == 0)
+        {
+            return false;
+        }
+
+        if (_strings.TryGetValue(address, out var stringState))
+        {
+            value = stringState.Value;
+            return true;
+        }
+
+        if (JsonObjectHeap.Strings.TryGetValue(address, out var heapValue))
+        {
+            value = heapValue;
+            return true;
+        }
+
+        return ctx.TryReadUInt64(address, out var bufferAddress) &&
+            TryReadUtf8CString(ctx, bufferAddress, 4096, out value);
+    }
+
     private static int SetReturn(CpuContext ctx, int result)
     {
         ctx[CpuRegister.Rax] = unchecked((ulong)result);
@@ -682,5 +805,22 @@ public static class JsonExports
         var preview = value.Length <= 128 ? value : value[..128];
         Console.Error.WriteLine(
             $"[LOADER][TRACE] json.{operation} this=0x{thisAddress:X16} value={preview}");
+    }
+
+    private static void TraceJsonReference(
+        ulong valueAddress,
+        string key,
+        ulong childAddress,
+        int childType)
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_JSON"), "1", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var preview = key.Length <= 128 ? key : key[..128];
+        Console.Error.WriteLine(
+            $"[LOADER][TRACE] json.Value.refer this=0x{valueAddress:X16} key={preview} " +
+            $"child=0x{childAddress:X16} type={childType}");
     }
 }

--- a/src/SharpEmu.Libs/Json/JsonValueExports.cs
+++ b/src/SharpEmu.Libs/Json/JsonValueExports.cs
@@ -117,7 +117,9 @@ public static class JsonValueExports
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libSceJson")]
     public static int ValueDestructor(CpuContext ctx)
     {
-        JsonObjectHeap.RemoveValue(ctx[CpuRegister.Rdi]);
+        var thisAddress = ctx[CpuRegister.Rdi];
+        JsonExports.RemoveCompleteValueShadow(ctx, thisAddress);
+        JsonObjectHeap.RemoveValue(thisAddress);
         return ReturnVoid(ctx);
     }
 
@@ -228,7 +230,9 @@ public static class JsonValueExports
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libSceJson")]
     public static int StringDestructor(CpuContext ctx)
     {
-        JsonObjectHeap.RemoveString(ctx[CpuRegister.Rdi]);
+        var thisAddress = ctx[CpuRegister.Rdi];
+        JsonExports.RemoveCompleteStringShadow(ctx, thisAddress);
+        JsonObjectHeap.RemoveString(thisAddress);
         return ReturnVoid(ctx);
     }
 }

--- a/src/SharpEmu.Libs/Json/JsonValueModel.cs
+++ b/src/SharpEmu.Libs/Json/JsonValueModel.cs
@@ -102,6 +102,7 @@ internal static class JsonObjectHeap
 
     internal static void ResetForTests()
     {
+        JsonExports.ResetForTests();
         Values.Clear();
         Strings.Clear();
         GlobalNullAccessCallback = 0;

--- a/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
@@ -77,7 +77,10 @@ public static class KernelSemaphoreCompatExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
-        TraceSemaphore($"create handle=0x{handle:X8} name='{name}' attr=0x{attr:X} init={initialCount} max={maxCount}");
+        if (_traceSema)
+        {
+            TraceSemaphore($"create handle=0x{handle:X8} name='{name}' attr=0x{attr:X} init={initialCount} max={maxCount}");
+        }
         return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
@@ -118,7 +121,10 @@ public static class KernelSemaphoreCompatExports
                     _ = TryWriteUInt32(ctx, timeoutAddress, timeoutUsec);
                 }
 
-                TraceSemaphore($"wait handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} timeout={(timeoutAddress == 0 ? "infinite" : timeoutUsec)}");
+                if (_traceSema)
+                {
+                    TraceSemaphore($"wait handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} timeout={(timeoutAddress == 0 ? "infinite" : timeoutUsec)}");
+                }
                 return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
             }
 
@@ -158,7 +164,10 @@ public static class KernelSemaphoreCompatExports
 
             if (acquired)
             {
-                TraceSemaphore($"wait-wake handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                if (_traceSema)
+                {
+                    TraceSemaphore($"wait-wake handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                }
                 return (int)OrbisGen2Result.ORBIS_GEN2_OK;
             }
 
@@ -167,7 +176,10 @@ public static class KernelSemaphoreCompatExports
                 semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
             }
 
-            TraceSemaphore($"wait-timeout handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+            if (_traceSema)
+            {
+                TraceSemaphore($"wait-timeout handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+            }
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT;
         }
 
@@ -179,7 +191,10 @@ public static class KernelSemaphoreCompatExports
                 WakePredicate,
                 deadline))
         {
-            TraceSemaphore($"wait-block handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} timeout={(timeoutAddress == 0 ? "infinite" : timeoutUsec)} waiters={semaphore.WaitingThreads} {FormatCallSite(ctx)}");
+            if (_traceSema)
+            {
+                TraceSemaphore($"wait-block handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} timeout={(timeoutAddress == 0 ? "infinite" : timeoutUsec)} waiters={semaphore.WaitingThreads} {FormatCallSite(ctx)}");
+            }
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
         }
 
@@ -201,9 +216,12 @@ public static class KernelSemaphoreCompatExports
             : long.MaxValue;
         lock (semaphore.Gate)
         {
-            TraceSemaphore(
-                $"wait-host-block handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} " +
-                $"count={semaphore.Count} timeout={(timeoutAddress == 0 ? "infinite" : timeoutUsec)} {FormatCallSite(ctx)}");
+            if (_traceSema)
+            {
+                TraceSemaphore(
+                    $"wait-host-block handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} " +
+                    $"count={semaphore.Count} timeout={(timeoutAddress == 0 ? "infinite" : timeoutUsec)} {FormatCallSite(ctx)}");
+            }
             while (semaphore.Count < needCount)
             {
                 var remaining = deadlineMs - Environment.TickCount64;
@@ -219,8 +237,11 @@ public static class KernelSemaphoreCompatExports
 
             semaphore.Count -= needCount;
             semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
-            TraceSemaphore(
-                $"wait-host-wake handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} {FormatCallSite(ctx)}");
+            if (_traceSema)
+            {
+                TraceSemaphore(
+                    $"wait-host-wake handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} {FormatCallSite(ctx)}");
+            }
             if (timeoutAddress != 0)
             {
                 _ = TryWriteUInt32(ctx, timeoutAddress, 0);
@@ -253,12 +274,18 @@ public static class KernelSemaphoreCompatExports
         {
             if (semaphore.Count < needCount)
             {
-                TraceSemaphore($"poll-busy handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                if (_traceSema)
+                {
+                    TraceSemaphore($"poll-busy handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+                }
                 return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY);
             }
 
             semaphore.Count -= needCount;
-            TraceSemaphore($"poll handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+            if (_traceSema)
+            {
+                TraceSemaphore($"poll handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count}");
+            }
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
         }
     }
@@ -290,7 +317,10 @@ public static class KernelSemaphoreCompatExports
             semaphore.Count += signalCount;
             // Wake host-thread waiters parked in the fallback path.
             Monitor.PulseAll(semaphore.Gate);
-            TraceSemaphore($"signal handle=0x{handle:X8} name='{semaphore.Name}' signal={signalCount} count={semaphore.Count} waiters={semaphore.WaitingThreads} {FormatCallSite(ctx)}");
+            if (_traceSema)
+            {
+                TraceSemaphore($"signal handle=0x{handle:X8} name='{semaphore.Name}' signal={signalCount} count={semaphore.Count} waiters={semaphore.WaitingThreads} {FormatCallSite(ctx)}");
+            }
         }
 
         // Wake cooperatively-blocked guest threads; their wake predicate
@@ -326,7 +356,10 @@ public static class KernelSemaphoreCompatExports
             semaphore.Count = setCount < 0 ? semaphore.InitialCount : setCount;
             semaphore.WaitingThreads = 0;
             Monitor.PulseAll(semaphore.Gate);
-            TraceSemaphore($"cancel handle=0x{handle:X8} name='{semaphore.Name}' set={setCount} count={semaphore.Count}");
+            if (_traceSema)
+            {
+                TraceSemaphore($"cancel handle=0x{handle:X8} name='{semaphore.Name}' set={setCount} count={semaphore.Count}");
+            }
         }
 
         _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
@@ -346,7 +379,10 @@ public static class KernelSemaphoreCompatExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND);
         }
 
-        TraceSemaphore($"delete handle=0x{handle:X8} name='{semaphore.Name}'");
+        if (_traceSema)
+        {
+            TraceSemaphore($"delete handle=0x{handle:X8} name='{semaphore.Name}'");
+        }
         return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
@@ -385,7 +421,10 @@ public static class KernelSemaphoreCompatExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
-        TraceSemaphore($"posix-init address=0x{semaphoreAddress:X16} handle=0x{handle:X8} count={initialCount}");
+        if (_traceSema)
+        {
+            TraceSemaphore($"posix-init address=0x{semaphoreAddress:X16} handle=0x{handle:X8} count={initialCount}");
+        }
         return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
@@ -582,6 +621,11 @@ public static class KernelSemaphoreCompatExports
 
     private static void TraceSemaphore(string message)
     {
+        if (!_traceSema)
+        {
+            return;
+        }
+
         Console.Error.WriteLine($"[LOADER][TRACE] sema.{message}");
     }
 

--- a/src/SharpEmu.Libs/VideoOut/HeadPreservingQueueRetention.cs
+++ b/src/SharpEmu.Libs/VideoOut/HeadPreservingQueueRetention.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Libs.VideoOut;
+
+internal static class HeadPreservingQueueRetention
+{
+    /// <summary>
+    /// Bounds a FIFO while preserving its oldest item and the newest tail.
+    /// Intermediate items are removed oldest-first so an unconsumed head
+    /// cannot be starved by a producer that continuously outruns its consumer.
+    /// </summary>
+    public static int CoalesceIntermediateItems<T>(
+        LinkedList<T> pending,
+        int maximumCount,
+        Action<T>? onCoalesced = null)
+    {
+        ArgumentNullException.ThrowIfNull(pending);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maximumCount, 1);
+
+        var coalescedCount = 0;
+        while (pending.Count > maximumCount)
+        {
+            var oldestIntermediate = pending.First!.Next;
+            System.Diagnostics.Debug.Assert(oldestIntermediate is not null);
+            var coalescedItem = oldestIntermediate!.Value;
+            pending.Remove(oldestIntermediate!);
+            onCoalesced?.Invoke(coalescedItem);
+            coalescedCount++;
+        }
+
+        return coalescedCount;
+    }
+}
+
+internal static class GuestPresentationScheduling
+{
+    /// <summary>
+    /// An ordered flip has captured an immutable guest-image generation and
+    /// enqueued its presentation. Yielding the guest-work drain at this point
+    /// gives that FIFO head a presentation opportunity before newer flips can
+    /// coalesce intermediate generations behind it.
+    /// </summary>
+    public static bool ShouldYieldToPresenter(object completedWork)
+    {
+        ArgumentNullException.ThrowIfNull(completedWork);
+        return completedWork is VulkanOrderedGuestFlip;
+    }
+}

--- a/src/SharpEmu.Libs/VideoOut/VulkanHostBufferPool.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanHostBufferPool.cs
@@ -18,10 +18,16 @@ internal readonly record struct VulkanHostBufferAllocation(
 
 internal sealed class VulkanHostBufferPool : IDisposable
 {
-    private readonly Dictionary<VulkanHostBufferPoolKey, Stack<VulkanHostBufferAllocation>>
+    private sealed record CachedAllocation(
+        VulkanHostBufferAllocation Allocation,
+        LinkedListNode<VulkanHostBufferAllocation> BucketNode,
+        LinkedListNode<ulong> RecencyNode);
+
+    private readonly Dictionary<VulkanHostBufferPoolKey, LinkedList<VulkanHostBufferAllocation>>
         _available = [];
     private readonly Dictionary<ulong, VulkanHostBufferAllocation> _allocations = [];
-    private readonly HashSet<ulong> _cachedHandles = [];
+    private readonly Dictionary<ulong, CachedAllocation> _cached = [];
+    private readonly LinkedList<ulong> _recency = [];
     private readonly Action<VulkanHostBufferAllocation> _destroy;
 
     public VulkanHostBufferPool(
@@ -41,13 +47,22 @@ internal sealed class VulkanHostBufferPool : IDisposable
         out VulkanHostBufferAllocation allocation)
     {
         if (!_available.TryGetValue(key, out var available) ||
-            !available.TryPop(out allocation))
+            available.Last is not { } availableNode)
         {
             allocation = default;
             return false;
         }
 
-        _cachedHandles.Remove(allocation.Buffer.Handle);
+        allocation = availableNode.Value;
+        var cached = _cached[allocation.Buffer.Handle];
+        available.Remove(availableNode);
+        if (available.Count == 0)
+        {
+            _available.Remove(key);
+        }
+
+        _recency.Remove(cached.RecencyNode);
+        _cached.Remove(allocation.Buffer.Handle);
         CachedBytes -= allocation.Key.Capacity;
         return true;
     }
@@ -70,17 +85,21 @@ internal sealed class VulkanHostBufferPool : IDisposable
             return false;
         }
 
-        if (!_cachedHandles.Add(buffer.Handle))
+        if (_cached.ContainsKey(buffer.Handle))
         {
             return true;
         }
 
-        if (allocation.Key.Capacity > MaximumCachedBytes - CachedBytes)
+        if (allocation.Key.Capacity > MaximumCachedBytes)
         {
-            _cachedHandles.Remove(buffer.Handle);
             _allocations.Remove(buffer.Handle);
             _destroy(allocation);
             return true;
+        }
+
+        while (CachedBytes > MaximumCachedBytes - allocation.Key.Capacity)
+        {
+            EvictLeastRecentlyUsed();
         }
 
         if (!_available.TryGetValue(allocation.Key, out var available))
@@ -89,9 +108,35 @@ internal sealed class VulkanHostBufferPool : IDisposable
             _available.Add(allocation.Key, available);
         }
 
-        available.Push(allocation);
+        var bucketNode = available.AddLast(allocation);
+        var recencyNode = _recency.AddLast(buffer.Handle);
+        _cached.Add(
+            buffer.Handle,
+            new CachedAllocation(allocation, bucketNode, recencyNode));
         CachedBytes += allocation.Key.Capacity;
         return true;
+    }
+
+    private void EvictLeastRecentlyUsed()
+    {
+        var recencyNode = _recency.First ??
+            throw new InvalidOperationException("Host-buffer cache accounting is inconsistent.");
+        var handle = recencyNode.Value;
+        var cached = _cached[handle];
+        var allocation = cached.Allocation;
+
+        _recency.Remove(recencyNode);
+        _cached.Remove(handle);
+        var available = _available[allocation.Key];
+        available.Remove(cached.BucketNode);
+        if (available.Count == 0)
+        {
+            _available.Remove(allocation.Key);
+        }
+
+        CachedBytes -= allocation.Key.Capacity;
+        _allocations.Remove(handle);
+        _destroy(allocation);
     }
 
     public void Dispose()
@@ -103,7 +148,8 @@ internal sealed class VulkanHostBufferPool : IDisposable
 
         _allocations.Clear();
         _available.Clear();
-        _cachedHandles.Clear();
+        _cached.Clear();
+        _recency.Clear();
         CachedBytes = 0;
     }
 }

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -107,6 +107,29 @@ internal static unsafe class VulkanVideoPresenter
     // thread's physical-device query) gives shader translation and descriptor
     // creation one stable aliasing contract on every conformant device.
     internal const ulong GuestStorageBufferOffsetAlignment = 256;
+    internal const PipelineStageFlags SampledImageShaderReadStages =
+        PipelineStageFlags.VertexShaderBit |
+        PipelineStageFlags.FragmentShaderBit |
+        PipelineStageFlags.ComputeShaderBit;
+
+    internal static PipelineStageFlags SampledImageOverwriteSourceStages(bool initialized) =>
+        initialized
+            ? SampledImageShaderReadStages
+            : PipelineStageFlags.TopOfPipeBit;
+
+    private static uint _supportedSubgroupStages;
+    private static int _supportsFragmentShaderBarycentric;
+    internal static bool SupportsVertexSubgroupOperations =>
+        (System.Threading.Volatile.Read(ref _supportedSubgroupStages) &
+         (uint)ShaderStageFlags.VertexBit) != 0;
+    internal static bool SupportsFragmentSubgroupOperations =>
+        (System.Threading.Volatile.Read(ref _supportedSubgroupStages) &
+         (uint)ShaderStageFlags.FragmentBit) != 0;
+    internal static bool SupportsComputeSubgroupOperations =>
+        (System.Threading.Volatile.Read(ref _supportedSubgroupStages) &
+         (uint)ShaderStageFlags.ComputeBit) != 0;
+    internal static bool SupportsFragmentShaderBarycentric =>
+        System.Threading.Volatile.Read(ref _supportsFragmentShaderBarycentric) != 0;
     // Guest draw snapshots churn through a small set of 128 KiB-16 MiB size
     // classes thousands of times per second. The process-wide shared pool
     // trims and repartitions those large arrays aggressively under GC load,
@@ -126,8 +149,9 @@ internal static unsafe class VulkanVideoPresenter
     private const int MaxPendingGuestWork = 64;
     private const ulong MaximumCachedHostBufferBytes = 128UL * 1024 * 1024;
     // A captured 4K flip can consume tens of MiB of device-local memory.
-    // Retain only a short presentation queue while always preserving the
-    // newest generation; older immutable versions are retired immediately.
+    // Retain only a short presentation queue while preserving both the oldest
+    // unpresented generation and the newest tail. Intermediate immutable
+    // versions are coalesced and retired immediately.
     private const int MaxPendingGuestFlipVersions = 4;
     // A count-only queue bound is not a memory bound: one compute dispatch can
     // carry dozens of full-resolution texture snapshots.  At 4K, 64 queued
@@ -229,7 +253,7 @@ internal static unsafe class VulkanVideoPresenter
     // with the next frame: the guest can enqueue the next frame before the
     // render thread reaches the previous image, which otherwise starves
     // presentation indefinitely.
-    private static readonly Queue<Presentation> _pendingGuestImagePresentations = new();
+    private static readonly LinkedList<Presentation> _pendingGuestImagePresentations = new();
     private static readonly Dictionary<ulong, long> _guestImageWorkSequences = new();
     private static readonly Dictionary<ulong, uint> _availableGuestImages = new();
     private static readonly Dictionary<(int Handle, int BufferIndex), long>
@@ -260,6 +284,15 @@ internal static unsafe class VulkanVideoPresenter
             Environment.GetEnvironmentVariable("SHARPEMU_TRACE_GUEST_WORK_COMPLETION"),
             "1",
             StringComparison.Ordinal);
+    private static readonly int _maxGuestFlipQueueTraceEventsPerKind =
+        int.TryParse(
+            Environment.GetEnvironmentVariable("SHARPEMU_TRACE_GUEST_FLIP_QUEUE_LIMIT"),
+            out var guestFlipQueueTraceLimit) && guestFlipQueueTraceLimit > 0
+                ? Math.Min(guestFlipQueueTraceLimit, 4096)
+                : 16;
+    private static long _guestFlipEnqueuedTraceCount;
+    private static long _guestFlipPresentedTraceCount;
+    private static long _guestFlipCoalescedTraceCount;
     private static readonly HashSet<(ulong Address, uint Width, uint Height)>
         _tracedGuestImageSubmissions = [];
     private static Thread? _thread;
@@ -673,7 +706,15 @@ internal static unsafe class VulkanVideoPresenter
         if (RenderTargetsMismatchedOrAliased(targets, firstTarget))
         {
             Console.Error.WriteLine(
-                "[LOADER][WARN] Vulkan skipped MRT draw with mismatched dimensions or aliased targets.");
+                "[LOADER][WARN] Vulkan skipped MRT draw with mismatched dimensions or aliased targets " +
+                $"shader=0x{shaderAddress:X16} targets=[" +
+                string.Join(
+                    ',',
+                    targets.Select((target, index) =>
+                        $"{index}:0x{target.Address:X16}:" +
+                        $"{target.Width}x{target.Height}:" +
+                        $"f{target.Format}/n{target.NumberType}")) +
+                "].");
             return;
         }
 
@@ -1143,11 +1184,10 @@ internal static unsafe class VulkanVideoPresenter
                 IsSplash: false,
                 GuestImageAddress: address);
             _latestPresentation = presentation;
-            _pendingGuestImagePresentations.Enqueue(presentation);
-            while (_pendingGuestImagePresentations.Count > MaxPendingGuestWork)
-            {
-                _pendingGuestImagePresentations.Dequeue();
-            }
+            _pendingGuestImagePresentations.AddLast(presentation);
+            HeadPreservingQueueRetention.CoalesceIntermediateItems(
+                _pendingGuestImagePresentations,
+                MaxPendingGuestWork);
         }
 
         if (traceSubmission)
@@ -1463,6 +1503,13 @@ internal static unsafe class VulkanVideoPresenter
     internal static bool TryDecodeRenderTargetFormat(
         uint dataFormat,
         uint numberType,
+        out VulkanRenderTargetFormat result) =>
+        TryDecodeRenderTargetFormat(dataFormat, numberType, componentSwap: 0, out result);
+
+    internal static bool TryDecodeRenderTargetFormat(
+        uint dataFormat,
+        uint numberType,
+        uint componentSwap,
         out VulkanRenderTargetFormat result)
     {
         var format = (dataFormat, numberType) switch
@@ -1474,7 +1521,13 @@ internal static unsafe class VulkanVideoPresenter
             (5, 5) => Format.R16G16Sint,
             (5, 7) => Format.R16G16Sfloat,
             (6, 7) or (7, 7) => Format.B10G11R11UfloatPack32,
-            (9, _) => Format.A2R10G10B10UnormPack32,
+            // CB_COLOR_INFO.COMP_SWAP is independent from FORMAT. For
+            // COLOR_2_10_10_10, STD exposes the low 10-bit component as R
+            // (A2B10G10R10 in Vulkan); ALT reverses R/B. Void Terrarium uses
+            // STD (CB_COLOR_INFO=0x00008024).
+            (9, _) when componentSwap == 0 => Format.A2B10G10R10UnormPack32,
+            (9, _) when componentSwap == 1 => Format.A2R10G10B10UnormPack32,
+            (9, _) => Format.Undefined,
             (10, 4) => Format.R8G8B8A8Uint,
             (10, 5) => Format.R8G8B8A8Sint,
             (10, 9) => Format.R8G8B8A8Srgb,
@@ -1719,8 +1772,20 @@ internal static unsafe class VulkanVideoPresenter
 
         try
         {
+            Console.Error.WriteLine(
+                $"[LOADER][INFO] Vulkan presenter phase: construct-begin " +
+                $"thread={Environment.CurrentManagedThreadId} size={width}x{height}");
             using var presenter = new Presenter(width, height);
+            Console.Error.WriteLine(
+                $"[LOADER][INFO] Vulkan presenter phase: construct-complete " +
+                $"thread={Environment.CurrentManagedThreadId}");
+            Console.Error.WriteLine(
+                $"[LOADER][INFO] Vulkan presenter phase: run-begin " +
+                $"thread={Environment.CurrentManagedThreadId}");
             presenter.Run();
+            Console.Error.WriteLine(
+                $"[LOADER][INFO] Vulkan presenter phase: run-complete " +
+                $"thread={Environment.CurrentManagedThreadId}");
         }
         catch (Exception exception)
         {
@@ -1746,17 +1811,18 @@ internal static unsafe class VulkanVideoPresenter
             // while it drains expensive work, so use the first completed flip
             // rather than repeatedly asking only for the newest one.
             while (_pendingGuestImagePresentations.Count > 0 &&
-                   _pendingGuestImagePresentations.Peek().Sequence <= presentedSequence)
+                   _pendingGuestImagePresentations.First!.Value.Sequence <= presentedSequence)
             {
-                _pendingGuestImagePresentations.Dequeue();
+                _pendingGuestImagePresentations.RemoveFirst();
             }
 
             if (_pendingGuestImagePresentations.Count > 0)
             {
-                var pending = _pendingGuestImagePresentations.Peek();
+                var pending = _pendingGuestImagePresentations.First!.Value;
                 if (IsGuestWorkCompletedLocked(pending.RequiredGuestWorkSequence))
                 {
-                    presentation = _pendingGuestImagePresentations.Dequeue();
+                    presentation = pending;
+                    _pendingGuestImagePresentations.RemoveFirst();
                     TryReplaceWithBinkFrame(ref presentation);
                     return true;
                 }
@@ -2231,6 +2297,43 @@ internal static unsafe class VulkanVideoPresenter
         ulong GuestImageAddress = 0,
         long GuestImageVersion = 0);
 
+    private static void TraceGuestFlipQueueEvent(
+        string eventName,
+        ref long eventCount,
+        in Presentation presentation,
+        int pendingCount = -1,
+        int coalescedCount = 0)
+    {
+        if (!_traceGuestImageEvents || presentation.GuestImageVersion == 0)
+        {
+            return;
+        }
+
+        var ordinal = Interlocked.Increment(ref eventCount);
+        if (ordinal > _maxGuestFlipQueueTraceEventsPerKind + 1)
+        {
+            return;
+        }
+
+        if (ordinal == _maxGuestFlipQueueTraceEventsPerKind + 1)
+        {
+            Console.Error.WriteLine(
+                $"[LOADER][TRACE] vk.flip_queue_{eventName} further events suppressed");
+            return;
+        }
+
+        var pendingDetail = pendingCount >= 0 ? $" pending={pendingCount}" : string.Empty;
+        var coalescedDetail = coalescedCount > 0
+            ? $" coalesced={coalescedCount}"
+            : string.Empty;
+        Console.Error.WriteLine(
+            $"[LOADER][TRACE] vk.flip_queue_{eventName} ordinal={ordinal} " +
+            $"version={presentation.GuestImageVersion} sequence={presentation.Sequence} " +
+            $"required_work={presentation.RequiredGuestWorkSequence} " +
+            $"addr=0x{presentation.GuestImageAddress:X16}" +
+            pendingDetail + coalescedDetail);
+    }
+
     private sealed class Presenter : IDisposable
     {
         private const string FullscreenBarycentricVertexSpirv =
@@ -2632,7 +2735,13 @@ internal static unsafe class VulkanVideoPresenter
             options.VSync = true;
             options.FramesPerSecond = 60;
             options.UpdatesPerSecond = 60;
+            Console.Error.WriteLine(
+                $"[LOADER][INFO] Vulkan presenter phase: window-create-begin " +
+                $"thread={Environment.CurrentManagedThreadId}");
             _window = Window.Create(options);
+            Console.Error.WriteLine(
+                $"[LOADER][INFO] Vulkan presenter phase: window-create-complete " +
+                $"thread={Environment.CurrentManagedThreadId}");
             _window.Load += Initialize;
             _window.Render += Render;
             _window.Closing += () =>
@@ -2665,6 +2774,9 @@ internal static unsafe class VulkanVideoPresenter
 
         private void Initialize()
         {
+            Console.Error.WriteLine(
+                $"[LOADER][INFO] Vulkan presenter phase: initialize-entry " +
+                $"thread={Environment.CurrentManagedThreadId}");
             LogGlfwPlatformInUse();
             if (!OperatingSystem.IsWindows())
             {
@@ -3245,6 +3357,9 @@ internal static unsafe class VulkanVideoPresenter
                 PNext = &subgroup,
             };
             _vk.GetPhysicalDeviceProperties2(_physicalDevice, &properties2);
+            System.Threading.Volatile.Write(
+                ref _supportedSubgroupStages,
+                (uint)subgroup.SupportedStages);
             _maxComputeWorkGroupCountX = properties.Limits.MaxComputeWorkGroupCount[0];
             _maxComputeWorkGroupCountY = properties.Limits.MaxComputeWorkGroupCount[1];
             _maxComputeWorkGroupCountZ = properties.Limits.MaxComputeWorkGroupCount[2];
@@ -3282,6 +3397,8 @@ internal static unsafe class VulkanVideoPresenter
 
         private void CreateDevice()
         {
+            const string fragmentShaderBarycentricExtensionName =
+                "VK_KHR_fragment_shader_barycentric";
             var priority = 1.0f;
             var queueInfo = new DeviceQueueCreateInfo
             {
@@ -3345,6 +3462,16 @@ internal static unsafe class VulkanVideoPresenter
             {
                 SType = StructureType.PhysicalDeviceMaintenance8FeaturesKhr,
             };
+            var fragmentShaderBarycentricAvailable =
+                IsDeviceExtensionAvailable(fragmentShaderBarycentricExtensionName);
+            var fragmentShaderBarycentricFeatures =
+                new PhysicalDeviceFragmentShaderBarycentricFeaturesKHR
+                {
+                    SType = StructureType.PhysicalDeviceFragmentShaderBarycentricFeaturesKhr,
+                };
+            maintenance8Features.PNext = fragmentShaderBarycentricAvailable
+                ? &fragmentShaderBarycentricFeatures
+                : null;
             var robustness2Features = new PhysicalDeviceRobustness2FeaturesEXT
             {
                 SType = StructureType.PhysicalDeviceRobustness2FeaturesExt,
@@ -3361,6 +3488,12 @@ internal static unsafe class VulkanVideoPresenter
             var supportsRobustImageAccess2 = robustness2Features.RobustImageAccess2;
             var supportsNullDescriptor = robustness2Features.NullDescriptor;
             var supportsRobustness2 = supportsRobustImageAccess2 || supportsNullDescriptor;
+            var supportsFragmentShaderBarycentric =
+                fragmentShaderBarycentricAvailable &&
+                fragmentShaderBarycentricFeatures.FragmentShaderBarycentric;
+            System.Threading.Volatile.Write(
+                ref _supportsFragmentShaderBarycentric,
+                supportsFragmentShaderBarycentric ? 1 : 0);
             if (!supportsMaintenance8)
             {
                 Console.Error.WriteLine(
@@ -3375,13 +3508,23 @@ internal static unsafe class VulkanVideoPresenter
                     "translated shaders performing out-of-bounds image access may cause device loss.");
             }
 
+            if (!supportsFragmentShaderBarycentric)
+            {
+                Console.Error.WriteLine(
+                    "[LOADER][WARN] GPU does not support " +
+                    "VK_KHR_fragment_shader_barycentric; translated pixel shaders " +
+                    "using V_INTERP_MOV_F32 will fail.");
+            }
+
             var swapchainExtension = (byte*)SilkMarshal.StringToPtr("VK_KHR_swapchain");
             var maintenance8Extension = (byte*)SilkMarshal.StringToPtr("VK_KHR_maintenance8");
             var robustness2Extension = (byte*)SilkMarshal.StringToPtr("VK_EXT_robustness2");
+            var fragmentShaderBarycentricExtension =
+                (byte*)SilkMarshal.StringToPtr(fragmentShaderBarycentricExtensionName);
             var portabilitySubsetExtension = (byte*)SilkMarshal.StringToPtr(PortabilitySubsetExtensionName);
             try
             {
-                var extensions = stackalloc byte*[4];
+                var extensions = stackalloc byte*[5];
                 var extensionCount = 0u;
                 extensions[extensionCount++] = swapchainExtension;
                 if (supportsMaintenance8)
@@ -3394,6 +3537,11 @@ internal static unsafe class VulkanVideoPresenter
                     extensions[extensionCount++] = robustness2Extension;
                 }
 
+                if (supportsFragmentShaderBarycentric)
+                {
+                    extensions[extensionCount++] = fragmentShaderBarycentricExtension;
+                }
+
                 if (IsDeviceExtensionAvailable(PortabilitySubsetExtensionName))
                 {
                     // The spec requires enabling this when the (MoltenVK)
@@ -3402,18 +3550,31 @@ internal static unsafe class VulkanVideoPresenter
                 }
 
                 maintenance8Features.Maintenance8 = supportsMaintenance8;
-                maintenance8Features.PNext = null;
+                fragmentShaderBarycentricFeatures.FragmentShaderBarycentric =
+                    supportsFragmentShaderBarycentric;
+                fragmentShaderBarycentricFeatures.PNext = null;
+                maintenance8Features.PNext = supportsFragmentShaderBarycentric
+                    ? &fragmentShaderBarycentricFeatures
+                    : null;
                 robustness2Features.RobustBufferAccess2 =
                     supportsRobustBufferAccess2 && supportedFeatures.RobustBufferAccess;
                 robustness2Features.RobustImageAccess2 = supportsRobustImageAccess2;
                 robustness2Features.NullDescriptor = supportsNullDescriptor;
-                robustness2Features.PNext = supportsMaintenance8 ? &maintenance8Features : null;
+                robustness2Features.PNext = supportsMaintenance8
+                    ? &maintenance8Features
+                    : (supportsFragmentShaderBarycentric
+                        ? &fragmentShaderBarycentricFeatures
+                        : null);
                 var features2 = new PhysicalDeviceFeatures2
                 {
                     SType = StructureType.PhysicalDeviceFeatures2,
                     PNext = supportsRobustness2
                         ? &robustness2Features
-                        : (supportsMaintenance8 ? &maintenance8Features : null),
+                        : (supportsMaintenance8
+                            ? &maintenance8Features
+                            : (supportsFragmentShaderBarycentric
+                                ? &fragmentShaderBarycentricFeatures
+                                : null)),
                     Features = enabledFeatures,
                 };
                 var createInfo = new DeviceCreateInfo
@@ -3433,6 +3594,7 @@ internal static unsafe class VulkanVideoPresenter
                 SilkMarshal.Free((nint)swapchainExtension);
                 SilkMarshal.Free((nint)maintenance8Extension);
                 SilkMarshal.Free((nint)robustness2Extension);
+                SilkMarshal.Free((nint)fragmentShaderBarycentricExtension);
                 SilkMarshal.Free((nint)portabilitySubsetExtension);
             }
 
@@ -4623,10 +4785,26 @@ internal static unsafe class VulkanVideoPresenter
                         GuestImageAddress: work.Address,
                         GuestImageVersion: work.Version);
                     _latestPresentation = presentation;
-                    _pendingGuestImagePresentations.Enqueue(presentation);
-                    while (_pendingGuestImagePresentations.Count > MaxPendingGuestFlipVersions)
+                    _pendingGuestImagePresentations.AddLast(presentation);
+                    List<Presentation> coalescedPresentations = [];
+                    var coalescedCount =
+                        HeadPreservingQueueRetention.CoalesceIntermediateItems(
+                            _pendingGuestImagePresentations,
+                            MaxPendingGuestFlipVersions,
+                            coalescedPresentations.Add);
+                    TraceGuestFlipQueueEvent(
+                        "enqueued",
+                        ref _guestFlipEnqueuedTraceCount,
+                        presentation,
+                        _pendingGuestImagePresentations.Count);
+                    foreach (var coalescedPresentation in coalescedPresentations)
                     {
-                        _pendingGuestImagePresentations.Dequeue();
+                        TraceGuestFlipQueueEvent(
+                            "coalesced",
+                            ref _guestFlipCoalescedTraceCount,
+                            coalescedPresentation,
+                            _pendingGuestImagePresentations.Count,
+                            coalescedCount: 1);
                     }
                 }
 
@@ -5385,12 +5563,15 @@ internal static unsafe class VulkanVideoPresenter
 
                 if (draw.IndexBuffer is { Length: > 0 } indexBuffer)
                 {
-                    resources.IndexBuffer = CreateHostBuffer(
-                        indexBuffer.Data.AsSpan(0, indexBuffer.Length),
-                        BufferUsageFlags.IndexBufferBit,
-                        out resources.IndexMemory,
-                        out _);
-                    resources.Index32Bit = indexBuffer.Is32Bit;
+                    if (!forceFullscreenVertex)
+                    {
+                        resources.IndexBuffer = CreateHostBuffer(
+                            indexBuffer.Data.AsSpan(0, indexBuffer.Length),
+                            BufferUsageFlags.IndexBufferBit,
+                            out resources.IndexMemory,
+                            out _);
+                        resources.Index32Bit = indexBuffer.Is32Bit;
+                    }
                     if (indexBuffer.Pooled)
                     {
                         GuestDataPool.Return(indexBuffer.Data);
@@ -7035,6 +7216,11 @@ internal static unsafe class VulkanVideoPresenter
                 _guestImages.Add(texture.Address, guestImage);
                 resource.OwnsStorage = false;
                 resource.GuestImage = guestImage;
+                SharpEmu.HLE.GuestImageWriteTracker.Track(
+                    texture.Address,
+                    expectedSize,
+                    CurrentGuestWorkSequenceForDiagnostics,
+                    "vulkan.sampled-image");
                 lock (_gate)
                 {
                     if (guestFormat != 0)
@@ -8809,7 +8995,9 @@ internal static unsafe class VulkanVideoPresenter
                         SubmitGuestCommandBuffer(
                             commandBuffer,
                             [resources],
-                            GetTraceImages(resources, shaderAddress: work.ShaderAddress));
+                            GetTraceImages(
+                                resources,
+                                shaderAddress: work.ShaderAddress));
                         submitted = true;
                     }
                     else
@@ -9414,7 +9602,11 @@ internal static unsafe class VulkanVideoPresenter
             for (var index = 0; index < targetFormats.Length; index++)
             {
                 var target = work.Targets[index];
-                if (!TryDecodeRenderTargetFormat(target.Format, target.NumberType, out targetFormats[index]) ||
+                if (!TryDecodeRenderTargetFormat(
+                        target.Format,
+                        target.NumberType,
+                        target.ComponentSwap,
+                        out targetFormats[index]) ||
                     !SupportsColorAttachment(targetFormats[index].Format))
                 {
                     Console.Error.WriteLine(
@@ -9846,6 +10038,7 @@ internal static unsafe class VulkanVideoPresenter
                 MarkSampledImagesInitialized(resources);
                 MarkStorageImagesInitialized(resources, traceContents: false);
 
+
                 if (work.PublishTarget)
                 {
                     for (var index = 0; index < targets.Length; index++)
@@ -10036,9 +10229,7 @@ internal static unsafe class VulkanVideoPresenter
             };
             _vk.CmdPipelineBarrier(
                 commandBuffer,
-                target.Initialized
-                    ? PipelineStageFlags.FragmentShaderBit
-                    : PipelineStageFlags.TopOfPipeBit,
+                SampledImageOverwriteSourceStages(target.Initialized),
                 PipelineStageFlags.TransferBit,
                 0,
                 0,
@@ -10077,7 +10268,7 @@ internal static unsafe class VulkanVideoPresenter
             _vk.CmdPipelineBarrier(
                 commandBuffer,
                 PipelineStageFlags.TransferBit,
-                PipelineStageFlags.FragmentShaderBit,
+                SampledImageShaderReadStages,
                 0,
                 0,
                 null,
@@ -10131,9 +10322,7 @@ internal static unsafe class VulkanVideoPresenter
                 };
                 _vk.CmdPipelineBarrier(
                     commandBuffer,
-                    target.Initialized
-                        ? PipelineStageFlags.FragmentShaderBit
-                        : PipelineStageFlags.TopOfPipeBit,
+                    SampledImageOverwriteSourceStages(target.Initialized),
                     PipelineStageFlags.TransferBit,
                     0,
                     0,
@@ -10179,7 +10368,7 @@ internal static unsafe class VulkanVideoPresenter
                 _vk.CmdPipelineBarrier(
                     commandBuffer,
                     PipelineStageFlags.TransferBit,
-                    PipelineStageFlags.FragmentShaderBit,
+                    SampledImageShaderReadStages,
                     0,
                     0,
                     null,
@@ -11376,6 +11565,16 @@ internal static unsafe class VulkanVideoPresenter
 
                 completedWork++;
 
+                // ExecuteOrderedGuestFlip has captured an immutable image,
+                // submitted its Vulkan work, and enqueued the corresponding
+                // FIFO presentation. Give it a presentation opportunity now;
+                // draining newer flips first can fill the bounded queue and
+                // coalesce an animation phase before the window ever sees it.
+                if (GuestPresentationScheduling.ShouldYieldToPresenter(work))
+                {
+                    break;
+                }
+
                 // Return to the main-thread event pump + present once the
                 // per-frame budget is spent; remaining guest work is drained
                 // on subsequent Render() calls. Without this a compute-heavy
@@ -11693,6 +11892,10 @@ internal static unsafe class VulkanVideoPresenter
             CheckSwapchainResult(presentResult, "vkQueuePresentKHR");
             recreateAfterPresent |= presentResult == Result.SuboptimalKhr;
             VideoOutExports.ReportPresentedFrame();
+            TraceGuestFlipQueueEvent(
+                "presented",
+                ref _guestFlipPresentedTraceCount,
+                presentation);
             PerfOverlay.RecordPresent();
             if (_swapchainReadbackPending || !_pendingAliasImageDumps.IsEmpty)
             {
@@ -11870,7 +12073,8 @@ internal static unsafe class VulkanVideoPresenter
                 try
                 {
                     var bytes = new ReadOnlySpan<byte>(mapped, checked((int)byteCount));
-                    if (GuestImageTraceInterval() is not null && bytesPerPixel == 4)
+                    if (GuestImageTraceInterval() is not null &&
+                        bytesPerPixel == 4)
                     {
                         long r = 0, g = 0, b = 0, a = 0, samples = 0;
                         for (var offset = 0; offset + 4 <= bytes.Length; offset += 4 * 251)
@@ -12108,11 +12312,18 @@ internal static unsafe class VulkanVideoPresenter
                     continue;
                 }
 
+                var overwritesInitializedGuestImage =
+                    texture.GuestImage is { Initialized: true };
                 var toTransfer = new ImageMemoryBarrier
                 {
                     SType = StructureType.ImageMemoryBarrier,
+                    SrcAccessMask = overwritesInitializedGuestImage
+                        ? AccessFlags.ShaderReadBit
+                        : 0,
                     DstAccessMask = AccessFlags.TransferWriteBit,
-                    OldLayout = ImageLayout.Undefined,
+                    OldLayout = overwritesInitializedGuestImage
+                        ? ImageLayout.ShaderReadOnlyOptimal
+                        : ImageLayout.Undefined,
                     NewLayout = ImageLayout.TransferDstOptimal,
                     SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
                     DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
@@ -12121,7 +12332,7 @@ internal static unsafe class VulkanVideoPresenter
                 };
                 _vk.CmdPipelineBarrier(
                     _commandBuffer,
-                    PipelineStageFlags.TopOfPipeBit,
+                    SampledImageOverwriteSourceStages(overwritesInitializedGuestImage),
                     PipelineStageFlags.TransferBit,
                     0,
                     0,
@@ -12790,7 +13001,8 @@ internal static unsafe class VulkanVideoPresenter
                 return false;
             }
 
-            var addressMatched = ShouldTraceGuestImageAddressForDiagnostics(image.Address);
+            var addressMatched =
+                ShouldTraceGuestImageAddressForDiagnostics(image.Address);
             if (addressMatched && _traceGuestImageOccurrence > 0)
             {
                 var count = _guestImageTraceCounts.TryGetValue(image.Address, out var previous)
@@ -12813,7 +13025,7 @@ internal static unsafe class VulkanVideoPresenter
                     return false;
                 }
 
-                if (image.Width < 1280 || image.Height < 720)
+                if (!addressMatched && (image.Width < 1280 || image.Height < 720))
                 {
                     return false;
                 }
@@ -13049,6 +13261,7 @@ internal static unsafe class VulkanVideoPresenter
                 "SHARPEMU_TRACE_GUEST_WRITES",
                 address);
         }
+
 
         private static bool AddressListContains(
             string environmentVariable,

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
@@ -107,6 +107,23 @@ public static partial class Gen5SpirvTranslator
                 case "VMovB32":
                     result = GetRawSource(instruction, 0);
                     break;
+                case "VMovrelsB32":
+                {
+                    if (instruction.Sources.Count == 0 ||
+                        instruction.Sources[0].Kind != Gen5OperandKind.VectorRegister)
+                    {
+                        error = "VMovrelsB32 expects a VGPR source";
+                        return false;
+                    }
+
+                    var relativeIndex = BitwiseAnd(
+                        IAdd(
+                            UInt(instruction.Sources[0].Value),
+                            LoadS(124)),
+                        UInt(VectorRegisterCount - 1));
+                    result = Load(_uintType, VectorPointerDynamic(relativeIndex));
+                    break;
+                }
                 case "VWritelaneB32":
                 {
                     // vdst[lane(src1)] = src0
@@ -892,17 +909,29 @@ public static partial class Gen5SpirvTranslator
                     StoreCarryOut(instruction, carry);
                     break;
                 }
-                case "VBfeU32":
-                {
-                    var width = BitwiseAnd(GetRawSource(instruction, 2), UInt(31));
-                    result = _module.AddInstruction(
-                        SpirvOp.BitFieldUExtract,
+            case "VBfeU32":
+            {
+                var width = BitwiseAnd(GetRawSource(instruction, 2), UInt(31));
+                result = _module.AddInstruction(
+                    SpirvOp.BitFieldUExtract,
                         _uintType,
                         GetRawSource(instruction, 0),
                         BitwiseAnd(GetRawSource(instruction, 1), UInt(31)),
-                        width);
-                    break;
-                }
+                    width);
+                break;
+            }
+            case "VBfeI32":
+            {
+                var width = BitwiseAnd(GetRawSource(instruction, 2), UInt(31));
+                var extracted = _module.AddInstruction(
+                    SpirvOp.BitFieldSExtract,
+                    _intType,
+                    Bitcast(_intType, GetRawSource(instruction, 0)),
+                    BitwiseAnd(GetRawSource(instruction, 1), UInt(31)),
+                    width);
+                result = Bitcast(_uintType, extracted);
+                break;
+            }
                 case "VBfiB32":
                 {
                     var mask = GetRawSource(instruction, 0);
@@ -927,9 +956,6 @@ public static partial class Gen5SpirvTranslator
                         first,
                         second);
                     result = Ext(58, _uintType, vector);
-                    StorePackedHalf(
-                        destination,
-                        vector);
                     break;
                 }
                 case "VCvtPknormI16F32":
@@ -1290,6 +1316,37 @@ public static partial class Gen5SpirvTranslator
             if (instruction.Opcode.EndsWith("B64", StringComparison.Ordinal) ||
                 instruction.Opcode is "SWqmB64" or "SBfeU64" or "SBfeI64")
             {
+                if (instruction.Opcode == "SFF1I32B64")
+                {
+                    var source = GetRawSource64(instruction, 0);
+                    var low = _module.AddInstruction(
+                        SpirvOp.UConvert,
+                        _uintType,
+                        source);
+                    var high = _module.AddInstruction(
+                        SpirvOp.UConvert,
+                        _uintType,
+                        ShiftRightLogical64(
+                            source,
+                            _module.Constant64(_ulongType, 32)));
+                    var lowIndex = Ext(73, _uintType, low);
+                    var highIndex = IAdd(UInt(32), Ext(73, _uintType, high));
+                    var index = _module.AddInstruction(
+                        SpirvOp.Select,
+                        _uintType,
+                        IsNotZero(low),
+                        lowIndex,
+                        _module.AddInstruction(
+                            SpirvOp.Select,
+                            _uintType,
+                            IsNotZero(high),
+                            highIndex,
+                            UInt(uint.MaxValue)));
+                    StoreS(destination, index);
+                    Store(_scc, IsNotZero(index));
+                    return true;
+                }
+
                 return TryEmitScalar64(instruction, destination, out error);
             }
 
@@ -1350,6 +1407,25 @@ public static partial class Gen5SpirvTranslator
                 case "SMovB32":
                     result = left;
                     break;
+                case "SWqmB32":
+                {
+                    var quadAny = BitwiseOr(
+                        left,
+                        BitwiseOr(
+                            ShiftRightLogical(left, UInt(1)),
+                            BitwiseOr(
+                                ShiftRightLogical(left, UInt(2)),
+                                ShiftRightLogical(left, UInt(3)))));
+                    quadAny = BitwiseAnd(quadAny, UInt(0x1111_1111));
+                    result = _module.AddInstruction(
+                        SpirvOp.IMul,
+                        _uintType,
+                        quadAny,
+                        UInt(0xF));
+                    StoreS(destination, result);
+                    Store(_scc, IsNotZero(result));
+                    return true;
+                }
                 case "SNotB32":
                     result = _module.AddInstruction(SpirvOp.Not, _uintType, left);
                     StoreS(destination, result);
@@ -1740,6 +1816,22 @@ public static partial class Gen5SpirvTranslator
             {
                 error = "missing scalar compare source";
                 return false;
+            }
+
+            if (instruction.Opcode is "SCmpEqU64" or "SCmpLgU64")
+            {
+                var left64 = GetRawSource64(instruction, 0);
+                var right64 = GetRawSource64(instruction, 1);
+                Store(
+                    _scc,
+                    _module.AddInstruction(
+                        instruction.Opcode == "SCmpEqU64"
+                            ? SpirvOp.IEqual
+                            : SpirvOp.INotEqual,
+                        _boolType,
+                        left64,
+                        right64));
+                return true;
             }
 
             var left = GetRawSource(instruction, 0);
@@ -3248,6 +3340,18 @@ public static partial class Gen5SpirvTranslator
                 3 => _module.AddInstruction(SpirvOp.FMul, _floatType, value, Float(0.5f)),
                 _ => value,
             };
+            // MODE.DX10_CLAMP is initialized from SPI_SHADER_PGM_RSRC1_*.
+            // RDNA clamps NaN ALU results to zero when this mode is enabled.
+            if (_dx10Clamp)
+            {
+                value = _module.AddInstruction(
+                    SpirvOp.Select,
+                    _floatType,
+                    _module.AddInstruction(SpirvOp.IsNan, _boolType, value),
+                    Float(0),
+                    value);
+            }
+
             if (clamp)
             {
                 value = Ext(43, _floatType, value, Float(0), Float(1));

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -31,7 +31,10 @@ public static partial class Gen5SpirvTranslator
         int pixelRenderTargetSlot = 0,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
-        ulong storageBufferOffsetAlignment = 1) =>
+        ulong storageBufferOffsetAlignment = 1,
+        bool nativeSubgroupOperations = true,
+        bool fragmentShaderBarycentric = true,
+        IReadOnlyList<uint>? pixelInputControls = null) =>
         TryCompilePixelShader(
             state,
             evaluation,
@@ -44,7 +47,10 @@ public static partial class Gen5SpirvTranslator
             initialScalarBufferIndex,
             pixelInputEnable,
             pixelInputAddress,
-            storageBufferOffsetAlignment);
+            storageBufferOffsetAlignment,
+            nativeSubgroupOperations,
+            fragmentShaderBarycentric,
+            pixelInputControls);
 
     public static bool TryCompilePixelShader(
         Gen5ShaderState state,
@@ -58,7 +64,10 @@ public static partial class Gen5SpirvTranslator
         int initialScalarBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
-        ulong storageBufferOffsetAlignment = 1)
+        ulong storageBufferOffsetAlignment = 1,
+        bool nativeSubgroupOperations = true,
+        bool fragmentShaderBarycentric = true,
+        IReadOnlyList<uint>? pixelInputControls = null)
     {
         if (outputs.Count > 8 || outputs.Any(output => output.GuestSlot > 7))
         {
@@ -67,17 +76,42 @@ public static partial class Gen5SpirvTranslator
             return false;
         }
 
-        if (outputs.Select(output => output.GuestSlot).Distinct().Count() != outputs.Count ||
-            outputs.Select(output => output.HostLocation).Distinct().Count() != outputs.Count)
+        if (outputs.Select(output => output.GuestSlot).Distinct().Count() != outputs.Count)
         {
             shader = default!;
-            error = "pixel output guest slots and host locations must be unique";
+            error = "pixel output guest slots must be unique";
             return false;
         }
 
+        foreach (var hostOutputs in outputs.GroupBy(output => output.HostLocation))
+        {
+            if (hostOutputs.Select(output => output.Kind).Distinct().Count() != 1)
+            {
+                shader = default!;
+                error = "pixel outputs sharing a host location must use the same kind";
+                return false;
+            }
+
+            var combinedMask = 0u;
+            foreach (var output in hostOutputs)
+            {
+                var writeMask = output.WriteMask & 0xFu;
+                if ((combinedMask & writeMask) != 0)
+                {
+                    shader = default!;
+                    error = "pixel outputs sharing a host location must have disjoint write masks";
+                    return false;
+                }
+
+                combinedMask |= writeMask;
+            }
+        }
+
         if (!outputs
-                .OrderBy(output => output.HostLocation)
-                .Select((output, index) => output.HostLocation == (uint)index)
+                .Select(output => output.HostLocation)
+                .Distinct()
+                .Order()
+                .Select((location, index) => location == (uint)index)
                 .All(isDense => isDense))
         {
             shader = default!;
@@ -99,7 +133,10 @@ public static partial class Gen5SpirvTranslator
             initialScalarBufferIndex,
             pixelInputEnable: pixelInputEnable,
             pixelInputAddress: pixelInputAddress,
-            storageBufferOffsetAlignment: storageBufferOffsetAlignment);
+            storageBufferOffsetAlignment: storageBufferOffsetAlignment,
+            nativeSubgroupOperations: nativeSubgroupOperations,
+            fragmentShaderBarycentric: fragmentShaderBarycentric,
+            pixelInputControls: pixelInputControls);
         return context.TryCompile(out shader, out error);
     }
 
@@ -113,7 +150,9 @@ public static partial class Gen5SpirvTranslator
         int imageBindingBase = 0,
         int initialScalarBufferIndex = -1,
         int requiredVertexOutputCount = 0,
-        ulong storageBufferOffsetAlignment = 1)
+        ulong storageBufferOffsetAlignment = 1,
+        bool nativeSubgroupOperations = true,
+        IReadOnlyList<uint>? pixelInputControls = null)
     {
         var context = new CompilationContext(
             Gen5SpirvStage.Vertex,
@@ -128,7 +167,9 @@ public static partial class Gen5SpirvTranslator
             imageBindingBase,
             initialScalarBufferIndex,
             requiredVertexOutputCount: requiredVertexOutputCount,
-            storageBufferOffsetAlignment: storageBufferOffsetAlignment);
+            storageBufferOffsetAlignment: storageBufferOffsetAlignment,
+            nativeSubgroupOperations: nativeSubgroupOperations,
+            pixelInputControls: pixelInputControls);
         return context.TryCompile(out shader, out error);
     }
 
@@ -143,7 +184,8 @@ public static partial class Gen5SpirvTranslator
         int totalGlobalBufferCount = -1,
         int initialScalarBufferIndex = -1,
         uint waveLaneCount = 32,
-        ulong storageBufferOffsetAlignment = 1)
+        ulong storageBufferOffsetAlignment = 1,
+        bool nativeSubgroupOperations = true)
     {
         var context = new CompilationContext(
             Gen5SpirvStage.Compute,
@@ -158,7 +200,8 @@ public static partial class Gen5SpirvTranslator
             0,
             initialScalarBufferIndex,
             waveLaneCount: waveLaneCount,
-            storageBufferOffsetAlignment: storageBufferOffsetAlignment);
+            storageBufferOffsetAlignment: storageBufferOffsetAlignment,
+            nativeSubgroupOperations: nativeSubgroupOperations);
         return context.TryCompile(out shader, out error);
     }
 
@@ -170,6 +213,7 @@ public static partial class Gen5SpirvTranslator
         private const long InitialScalarDefinition = -1;
         private const long ConflictingScalarDefinition = -2;
         private const long UnreachableScalarDefinition = -3;
+        private const uint ShaderProgramResourceDx10Clamp = 1u << 21;
 
         private readonly SpirvModuleBuilder _module = new();
         private readonly Gen5SpirvStage _stage;
@@ -178,6 +222,9 @@ public static partial class Gen5SpirvTranslator
         private readonly IReadOnlyList<Gen5PixelOutputBinding> _pixelOutputBindings;
         private readonly uint _waveLaneCount;
         private readonly bool _emulateWave64;
+        private readonly bool _dx10Clamp;
+        private readonly bool _nativeSubgroupOperations;
+        private readonly bool _fragmentShaderBarycentric;
 
         // Safety valve for the PC-dispatcher loop. Each iteration executes one
         // GCN basic block; a correctly-translated shader always reaches its
@@ -226,11 +273,21 @@ public static partial class Gen5SpirvTranslator
         private readonly int _initialScalarBufferIndex;
         private readonly uint _pixelInputEnable;
         private readonly uint _pixelInputAddress;
+        private readonly IReadOnlyList<uint> _pixelInputControls;
         private readonly ulong _storageBufferOffsetAlignment;
         private readonly List<uint> _interfaces = [];
-        private readonly Dictionary<uint, uint> _pixelInputs = [];
+        private readonly Dictionary<uint, SpirvPixelInput> _pixelInputs = [];
+        private readonly HashSet<uint> _interpolationMoveAttributes;
+        private readonly Dictionary<
+            (uint Attribute, uint Channel),
+            SpirvInterpolationCoefficients> _interpolationCoefficients = [];
         private readonly Dictionary<uint, SpirvPixelOutput> _pixelOutputs = [];
+        // Fragment locations are keyed by pixel-attribute index so they remain
+        // unique when multiple SPI_PS_INPUT_CNTL entries alias one guest
+        // parameter. Vertex exports are fanned out through the reverse map.
         private readonly Dictionary<uint, uint> _vertexOutputs = [];
+        private readonly Dictionary<uint, List<uint>>
+            _vertexOutputsByGuestLocation = [];
         private readonly Dictionary<uint, SpirvVertexInput> _vertexInputsByPc = [];
         private readonly List<SpirvImageResource> _imageResources = [];
         private readonly Dictionary<uint, int> _imageBindingByPc = [];
@@ -253,6 +310,7 @@ public static partial class Gen5SpirvTranslator
         private uint _privateVec2Pointer;
         private uint _privateBoolPointer;
         private uint _runtimeBufferBiases;
+        private uint _runtimeBufferDwordCounts;
         private uint _scalarRegisters;
         private uint _vectorRegisters;
         private uint _packedHalfRegisters;
@@ -274,6 +332,8 @@ public static partial class Gen5SpirvTranslator
         private uint _vertexIndexInput;
         private uint _instanceIndexInput;
         private uint _fragCoordInput;
+        private uint _baryCoordInput;
+        private uint _baryCoordNoPerspInput;
         private uint _localInvocationIdInput;
         private uint _localInvocationIndexInput;
         private uint _workGroupIdInput;
@@ -307,10 +367,20 @@ public static partial class Gen5SpirvTranslator
             uint Type,
             uint ComponentCount);
 
+        private readonly record struct SpirvPixelInput(
+            uint Variable,
+            uint Control);
+
+        private readonly record struct SpirvInterpolationCoefficients(
+            uint P0,
+            uint P10,
+            uint P20);
+
         private readonly record struct SpirvPixelOutput(
             uint Variable,
             uint Type,
-            Gen5PixelOutputKind Kind);
+            Gen5PixelOutputKind Kind,
+            uint WriteMask);
 
         public CompilationContext(
             Gen5SpirvStage stage,
@@ -328,13 +398,20 @@ public static partial class Gen5SpirvTranslator
             uint pixelInputAddress = 0,
             int requiredVertexOutputCount = 0,
             uint waveLaneCount = 32,
-            ulong storageBufferOffsetAlignment = 1)
+            ulong storageBufferOffsetAlignment = 1,
+            bool nativeSubgroupOperations = true,
+            bool fragmentShaderBarycentric = true,
+            IReadOnlyList<uint>? pixelInputControls = null)
         {
             _stage = stage;
             _requiredVertexOutputCount = requiredVertexOutputCount;
             _state = state;
             _evaluation = evaluation;
             _pixelOutputBindings = pixelOutputBindings;
+            _dx10Clamp =
+                (state.ProgramResource1 & ShaderProgramResourceDx10Clamp) != 0;
+            _nativeSubgroupOperations = nativeSubgroupOperations;
+            _fragmentShaderBarycentric = fragmentShaderBarycentric;
             _waveLaneCount = waveLaneCount == 64 ? 64u : 32u;
             _emulateWave64 =
                 stage == Gen5SpirvStage.Compute &&
@@ -351,6 +428,12 @@ public static partial class Gen5SpirvTranslator
             _initialScalarBufferIndex = initialScalarBufferIndex;
             _pixelInputEnable = pixelInputEnable;
             _pixelInputAddress = pixelInputAddress;
+            _pixelInputControls = pixelInputControls ?? [];
+            _interpolationMoveAttributes = state.Program.Instructions
+                .Where(static instruction => instruction.Opcode == "VInterpMovF32")
+                .Select(static instruction =>
+                    ((Gen5InterpolationControl)instruction.Control!).Attribute)
+                .ToHashSet();
             if (storageBufferOffsetAlignment == 0 ||
                 (storageBufferOffsetAlignment & (storageBufferOffsetAlignment - 1)) != 0 ||
                 storageBufferOffsetAlignment > uint.MaxValue)
@@ -370,6 +453,15 @@ public static partial class Gen5SpirvTranslator
             error = string.Empty;
             try
             {
+                if (_stage == Gen5SpirvStage.Pixel &&
+                    _interpolationMoveAttributes.Count != 0 &&
+                    !_fragmentShaderBarycentric)
+                {
+                    error =
+                        "V_INTERP_MOV_F32 requires VK_KHR_fragment_shader_barycentric";
+                    return false;
+                }
+
                 if (Environment.GetEnvironmentVariable(
                         "SHARPEMU_TRACE_TITLE_INTERFACE") == "1" &&
                     _state.Program.Address is 0x0000000500780000ul or
@@ -481,6 +573,10 @@ public static partial class Gen5SpirvTranslator
                     _module.AddLabel();
                 }
                 EmitInitialState();
+                if (!TryEmitInterpolationCoefficientState(out error))
+                {
+                    return false;
+                }
 
                 var loopHeader = _module.AllocateId();
                 var switchHeader = _module.AllocateId();
@@ -666,6 +762,12 @@ public static partial class Gen5SpirvTranslator
             _module.AddCapability(SpirvCapability.Shader);
             _module.AddCapability(SpirvCapability.Int64);
             _module.AddCapability(SpirvCapability.ImageQuery);
+            if (_stage == Gen5SpirvStage.Pixel &&
+                _interpolationMoveAttributes.Count != 0)
+            {
+                _module.AddExtension("SPV_KHR_fragment_shader_barycentric");
+                _module.AddCapability(SpirvCapability.FragmentBarycentricKhr);
+            }
             if (_evaluation.ImageBindings.Any(
                     static binding =>
                         (binding.Opcode.StartsWith(
@@ -803,6 +905,14 @@ public static partial class Gen5SpirvTranslator
                     _module.ConstantNull(biasArrayType));
                 _module.AddName(_runtimeBufferBiases, "guestBufferByteBias");
                 _interfaces.Add(_runtimeBufferBiases);
+                _runtimeBufferDwordCounts = _module.AddGlobalVariable(
+                    privateBiasArrayPointer,
+                    SpirvStorageClass.Private,
+                    _module.ConstantNull(biasArrayType));
+                _module.AddName(
+                    _runtimeBufferDwordCounts,
+                    "guestBufferDwordCount");
+                _interfaces.Add(_runtimeBufferDwordCounts);
             }
 
             DeclareBuffers();
@@ -1159,29 +1269,40 @@ public static partial class Gen5SpirvTranslator
                     (uint)SpirvBuiltIn.Position);
                 _interfaces.Add(_positionOutput);
 
-                var parameters = _state.Program.Instructions
-                    .Select(instruction => instruction.Control)
-                    .OfType<Gen5ExportControl>()
-                    .Where(export => export.Target is >= 32 and < 64)
-                    .Select(export => export.Target - 32)
-                    // Cover every location the paired fragment shader reads, even
-                    // ones this vertex program never exports, so Metal's exact
-                    // vertex-out/fragment-in interface match succeeds. Extras are
-                    // zero-filled in EmitInitialState.
-                    .Concat(Enumerable
-                        .Range(0, Math.Max(_requiredVertexOutputCount, 0))
-                        .Select(location => (uint)location))
-                    .Distinct()
-                    .Order()
-                    .ToArray();
-                foreach (var parameter in parameters)
+                if (_pixelInputControls.Count != 0)
                 {
-                    var variable = _module.AddGlobalVariable(
-                        outputPointer,
-                        SpirvStorageClass.Output);
-                    _module.AddDecoration(variable, SpirvDecoration.Location, parameter);
-                    _vertexOutputs.Add(parameter, variable);
-                    _interfaces.Add(variable);
+                    for (var attribute = 0;
+                         attribute < _pixelInputControls.Count;
+                         attribute++)
+                    {
+                        DeclareVertexParameterOutput(
+                            outputPointer,
+                            checked((uint)attribute),
+                            _pixelInputControls[attribute] & 0x1Fu);
+                    }
+                }
+                else
+                {
+                    var parameters = _state.Program.Instructions
+                        .Select(instruction => instruction.Control)
+                        .OfType<Gen5ExportControl>()
+                        .Where(export => export.Target is >= 32 and < 64)
+                        .Select(export => export.Target - 32)
+                        // Cover every location the paired fragment shader reads,
+                        // even ones this vertex program never exports, so Metal's
+                        // exact interface match succeeds. Extras are zero-filled.
+                        .Concat(Enumerable
+                            .Range(0, Math.Max(_requiredVertexOutputCount, 0))
+                            .Select(location => (uint)location))
+                        .Distinct()
+                        .Order();
+                    foreach (var parameter in parameters)
+                    {
+                        DeclareVertexParameterOutput(
+                            outputPointer,
+                            parameter,
+                            parameter);
+                    }
                 }
             }
             else if (_stage == Gen5SpirvStage.Pixel)
@@ -1197,12 +1318,50 @@ public static partial class Gen5SpirvTranslator
                     .ToArray();
                 foreach (var attribute in attributes)
                 {
+                    var inputControl = GetPixelInputControl(attribute);
                     var variable = _module.AddGlobalVariable(
                         inputVec4Pointer,
                         SpirvStorageClass.Input);
+                    // The paired vertex module remaps the guest source selected
+                    // by this control into the unique pixel-attribute location.
                     _module.AddDecoration(variable, SpirvDecoration.Location, attribute);
-                    _pixelInputs.Add(attribute, variable);
+                    if ((inputControl & 0x400u) != 0)
+                    {
+                        _module.AddDecoration(variable, SpirvDecoration.Flat);
+                    }
+                    _pixelInputs.Add(
+                        attribute,
+                        new SpirvPixelInput(variable, inputControl));
                     _interfaces.Add(variable);
+                }
+
+                if (_interpolationMoveAttributes.Count != 0)
+                {
+                    var inputVec3Pointer =
+                        _module.TypePointer(SpirvStorageClass.Input, _vec3Type);
+                    if ((_pixelInputAddress & 0xFu) != 0)
+                    {
+                        _baryCoordInput = _module.AddGlobalVariable(
+                            inputVec3Pointer,
+                            SpirvStorageClass.Input);
+                        _module.AddDecoration(
+                            _baryCoordInput,
+                            SpirvDecoration.BuiltIn,
+                            (uint)SpirvBuiltIn.BaryCoordKhr);
+                        _interfaces.Add(_baryCoordInput);
+                    }
+
+                    if ((_pixelInputAddress & 0x70u) != 0)
+                    {
+                        _baryCoordNoPerspInput = _module.AddGlobalVariable(
+                            inputVec3Pointer,
+                            SpirvStorageClass.Input);
+                        _module.AddDecoration(
+                            _baryCoordNoPerspInput,
+                            SpirvDecoration.BuiltIn,
+                            (uint)SpirvBuiltIn.BaryCoordNoPerspKhr);
+                        _interfaces.Add(_baryCoordNoPerspInput);
+                    }
                 }
 
                 _fragCoordInput = _module.AddGlobalVariable(
@@ -1220,23 +1379,34 @@ public static partial class Gen5SpirvTranslator
                     _state.Program.Address == 0x0000000500781200ul
                         ? _pixelOutputBindings.Take(1)
                         : _pixelOutputBindings;
+                var hostPixelOutputs = new Dictionary<uint, SpirvPixelOutput>();
                 foreach (var binding in declaredPixelOutputs)
                 {
-                    var outputType = GetPixelOutputType(binding.Kind);
-                    var outputPointer =
-                        _module.TypePointer(SpirvStorageClass.Output, outputType);
-                    var variable = _module.AddGlobalVariable(
-                        outputPointer,
-                        SpirvStorageClass.Output);
-                    _module.AddName(variable, $"mrt{binding.GuestSlot}");
-                    _module.AddDecoration(
-                        variable,
-                        SpirvDecoration.Location,
-                        binding.HostLocation);
+                    if (!hostPixelOutputs.TryGetValue(binding.HostLocation, out var hostOutput))
+                    {
+                        var outputType = GetPixelOutputType(binding.Kind);
+                        var outputPointer =
+                            _module.TypePointer(SpirvStorageClass.Output, outputType);
+                        var variable = _module.AddGlobalVariable(
+                            outputPointer,
+                            SpirvStorageClass.Output);
+                        _module.AddName(variable, $"mrt{binding.HostLocation}");
+                        _module.AddDecoration(
+                            variable,
+                            SpirvDecoration.Location,
+                            binding.HostLocation);
+                        hostOutput = new SpirvPixelOutput(
+                            variable,
+                            outputType,
+                            binding.Kind,
+                            0);
+                        hostPixelOutputs.Add(binding.HostLocation, hostOutput);
+                        _interfaces.Add(variable);
+                    }
+
                     _pixelOutputs.Add(
                         binding.GuestSlot,
-                        new SpirvPixelOutput(variable, outputType, binding.Kind));
-                    _interfaces.Add(variable);
+                        hostOutput with { WriteMask = binding.WriteMask & 0xFu });
                 }
             }
             else
@@ -1260,6 +1430,31 @@ public static partial class Gen5SpirvTranslator
                 _interfaces.Add(_localInvocationIdInput);
                 _interfaces.Add(_workGroupIdInput);
             }
+        }
+
+        private void DeclareVertexParameterOutput(
+            uint outputPointer,
+            uint hostLocation,
+            uint guestLocation)
+        {
+            var variable = _module.AddGlobalVariable(
+                outputPointer,
+                SpirvStorageClass.Output);
+            _module.AddDecoration(
+                variable,
+                SpirvDecoration.Location,
+                hostLocation);
+            _vertexOutputs.Add(hostLocation, variable);
+            if (!_vertexOutputsByGuestLocation.TryGetValue(
+                    guestLocation,
+                    out var consumers))
+            {
+                consumers = [];
+                _vertexOutputsByGuestLocation.Add(guestLocation, consumers);
+            }
+
+            consumers.Add(variable);
+            _interfaces.Add(variable);
         }
 
         private void DeclareVertexInputs()
@@ -1316,7 +1511,9 @@ public static partial class Gen5SpirvTranslator
                     {
                         StoreS(
                             index,
-                            LoadBufferWord(_initialScalarBufferIndex, UInt(index)));
+                            LoadBufferWordUnchecked(
+                                _initialScalarBufferIndex,
+                                UInt(index)));
                     }
                 }
 
@@ -1328,9 +1525,18 @@ public static partial class Gen5SpirvTranslator
                 {
                     Store(
                         RuntimeBufferBiasPointer(binding),
-                        LoadBufferWord(
+                        LoadBufferWordUnchecked(
                             _initialScalarBufferIndex,
-                            UInt(checked(256u + (uint)binding))));
+                            UInt(checked((uint)
+                                Gen5RuntimeScalarLayout
+                                    .GetByteBiasDwordIndex(binding)))));
+                    Store(
+                        RuntimeBufferDwordCountPointer(binding),
+                        LoadBufferWordUnchecked(
+                            _initialScalarBufferIndex,
+                            UInt(checked((uint)
+                                Gen5RuntimeScalarLayout
+                                    .GetBufferDwordCountDwordIndex(binding)))));
                 }
             }
             else
@@ -1373,6 +1579,20 @@ public static partial class Gen5SpirvTranslator
             {
                 StoreV(5, Load(_uintType, _vertexIndexInput), guardWithExec: false);
                 StoreV(8, Load(_uintType, _instanceIndexInput), guardWithExec: false);
+
+                // An EXEC-masked position export selects the previous output.
+                // SPIR-V output variables have no implicit initial value, so
+                // initialize inactive vertices outside the clip volume instead
+                // of loading undefined gl_Position data.
+                Store(
+                    _positionOutput,
+                    _module.AddInstruction(
+                        SpirvOp.CompositeConstruct,
+                        _vec4Type,
+                        Float(0f),
+                        Float(0f),
+                        Float(2f),
+                        Float(1f)));
 
                 // Give every declared param output a defined starting value.
                 // Outputs the program actually exports overwrite this; the
@@ -1477,13 +1697,13 @@ public static partial class Gen5SpirvTranslator
             // interpolation inputs occupy register slots even though V_INTERP
             // is lowered directly from SPIR-V interpolants; position inputs
             // following them must still land in the hardware-selected VGPRs.
-            AdvancePixelInput(0, 2, ref vgpr); // PERSP_SAMPLE
-            AdvancePixelInput(1, 2, ref vgpr); // PERSP_CENTER
-            AdvancePixelInput(2, 2, ref vgpr); // PERSP_CENTROID
+            EmitPixelBarycentricInput(0, _baryCoordInput, ref vgpr); // PERSP_SAMPLE
+            EmitPixelBarycentricInput(1, _baryCoordInput, ref vgpr); // PERSP_CENTER
+            EmitPixelBarycentricInput(2, _baryCoordInput, ref vgpr); // PERSP_CENTROID
             AdvancePixelInput(3, 3, ref vgpr); // PERSP_PULL_MODEL
-            AdvancePixelInput(4, 2, ref vgpr); // LINEAR_SAMPLE
-            AdvancePixelInput(5, 2, ref vgpr); // LINEAR_CENTER
-            AdvancePixelInput(6, 2, ref vgpr); // LINEAR_CENTROID
+            EmitPixelBarycentricInput(4, _baryCoordNoPerspInput, ref vgpr); // LINEAR_SAMPLE
+            EmitPixelBarycentricInput(5, _baryCoordNoPerspInput, ref vgpr); // LINEAR_CENTER
+            EmitPixelBarycentricInput(6, _baryCoordNoPerspInput, ref vgpr); // LINEAR_CENTROID
             AdvancePixelInput(7, 1, ref vgpr); // LINE_STIPPLE
 
             EmitPixelPositionInput(8, 0, fragCoord, ref vgpr); // POS_X_FLOAT
@@ -1498,6 +1718,34 @@ public static partial class Gen5SpirvTranslator
             AdvancePixelInput(13, 1, ref vgpr);
             AdvancePixelInput(14, 1, ref vgpr);
             AdvancePixelInput(15, 1, ref vgpr);
+        }
+
+        private void EmitPixelBarycentricInput(int bit, uint input, ref uint vgpr)
+        {
+            var mask = 1u << bit;
+            if ((_pixelInputAddress & mask) == 0)
+            {
+                return;
+            }
+
+            if ((_pixelInputEnable & mask) != 0 && input != 0)
+            {
+                var barycentrics = Load(_vec3Type, input);
+                // Match the guest interpolation equation
+                // P0 + P10 * I + P20 * J by treating vertex zero as the
+                // coefficient origin and using weights for vertices one/two.
+                for (uint component = 0; component < 2; component++)
+                {
+                    var value = _module.AddInstruction(
+                        SpirvOp.CompositeExtract,
+                        _floatType,
+                        barycentrics,
+                        component + 1);
+                    StoreV(vgpr + component, Bitcast(_uintType, value), guardWithExec: false);
+                }
+            }
+
+            vgpr += 2;
         }
 
         private void AdvancePixelInput(int bit, uint dwordCount, ref uint vgpr)
@@ -1708,10 +1956,15 @@ public static partial class Gen5SpirvTranslator
                 "SNop" or
                 "SWaitcnt" or
                 "SInstPrefetch" or
-                "STtraceData" or
-                "VInterpMovF32")
+                "STtraceData")
             {
                 return true;
+            }
+
+            if (instruction.Opcode == "STrap")
+            {
+                error = "guest S_TRAP handling is not implemented";
+                return false;
             }
 
             if (instruction.Opcode == "SBarrier")
@@ -1786,9 +2039,7 @@ public static partial class Gen5SpirvTranslator
             out string error)
         {
             error = string.Empty;
-            if (_lds == 0 ||
-                _ldsElementPointer == 0 ||
-                instruction.Control is not Gen5DataShareControl control)
+            if (instruction.Control is not Gen5DataShareControl control)
             {
                 error = "invalid LDS instruction";
                 return false;
@@ -1800,8 +2051,80 @@ public static partial class Gen5SpirvTranslator
                 return false;
             }
 
+            if (instruction.Opcode != "DsPermuteB32" &&
+                (_lds == 0 || _ldsElementPointer == 0))
+            {
+                error = "invalid LDS instruction";
+                return false;
+            }
+
             switch (instruction.Opcode)
             {
+                case "DsPermuteB32":
+                {
+                    if (instruction.Destinations.Count < 1 ||
+                        instruction.Sources.Count < 2 ||
+                        _subgroupInvocationIdInput == 0)
+                    {
+                        error = "DS_PERMUTE_B32 requires subgroup shuffle support";
+                        return false;
+                    }
+
+                    var address = GetRawSource(instruction, 0);
+                    var data = GetRawSource(instruction, 1);
+                    var targetLane = BitwiseAnd(
+                        ShiftRightLogical(
+                            IAdd(address, UInt(control.Offset0)),
+                            UInt(2)),
+                        UInt(31));
+                    var currentLane = BitwiseAnd(GuestWaveLane(), UInt(31));
+                    var activeWord = _module.AddInstruction(
+                        SpirvOp.Select,
+                        _uintType,
+                        Load(_boolType, _exec),
+                        UInt(1),
+                        UInt(0));
+                    var result = UInt(0);
+                    for (var sourceLane = 0u; sourceLane < 32; sourceLane++)
+                    {
+                        var shuffledTarget = _module.AddInstruction(
+                            SpirvOp.GroupNonUniformShuffle,
+                            _uintType,
+                            UInt(3),
+                            targetLane,
+                            UInt(sourceLane));
+                        var shuffledData = _module.AddInstruction(
+                            SpirvOp.GroupNonUniformShuffle,
+                            _uintType,
+                            UInt(3),
+                            data,
+                            UInt(sourceLane));
+                        var shuffledActive = _module.AddInstruction(
+                            SpirvOp.GroupNonUniformShuffle,
+                            _uintType,
+                            UInt(3),
+                            activeWord,
+                            UInt(sourceLane));
+                        var writesCurrentLane = _module.AddInstruction(
+                            SpirvOp.LogicalAnd,
+                            _boolType,
+                            IsNotZero(shuffledActive),
+                            _module.AddInstruction(
+                                SpirvOp.IEqual,
+                                _boolType,
+                                shuffledTarget,
+                                currentLane));
+                        result = _module.AddInstruction(
+                            SpirvOp.Select,
+                            _uintType,
+                            writesCurrentLane,
+                            shuffledData,
+                            result);
+                    }
+
+                    StoreV(instruction.Destinations[0].Value, result);
+                    return true;
+                }
                 case "DsWriteB32":
                 {
                     if (instruction.Sources.Count < 2)
@@ -1959,6 +2282,10 @@ public static partial class Gen5SpirvTranslator
         private static uint EffectiveDsPairOffsetBytes(uint offset, bool st64 = false) =>
             offset * (st64 ? 256u : sizeof(uint));
 
+        private static uint EffectiveDsSingleOffsetBytes(
+            Gen5DataShareControl control) =>
+            control.Offset0 | (control.Offset1 << 8);
+
         private uint LdsPointer(uint address, uint offsetBytes)
         {
             var addressWithOffset = offsetBytes == 0
@@ -2021,7 +2348,9 @@ public static partial class Gen5SpirvTranslator
             }
 
             var address = GetRawSource(instruction, 0);
-            var pointer = LdsPointer(address, control.Offset0);
+            var pointer = LdsPointer(
+                address,
+                EffectiveDsSingleOffsetBytes(control));
             EmitExecConditional(() =>
             {
                 var original = EmitAtomic(
@@ -2037,7 +2366,10 @@ public static partial class Gen5SpirvTranslator
                     comparator: () => GetRawSource(instruction, 1));
                 if (instruction.Destinations.Count > 0)
                 {
-                    StoreV(instruction.Destinations[0].Value, original);
+                    StoreV(
+                        instruction.Destinations[0].Value,
+                        original,
+                        guardWithExec: false);
                 }
             });
 
@@ -2125,13 +2457,249 @@ public static partial class Gen5SpirvTranslator
                 return false;
             }
 
-            var vector = Load(_vec4Type, input);
+            var vector = Load(_vec4Type, input.Variable);
             var component = _module.AddInstruction(
                 SpirvOp.CompositeExtract,
                 _floatType,
                 vector,
                 interpolation.Channel);
-            StoreV(destination, Bitcast(_uintType, component));
+            if (!_interpolationMoveAttributes.Contains(interpolation.Attribute))
+            {
+                StoreV(destination, Bitcast(_uintType, component));
+                return true;
+            }
+
+            if (instruction.Opcode == "VInterpMovF32" &&
+                IsCustomInterpolation(input.Control))
+            {
+                // Custom interpolation carries packed payloads whose bits must
+                // not be reconstructed through floating-point derivatives.
+                // Until the backend exposes all three per-vertex parameters,
+                // use the exact provoking-vertex word for every selector. The
+                // guest's manual interpolation then collapses to a stable,
+                // faceted value instead of unpacking derivative noise.
+                StoreV(destination, Bitcast(_uintType, component));
+                return true;
+            }
+
+            if (!_interpolationCoefficients.TryGetValue(
+                    (interpolation.Attribute, interpolation.Channel),
+                    out var coefficients))
+            {
+                error =
+                    $"missing interpolation coefficients for attribute " +
+                    $"{interpolation.Attribute} channel {interpolation.Channel}";
+                return false;
+            }
+
+            uint result;
+            if (instruction.Opcode == "VInterpMovF32")
+            {
+                if (instruction.Sources.Count == 0)
+                {
+                    error = "interpolation move is missing its P10/P20/P0 selector";
+                    return false;
+                }
+
+                result = instruction.Sources[0].Value switch
+                {
+                    0 => coefficients.P10,
+                    1 => coefficients.P20,
+                    2 => coefficients.P0,
+                    _ => 0,
+                };
+                if (result == 0)
+                {
+                    error = $"invalid interpolation move selector {instruction.Sources[0].Value}";
+                    return false;
+                }
+            }
+            else
+            {
+                if (instruction.Sources.Count == 0 ||
+                    instruction.Sources[0].Kind != Gen5OperandKind.VectorRegister)
+                {
+                    error = "interpolation instruction is missing its barycentric source";
+                    return false;
+                }
+
+                var barycentric = Bitcast(
+                    _floatType,
+                    LoadV(instruction.Sources[0].Value));
+                if (instruction.Opcode == "VInterpP1F32")
+                {
+                    result = _module.AddInstruction(
+                        SpirvOp.FAdd,
+                        _floatType,
+                        coefficients.P0,
+                        _module.AddInstruction(
+                            SpirvOp.FMul,
+                            _floatType,
+                            coefficients.P10,
+                            barycentric));
+                }
+                else if (instruction.Opcode == "VInterpP2F32")
+                {
+                    result = _module.AddInstruction(
+                        SpirvOp.FAdd,
+                        _floatType,
+                        Bitcast(_floatType, LoadV(destination)),
+                        _module.AddInstruction(
+                            SpirvOp.FMul,
+                            _floatType,
+                            coefficients.P20,
+                            barycentric));
+                }
+                else
+                {
+                    error = $"unsupported interpolation opcode {instruction.Opcode}";
+                    return false;
+                }
+            }
+
+            StoreV(destination, Bitcast(_uintType, result));
+            return true;
+        }
+
+        private bool TryEmitInterpolationCoefficientState(out string error)
+        {
+            error = string.Empty;
+            if (_stage != Gen5SpirvStage.Pixel ||
+                _interpolationMoveAttributes.Count == 0)
+            {
+                return true;
+            }
+
+            // Derivatives are only defined in uniform control flow. The guest
+            // shader body runs inside a PC dispatcher whose cases can diverge,
+            // so reconstruct every coefficient once in the entry block and
+            // let V_INTERP instructions read the dominating SSA values.
+            var controls = _state.Program.Instructions
+                .Where(static instruction => instruction.Opcode == "VInterpMovF32")
+                .Select(static instruction =>
+                    (Gen5InterpolationControl)instruction.Control!)
+                .Select(static control => (control.Attribute, control.Channel))
+                .Distinct()
+                .OrderBy(static control => control.Attribute)
+                .ThenBy(static control => control.Channel);
+            foreach (var (attribute, channel) in controls)
+            {
+                if (_pixelInputs.TryGetValue(attribute, out var input) &&
+                    IsCustomInterpolation(input.Control))
+                {
+                    continue;
+                }
+
+                if (!TryCreateInterpolationCoefficients(
+                        attribute,
+                        channel,
+                        out var coefficients,
+                        out error))
+                {
+                    return false;
+                }
+
+                _interpolationCoefficients.Add((attribute, channel), coefficients);
+            }
+
+            return true;
+        }
+
+        private uint GetPixelInputControl(uint attribute) =>
+            attribute < (uint)_pixelInputControls.Count
+                ? _pixelInputControls[(int)attribute]
+                : attribute;
+
+        private static bool IsCustomInterpolation(uint control) =>
+            (control & 0x420u) == 0x420u;
+
+        private bool TryCreateInterpolationCoefficients(
+            uint attribute,
+            uint channel,
+            out SpirvInterpolationCoefficients coefficients,
+            out string error)
+        {
+            coefficients = default;
+            error = string.Empty;
+            if (!_pixelInputs.TryGetValue(attribute, out var input))
+            {
+                error = $"invalid interpolated attribute {attribute}";
+                return false;
+            }
+
+            // MoltenVK exposes VK_KHR_fragment_shader_barycentric but its
+            // SPIR-V-to-MSL path cannot consume PerVertexKHR inputs. Rebuild
+            // the hardware interpolation coefficients from the ordinary
+            // interpolant and the derivatives of its barycentric weights:
+            //
+            //   F = P0 + P10*I + P20*J
+            //
+            // Differentiating in screen X/Y yields a 2x2 system for P10/P20;
+            // P0 then follows from F. Native Vulkan drivers use the same
+            // standard SPIR-V path.
+            var barycentricInput = _baryCoordInput != 0
+                ? _baryCoordInput
+                : _baryCoordNoPerspInput;
+            if (barycentricInput == 0)
+            {
+                error = "interpolation move requires a barycentric pixel input";
+                return false;
+            }
+
+            var vector = Load(_vec4Type, input.Variable);
+            var component = _module.AddInstruction(
+                SpirvOp.CompositeExtract,
+                _floatType,
+                vector,
+                channel);
+            var barycentrics = Load(_vec3Type, barycentricInput);
+            var i = _module.AddInstruction(
+                SpirvOp.CompositeExtract,
+                _floatType,
+                barycentrics,
+                1);
+            var j = _module.AddInstruction(
+                SpirvOp.CompositeExtract,
+                _floatType,
+                barycentrics,
+                2);
+            uint Binary(SpirvOp op, uint left, uint right) =>
+                _module.AddInstruction(op, _floatType, left, right);
+            uint Derivative(SpirvOp op, uint value) =>
+                _module.AddInstruction(op, _floatType, value);
+
+            var dFdx = Derivative(SpirvOp.DPdx, component);
+            var dFdy = Derivative(SpirvOp.DPdy, component);
+            var dIdx = Derivative(SpirvOp.DPdx, i);
+            var dIdy = Derivative(SpirvOp.DPdy, i);
+            var dJdx = Derivative(SpirvOp.DPdx, j);
+            var dJdy = Derivative(SpirvOp.DPdy, j);
+            var determinant = Binary(
+                SpirvOp.FSub,
+                Binary(SpirvOp.FMul, dIdx, dJdy),
+                Binary(SpirvOp.FMul, dIdy, dJdx));
+            var p10 = Binary(
+                SpirvOp.FDiv,
+                Binary(
+                    SpirvOp.FSub,
+                    Binary(SpirvOp.FMul, dFdx, dJdy),
+                    Binary(SpirvOp.FMul, dFdy, dJdx)),
+                determinant);
+            var p20 = Binary(
+                SpirvOp.FDiv,
+                Binary(
+                    SpirvOp.FSub,
+                    Binary(SpirvOp.FMul, dIdx, dFdy),
+                    Binary(SpirvOp.FMul, dIdy, dFdx)),
+                determinant);
+            var p0 = Binary(
+                SpirvOp.FSub,
+                Binary(
+                    SpirvOp.FSub,
+                    component,
+                    Binary(SpirvOp.FMul, p10, i)),
+                Binary(SpirvOp.FMul, p20, j));
+            coefficients = new SpirvInterpolationCoefficients(p0, p10, p20);
             return true;
         }
 
@@ -3188,6 +3756,14 @@ public static partial class Gen5SpirvTranslator
             out string error)
         {
             error = string.Empty;
+            if (instruction.Opcode == "ImageBvhIntersectRay")
+            {
+                error =
+                    "IMAGE_BVH_INTERSECT_RAY requires acceleration-structure " +
+                    "traversal, which is not implemented";
+                return false;
+            }
+
             if (!TryResolveDominatingImageBinding(instruction, image, out var bindingIndex))
             {
                 var candidates = _evaluation.ImageBindings
@@ -4133,7 +4709,8 @@ public static partial class Gen5SpirvTranslator
                 var values = new uint[4];
                 for (var component = 0; component < 4; component++)
                 {
-                    var enabled = (export.EnableMask & (1u << component)) != 0;
+                    var enabled =
+                        (export.EnableMask & output.WriteMask & (1u << component)) != 0;
                     if (!enabled)
                     {
                         values[component] = _module.AddInstruction(
@@ -4296,7 +4873,7 @@ public static partial class Gen5SpirvTranslator
                 return true;
             }
 
-            uint outputVariable;
+            IReadOnlyList<uint> outputVariables;
             if (export.Target is >= 12 and < 16)
             {
                 if (export.Target != 12)
@@ -4304,12 +4881,14 @@ public static partial class Gen5SpirvTranslator
                     return true;
                 }
 
-                outputVariable = _positionOutput;
+                outputVariables = [_positionOutput];
             }
             else if (export.Target is >= 32 and < 64 &&
-                     _vertexOutputs.TryGetValue(export.Target - 32, out var parameter))
+                     _vertexOutputsByGuestLocation.TryGetValue(
+                         export.Target - 32,
+                         out var parameters))
             {
-                outputVariable = parameter;
+                outputVariables = parameters;
             }
             else
             {
@@ -4345,13 +4924,17 @@ public static partial class Gen5SpirvTranslator
                     Float(1f),
                     Float(1f));
             }
-            outputValue = _module.AddInstruction(
-                SpirvOp.Select,
-                _vec4Type,
-                Load(_boolType, _exec),
-                outputValue,
-                Load(_vec4Type, outputVariable));
-            Store(outputVariable, outputValue);
+            var exportActive = Load(_boolType, _exec);
+            foreach (var outputVariable in outputVariables)
+            {
+                var selectedValue = _module.AddInstruction(
+                    SpirvOp.Select,
+                    _vec4Type,
+                    exportActive,
+                    outputValue,
+                    Load(_vec4Type, outputVariable));
+                Store(outputVariable, selectedValue);
+            }
             return true;
         }
 
@@ -4629,14 +5212,6 @@ public static partial class Gen5SpirvTranslator
             Gen5ShaderInstruction instruction,
             int component)
         {
-            if (TryLoadPackedHalfExportComponent(
-                    instruction,
-                    component,
-                    out var shadowValue))
-            {
-                return shadowValue;
-            }
-
             var packed = LoadV(instruction.Sources[component >> 1].Value);
             var unpacked = Ext(62, _vec2Type, packed);
             return _module.AddInstruction(
@@ -4798,6 +5373,9 @@ public static partial class Gen5SpirvTranslator
                 UInt(0));
         }
 
+        private uint LoadBufferWordUnchecked(int binding, uint dwordAddress) =>
+            Load(_uintType, BufferWordPointer(binding, dwordAddress));
+
         private uint ApplyGuestBufferByteBias(int binding, uint byteAddress)
         {
             var evaluationBinding = binding - _globalBufferBase;
@@ -4848,16 +5426,35 @@ public static partial class Gen5SpirvTranslator
 
         private uint IsBufferWordInRange(int binding, uint dwordAddress)
         {
-            var buffer = _module.AddInstruction(
-                SpirvOp.AccessChain,
-                _storageBlockPointer,
-                _globalBuffers,
-                UInt((uint)binding));
-            var length = _module.AddInstruction(
-                SpirvOp.ArrayLength,
-                _uintType,
-                buffer,
-                0);
+            uint length;
+            if (_initialScalarBufferIndex >= 0)
+            {
+                length = Load(
+                    _uintType,
+                    RuntimeBufferDwordCountPointer(binding));
+            }
+            else
+            {
+                var evaluationBinding = binding - _globalBufferBase;
+                if ((uint)evaluationBinding >=
+                    (uint)_evaluation.GlobalMemoryBindings.Count)
+                {
+                    return _module.ConstantBool(false);
+                }
+
+                var guestBinding =
+                    _evaluation.GlobalMemoryBindings[evaluationBinding];
+                var byteBias = guestBinding.BaseAddress &
+                    (_storageBufferOffsetAlignment - 1);
+                var descriptorBytes = checked(
+                    (long)Math.Max(guestBinding.DataLength, sizeof(uint)) +
+                    (long)byteBias);
+                var dwordCount = checked((uint)(
+                    (descriptorBytes + sizeof(uint) - 1) /
+                    sizeof(uint)));
+                length = UInt(dwordCount);
+            }
+
             return _module.AddInstruction(
                 SpirvOp.ULessThan,
                 _boolType,
@@ -4888,12 +5485,26 @@ public static partial class Gen5SpirvTranslator
                 _runtimeBufferBiases,
                 UInt(checked((uint)binding)));
 
+        private uint RuntimeBufferDwordCountPointer(int binding) =>
+            _module.AddInstruction(
+                SpirvOp.AccessChain,
+                _privateUintPointer,
+                _runtimeBufferDwordCounts,
+                UInt(checked((uint)binding)));
+
         private uint VectorPointer(uint register) =>
             _module.AddInstruction(
                 SpirvOp.AccessChain,
                 _privateUintPointer,
                 _vectorRegisters,
                 UInt(register));
+
+        private uint VectorPointerDynamic(uint register) =>
+            _module.AddInstruction(
+                SpirvOp.AccessChain,
+                _privateUintPointer,
+                _vectorRegisters,
+                register);
 
         private uint PackedHalfPointer(uint register) =>
             _module.AddInstruction(
@@ -5259,12 +5870,17 @@ public static partial class Gen5SpirvTranslator
 
         private bool UsesLds() =>
             _state.Program.Instructions.Any(instruction =>
-                instruction.Control is Gen5DataShareControl);
+                instruction.Control is Gen5DataShareControl &&
+                instruction.Opcode != "DsPermuteB32");
 
         private bool UsesSubgroupShuffle() =>
             _state.Program.Instructions.Any(instruction =>
                 instruction.Control is Gen5DppControl or Gen5Dpp8Control ||
-                instruction.Opcode is "VPermlane16B32" or "VPermlanex16B32" or "VReadlaneB32");
+                instruction.Opcode is
+                    "VPermlane16B32" or
+                    "VPermlanex16B32" or
+                    "VReadlaneB32" or
+                    "DsPermuteB32");
 
         private bool UsesSubgroupBroadcast() =>
             _state.Program.Instructions.Any(instruction =>
@@ -5280,12 +5896,13 @@ public static partial class Gen5SpirvTranslator
                 instruction.Destinations.Any(IsWaveMaskOperand));
 
         private bool UsesSubgroupOperations() =>
-            _stage == Gen5SpirvStage.Compute &&
+            _nativeSubgroupOperations &&
             (UsesSubgroupShuffle() ||
              UsesSubgroupBroadcast() ||
-             UsesWaveControl() ||
-             _state.Program.Instructions.Any(static instruction =>
-                 instruction.Opcode is "VMbcntLoU32B32" or "VMbcntHiU32B32"));
+             (_stage == Gen5SpirvStage.Compute &&
+              (UsesWaveControl() ||
+               _state.Program.Instructions.Any(static instruction =>
+                   instruction.Opcode is "VMbcntLoU32B32" or "VMbcntHiU32B32"))));
 
         private static bool IsWaveMaskOperand(Gen5Operand operand) =>
             operand.Kind == Gen5OperandKind.ScalarRegister &&

--- a/src/SharpEmu.ShaderCompiler.Vulkan/SpirvModuleBuilder.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/SpirvModuleBuilder.cs
@@ -93,6 +93,8 @@ public enum SpirvOp : ushort
     SMod = 139,
     FRem = 140,
     FMod = 141,
+    DPdx = 207,
+    DPdy = 208,
     IAddCarry = 149,
     ISubBorrow = 150,
     UMulExtended = 151,
@@ -196,6 +198,7 @@ public enum SpirvCapability : uint
     GroupNonUniformVote = 62,
     GroupNonUniformBallot = 64,
     GroupNonUniformShuffle = 65,
+    FragmentBarycentricKhr = 5284,
     RuntimeDescriptorArray = 5302,
 }
 
@@ -234,10 +237,13 @@ public enum SpirvDecoration : uint
     BuiltIn = 11,
     NoPerspective = 13,
     Flat = 14,
+    Centroid = 16,
+    Sample = 17,
     Location = 30,
     Binding = 33,
     DescriptorSet = 34,
     Offset = 35,
+    PerVertexKhr = 5285,
 }
 
 public enum SpirvBuiltIn : uint
@@ -252,6 +258,8 @@ public enum SpirvBuiltIn : uint
     GlobalInvocationId = 28,
     LocalInvocationIndex = 29,
     SubgroupLocalInvocationId = 41,
+    BaryCoordKhr = 5286,
+    BaryCoordNoPerspKhr = 5287,
 }
 
 public enum SpirvImageDim : uint

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
@@ -52,7 +52,8 @@ public enum Gen5PixelOutputKind
 public readonly record struct Gen5PixelOutputBinding(
     uint GuestSlot,
     uint HostLocation,
-    Gen5PixelOutputKind Kind);
+    Gen5PixelOutputKind Kind,
+    uint WriteMask = 0xFu);
 
 public readonly record struct Gen5ShaderResourceMapping(
     Gen5ShaderResourceKind Kind,
@@ -124,7 +125,38 @@ public sealed record Gen5ShaderState(
     IReadOnlyList<uint> UserData,
     Gen5ShaderMetadata? Metadata,
     Gen5ComputeSystemRegisters? ComputeSystemRegisters = null,
-    uint UserDataScalarRegisterBase = 0);
+    uint UserDataScalarRegisterBase = 0,
+    uint ProgramResource1 = 0);
+
+/// <summary>
+/// Shared ABI for the per-draw scalar block consumed by translated shaders.
+/// Buffer metadata is interleaved by absolute descriptor index so every stage
+/// can address its own bindings without knowing another stage's binding count.
+/// </summary>
+public static class Gen5RuntimeScalarLayout
+{
+    public const int ScalarRegisterDwordCount = 256;
+    public const int BufferMetadataDwordCount = 2;
+
+    public static int GetByteBiasDwordIndex(int bindingIndex)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(bindingIndex);
+        return checked(
+            ScalarRegisterDwordCount +
+            bindingIndex * BufferMetadataDwordCount);
+    }
+
+    public static int GetBufferDwordCountDwordIndex(int bindingIndex) =>
+        checked(GetByteBiasDwordIndex(bindingIndex) + 1);
+
+    public static int GetDwordLength(int bindingCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(bindingCount);
+        return checked(
+            ScalarRegisterDwordCount +
+            bindingCount * BufferMetadataDwordCount);
+    }
+}
 
 public readonly record struct Gen5Operand(Gen5OperandKind Kind, uint Value)
 {

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -1148,6 +1148,25 @@ public static class Gen5ShaderScalarEvaluator
             return true;
         }
 
+        if (instruction.Opcode == "SFF1I32B64")
+        {
+            if (!TryEvaluateScalarOperand64(
+                    instruction.Sources[0],
+                    registers,
+                    execMask,
+                    out var value))
+            {
+                error = $"scalar-source64 pc=0x{instruction.Pc:X} op={instruction.Opcode}";
+                return false;
+            }
+
+            registers[destination.Value] = value == 0
+                ? uint.MaxValue
+                : (uint)BitOperations.TrailingZeroCount(value);
+            scalarConditionCode = registers[destination.Value] != 0;
+            return true;
+        }
+
         if (instruction.Opcode is "SMovB64" or "SWqmB64" or "SNotB64")
         {
             if (destination.Value >= ScalarRegisterCount - 1 ||
@@ -1330,6 +1349,22 @@ public static class Gen5ShaderScalarEvaluator
         if (instruction.Opcode == "SMovB32")
         {
             registers[destination.Value] = left;
+            return true;
+        }
+
+        if (instruction.Opcode == "SWqmB32")
+        {
+            var quadAny = (left | (left >> 1) | (left >> 2) | (left >> 3)) &
+                0x1111_1111u;
+            var value = quadAny * 0xFu;
+            registers[destination.Value] = value;
+            if (destination.Value == 126)
+            {
+                execMask = value;
+                registers[127] = 0;
+            }
+
+            scalarConditionCode = value != 0;
             return true;
         }
 
@@ -1728,6 +1763,30 @@ public static class Gen5ShaderScalarEvaluator
     {
         scalarConditionCode = false;
         error = string.Empty;
+        if (instruction.Opcode is "SCmpEqU64" or "SCmpLgU64")
+        {
+            if (instruction.Sources.Count != 2 ||
+                !TryEvaluateScalarOperand64(
+                    instruction.Sources[0],
+                    registers,
+                    ulong.MaxValue,
+                    out var left64) ||
+                !TryEvaluateScalarOperand64(
+                    instruction.Sources[1],
+                    registers,
+                    ulong.MaxValue,
+                    out var right64))
+            {
+                error = $"scalar-compare-source64 pc=0x{instruction.Pc:X} op={instruction.Opcode}";
+                return false;
+            }
+
+            scalarConditionCode = instruction.Opcode == "SCmpEqU64"
+                ? left64 == right64
+                : left64 != right64;
+            return true;
+        }
+
         if (instruction.Sources.Count != 2 ||
             !TryEvaluateScalarOperand(instruction.Sources[0], registers, out var left) ||
             !TryEvaluateScalarOperand(instruction.Sources[1], registers, out var right))

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
@@ -80,7 +80,11 @@ public static class Gen5ShaderTranslator
     public static bool IsScalarConsumed(ulong[] mask, uint register) =>
         register < 256 && (mask[register >> 6] & (1UL << (int)(register & 63))) != 0;
 
-    private const int MaxInstructions = 4096;
+    // Headerless compatibility paths have no authoritative byte length. Keep
+    // those scans byte-bounded; normal AGC-created shaders use their declared size.
+    private const uint MaximumHeaderlessShaderBytes = 64 * 1024;
+    private const ulong ShaderSizeOffset = 0x44;
+    private const uint MaximumShaderSizeBytes = 1024 * 1024;
     private const uint PsUserDataRegister = 0x0C;
     private const uint VsUserDataRegister = 0x4C;
     private const uint GsUserDataRegister = 0x8C;
@@ -93,7 +97,7 @@ public static class Gen5ShaderTranslator
     private sealed class ShaderDecodeCache
     {
         public object Gate { get; } = new();
-        public Dictionary<ulong, Gen5ShaderProgram> Programs { get; } = new();
+        public Dictionary<(ulong Address, uint SizeBytes), Gen5ShaderProgram> Programs { get; } = new();
         public Dictionary<ulong, Gen5ShaderMetadata?> Metadata { get; } = new();
     }
 
@@ -202,23 +206,44 @@ public static class Gen5ShaderTranslator
         ValidateUserSgprCountDecoding();
         state = default!;
         error = string.Empty;
+        uint shaderSizeBytes = 0;
+        if (shaderHeaderAddress != 0 &&
+            (!TryReadUInt32(
+                 ctx,
+                 shaderHeaderAddress + ShaderSizeOffset,
+                 out shaderSizeBytes) ||
+             shaderSizeBytes == 0 ||
+             (shaderSizeBytes & (sizeof(uint) - 1)) != 0 ||
+             shaderSizeBytes > MaximumShaderSizeBytes))
+        {
+            error = $"invalid-shader-size header=0x{shaderHeaderAddress:X} " +
+                $"size=0x{shaderSizeBytes:X}";
+            return false;
+        }
+
         var cache = _decodeCaches.GetValue(ctx.Memory, static _ => new ShaderDecodeCache());
+        var programKey = (shaderAddress, shaderSizeBytes);
         Gen5ShaderProgram? program;
         lock (cache.Gate)
         {
-            cache.Programs.TryGetValue(shaderAddress, out program);
+            cache.Programs.TryGetValue(programKey, out program);
         }
 
         if (program is null)
         {
-            if (!TryDecodeProgram(ctx, shaderAddress, out program, out error))
+            if (!TryDecodeProgram(
+                    ctx,
+                    shaderAddress,
+                    shaderSizeBytes,
+                    out program,
+                    out error))
             {
                 return false;
             }
 
             lock (cache.Gate)
             {
-                cache.Programs.TryAdd(shaderAddress, program);
+                cache.Programs.TryAdd(programKey, program);
             }
         }
 
@@ -267,12 +292,15 @@ public static class Gen5ShaderTranslator
             shaderRegisters.TryGetValue(userDataBaseRegister + index, out userData[index]);
         }
 
+        shaderRegisters.TryGetValue(rsrc2Register - 1, out var programResource1);
+
         state = new Gen5ShaderState(
             program,
             userData,
             metadata,
             computeSystemRegisters,
-            userDataScalarRegisterBase);
+            userDataScalarRegisterBase,
+            programResource1);
         return true;
     }
 
@@ -409,6 +437,14 @@ public static class Gen5ShaderTranslator
         CpuContext ctx,
         ulong address,
         out Gen5ShaderProgram program,
+        out string error) =>
+        TryDecodeProgram(ctx, address, 0, out program, out error);
+
+    private static bool TryDecodeProgram(
+        CpuContext ctx,
+        ulong address,
+        uint shaderSizeBytes,
+        out Gen5ShaderProgram program,
         out string error)
     {
         ValidateDppControlVectors();
@@ -422,8 +458,19 @@ public static class Gen5ShaderTranslator
 
         var instructions = new List<Gen5ShaderInstruction>();
         var instructionCount = 0;
-        for (uint pc = 0; instructionCount < MaxInstructions;)
+        var programLimitBytes = shaderSizeBytes == 0
+            ? MaximumHeaderlessShaderBytes
+            : shaderSizeBytes;
+        var maximumInstructions = checked((int)(programLimitBytes / sizeof(uint)));
+        uint pc = 0;
+        for (; instructionCount < maximumInstructions && pc < programLimitBytes;)
         {
+            if (programLimitBytes - pc < sizeof(uint))
+            {
+                error = $"truncated-word pc=0x{pc:X} limit=0x{programLimitBytes:X}";
+                return false;
+            }
+
             if (!TryReadUInt32(ctx, address + pc, out var word))
             {
                 error = $"read-failed pc=0x{pc:X}";
@@ -435,11 +482,20 @@ public static class Gen5ShaderTranslator
                     address,
                     pc,
                     word,
+                    programLimitBytes - pc,
                     out var encoding,
                     out var name,
                     out var sizeDwords,
                     out error))
             {
+                return false;
+            }
+
+            var instructionBytes = sizeDwords * sizeof(uint);
+            if (instructionBytes > programLimitBytes - pc)
+            {
+                error = $"truncated-instruction pc=0x{pc:X} " +
+                    $"dwords={sizeDwords} limit=0x{programLimitBytes:X}";
                 return false;
             }
 
@@ -457,7 +513,7 @@ public static class Gen5ShaderTranslator
             instructions.Add(CreateInstruction(pc, encoding, name, words));
             instructionCount++;
 
-            pc += sizeDwords * sizeof(uint);
+            pc += instructionBytes;
             if (string.Equals(name, "SEndpgm", StringComparison.Ordinal))
             {
                 program = new Gen5ShaderProgram(address, instructions);
@@ -465,7 +521,10 @@ public static class Gen5ShaderTranslator
             }
         }
 
-        error = "unterminated";
+        error = $"unterminated pc=0x{pc:X} instructions={instructionCount}" +
+            (shaderSizeBytes == 0
+                ? $" fallback_limit=0x{programLimitBytes:X}"
+                : $" size=0x{shaderSizeBytes:X}");
         return false;
     }
 
@@ -520,6 +579,7 @@ public static class Gen5ShaderTranslator
         ulong baseAddress,
         uint pc,
         uint word,
+        uint availableBytes,
         out Gen5ShaderEncoding encoding,
         out string name,
         out uint sizeDwords,
@@ -573,7 +633,8 @@ public static class Gen5ShaderTranslator
             case 0x34:
             case 0x35:
                 encoding = Gen5ShaderEncoding.Vop3;
-                if (!TryReadUInt32(ctx, baseAddress + pc + sizeof(uint), out var vop3Extra))
+                if (availableBytes < 2 * sizeof(uint) ||
+                    !TryReadUInt32(ctx, baseAddress + pc + sizeof(uint), out var vop3Extra))
                 {
                     error = $"vop3-extra-read-failed pc=0x{pc:X}";
                     return false;
@@ -594,7 +655,8 @@ public static class Gen5ShaderTranslator
                 return DecodeFlat(word, out name, out sizeDwords, out error);
             case 0x38:
                 encoding = Gen5ShaderEncoding.Mubuf;
-                if (!TryReadUInt32(ctx, baseAddress + pc + sizeof(uint), out var mubufExtra))
+                if (availableBytes < 2 * sizeof(uint) ||
+                    !TryReadUInt32(ctx, baseAddress + pc + sizeof(uint), out var mubufExtra))
                 {
                     error = $"mubuf-extra-read-failed pc=0x{pc:X}";
                     return false;
@@ -603,7 +665,8 @@ public static class Gen5ShaderTranslator
                 return DecodeMubuf(word, mubufExtra, out name, out sizeDwords, out error);
             case 0x3A:
                 encoding = Gen5ShaderEncoding.Mtbuf;
-                if (!TryReadUInt32(ctx, baseAddress + pc + sizeof(uint), out var mtbufExtra))
+                if (availableBytes < 2 * sizeof(uint) ||
+                    !TryReadUInt32(ctx, baseAddress + pc + sizeof(uint), out var mtbufExtra))
                 {
                     error = $"mtbuf-extra-read-failed pc=0x{pc:X}";
                     return false;
@@ -645,6 +708,7 @@ public static class Gen5ShaderTranslator
             0,
             pc,
             word,
+            uint.MaxValue,
             out _,
             out name,
             out sizeDwords,
@@ -675,10 +739,12 @@ public static class Gen5ShaderTranslator
             0x04 => "SMovB64",
             0x07 => "SNotB32",
             0x08 => "SNotB64",
+            0x09 => "SWqmB32",
             0x0A => "SWqmB64",
             0x0B => "SBrevB32",
             0x0F => "SBcnt1I32B32",
             0x13 => "SFF1I32B32",
+            0x14 => "SFF1I32B64",
             0x1D => "SBitset1B32",
             0x1F => "SGetpcB64",
             0x20 => "SSetpcB64",
@@ -800,6 +866,8 @@ public static class Gen5ShaderTranslator
             0x0D => "SBitcmp1B32",
             0x0E => "SBitcmp0B64",
             0x0F => "SBitcmp1B64",
+            0x12 => "SCmpEqU64",
+            0x13 => "SCmpLgU64",
             _ => string.Empty,
         };
 
@@ -825,6 +893,7 @@ public static class Gen5ShaderTranslator
             0x0A => "SBarrier",
             0x0C => "SWaitcnt",
             0x10 => "SSendmsg",
+            0x12 => "STrap",
             0x16 => "STtraceData",
             0x20 => "SInstPrefetch",
             0x21 => "SClause",
@@ -1116,6 +1185,7 @@ public static class Gen5ShaderTranslator
             0x15D => "VSadU32",
             0x15E => "VCvtPkU8F32",
             0x148 => "VBfeU32",
+            0x149 => "VBfeI32",
             0x169 => "VMulLoU32",
             0x16A => "VMulHiU32",
             0x16B => "VMulLoI32",
@@ -1203,6 +1273,7 @@ public static class Gen5ShaderTranslator
             0x36 => "DsReadB32",
             0x37 => "DsRead2B32",
             0x38 => "DsRead2St64B32",
+            0x3E => "DsPermuteB32",
             0x4D => "DsWriteB64",
             0xDE => "DsWriteB96",
             0xDF => "DsWriteB128",
@@ -1413,7 +1484,10 @@ public static class Gen5ShaderTranslator
 
     private static bool DecodeMimg(uint word, out string name, out uint sizeDwords, out string error)
     {
-        var opcode = (word >> 18) & 0x7F;
+        // GFX10 MIMG stores OP[6:0] in bits 24:18 and OP[7] in bit 0.
+        // Bit 0 used to be dropped here, misreporting ray/BVH opcode 0xE6 as
+        // the otherwise unrelated low opcode 0x66.
+        var opcode = ((word & 1) << 7) | ((word >> 18) & 0x7F);
         sizeDwords = 2 + ((word >> 1) & 0x3);
         error = string.Empty;
         name = opcode switch
@@ -1451,6 +1525,7 @@ public static class Gen5ShaderTranslator
             0x4E => "ImageGather4CBCl",
             0x57 => "ImageGather4LzO",
             0x5F => "ImageGather4CLzO",
+            0xE6 => "ImageBvhIntersectRay",
             _ => string.Empty,
         };
 
@@ -1880,6 +1955,10 @@ public static class Gen5ShaderTranslator
                         Gen5Operand.Vector(vectorData1),
                     ],
                     "DsSwizzleB32" => [Gen5Operand.Vector(vectorData0)],
+                    "DsPermuteB32" => [
+                        Gen5Operand.Vector(vectorAddress),
+                        Gen5Operand.Vector(vectorData0),
+                    ],
                     // DS_CMPST operand order is reversed vs buffer/image cmpswap:
                     // DATA0 holds the comparator, DATA1 holds the new value.
                     "DsCmpstB32" or "DsCmpstRtnB32" => [
@@ -1895,7 +1974,10 @@ public static class Gen5ShaderTranslator
                 };
                 destinations = opcode switch
                 {
-                    "DsReadB32" or "DsSwizzleB32" => [
+                    "DsAddRtnU32" => [
+                        Gen5Operand.Vector(vectorDestination),
+                    ],
+                    "DsReadB32" or "DsSwizzleB32" or "DsPermuteB32" => [
                         Gen5Operand.Vector(vectorDestination),
                     ],
                     "DsRead2B32" or "DsRead2St64B32" => [
@@ -2092,6 +2174,7 @@ public static class Gen5ShaderTranslator
                 var vectorData = (extra >> 8) & 0xFF;
                 var scalarResource = ((extra >> 16) & 0x1F) * 4;
                 var scalarSampler = ((extra >> 21) & 0x1F) * 4;
+                var isBvhIntersectRay = opcode == "ImageBvhIntersectRay";
                 var addressRegisters = new List<uint>(1 + Math.Max(0, words.Length - 2) * 4)
                 {
                     vectorAddress,
@@ -2104,6 +2187,15 @@ public static class Gen5ShaderTranslator
                     }
                 }
 
+                // GFX10 IMAGE_BVH_INTERSECT_RAY has 11 A16=0 address VGPRs.
+                // Its final NSA dword contains two padding bytes, which are not
+                // v0 operands.  It also consumes a special four-SGPR BVH
+                // descriptor and no sampler.
+                if (isBvhIntersectRay && addressRegisters.Count > 11)
+                {
+                    addressRegisters.RemoveRange(11, addressRegisters.Count - 11);
+                }
+
                 var imageSources = new List<Gen5Operand>(addressRegisters.Count + 2);
                 foreach (var addressRegister in addressRegisters)
                 {
@@ -2111,11 +2203,23 @@ public static class Gen5ShaderTranslator
                 }
 
                 imageSources.Add(Gen5Operand.Scalar(scalarResource));
-                imageSources.Add(Gen5Operand.Scalar(scalarSampler));
+                if (!isBvhIntersectRay)
+                {
+                    imageSources.Add(Gen5Operand.Scalar(scalarSampler));
+                }
                 sources = imageSources;
-                destinations = opcode.StartsWith("ImageStore", StringComparison.Ordinal)
-                    ? []
-                    : [Gen5Operand.Vector(vectorData)];
+                destinations = opcode switch
+                {
+                    _ when opcode.StartsWith("ImageStore", StringComparison.Ordinal) => [],
+                    "ImageBvhIntersectRay" =>
+                    [
+                        Gen5Operand.Vector(vectorData),
+                        Gen5Operand.Vector(vectorData + 1),
+                        Gen5Operand.Vector(vectorData + 2),
+                        Gen5Operand.Vector(vectorData + 3),
+                    ],
+                    _ => [Gen5Operand.Vector(vectorData)],
+                };
                 var dimension = (word >> 3) & 0x7;
                 control = new Gen5ImageControl(
                     (word >> 8) & 0xF,
@@ -2123,7 +2227,7 @@ public static class Gen5ShaderTranslator
                     addressRegisters,
                     vectorData,
                     scalarResource,
-                    scalarSampler,
+                    isBvhIntersectRay ? 0 : scalarSampler,
                     dimension,
                     dimension is 4 or 5 or 7,
                     ((word >> 13) & 1) != 0,

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcGuestImageDirtyRefreshTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcGuestImageDirtyRefreshTests.cs
@@ -1,0 +1,124 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Runtime.InteropServices;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed unsafe class AgcGuestImageDirtyRefreshTests
+{
+    private const nuint PageSize = 4096;
+
+    [Fact]
+    public void CleanAvailableGuestImageKeepsEmptyPixelShortcut()
+    {
+        if (!GuestImageWriteTracker.Enabled)
+        {
+            return;
+        }
+
+        var page = AllocateTrackedPage(out var address);
+        try
+        {
+            Assert.True(AgcExports.TryUseAvailableGuestImageWithoutSnapshot(
+                address,
+                guestImageAvailable: true,
+                out var dirtySnapshotClaimed));
+            Assert.False(dirtySnapshotClaimed);
+        }
+        finally
+        {
+            ReleaseTrackedPage(page, address);
+        }
+    }
+
+    [Fact]
+    public void DirtyAvailableGuestImageClaimsOneSnapshotAndRearmsAfterSuccess()
+    {
+        if (!GuestImageWriteTracker.Enabled)
+        {
+            return;
+        }
+
+        var page = AllocateTrackedPage(out var address);
+        try
+        {
+            GuestImageWriteTracker.NotifyManagedWrite(address + 64, 1);
+
+            Assert.False(AgcExports.TryUseAvailableGuestImageWithoutSnapshot(
+                address,
+                guestImageAvailable: true,
+                out var dirtySnapshotClaimed));
+            Assert.True(dirtySnapshotClaimed);
+            Assert.False(GuestImageWriteTracker.PeekDirty(address));
+
+            AgcExports.CompleteGuestImageSnapshot(address, succeeded: true);
+            Assert.True(AgcExports.TryUseAvailableGuestImageWithoutSnapshot(
+                address,
+                guestImageAvailable: true,
+                out var duplicateClaim));
+            Assert.False(duplicateClaim);
+
+            GuestImageWriteTracker.NotifyManagedWrite(address + 128, 1);
+
+            Assert.True(GuestImageWriteTracker.PeekDirty(address));
+        }
+        finally
+        {
+            ReleaseTrackedPage(page, address);
+        }
+    }
+
+    [Fact]
+    public void FailedDirtySnapshotRemainsDirtyForRetry()
+    {
+        if (!GuestImageWriteTracker.Enabled)
+        {
+            return;
+        }
+
+        var page = AllocateTrackedPage(out var address);
+        try
+        {
+            GuestImageWriteTracker.NotifyManagedWrite(address + 64, 1);
+            Assert.False(AgcExports.TryUseAvailableGuestImageWithoutSnapshot(
+                address,
+                guestImageAvailable: true,
+                out var firstClaim));
+            Assert.True(firstClaim);
+
+            AgcExports.CompleteGuestImageSnapshot(address, succeeded: false);
+
+            Assert.True(GuestImageWriteTracker.PeekDirty(address));
+            Assert.False(AgcExports.TryUseAvailableGuestImageWithoutSnapshot(
+                address,
+                guestImageAvailable: true,
+                out var retryClaim));
+            Assert.True(retryClaim);
+            AgcExports.CompleteGuestImageSnapshot(address, succeeded: true);
+        }
+        finally
+        {
+            ReleaseTrackedPage(page, address);
+        }
+    }
+
+    private static byte* AllocateTrackedPage(out ulong address)
+    {
+        var page = (byte*)NativeMemory.AlignedAlloc(PageSize, PageSize);
+        Assert.NotEqual(nint.Zero, (nint)page);
+        new Span<byte>(page, checked((int)PageSize)).Clear();
+        address = (ulong)page;
+        GuestImageWriteTracker.Track(address, checked((ulong)PageSize));
+        return page;
+    }
+
+    private static void ReleaseTrackedPage(byte* page, ulong address)
+    {
+        GuestImageWriteTracker.Untrack(address);
+        NativeMemory.AlignedFree(page);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcInterpolantMappingTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcInterpolantMappingTests.cs
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcInterpolantMappingTests
+{
+    private const ulong BaseAddress = 0x1_0000_0000;
+    private const ulong RegistersAddress = BaseAddress + 0x100;
+    private const ulong GeometryShaderAddress = BaseAddress + 0x400;
+    private const ulong PixelShaderAddress = BaseAddress + 0x600;
+    private const ulong OutputSemanticsAddress = BaseAddress + 0x800;
+    private const ulong InputSemanticsAddress = BaseAddress + 0x900;
+
+    [Fact]
+    public void CreateInterpolantMappingMatchesSemanticIdsAndCustomFlags()
+    {
+        var memory = CreateMemory(
+            geometrySemantics:
+            [
+                0x0000_0000u,
+                0x0000_0101u,
+                0x0000_0202u,
+                0x0000_0303u,
+            ],
+            pixelSemantics:
+            [
+                0x0000_0000u,
+                0x0000_0002u,
+                0x4100_0003u,
+            ]);
+
+        var result = Invoke(memory);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        AssertRegister(memory, 0, 0x000u);
+        AssertRegister(memory, 1, 0x002u);
+        AssertRegister(memory, 2, 0x423u);
+        AssertRegister(memory, 3, 0x003u);
+        AssertRegister(memory, 31, 0x01Fu);
+    }
+
+    [Fact]
+    public void CreateInterpolantMappingPreservesF16Mode()
+    {
+        var memory = CreateMemory(
+            geometrySemantics: [0x0010_0705u],
+            pixelSemantics: [0x0010_0005u]);
+
+        var result = Invoke(memory);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        AssertRegister(memory, 0, 0x0118_0007u);
+    }
+
+    private static FakeCpuMemory CreateMemory(
+        IReadOnlyList<uint> geometrySemantics,
+        IReadOnlyList<uint> pixelSemantics)
+    {
+        var memory = new FakeCpuMemory(BaseAddress, 0x2000);
+        WriteUInt64(
+            memory,
+            GeometryShaderAddress + 0x38,
+            OutputSemanticsAddress);
+        WriteUInt32(
+            memory,
+            GeometryShaderAddress + 0x56,
+            (uint)geometrySemantics.Count);
+        WriteUInt64(
+            memory,
+            PixelShaderAddress + 0x30,
+            InputSemanticsAddress);
+        WriteUInt32(
+            memory,
+            PixelShaderAddress + 0x50,
+            (uint)pixelSemantics.Count);
+
+        for (var index = 0; index < geometrySemantics.Count; index++)
+        {
+            WriteUInt32(
+                memory,
+                OutputSemanticsAddress + (ulong)(index * sizeof(uint)),
+                geometrySemantics[index]);
+        }
+
+        for (var index = 0; index < pixelSemantics.Count; index++)
+        {
+            WriteUInt32(
+                memory,
+                InputSemanticsAddress + (ulong)(index * sizeof(uint)),
+                pixelSemantics[index]);
+        }
+
+        return memory;
+    }
+
+    private static int Invoke(FakeCpuMemory memory)
+    {
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        ctx[CpuRegister.Rdi] = RegistersAddress;
+        ctx[CpuRegister.Rsi] = GeometryShaderAddress;
+        ctx[CpuRegister.Rdx] = PixelShaderAddress;
+        return AgcExports.CreateInterpolantMapping(ctx);
+    }
+
+    private static void AssertRegister(
+        FakeCpuMemory memory,
+        uint index,
+        uint expectedValue)
+    {
+        var address = RegistersAddress + (index * 8);
+        Assert.Equal(0x191u + index, ReadUInt32(memory, address));
+        Assert.Equal(expectedValue, ReadUInt32(memory, address + sizeof(uint)));
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        Assert.True(memory.TryRead(address, bytes));
+        return BinaryPrimitives.ReadUInt32LittleEndian(bytes);
+    }
+
+    private static void WriteUInt32(
+        FakeCpuMemory memory,
+        ulong address,
+        uint value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static void WriteUInt64(
+        FakeCpuMemory memory,
+        ulong address,
+        ulong value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcRuntimeScalarMetadataTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcRuntimeScalarMetadataTests.cs
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.Libs.Agc;
+using SharpEmu.ShaderCompiler;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcRuntimeScalarMetadataTests
+{
+    [Fact]
+    public void BufferBiasAndCountAreInterleavedByAbsoluteBinding()
+    {
+        var registers = new uint[] { 0x12345678 };
+        var bindings = new Gen5GlobalMemoryBinding[]
+        {
+            CreateBinding(0x1003, 5),
+            CreateBinding(0x2040, 9),
+            CreateBinding(0x30FF, 4),
+            CreateBinding(0x4000, 1),
+            CreateBinding(0x5008, 16),
+        };
+        var bytes = new byte[
+            Gen5RuntimeScalarLayout.GetDwordLength(bindings.Length) *
+            sizeof(uint)];
+
+        AgcExports.PackRuntimeScalarStateInto(bytes, registers, bindings);
+
+        Assert.Equal(0x12345678u, ReadDword(bytes, 0));
+        AssertMetadata(bytes, 0, expectedBias: 3, expectedCount: 2);
+        AssertMetadata(bytes, 1, expectedBias: 64, expectedCount: 19);
+        AssertMetadata(bytes, 2, expectedBias: 255, expectedCount: 65);
+        AssertMetadata(bytes, 3, expectedBias: 0, expectedCount: 1);
+        AssertMetadata(bytes, 4, expectedBias: 8, expectedCount: 6);
+    }
+
+    private static Gen5GlobalMemoryBinding CreateBinding(
+        ulong baseAddress,
+        int dataLength) =>
+        new(0, baseAddress, [], new byte[dataLength], dataLength, false);
+
+    private static void AssertMetadata(
+        byte[] bytes,
+        int binding,
+        uint expectedBias,
+        uint expectedCount)
+    {
+        Assert.Equal(
+            expectedBias,
+            ReadDword(
+                bytes,
+                Gen5RuntimeScalarLayout.GetByteBiasDwordIndex(binding)));
+        Assert.Equal(
+            expectedCount,
+            ReadDword(
+                bytes,
+                Gen5RuntimeScalarLayout.GetBufferDwordCountDwordIndex(binding)));
+    }
+
+    private static uint ReadDword(byte[] bytes, int dwordIndex) =>
+        BinaryPrimitives.ReadUInt32LittleEndian(
+            bytes.AsSpan(dwordIndex * sizeof(uint), sizeof(uint)));
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/Gen5SpirvPackedHalfExportTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/Gen5SpirvPackedHalfExportTests.cs
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class Gen5SpirvPackedHalfExportTests
+{
+    private const ulong ShaderAddress = 0x1_0000_0000;
+    private const uint PsUserDataRegister = 0x0C;
+
+    [Fact]
+    public void CompressedExport_UnpacksTheStoredHalfPrecisionVgpr()
+    {
+        var memory = new FakeCpuMemory(ShaderAddress, 0x1000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Gen5ShaderAtomicDecodeTests.WriteProgram(
+            memory,
+            ShaderAddress,
+            [
+                // v_cvt_pkrtz_f16_f32 v2, v2, v3
+                0x5E040702,
+                // v_cvt_pkrtz_f16_f32 v3, v4, v5
+                0x5E060B04,
+                // exp mrt0, v2, v3 compr done vm
+                0xF8001C0F, 0x00000302,
+            ]);
+        var shaderRegisters = new Dictionary<uint, uint>
+        {
+            // SPI_SHADER_PGM_RSRC2_PS advertises zero user SGPRs.
+            [PsUserDataRegister - 1] = 0,
+        };
+
+        Assert.True(
+            Gen5ShaderTranslator.TryCreateState(
+                ctx,
+                ShaderAddress,
+                0,
+                shaderRegisters,
+                PsUserDataRegister,
+                out var state,
+                out var error),
+            error);
+        Assert.True(
+            Gen5ShaderScalarEvaluator.TryEvaluate(ctx, state, out var evaluation, out error),
+            error);
+        Assert.True(
+            Gen5SpirvTranslator.TryCompilePixelShader(
+                state,
+                evaluation,
+                Gen5PixelOutputKind.Float,
+                out var shader,
+                out error),
+            error);
+
+        // GLSL.std.450 instruction 62 is UnpackHalf2x16. The compressed export
+        // must consume the packed VGPR value, including its half-precision
+        // rounding, instead of bypassing it through a float32 shadow value.
+        Assert.Contains(62u, CollectExtInstNumbers(shader.Spirv));
+    }
+
+    private static HashSet<uint> CollectExtInstNumbers(byte[] spirv)
+    {
+        var instructions = new HashSet<uint>();
+        for (var offset = 5 * sizeof(uint); offset + sizeof(uint) <= spirv.Length;)
+        {
+            var word = BinaryPrimitives.ReadUInt32LittleEndian(
+                spirv.AsSpan(offset, sizeof(uint)));
+            var wordCount = Math.Max((int)(word >> 16), 1);
+            if ((ushort)word == (ushort)SpirvOp.ExtInst && wordCount >= 5)
+            {
+                instructions.Add(
+                    BinaryPrimitives.ReadUInt32LittleEndian(
+                        spirv.AsSpan(offset + (4 * sizeof(uint)), sizeof(uint))));
+            }
+
+            offset += wordCount * sizeof(uint);
+        }
+
+        return instructions;
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/AvPlayer/AvPlayerNv12LayoutTests.cs
+++ b/tests/SharpEmu.Libs.Tests/AvPlayer/AvPlayerNv12LayoutTests.cs
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.AvPlayer;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.AvPlayer;
+
+public sealed class AvPlayerNv12LayoutTests
+{
+    [Theory]
+    [InlineData(1920, 2048)]
+    [InlineData(3840, 3840)]
+    [InlineData(4097, 4352)]
+    public void CalculateNv12Pitch_AlignsTo256Bytes(int width, int expectedPitch)
+    {
+        Assert.Equal(expectedPitch, AvPlayerExports.CalculateNv12Pitch(width));
+    }
+
+    [Fact]
+    public void CalculateNv12BufferSize_IncludesBothPlanesAtTheAlignedPitch()
+    {
+        Assert.Equal(3_317_760, AvPlayerExports.CalculateNv12BufferSize(2048, 1080));
+    }
+
+    [Fact]
+    public void CopyNv12ToGuestBuffer_UsesSourceStridesAndPitchedUvOffset()
+    {
+        const int width = 4;
+        const int height = 4;
+        const int sourceLumaStride = 6;
+        const int sourceChromaStride = 8;
+        const int destinationPitch = 8;
+        var source = Enumerable.Repeat((byte)0xEE, 40).ToArray();
+        for (var row = 0; row < height; row++)
+        {
+            for (var column = 0; column < width; column++)
+            {
+                source[(row * sourceLumaStride) + column] = checked((byte)(1 + (row * 10) + column));
+            }
+        }
+        var sourceChromaOffset = sourceLumaStride * height;
+        for (var row = 0; row < height / 2; row++)
+        {
+            for (var column = 0; column < width; column++)
+            {
+                source[sourceChromaOffset + (row * sourceChromaStride) + column] =
+                    checked((byte)(101 + (row * 10) + column));
+            }
+        }
+
+        var destination = Enumerable.Repeat((byte)0xCC, 48).ToArray();
+        AvPlayerExports.CopyNv12ToGuestBuffer(
+            source,
+            destination,
+            width,
+            height,
+            sourceLumaStride,
+            sourceChromaStride,
+            destinationPitch);
+
+        var expected = new byte[48];
+        for (var row = 0; row < height; row++)
+        {
+            source.AsSpan(row * sourceLumaStride, width)
+                .CopyTo(expected.AsSpan(row * destinationPitch, width));
+        }
+        var destinationChromaOffset = destinationPitch * height;
+        for (var row = 0; row < height / 2; row++)
+        {
+            source.AsSpan(sourceChromaOffset + (row * sourceChromaStride), width)
+                .CopyTo(expected.AsSpan(destinationChromaOffset + (row * destinationPitch), width));
+        }
+        Assert.Equal(expected, destination);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Json/JsonExportRegistrationTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Json/JsonExportRegistrationTests.cs
@@ -22,6 +22,7 @@ public sealed class JsonExportRegistrationTests
         ("BSmWDIkV4w4", "_ZN3sce4Json5Value3setEd"),
         ("IKQimvG9Wqs", "_ZN3sce4Json5Value3setENS0_9ValueTypeE"),
         ("6l3Bv2gysNc", "_ZN3sce4Json5Value3setERKNS0_6StringE"),
+        ("wLsJlmgEIaI", "_ZN3sce4Json5Value10referValueERKNS0_6StringE"),
         ("9KUZFjI1IxA", "_ZN3sce4Json6StringC1EPKc"),
         ("cG1VE2HMl6c", "_ZN3sce4Json6StringD1Ev"),
         ("+drDFyAS6u4", "_ZN3sce4Json11Initializer27setGlobalNullAccessCallbackEPFRKNS0_5ValueENS0_9ValueTypeEPS3_PvES7_"),

--- a/tests/SharpEmu.Libs.Tests/Json/JsonExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Json/JsonExportsTests.cs
@@ -1,0 +1,136 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Json;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Json;
+
+[Collection("JsonObjectHeap")]
+public sealed class JsonExportsTests
+{
+    private const ulong BaseAddress = 0x2_0000_0000;
+    private const ulong ValueAddress = BaseAddress + 0x1000;
+    private const ulong StringAddress = BaseAddress + 0x2000;
+    private const ulong TextAddress = BaseAddress + 0x3000;
+    private const ulong BufferAddress = BaseAddress + 0x4000;
+
+    private readonly AllocatingCpuMemory _memory = new(BaseAddress, 0x20000, BaseAddress + 0x10000);
+    private readonly CpuContext _ctx;
+
+    public JsonExportsTests()
+    {
+        JsonObjectHeap.ResetForTests();
+        _ctx = new CpuContext(_memory, Generation.Gen5);
+    }
+
+    [Fact]
+    public void ReferValueByString_ReturnsParsedBooleanChild()
+    {
+        var json = Encoding.UTF8.GetBytes("{\"enabled\":true}");
+        Assert.True(_memory.TryWrite(BufferAddress, json));
+        _ctx[CpuRegister.Rdi] = ValueAddress;
+        _ctx[CpuRegister.Rsi] = BufferAddress;
+        _ctx[CpuRegister.Rdx] = (ulong)json.Length;
+        Assert.Equal(0, JsonExports.ParserParseBuffer(_ctx));
+
+        _memory.WriteCString(TextAddress, "enabled");
+        _ctx[CpuRegister.Rdi] = StringAddress;
+        _ctx[CpuRegister.Rsi] = TextAddress;
+        JsonValueExports.StringCStringConstructor(_ctx);
+
+        _ctx[CpuRegister.Rdi] = ValueAddress;
+        _ctx[CpuRegister.Rsi] = StringAddress;
+        Assert.Equal(0, JsonExports.ValueReferValueByString(_ctx));
+
+        var childAddress = _ctx[CpuRegister.Rax];
+        Assert.NotEqual(0UL, childAddress);
+        _ctx[CpuRegister.Rdi] = StringAddress;
+        JsonValueExports.StringDestructor(_ctx);
+
+        _memory.WriteCString(TextAddress, "enabled");
+        _ctx[CpuRegister.Rdi] = StringAddress;
+        _ctx[CpuRegister.Rsi] = TextAddress;
+        JsonValueExports.StringCStringConstructor(_ctx);
+        _ctx[CpuRegister.Rdi] = ValueAddress;
+        _ctx[CpuRegister.Rsi] = StringAddress;
+        JsonExports.ValueReferValueByString(_ctx);
+        Assert.Equal(childAddress, _ctx[CpuRegister.Rax]);
+
+        _ctx[CpuRegister.Rdi] = childAddress;
+        JsonExports.ValueGetType(_ctx);
+        Assert.Equal(1UL, _ctx[CpuRegister.Rax]);
+        JsonExports.ValueGetBoolean(_ctx);
+        Assert.Equal(childAddress + 0x10, _ctx[CpuRegister.Rax]);
+        Span<byte> boolean = stackalloc byte[1];
+        Assert.True(_memory.TryRead(childAddress + 0x10, boolean));
+        Assert.Equal(1, boolean[0]);
+    }
+
+    [Fact]
+    public void ReferValueByString_ReturnsNullForMissingMember()
+    {
+        var json = Encoding.UTF8.GetBytes("{}");
+        Assert.True(_memory.TryWrite(BufferAddress, json));
+        _ctx[CpuRegister.Rdi] = ValueAddress;
+        _ctx[CpuRegister.Rsi] = BufferAddress;
+        _ctx[CpuRegister.Rdx] = (ulong)json.Length;
+        Assert.Equal(0, JsonExports.ParserParseBuffer(_ctx));
+
+        _memory.WriteCString(TextAddress, "missing");
+        _ctx[CpuRegister.Rdi] = StringAddress;
+        _ctx[CpuRegister.Rsi] = TextAddress;
+        JsonValueExports.StringCStringConstructor(_ctx);
+
+        _ctx[CpuRegister.Rdi] = ValueAddress;
+        _ctx[CpuRegister.Rsi] = StringAddress;
+        Assert.Equal(0, JsonExports.ValueReferValueByString(_ctx));
+        Assert.Equal(0UL, _ctx[CpuRegister.Rax]);
+    }
+
+    private sealed class AllocatingCpuMemory : ICpuMemory, IGuestMemoryAllocator
+    {
+        private readonly FakeCpuMemory _memory;
+        private readonly ulong _endAddress;
+        private ulong _nextAddress;
+
+        public AllocatingCpuMemory(ulong baseAddress, int size, ulong allocationStart)
+        {
+            _memory = new FakeCpuMemory(baseAddress, size);
+            _nextAddress = allocationStart;
+            _endAddress = baseAddress + (ulong)size;
+        }
+
+        public bool TryRead(ulong virtualAddress, Span<byte> destination) =>
+            _memory.TryRead(virtualAddress, destination);
+
+        public bool TryWrite(ulong virtualAddress, ReadOnlySpan<byte> source) =>
+            _memory.TryWrite(virtualAddress, source);
+
+        public ulong WriteCString(ulong virtualAddress, string text) =>
+            _memory.WriteCString(virtualAddress, text);
+
+        public bool TryAllocateGuestMemory(ulong size, ulong alignment, out ulong address)
+        {
+            address = 0;
+            if (size == 0 || alignment == 0 || (alignment & (alignment - 1)) != 0)
+            {
+                return false;
+            }
+
+            var aligned = (_nextAddress + alignment - 1) & ~(alignment - 1);
+            if (aligned > _endAddress || size > _endAddress - aligned)
+            {
+                return false;
+            }
+
+            address = aligned;
+            _nextAddress = aligned + size;
+            return true;
+        }
+
+        public bool TryFreeGuestMemory(ulong address) => false;
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Memory/GuestImageWriteTrackerTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Memory/GuestImageWriteTrackerTests.cs
@@ -1,0 +1,118 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Runtime.InteropServices;
+using SharpEmu.Core.Cpu;
+using SharpEmu.HLE;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Memory;
+
+public sealed unsafe class GuestImageWriteTrackerTests
+{
+    private const nuint PageSize = 4096;
+
+    [Fact]
+    public void TrackedCpuMemoryManagedWriteMarksTrackedImageDirty()
+    {
+        if (!GuestImageWriteTracker.Enabled)
+        {
+            return;
+        }
+
+        var page = (byte*)NativeMemory.AlignedAlloc(PageSize, PageSize);
+        Assert.NotEqual(nint.Zero, (nint)page);
+        new Span<byte>(page, checked((int)PageSize)).Clear();
+        var address = (ulong)page;
+        var memory = new TrackedCpuMemory(
+            new PointerCpuMemory(address, checked((ulong)PageSize)));
+
+        GuestImageWriteTracker.Track(address, checked((ulong)PageSize));
+        try
+        {
+            Assert.True(memory.TryWrite(address + 128, [1, 2, 3, 4]));
+            Assert.True(GuestImageWriteTracker.ConsumeDirty(address));
+            Assert.False(GuestImageWriteTracker.ConsumeDirty(address));
+
+            Span<byte> actual = stackalloc byte[4];
+            Assert.True(memory.TryRead(address + 128, actual));
+            Assert.Equal([1, 2, 3, 4], actual.ToArray());
+
+            GuestImageWriteTracker.Rearm(address);
+            Assert.True(memory.TryWrite(address + 256, [5]));
+            Assert.True(GuestImageWriteTracker.ConsumeDirty(address));
+        }
+        finally
+        {
+            GuestImageWriteTracker.Untrack(address);
+            NativeMemory.AlignedFree(page);
+        }
+    }
+
+    [Fact]
+    public void ManagedWriteMarksEveryTrackedOwnerOfSharedPageDirty()
+    {
+        if (!GuestImageWriteTracker.Enabled)
+        {
+            return;
+        }
+
+        var page = (byte*)NativeMemory.AlignedAlloc(PageSize, PageSize);
+        Assert.NotEqual(nint.Zero, (nint)page);
+        new Span<byte>(page, checked((int)PageSize)).Clear();
+        var firstAddress = (ulong)page + 64;
+        var secondAddress = (ulong)page + 2048;
+
+        GuestImageWriteTracker.Track(firstAddress, 512);
+        GuestImageWriteTracker.Track(secondAddress, 512);
+        try
+        {
+            GuestImageWriteTracker.NotifyManagedWrite(secondAddress + 32, 1);
+
+            Assert.True(GuestImageWriteTracker.ConsumeDirty(firstAddress));
+            Assert.True(GuestImageWriteTracker.ConsumeDirty(secondAddress));
+        }
+        finally
+        {
+            GuestImageWriteTracker.Untrack(firstAddress);
+            GuestImageWriteTracker.Untrack(secondAddress);
+            NativeMemory.AlignedFree(page);
+        }
+    }
+
+    private sealed class PointerCpuMemory(ulong baseAddress, ulong length) : ICpuMemory
+    {
+        private readonly ulong _baseAddress = baseAddress;
+        private readonly ulong _length = length;
+
+        public bool TryRead(ulong virtualAddress, Span<byte> destination)
+        {
+            if (!Contains(virtualAddress, destination.Length))
+            {
+                return false;
+            }
+
+            new ReadOnlySpan<byte>((void*)virtualAddress, destination.Length).CopyTo(destination);
+            return true;
+        }
+
+        public bool TryWrite(ulong virtualAddress, ReadOnlySpan<byte> source)
+        {
+            if (!Contains(virtualAddress, source.Length))
+            {
+                return false;
+            }
+
+            source.CopyTo(new Span<byte>((void*)virtualAddress, source.Length));
+            return true;
+        }
+
+        private bool Contains(ulong virtualAddress, int byteCount)
+        {
+            var length = checked((ulong)byteCount);
+            return virtualAddress >= _baseAddress &&
+                length <= _length &&
+                virtualAddress - _baseAddress <= _length - length;
+        }
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/VideoOut/HeadPreservingQueueRetentionTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/HeadPreservingQueueRetentionTests.cs
@@ -1,0 +1,128 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class HeadPreservingQueueRetentionTests
+{
+    [Fact]
+    public void LeavesQueueUnchangedWhenWithinLimit()
+    {
+        var pending = new LinkedList<int>([1, 2, 3, 4]);
+
+        var coalesced = HeadPreservingQueueRetention.CoalesceIntermediateItems(
+            pending,
+            maximumCount: 4);
+
+        Assert.Equal(0, coalesced);
+        Assert.Equal([1, 2, 3, 4], pending);
+    }
+
+    [Fact]
+    public void RetainsHeadAndNewestTailWhenOverloaded()
+    {
+        var pending = new LinkedList<int>([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        var coalesced = HeadPreservingQueueRetention.CoalesceIntermediateItems(
+            pending,
+            maximumCount: 4);
+
+        Assert.Equal(4, coalesced);
+        Assert.Equal([1, 6, 7, 8], pending);
+    }
+
+    [Fact]
+    public void RepeatedOverloadNeverEvictsUnconsumedHead()
+    {
+        var pending = new LinkedList<int>([1, 2, 3, 4]);
+
+        pending.AddLast(5);
+        Assert.Equal(
+            1,
+            HeadPreservingQueueRetention.CoalesceIntermediateItems(pending, 4));
+        Assert.Equal([1, 3, 4, 5], pending);
+
+        pending.AddLast(6);
+        Assert.Equal(
+            1,
+            HeadPreservingQueueRetention.CoalesceIntermediateItems(pending, 4));
+        Assert.Equal([1, 4, 5, 6], pending);
+    }
+
+    [Fact]
+    public void ReportsExactIntermediateItemsThatWereCoalesced()
+    {
+        var pending = new LinkedList<int>([1, 2, 3, 4, 5, 6]);
+        List<int> removed = [];
+
+        var coalesced = HeadPreservingQueueRetention.CoalesceIntermediateItems(
+            pending,
+            maximumCount: 4,
+            onCoalesced: removed.Add);
+
+        Assert.Equal(2, coalesced);
+        Assert.Equal([2, 3], removed);
+        Assert.Equal([1, 4, 5, 6], pending);
+    }
+
+    [Fact]
+    public void OrderedFlipYieldsToPresenter()
+    {
+        var flip = new VulkanOrderedGuestFlip(
+            Version: 1,
+            VideoOutHandle: 1,
+            DisplayBufferIndex: 0,
+            Address: 0x1000,
+            Width: 1920,
+            Height: 1080,
+            PitchInPixel: 1920);
+
+        Assert.True(GuestPresentationScheduling.ShouldYieldToPresenter(flip));
+    }
+
+    [Fact]
+    public void NonFlipGuestWorkContinuesDraining()
+    {
+        var wait = new VulkanOrderedGuestFlipWait(
+            Version: 1,
+            VideoOutHandle: 1,
+            DisplayBufferIndex: 0);
+
+        Assert.False(GuestPresentationScheduling.ShouldYieldToPresenter(wait));
+        Assert.False(GuestPresentationScheduling.ShouldYieldToPresenter(
+            new VulkanOrderedGuestAction(() => { }, "test")));
+    }
+
+    [Fact]
+    public void YieldAfterEveryFlipExposesEveryGenerationInOrder()
+    {
+        var pending = new LinkedList<int>();
+        List<int> presented = [];
+
+        for (var version = 1; version <= 12; version++)
+        {
+            pending.AddLast(version);
+            HeadPreservingQueueRetention.CoalesceIntermediateItems(pending, 4);
+
+            var flip = new VulkanOrderedGuestFlip(
+                Version: version,
+                VideoOutHandle: 1,
+                DisplayBufferIndex: 0,
+                Address: 0x1000,
+                Width: 1920,
+                Height: 1080,
+                PitchInPixel: 1920);
+            if (GuestPresentationScheduling.ShouldYieldToPresenter(flip))
+            {
+                presented.Add(pending.First!.Value);
+                pending.RemoveFirst();
+            }
+        }
+
+        Assert.Equal(Enumerable.Range(1, 12), presented);
+        Assert.Empty(pending);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanGuestImageBarrierTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanGuestImageBarrierTests.cs
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.VideoOut;
+using Silk.NET.Vulkan;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VulkanGuestImageBarrierTests
+{
+    [Fact]
+    public void SampledImageReadStagesCoverEverySupportedShaderConsumer()
+    {
+        var stages = VulkanVideoPresenter.SampledImageShaderReadStages;
+
+        Assert.Equal(
+            PipelineStageFlags.VertexShaderBit,
+            stages & PipelineStageFlags.VertexShaderBit);
+        Assert.Equal(
+            PipelineStageFlags.FragmentShaderBit,
+            stages & PipelineStageFlags.FragmentShaderBit);
+        Assert.Equal(
+            PipelineStageFlags.ComputeShaderBit,
+            stages & PipelineStageFlags.ComputeShaderBit);
+    }
+
+    [Fact]
+    public void OverwriteSourceStageDependsOnWhetherTheImageWasInitialized()
+    {
+        Assert.Equal(
+            PipelineStageFlags.TopOfPipeBit,
+            VulkanVideoPresenter.SampledImageOverwriteSourceStages(initialized: false));
+        Assert.Equal(
+            VulkanVideoPresenter.SampledImageShaderReadStages,
+            VulkanVideoPresenter.SampledImageOverwriteSourceStages(initialized: true));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanHostBufferPoolTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanHostBufferPoolTests.cs
@@ -45,6 +45,49 @@ public sealed class VulkanHostBufferPoolTests
     }
 
     [Fact]
+    public void ReturnEvictsOldestCachedAllocationsToAdmitCurrentWorkload()
+    {
+        var destroyed = new List<VulkanHostBufferAllocation>();
+        using var pool = new VulkanHostBufferPool(512, destroyed.Add);
+        var oldKey = new VulkanHostBufferPoolKey(BufferUsageFlags.VertexBufferBit, 256);
+        var currentKey = new VulkanHostBufferPoolKey(BufferUsageFlags.StorageBufferBit, 512);
+        var oldFirst = Allocation(11, 12, oldKey);
+        var oldSecond = Allocation(13, 14, oldKey);
+        var current = Allocation(15, 16, currentKey);
+
+        pool.Register(oldFirst);
+        pool.Register(oldSecond);
+        pool.Register(current);
+        Assert.True(pool.Return(oldFirst.Buffer, oldFirst.Memory));
+        Assert.True(pool.Return(oldSecond.Buffer, oldSecond.Memory));
+        Assert.Equal(512UL, pool.CachedBytes);
+
+        Assert.True(pool.Return(current.Buffer, current.Memory));
+
+        Assert.Equal([oldFirst, oldSecond], destroyed);
+        Assert.Equal(512UL, pool.CachedBytes);
+        Assert.False(pool.TryRent(oldKey, out _));
+        Assert.True(pool.TryRent(currentKey, out var rented));
+        Assert.Equal(current, rented);
+    }
+
+    [Fact]
+    public void ZeroBudgetDestroysEveryReturnedAllocation()
+    {
+        var destroyed = new List<VulkanHostBufferAllocation>();
+        using var pool = new VulkanHostBufferPool(0, destroyed.Add);
+        var key = new VulkanHostBufferPoolKey(BufferUsageFlags.IndexBufferBit, 256);
+        var allocation = Allocation(21, 22, key);
+
+        pool.Register(allocation);
+
+        Assert.True(pool.Return(allocation.Buffer, allocation.Memory));
+        Assert.Equal([allocation], destroyed);
+        Assert.Equal(0UL, pool.CachedBytes);
+        Assert.False(pool.TryRent(key, out _));
+    }
+
+    [Fact]
     public void UnknownAllocationIsNotClaimedByPool()
     {
         using var pool = new VulkanHostBufferPool(1024, _ => { });

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanRenderTargetFormatTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanRenderTargetFormatTests.cs
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Silk.NET.Vulkan;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VulkanRenderTargetFormatTests
+{
+    [Theory]
+    [InlineData(0u, Format.A2B10G10R10UnormPack32)]
+    [InlineData(1u, Format.A2R10G10B10UnormPack32)]
+    public void Color2101010HonorsComponentSwap(uint componentSwap, Format expected)
+    {
+        Assert.True(VulkanVideoPresenter.TryDecodeRenderTargetFormat(
+            dataFormat: 9,
+            numberType: 0,
+            componentSwap,
+            out var result));
+        Assert.Equal(expected, result.Format);
+    }
+
+    [Theory]
+    [InlineData(2u)]
+    [InlineData(3u)]
+    public void Color2101010RejectsUnsupportedComponentSwap(uint componentSwap)
+    {
+        Assert.False(VulkanVideoPresenter.TryDecodeRenderTargetFormat(
+            dataFormat: 9,
+            numberType: 0,
+            componentSwap,
+            out _));
+    }
+}

--- a/tests/SharpEmu.ShaderCompiler.Tests/Gen5DataShareTests.cs
+++ b/tests/SharpEmu.ShaderCompiler.Tests/Gen5DataShareTests.cs
@@ -1,0 +1,179 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
+using Xunit;
+
+namespace SharpEmu.ShaderCompiler.Tests;
+
+public sealed class Gen5DataShareTests
+{
+    private const ulong ShaderAddress = 0x1_0000_4000;
+    private const uint SEndpgm = 0xBF810000;
+    private const ushort OpStore = 62;
+    private const ushort OpAtomicIAdd = 234;
+    private const ushort OpSelectionMerge = 247;
+
+    [Fact]
+    public void DsAddRtnU32DecodesOpcode20WithDestination()
+    {
+        var program = DecodeProgram(0x20, offset: 128);
+
+        var instruction = Assert.Single(
+            program.Instructions,
+            item => item.Opcode == "DsAddRtnU32");
+        Assert.Equal(Gen5ShaderEncoding.Ds, instruction.Encoding);
+        Assert.Equal(Gen5Operand.Vector(2), instruction.Sources[0]);
+        Assert.Equal(Gen5Operand.Vector(3), instruction.Sources[1]);
+        Assert.Equal(Gen5Operand.Vector(7), Assert.Single(instruction.Destinations));
+        var control = Assert.IsType<Gen5DataShareControl>(instruction.Control);
+        Assert.Equal(128U, control.Offset0);
+        Assert.False(control.Gds);
+    }
+
+    [Fact]
+    public void DsAddRtnU32PreservesFullUnsignedOffset16()
+    {
+        var program = DecodeProgram(0x20, offset: 0xAB80);
+
+        var instruction = Assert.Single(
+            program.Instructions,
+            item => item.Opcode == "DsAddRtnU32");
+        var control = Assert.IsType<Gen5DataShareControl>(instruction.Control);
+        Assert.Equal(0x80U, control.Offset0);
+        Assert.Equal(0xABU, control.Offset1);
+    }
+
+    [Fact]
+    public void DsAddRtnU32LowersToAtomicAddAndReturnedValueStore()
+    {
+        var noReturnOpcodes = CompileAndReadSpirvOpcodes(0x00);
+        var returnOpcodes = CompileAndReadSpirvOpcodes(0x20);
+
+        Assert.Equal(
+            noReturnOpcodes.Count(opcode => opcode == OpAtomicIAdd),
+            returnOpcodes.Count(opcode => opcode == OpAtomicIAdd));
+        Assert.Equal(
+            noReturnOpcodes.Count(opcode => opcode == OpStore) + 1,
+            returnOpcodes.Count(opcode => opcode == OpStore));
+        var returnOpcodeList = returnOpcodes.ToList();
+        Assert.True(
+            returnOpcodeList.IndexOf(OpSelectionMerge) <
+            returnOpcodeList.IndexOf(OpAtomicIAdd));
+    }
+
+    private static Gen5ShaderProgram DecodeProgram(uint opcode, uint offset = 0)
+    {
+        var memory = new TestCpuMemory(ShaderAddress, 0x100);
+        Span<byte> shader = stackalloc byte[3 * sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            shader,
+            0xD8000000u | (opcode << 18) | offset);
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            shader[sizeof(uint)..],
+            2u | (3u << 8) | (7u << 24));
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            shader[(2 * sizeof(uint))..],
+            SEndpgm);
+        Assert.True(memory.TryWrite(ShaderAddress, shader));
+
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Assert.True(
+            Gen5ShaderTranslator.TryDecodeProgram(
+                ctx,
+                ShaderAddress,
+                out var program,
+                out var error),
+            error);
+        return program;
+    }
+
+    private static IReadOnlyList<ushort> CompileAndReadSpirvOpcodes(uint opcode)
+    {
+        var program = DecodeProgram(opcode);
+        var state = new Gen5ShaderState(program, [], null);
+        var scalarRegisters = new uint[256];
+        var evaluation = new Gen5ShaderEvaluation(
+            scalarRegisters,
+            scalarRegisters,
+            [],
+            []);
+
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileComputeShader(
+                state,
+                evaluation,
+                1,
+                1,
+                1,
+                out var shader,
+                out var error),
+            error);
+
+        return ReadSpirvOpcodes(shader.Spirv);
+    }
+
+    private static IReadOnlyList<ushort> ReadSpirvOpcodes(byte[] spirv)
+    {
+        var opcodes = new List<ushort>();
+        for (var offset = 5 * sizeof(uint); offset < spirv.Length;)
+        {
+            var instruction = BinaryPrimitives.ReadUInt32LittleEndian(
+                spirv.AsSpan(offset));
+            var wordCount = checked((int)(instruction >> 16));
+            Assert.InRange(wordCount, 1, (spirv.Length - offset) / sizeof(uint));
+            opcodes.Add((ushort)instruction);
+            offset += wordCount * sizeof(uint);
+        }
+
+        return opcodes;
+    }
+
+    private sealed class TestCpuMemory(ulong baseAddress, int size) : ICpuMemory
+    {
+        private readonly byte[] _storage = new byte[size];
+
+        public bool TryRead(ulong virtualAddress, Span<byte> destination)
+        {
+            if (!TryResolve(virtualAddress, destination.Length, out var offset))
+            {
+                return false;
+            }
+
+            _storage.AsSpan(offset, destination.Length).CopyTo(destination);
+            return true;
+        }
+
+        public bool TryWrite(ulong virtualAddress, ReadOnlySpan<byte> source)
+        {
+            if (!TryResolve(virtualAddress, source.Length, out var offset))
+            {
+                return false;
+            }
+
+            source.CopyTo(_storage.AsSpan(offset, source.Length));
+            return true;
+        }
+
+        private bool TryResolve(ulong virtualAddress, int length, out int offset)
+        {
+            offset = 0;
+            if (virtualAddress < baseAddress)
+            {
+                return false;
+            }
+
+            var relative = virtualAddress - baseAddress;
+            if (relative + (ulong)length > (ulong)_storage.Length)
+            {
+                return false;
+            }
+
+            offset = (int)relative;
+            return true;
+        }
+    }
+}

--- a/tests/SharpEmu.ShaderCompiler.Tests/Gen5ImageTests.cs
+++ b/tests/SharpEmu.ShaderCompiler.Tests/Gen5ImageTests.cs
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using Xunit;
+
+namespace SharpEmu.ShaderCompiler.Tests;
+
+public sealed class Gen5ImageTests
+{
+    private const ulong ShaderAddress = 0x1_0000_C000;
+    private const uint SEndpgm = 0xBF810000;
+
+    [Fact]
+    public void BvhIntersectRayUsesSplitMimgOpcodeHighBit()
+    {
+        uint[] words =
+        [
+            0xF1989F07,
+            0x00040303,
+            0x43440D3F,
+            0x46424140,
+            0x00004847,
+            SEndpgm,
+        ];
+        var memory = new TestCpuMemory(ShaderAddress, 0x100);
+        Span<byte> shader = stackalloc byte[words.Length * sizeof(uint)];
+        for (var index = 0; index < words.Length; index++)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                shader[(index * sizeof(uint))..],
+                words[index]);
+        }
+
+        Assert.True(memory.TryWrite(ShaderAddress, shader));
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Assert.True(
+            Gen5ShaderTranslator.TryDecodeProgram(
+                ctx,
+                ShaderAddress,
+                out var program,
+                out var error),
+            error);
+
+        var instruction = Assert.Single(
+            program.Instructions,
+            item => item.Opcode == "ImageBvhIntersectRay");
+        Assert.Equal(Gen5ShaderEncoding.Mimg, instruction.Encoding);
+        Assert.Equal(5, instruction.Words.Count);
+        Assert.Equal(
+            new[]
+            {
+                Gen5Operand.Vector(3),
+                Gen5Operand.Vector(4),
+                Gen5Operand.Vector(5),
+                Gen5Operand.Vector(6),
+            },
+            instruction.Destinations);
+        var control = Assert.IsType<Gen5ImageControl>(instruction.Control);
+        Assert.Equal(
+            new uint[] { 3, 63, 13, 68, 67, 64, 65, 66, 70, 71, 72 },
+            control.AddressRegisters);
+        Assert.Equal(16U, control.ScalarResource);
+        Assert.Equal(0U, control.ScalarSampler);
+        Assert.Equal(0xFU, control.Dmask);
+        Assert.Equal(12, instruction.Sources.Count);
+    }
+
+    private sealed class TestCpuMemory(ulong baseAddress, int size) : ICpuMemory
+    {
+        private readonly byte[] _storage = new byte[size];
+
+        public bool TryRead(ulong address, Span<byte> destination)
+        {
+            if (address < baseAddress ||
+                address - baseAddress > (ulong)_storage.Length ||
+                destination.Length > _storage.Length - (int)(address - baseAddress))
+            {
+                return false;
+            }
+
+            _storage.AsSpan((int)(address - baseAddress), destination.Length)
+                .CopyTo(destination);
+            return true;
+        }
+
+        public bool TryWrite(ulong address, ReadOnlySpan<byte> source)
+        {
+            if (address < baseAddress ||
+                address - baseAddress > (ulong)_storage.Length ||
+                source.Length > _storage.Length - (int)(address - baseAddress))
+            {
+                return false;
+            }
+
+            source.CopyTo(
+                _storage.AsSpan((int)(address - baseAddress), source.Length));
+            return true;
+        }
+    }
+}

--- a/tests/SharpEmu.ShaderCompiler.Tests/Gen5InterpolationTests.cs
+++ b/tests/SharpEmu.ShaderCompiler.Tests/Gen5InterpolationTests.cs
@@ -1,0 +1,526 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
+using Xunit;
+
+namespace SharpEmu.ShaderCompiler.Tests;
+
+public sealed class Gen5InterpolationTests
+{
+    private const ulong ShaderAddress = 0x1_0000_0000;
+    private const uint SEndpgm = 0xBF810000;
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(1u)]
+    [InlineData(2u)]
+    public void VInterpMovF32DecodesCoefficientSelector(uint selector)
+    {
+        var memory = new TestCpuMemory(ShaderAddress, 0x100);
+        Span<byte> words = stackalloc byte[2 * sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(words, EncodeVInterpMov(selector));
+        BinaryPrimitives.WriteUInt32LittleEndian(words[sizeof(uint)..], SEndpgm);
+        Assert.True(memory.TryWrite(ShaderAddress, words));
+
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Assert.True(
+            Gen5ShaderTranslator.TryDecodeProgram(
+                ctx,
+                ShaderAddress,
+                out var program,
+                out var error),
+            error);
+
+        var instruction = Assert.Single(
+            program.Instructions,
+            item => item.Opcode == "VInterpMovF32");
+        Assert.Equal(Gen5ShaderEncoding.Vintrp, instruction.Encoding);
+        Assert.Equal(Gen5Operand.Vector(selector), Assert.Single(instruction.Sources));
+        Assert.Equal(Gen5Operand.Vector(9), Assert.Single(instruction.Destinations));
+        var interpolation = Assert.IsType<Gen5InterpolationControl>(instruction.Control);
+        Assert.Equal(7u, interpolation.Attribute);
+        Assert.Equal(3u, interpolation.Channel);
+    }
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(1u)]
+    [InlineData(2u)]
+    public void VInterpMovF32ReconstructsInterpolationCoefficients(uint selector)
+    {
+        var spirv = CompileVInterpMov(selector);
+        var instructions = ReadInstructions(spirv);
+
+        Assert.Contains(
+            instructions,
+            instruction => instruction.Opcode == (ushort)SpirvOp.Capability &&
+                instruction.Operands.SequenceEqual(
+                    [(uint)SpirvCapability.FragmentBarycentricKhr]));
+
+        var location = Assert.Single(
+            instructions,
+            instruction => IsDecoration(
+                instruction,
+                SpirvDecoration.Location,
+                7));
+        var inputVariable = location.Operands[0];
+        Assert.DoesNotContain(
+            instructions,
+            instruction => IsDecoration(
+                instruction,
+                SpirvDecoration.PerVertexKhr,
+                expectedOperand: null) &&
+                instruction.Operands[0] == inputVariable);
+
+        var loadIds = instructions
+            .Where(instruction => instruction.Opcode == (ushort)SpirvOp.Load &&
+                instruction.Operands.Length >= 3 &&
+                instruction.Operands[2] == inputVariable)
+            .Select(instruction => instruction.Operands[1])
+            .ToHashSet();
+        Assert.NotEmpty(loadIds);
+
+        Assert.Contains(
+            instructions,
+            instruction => instruction.Opcode == (ushort)SpirvOp.CompositeExtract &&
+                instruction.Operands.Length >= 4 &&
+                loadIds.Contains(instruction.Operands[2]) &&
+                instruction.Operands[3] == 3);
+        Assert.True(
+            instructions.Count(
+                instruction => instruction.Opcode == (ushort)SpirvOp.DPdx) >= 3);
+        Assert.True(
+            instructions.Count(
+                instruction => instruction.Opcode == (ushort)SpirvOp.DPdy) >= 3);
+    }
+
+    [Fact]
+    public void PixelBarycentricsPopulateGuestIAndJRegisters()
+    {
+        var instructions = ReadInstructions(CompileVInterpMov(2));
+        var builtIn = Assert.Single(
+            instructions,
+            instruction => IsDecoration(
+                instruction,
+                SpirvDecoration.BuiltIn,
+                (uint)SpirvBuiltIn.BaryCoordKhr));
+        var barycentricVariable = builtIn.Operands[0];
+        var barycentricLoadIds = instructions
+            .Where(instruction => instruction.Opcode == (ushort)SpirvOp.Load &&
+                instruction.Operands.Length >= 3 &&
+                instruction.Operands[2] == barycentricVariable)
+            .Select(instruction => instruction.Operands[1])
+            .ToHashSet();
+        Assert.NotEmpty(barycentricLoadIds);
+
+        foreach (var component in new uint[] { 1, 2 })
+        {
+            Assert.Contains(
+                instructions,
+                instruction => instruction.Opcode == (ushort)SpirvOp.CompositeExtract &&
+                    instruction.Operands.Length >= 4 &&
+                    barycentricLoadIds.Contains(instruction.Operands[2]) &&
+                    instruction.Operands[3] == component);
+        }
+    }
+
+    [Fact]
+    public void VInterpMovF32SelectorsProduceDistinctLowering()
+    {
+        var p10 = CompileVInterpMov(0);
+        var p20 = CompileVInterpMov(1);
+        var p0 = CompileVInterpMov(2);
+
+        Assert.False(p10.SequenceEqual(p20));
+        Assert.False(p10.SequenceEqual(p0));
+        Assert.False(p20.SequenceEqual(p0));
+    }
+
+    [Fact]
+    public void VInterpMovF32ReconstructsCoefficientsBeforeDispatcherLoop()
+    {
+        var instructions = ReadInstructions(CompileVInterpMov(2));
+        var loopMergeIndex = Assert.Single(
+            instructions
+                .Select((instruction, index) => (instruction, index))
+                .Where(item =>
+                    item.instruction.Opcode == (ushort)SpirvOp.LoopMerge)
+                .Select(item => item.index));
+        var derivativeIndices = instructions
+            .Select((instruction, index) => (instruction, index))
+            .Where(item =>
+                item.instruction.Opcode is
+                    (ushort)SpirvOp.DPdx or
+                    (ushort)SpirvOp.DPdy)
+            .Select(item => item.index)
+            .ToArray();
+
+        Assert.NotEmpty(derivativeIndices);
+        Assert.All(derivativeIndices, index => Assert.True(index < loopMergeIndex));
+    }
+
+    [Fact]
+    public void VInterpMovF32RequiresHostBarycentricSupport()
+    {
+        Assert.False(
+            TryCompileVInterpMov(
+                2,
+                out _,
+                out var error,
+                fragmentShaderBarycentric: false));
+        Assert.Contains("VK_KHR_fragment_shader_barycentric", error);
+    }
+
+    [Fact]
+    public void VInterpMovF32RejectsReservedSelector()
+    {
+        Assert.False(TryCompileVInterpMov(3, out _, out var error));
+        Assert.Contains("invalid interpolation move selector 3", error);
+    }
+
+    [Fact]
+    public void CustomVInterpMovUsesMappedFlatInputWithoutDerivatives()
+    {
+        Assert.True(
+            TryCompileVInterpMov(
+                2,
+                out var spirv,
+                out var error,
+                pixelInputControls: [0, 1, 2, 3, 4, 5, 6, 0x423]),
+            error);
+        var instructions = ReadInstructions(spirv);
+        var location = Assert.Single(
+            instructions,
+            instruction => IsDecoration(
+                instruction,
+                SpirvDecoration.Location,
+                7));
+        var inputVariable = location.Operands[0];
+        Assert.Contains(
+            instructions,
+            instruction => IsDecoration(
+                instruction,
+                SpirvDecoration.Flat,
+                expectedOperand: null) &&
+                instruction.Operands[0] == inputVariable);
+        Assert.DoesNotContain(
+            instructions,
+            instruction => instruction.Opcode is
+                (ushort)SpirvOp.DPdx or
+                (ushort)SpirvOp.DPdy);
+    }
+
+    [Fact]
+    public void AliasedGuestInputsUseDistinctHostLocations()
+    {
+        var interpolations = new[]
+        {
+            new Gen5ShaderInstruction(
+                0,
+                Gen5ShaderEncoding.Vintrp,
+                "VInterpP1F32",
+                [],
+                [],
+                [Gen5Operand.Vector(0)],
+                new Gen5InterpolationControl(0, 0)),
+            new Gen5ShaderInstruction(
+                4,
+                Gen5ShaderEncoding.Vintrp,
+                "VInterpP1F32",
+                [],
+                [],
+                [Gen5Operand.Vector(1)],
+                new Gen5InterpolationControl(1, 0)),
+        };
+        var export = new Gen5ShaderInstruction(
+            8,
+            Gen5ShaderEncoding.Exp,
+            "Exp",
+            [],
+            [
+                Gen5Operand.Vector(0),
+                Gen5Operand.Vector(1),
+                Gen5Operand.Vector(0),
+                Gen5Operand.Vector(1),
+            ],
+            [],
+            new Gen5ExportControl(0, 0xFu, false, true, true));
+        var end = new Gen5ShaderInstruction(
+            16,
+            Gen5ShaderEncoding.Sopp,
+            "SEndpgm",
+            [SEndpgm],
+            [],
+            [],
+            null);
+        var program = new Gen5ShaderProgram(
+            ShaderAddress,
+            [.. interpolations, export, end]);
+        var state = new Gen5ShaderState(program, [], null);
+        var scalarRegisters = new uint[256];
+        var evaluation = new Gen5ShaderEvaluation(
+            scalarRegisters,
+            scalarRegisters,
+            [],
+            []);
+
+        Assert.True(
+            Gen5SpirvTranslator.TryCompilePixelShader(
+                state,
+                evaluation,
+                Gen5PixelOutputKind.Float,
+                out var shader,
+                out var error,
+                pixelInputControls: [0, 0x400]),
+            error);
+        var instructions = ReadInstructions(shader.Spirv);
+        // Location zero is shared by the first input and MRT0 output; the
+        // second aliased guest input must still receive its own host location.
+        Assert.Equal(
+            2,
+            instructions.Count(
+                instruction => IsDecoration(
+                    instruction,
+                    SpirvDecoration.Location,
+                    0)));
+        var secondInputLocation = Assert.Single(
+            instructions,
+            instruction => IsDecoration(
+                instruction,
+                SpirvDecoration.Location,
+                1));
+        Assert.Contains(
+            instructions,
+            instruction => IsDecoration(
+                instruction,
+                SpirvDecoration.Flat,
+                expectedOperand: null) &&
+                instruction.Operands[0] == secondInputLocation.Operands[0]);
+    }
+
+    [Fact]
+    public void VertexExportFansOutThroughPixelSemanticMapping()
+    {
+        var export = new Gen5ShaderInstruction(
+            0,
+            Gen5ShaderEncoding.Exp,
+            "Exp",
+            [],
+            [
+                Gen5Operand.Vector(0),
+                Gen5Operand.Vector(1),
+                Gen5Operand.Vector(2),
+                Gen5Operand.Vector(3),
+            ],
+            [],
+            new Gen5ExportControl(35, 0xFu, false, true, true));
+        var end = new Gen5ShaderInstruction(
+            8,
+            Gen5ShaderEncoding.Sopp,
+            "SEndpgm",
+            [SEndpgm],
+            [],
+            [],
+            null);
+        var program = new Gen5ShaderProgram(ShaderAddress, [export, end]);
+        var state = new Gen5ShaderState(program, [], null);
+        var scalarRegisters = new uint[256];
+        var evaluation = new Gen5ShaderEvaluation(
+            scalarRegisters,
+            scalarRegisters,
+            [],
+            []);
+
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileVertexShader(
+                state,
+                evaluation,
+                out var shader,
+                out var error,
+                pixelInputControls: [0, 2, 0x423]),
+            error);
+        var instructions = ReadInstructions(shader.Spirv);
+        var mappedLocation = Assert.Single(
+            instructions,
+            instruction => IsDecoration(
+                instruction,
+                SpirvDecoration.Location,
+                2));
+        var mappedOutput = mappedLocation.Operands[0];
+        Assert.True(
+            instructions.Count(
+                instruction =>
+                    instruction.Opcode == (ushort)SpirvOp.Store &&
+                    instruction.Operands.Length >= 2 &&
+                    instruction.Operands[0] == mappedOutput) >= 2);
+    }
+
+    private static byte[] CompileVInterpMov(uint selector)
+    {
+        Assert.True(TryCompileVInterpMov(selector, out var spirv, out var error), error);
+        return spirv;
+    }
+
+    private static bool TryCompileVInterpMov(
+        uint selector,
+        out byte[] spirv,
+        out string error,
+        bool fragmentShaderBarycentric = true,
+        IReadOnlyList<uint>? pixelInputControls = null)
+    {
+        var interpolation = new Gen5ShaderInstruction(
+            0,
+            Gen5ShaderEncoding.Vintrp,
+            "VInterpMovF32",
+            [EncodeVInterpMov(selector)],
+            [Gen5Operand.Vector(selector)],
+            [Gen5Operand.Vector(9)],
+            new Gen5InterpolationControl(7, 3));
+        var export = new Gen5ShaderInstruction(
+            4,
+            Gen5ShaderEncoding.Exp,
+            "Exp",
+            [],
+            [
+                Gen5Operand.Vector(9),
+                Gen5Operand.Vector(9),
+                Gen5Operand.Vector(9),
+                Gen5Operand.Vector(9),
+            ],
+            [],
+            new Gen5ExportControl(0, 0xFu, false, true, true));
+        var end = new Gen5ShaderInstruction(
+            12,
+            Gen5ShaderEncoding.Sopp,
+            "SEndpgm",
+            [SEndpgm],
+            [],
+            [],
+            null);
+        var state = new Gen5ShaderState(
+            new Gen5ShaderProgram(ShaderAddress, [interpolation, export, end]),
+            [],
+            null);
+        var scalarRegisters = new uint[256];
+        var evaluation = new Gen5ShaderEvaluation(
+            scalarRegisters,
+            scalarRegisters,
+            [],
+            []);
+
+        var result = Gen5SpirvTranslator.TryCompilePixelShader(
+            state,
+            evaluation,
+            Gen5PixelOutputKind.Float,
+            out var shader,
+            out error,
+            pixelInputEnable: 1u << 1,
+            pixelInputAddress: 1u << 1,
+            fragmentShaderBarycentric: fragmentShaderBarycentric,
+            pixelInputControls: pixelInputControls);
+        spirv = result ? shader.Spirv : [];
+        return result;
+    }
+
+    private static uint EncodeVInterpMov(uint selector) =>
+        0xC8000000u |
+        (2u << 16) |
+        (9u << 18) |
+        (7u << 10) |
+        (3u << 8) |
+        selector;
+
+    private static bool IsDecoration(
+        SpirvInstruction instruction,
+        SpirvDecoration decoration,
+        uint? expectedOperand)
+    {
+        if (instruction.Opcode != (ushort)SpirvOp.Decorate ||
+            instruction.Operands.Length < 2 ||
+            instruction.Operands[1] != (uint)decoration)
+        {
+            return false;
+        }
+
+        return expectedOperand is null ||
+            (instruction.Operands.Length >= 3 &&
+             instruction.Operands[2] == expectedOperand.Value);
+    }
+
+    private static IReadOnlyList<SpirvInstruction> ReadInstructions(byte[] spirv)
+    {
+        Assert.Equal(0, spirv.Length % sizeof(uint));
+        Assert.True(spirv.Length >= 5 * sizeof(uint));
+        Assert.Equal(0x07230203u, BinaryPrimitives.ReadUInt32LittleEndian(spirv));
+
+        var instructions = new List<SpirvInstruction>();
+        for (var offset = 5 * sizeof(uint); offset < spirv.Length;)
+        {
+            var header = BinaryPrimitives.ReadUInt32LittleEndian(spirv.AsSpan(offset));
+            var wordCount = checked((int)(header >> 16));
+            Assert.InRange(wordCount, 1, (spirv.Length - offset) / sizeof(uint));
+            var operands = new uint[wordCount - 1];
+            for (var index = 0; index < operands.Length; index++)
+            {
+                operands[index] = BinaryPrimitives.ReadUInt32LittleEndian(
+                    spirv.AsSpan(offset + ((index + 1) * sizeof(uint))));
+            }
+
+            instructions.Add(new SpirvInstruction((ushort)header, operands));
+            offset += wordCount * sizeof(uint);
+        }
+
+        return instructions;
+    }
+
+    private sealed record SpirvInstruction(ushort Opcode, uint[] Operands);
+
+    private sealed class TestCpuMemory(ulong baseAddress, int size) : ICpuMemory
+    {
+        private readonly byte[] _storage = new byte[size];
+
+        public bool TryRead(ulong virtualAddress, Span<byte> destination)
+        {
+            if (!TryResolve(virtualAddress, destination.Length, out var offset))
+            {
+                return false;
+            }
+
+            _storage.AsSpan(offset, destination.Length).CopyTo(destination);
+            return true;
+        }
+
+        public bool TryWrite(ulong virtualAddress, ReadOnlySpan<byte> source)
+        {
+            if (!TryResolve(virtualAddress, source.Length, out var offset))
+            {
+                return false;
+            }
+
+            source.CopyTo(_storage.AsSpan(offset, source.Length));
+            return true;
+        }
+
+        private bool TryResolve(ulong virtualAddress, int length, out int offset)
+        {
+            offset = 0;
+            if (virtualAddress < baseAddress)
+            {
+                return false;
+            }
+
+            var relative = virtualAddress - baseAddress;
+            if (relative + (ulong)length > (ulong)_storage.Length)
+            {
+                return false;
+            }
+
+            offset = checked((int)relative);
+            return true;
+        }
+    }
+}

--- a/tests/SharpEmu.ShaderCompiler.Tests/Gen5ScalarControlTests.cs
+++ b/tests/SharpEmu.ShaderCompiler.Tests/Gen5ScalarControlTests.cs
@@ -1,0 +1,157 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using Xunit;
+
+namespace SharpEmu.ShaderCompiler.Tests;
+
+public sealed class Gen5ScalarControlTests
+{
+    private const ulong ShaderAddress = 0x1_0000_8000;
+    private const uint SEndpgm = 0xBF810000;
+
+    [Fact]
+    public void STrapDecodesOpcode12AndPreservesTrapId()
+    {
+        const uint trapId = 0x34;
+        var memory = new TestCpuMemory(ShaderAddress, 0x100);
+        Span<byte> shader = stackalloc byte[2 * sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            shader,
+            0xBF920000u | trapId);
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            shader[sizeof(uint)..],
+            SEndpgm);
+        Assert.True(memory.TryWrite(ShaderAddress, shader));
+
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Assert.True(
+            Gen5ShaderTranslator.TryDecodeProgram(
+                ctx,
+                ShaderAddress,
+                out var program,
+                out var error),
+            error);
+
+        var instruction = Assert.Single(
+            program.Instructions,
+            item => item.Opcode == "STrap");
+        Assert.Equal(Gen5ShaderEncoding.Sopp, instruction.Encoding);
+        Assert.Equal(trapId, instruction.Words[0] & 0xFFFFu);
+    }
+
+    [Fact]
+    public void ProgramLongerThan4096InstructionsReachesEndProgram()
+    {
+        const int nopCount = 4096;
+        const uint sNop = 0xBF800000;
+        var shader = new byte[(nopCount + 1) * sizeof(uint)];
+        for (var index = 0; index < nopCount; index++)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                shader.AsSpan(index * sizeof(uint), sizeof(uint)),
+                sNop);
+        }
+
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            shader.AsSpan(nopCount * sizeof(uint), sizeof(uint)),
+            SEndpgm);
+        var memory = new TestCpuMemory(ShaderAddress, shader.Length);
+        Assert.True(memory.TryWrite(ShaderAddress, shader));
+
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Assert.True(
+            Gen5ShaderTranslator.TryDecodeProgram(
+                ctx,
+                ShaderAddress,
+                out var program,
+                out var error),
+            error);
+        Assert.Equal(nopCount + 1, program.Instructions.Count);
+        Assert.Equal("SEndpgm", program.Instructions[^1].Opcode);
+    }
+
+    [Fact]
+    public void ProgramCacheIncludesDeclaredShaderSize()
+    {
+        const ulong headerAddress = ShaderAddress + 0x100;
+        const uint computePgmRsrc2 = 0x213;
+        const uint computeUserData = 0x240;
+        const uint sNop = 0xBF800000;
+        var memory = new TestCpuMemory(ShaderAddress, 0x200);
+        Span<byte> shader = stackalloc byte[2 * sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(shader, sNop);
+        BinaryPrimitives.WriteUInt32LittleEndian(shader[sizeof(uint)..], SEndpgm);
+        Assert.True(memory.TryWrite(ShaderAddress, shader));
+
+        Span<byte> size = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(size, (uint)shader.Length);
+        Assert.True(memory.TryWrite(headerAddress + 0x44, size));
+
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        var registers = new Dictionary<uint, uint>
+        {
+            [computePgmRsrc2] = 0,
+        };
+        Assert.True(
+            Gen5ShaderTranslator.TryCreateState(
+                ctx,
+                ShaderAddress,
+                headerAddress,
+                registers,
+                computeUserData,
+                out _,
+                out var error),
+            error);
+
+        BinaryPrimitives.WriteUInt32LittleEndian(size, sizeof(uint));
+        Assert.True(memory.TryWrite(headerAddress + 0x44, size));
+        Assert.False(
+            Gen5ShaderTranslator.TryCreateState(
+                ctx,
+                ShaderAddress,
+                headerAddress,
+                registers,
+                computeUserData,
+                out _,
+                out error));
+        Assert.Contains("unterminated", error);
+        Assert.Contains("size=0x4", error);
+    }
+
+    private sealed class TestCpuMemory(ulong baseAddress, int size) : ICpuMemory
+    {
+        private readonly byte[] _storage = new byte[size];
+
+        public bool TryRead(ulong address, Span<byte> destination)
+        {
+            if (address < baseAddress ||
+                address - baseAddress > (ulong)_storage.Length ||
+                destination.Length > _storage.Length - (int)(address - baseAddress))
+            {
+                return false;
+            }
+
+            _storage.AsSpan((int)(address - baseAddress), destination.Length)
+                .CopyTo(destination);
+            return true;
+        }
+
+        public bool TryWrite(ulong address, ReadOnlySpan<byte> source)
+        {
+            if (address < baseAddress ||
+                address - baseAddress > (ulong)_storage.Length ||
+                source.Length > _storage.Length - (int)(address - baseAddress))
+            {
+                return false;
+            }
+
+            source.CopyTo(
+                _storage.AsSpan((int)(address - baseAddress), source.Length));
+            return true;
+        }
+    }
+}

--- a/tests/SharpEmu.ShaderCompiler.Tests/Gen5Vop3Tests.cs
+++ b/tests/SharpEmu.ShaderCompiler.Tests/Gen5Vop3Tests.cs
@@ -1,0 +1,214 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
+using Xunit;
+
+namespace SharpEmu.ShaderCompiler.Tests;
+
+public sealed class Gen5Vop3Tests
+{
+    private const ulong ShaderAddress = 0x1_0000_0000;
+    private const uint SEndpgm = 0xBF810000;
+    private const ushort OpBitFieldSExtract = 202;
+    private const ushort OpBitFieldUExtract = 203;
+    private const ushort OpArrayLength = 68;
+    private const ushort OpULessThan = 176;
+
+    [Fact]
+    public void VBfeI32DecodesFromVop3Opcode149()
+    {
+        var program = DecodeProgram(0x149);
+
+        var instruction = Assert.Single(program.Instructions, item => item.Opcode == "VBfeI32");
+        Assert.Equal(Gen5ShaderEncoding.Vop3, instruction.Encoding);
+        Assert.Equal(Gen5Operand.Vector(0), instruction.Sources[0]);
+        Assert.Equal(Gen5Operand.Scalar(0), instruction.Sources[1]);
+        Assert.Equal(Gen5Operand.Scalar(1), instruction.Sources[2]);
+        Assert.Equal(Gen5Operand.Vector(3), Assert.Single(instruction.Destinations));
+    }
+
+    [Fact]
+    public void VBfeI32LowersToSignedBitFieldExtract()
+    {
+        var signedOpcodes = CompileAndReadSpirvOpcodes(0x149);
+        var unsignedOpcodes = CompileAndReadSpirvOpcodes(0x148);
+
+        Assert.Equal(
+            unsignedOpcodes.Count(opcode => opcode == OpBitFieldSExtract) + 1,
+            signedOpcodes.Count(opcode => opcode == OpBitFieldSExtract));
+        Assert.Equal(
+            unsignedOpcodes.Count(opcode => opcode == OpBitFieldUExtract),
+            signedOpcodes.Count(opcode => opcode == OpBitFieldUExtract) + 1);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void BufferBoundsDoNotUseRuntimeArrayLength(bool runtimeScalars)
+    {
+        var instruction = new Gen5ShaderInstruction(
+            0,
+            Gen5ShaderEncoding.Smem,
+            "SBufferLoadDword",
+            [],
+            [Gen5Operand.Scalar(0)],
+            [Gen5Operand.Scalar(4)],
+            new Gen5ScalarMemoryControl(1, 0, null));
+        var program = new Gen5ShaderProgram(ShaderAddress, [instruction]);
+        var state = new Gen5ShaderState(program, [], null);
+        var scalarRegisters = new uint[256];
+        var binding = new Gen5GlobalMemoryBinding(
+            0,
+            0x1003,
+            [0],
+            new byte[17],
+            17,
+            false);
+        var evaluation = new Gen5ShaderEvaluation(
+            scalarRegisters,
+            scalarRegisters,
+            [],
+            [binding]);
+        var initialScalarBufferIndex = runtimeScalars ? 1 : -1;
+        var totalGlobalBufferCount = runtimeScalars ? 2 : 1;
+
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileComputeShader(
+                state,
+                evaluation,
+                1,
+                1,
+                1,
+                out var shader,
+                out var error,
+                totalGlobalBufferCount,
+                initialScalarBufferIndex,
+                storageBufferOffsetAlignment: 256),
+            error);
+
+        var opcodes = ReadSpirvOpcodes(shader.Spirv);
+        Assert.DoesNotContain(OpArrayLength, opcodes);
+        Assert.Contains(OpULessThan, opcodes);
+    }
+
+    [Fact]
+    public void RuntimeScalarLayoutInterleavesMetadataByBinding()
+    {
+        Assert.Equal(256, Gen5RuntimeScalarLayout.GetByteBiasDwordIndex(0));
+        Assert.Equal(257, Gen5RuntimeScalarLayout.GetBufferDwordCountDwordIndex(0));
+        Assert.Equal(258, Gen5RuntimeScalarLayout.GetByteBiasDwordIndex(1));
+        Assert.Equal(259, Gen5RuntimeScalarLayout.GetBufferDwordCountDwordIndex(1));
+        Assert.Equal(266, Gen5RuntimeScalarLayout.GetDwordLength(5));
+    }
+
+    private static Gen5ShaderProgram DecodeProgram(uint opcode)
+    {
+        var memory = new TestCpuMemory(ShaderAddress, 0x100);
+        Span<byte> shader = stackalloc byte[3 * sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(shader, 0xD0000003u | (opcode << 16));
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            shader[sizeof(uint)..],
+            0x100u | (1u << 18)); // v0, s0, s1
+        BinaryPrimitives.WriteUInt32LittleEndian(shader[(2 * sizeof(uint))..], SEndpgm);
+        Assert.True(memory.TryWrite(ShaderAddress, shader));
+
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Assert.True(
+            Gen5ShaderTranslator.TryDecodeProgram(ctx, ShaderAddress, out var program, out var error),
+            error);
+        return program;
+    }
+
+    private static IReadOnlyList<ushort> CompileAndReadSpirvOpcodes(uint opcode)
+    {
+        var program = DecodeProgram(opcode);
+        var state = new Gen5ShaderState(program, [], null);
+        var scalarRegisters = new uint[256];
+        var evaluation = new Gen5ShaderEvaluation(
+            scalarRegisters,
+            scalarRegisters,
+            [],
+            []);
+
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileComputeShader(
+                state,
+                evaluation,
+                1,
+                1,
+                1,
+                out var shader,
+                out var error),
+            error);
+
+        return ReadSpirvOpcodes(shader.Spirv);
+    }
+
+    private static IReadOnlyList<ushort> ReadSpirvOpcodes(byte[] spirv)
+    {
+        Assert.Equal(0, spirv.Length % sizeof(uint));
+        Assert.True(spirv.Length >= 5 * sizeof(uint));
+        Assert.Equal(0x07230203u, BinaryPrimitives.ReadUInt32LittleEndian(spirv));
+
+        var opcodes = new List<ushort>();
+        for (var offset = 5 * sizeof(uint); offset < spirv.Length;)
+        {
+            var instruction = BinaryPrimitives.ReadUInt32LittleEndian(spirv.AsSpan(offset));
+            var wordCount = checked((int)(instruction >> 16));
+            Assert.InRange(wordCount, 1, (spirv.Length - offset) / sizeof(uint));
+            opcodes.Add((ushort)instruction);
+            offset += wordCount * sizeof(uint);
+        }
+
+        return opcodes;
+    }
+
+    private sealed class TestCpuMemory(ulong baseAddress, int size) : ICpuMemory
+    {
+        private readonly byte[] _storage = new byte[size];
+
+        public bool TryRead(ulong virtualAddress, Span<byte> destination)
+        {
+            if (!TryResolve(virtualAddress, destination.Length, out var offset))
+            {
+                return false;
+            }
+
+            _storage.AsSpan(offset, destination.Length).CopyTo(destination);
+            return true;
+        }
+
+        public bool TryWrite(ulong virtualAddress, ReadOnlySpan<byte> source)
+        {
+            if (!TryResolve(virtualAddress, source.Length, out var offset))
+            {
+                return false;
+            }
+
+            source.CopyTo(_storage.AsSpan(offset, source.Length));
+            return true;
+        }
+
+        private bool TryResolve(ulong virtualAddress, int length, out int offset)
+        {
+            offset = 0;
+            if (virtualAddress < baseAddress)
+            {
+                return false;
+            }
+
+            var relative = virtualAddress - baseAddress;
+            if (relative + (ulong)length > (ulong)_storage.Length)
+            {
+                return false;
+            }
+
+            offset = (int)relative;
+            return true;
+        }
+    }
+}

--- a/tests/SharpEmu.ShaderCompiler.Tests/SharpEmu.ShaderCompiler.Tests.csproj
+++ b/tests/SharpEmu.ShaderCompiler.Tests/SharpEmu.ShaderCompiler.Tests.csproj
@@ -1,0 +1,22 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SharpEmu.ShaderCompiler\SharpEmu.ShaderCompiler.csproj" />
+    <ProjectReference Include="..\..\src\SharpEmu.ShaderCompiler.Vulkan\SharpEmu.ShaderCompiler.Vulkan.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Checklist

- [x] I have read `CONTRIBUTING.md`.
- [x] I tested my changes.
- [ ] I wrote this description myself and did not copy AI-generated explanations.
- [x] I listed the game(s) I tested, if applicable.

> This is an AI-assisted draft. The contributor will review and rewrite/confirm the description in their own words before marking it ready for review.

## What this changes

This draft collects the generic compatibility work that moved complex guest graphics workloads beyond their boot animations and into deeper 3D scenes:

- implement JSON parse/stringify/value access and missing semaphore compatibility exports;
- extend Gen5 shader translation for scalar control flow, interpolation, image operations, data-share instructions, VOP3 operations, packed-half exports, and runtime scalar metadata;
- keep CPU and GPU guest-image contents coherent, add the required Vulkan image barriers and render-target format handling, and preserve semantic interpolants and component swizzles;
- retain the oldest unpresented flip while coalescing overloaded presentation queues, bound reusable host-buffer memory, and honor aligned NV12 plane pitches.

The history is intentionally split into three reviewable commits:

1. `[HLE] Implement JSON and semaphore compatibility exports`
2. `[Shader] Expand Gen5 translation coverage`
3. `[AGC/Vulkan] Improve guest image and presentation handling`

## Why this is needed

Before these changes, the tested workload could enter the graphics path but lost required shader behavior, guest-image updates, and presentation ordering before a complete title sequence could be shown. The changes implement those behaviors generically rather than matching a title or shader address.

This is intentionally a draft because the compatibility path spans HLE setup, shader translation, and AGC/Vulkan execution. The commits are separated for review, and the HLE commit can be split into a follow-up PR if maintainers prefer a narrower final scope.

## How this was verified

- Release solution build: **0 warnings, 0 errors**
- `SharpEmu.Libs.Tests`: **241 passed**
- `SharpEmu.ShaderCompiler.Tests`: **26 passed**
- `SharpEmu.SourceGenerators.Tests`: **33 passed**
- Game tested: **ASTRO BOT (PPSA21564, v01.007.000)** on macOS/MoltenVK
- E218 visual regression: controller-symbol animation → PS Studios wordmark → title scene → world map, using the original guest shaders

## E218 visual milestone

![E218 ASTRO BOT visual milestone sequence](https://raw.githubusercontent.com/Acelogic/sharpemu/2cd4f1f96e75dba0c4914ce9aee77ec44a562619/e218-visual-milestones.png)

The sheet shows the ordered controller-symbol animation, PS Studios wordmark, title scene, world-map transition, and the current red-frame endpoint from one run.

## Known limitations

- Rendering is not yet accurate enough to call the menu playable: the current ASTRO BOT run eventually reaches a uniform red frame instead of the recognizable final menu.
- Performance on the tested macOS path remains low during the intro/title sequence.
- Windows and Linux runtime regression coverage is still pending for this cleaned branch.

## Scope hygiene

This branch deliberately excludes the ASTRO BOT experiment journal, local test/capture harnesses, SDK-pin experiments, hard-coded guest addresses, shader-replacement bypasses, and one-off breakpoint/readback probes. The PR contains only reusable emulator behavior and focused tests.
