### PR TITLE
Fix event flag wake check and POSIX open/fstat ABI

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -3141,6 +3141,19 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					continue;
 				}
 
+				// BlockWaiter and BlockWakeHandler are mutually exclusive (set by
+				// the two RegisterBlockedGuestThreadContinuation overloads), but a
+				// thread parked via the resume/wake-handler overload (e.g.
+				// sceKernelWaitEventFlag) has BlockWaiter == null, so the check
+				// above never runs for it. Without this, WakeBlockedThreads marks
+				// it Ready unconditionally on any matching wake key, without ever
+				// confirming its actual wait condition (event-flag pattern, etc.)
+				// is satisfied -- the thread resumes later still unsatisfied.
+				if (thread.BlockWakeHandler is not null && !thread.BlockWakeHandler())
+				{
+					continue;
+				}
+
 				thread.State = GuestThreadRunState.Ready;
 				thread.BlockReason = null;
 				thread.BlockDeadlineTimestamp = 0;

--- a/src/SharpEmu.Libs/Kernel/KernelExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelExports.cs
@@ -362,7 +362,7 @@ public static class KernelExports
         ExportName = "open",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libKernel")]
-    public static int Open(CpuContext ctx) => KernelMemoryCompatExports.KernelOpenUnderscore(ctx);
+    public static int Open(CpuContext ctx) => KernelMemoryCompatExports.PosixOpen(ctx);
 
     [SysAbiExport(
         Nid = "1G3lF1Gg1k8",
@@ -376,7 +376,7 @@ public static class KernelExports
         ExportName = "fstat",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libc")]
-    public static int Fstat(CpuContext ctx) => KernelMemoryCompatExports.KernelFstat(ctx);
+    public static int Fstat(CpuContext ctx) => KernelMemoryCompatExports.PosixFstat(ctx);
 
     [SysAbiExport(
         Nid = "hcuQgD53UxM",

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -1504,6 +1504,32 @@ public static partial class KernelMemoryCompatExports
         }
     }
 
+    // open(2) follows the libc/POSIX ABI like stat/PosixStat below: failures
+    // return -1 and expose the reason through errno. Returning the raw Orbis
+    // kernel code here (e.g. ORBIS_GEN2_ERROR_NOT_FOUND = 0x80020002) makes a
+    // caller that checks "fd == -1" treat a missing file as a valid,
+    // wildly out-of-range descriptor, which then corrupts every subsequent
+    // fstat/lseek/close/read on that "fd".
+    public static int PosixOpen(CpuContext ctx)
+    {
+        var result = KernelOpenUnderscore(ctx);
+        if (result == (int)OrbisGen2Result.ORBIS_GEN2_OK)
+        {
+            return 0;
+        }
+
+        var errno = result switch
+        {
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT => Einval,
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT => Efault,
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_PERMISSION_DENIED => 13, // EACCES
+            _ => 2, // ENOENT
+        };
+        KernelRuntimeCompatExports.TrySetErrno(ctx, errno);
+        ctx[CpuRegister.Rax] = ulong.MaxValue;
+        return -1;
+    }
+
     [SysAbiExport(
         Nid = "NNtFaKJbPt0",
         ExportName = "_close",
@@ -1791,6 +1817,27 @@ public static partial class KernelMemoryCompatExports
 
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    // fstat(2) follows the libc/POSIX ABI like stat/PosixStat above: failures
+    // return -1 and expose the reason through errno, not the raw Orbis code.
+    public static int PosixFstat(CpuContext ctx)
+    {
+        var result = KernelFstat(ctx);
+        if (result == (int)OrbisGen2Result.ORBIS_GEN2_OK)
+        {
+            return 0;
+        }
+
+        var errno = result switch
+        {
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT => Einval,
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT => Efault,
+            _ => 9, // EBADF
+        };
+        KernelRuntimeCompatExports.TrySetErrno(ctx, errno);
+        ctx[CpuRegister.Rax] = ulong.MaxValue;
+        return -1;
     }
 
     [SysAbiExport(

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -4444,9 +4444,31 @@ internal static unsafe class VulkanVideoPresenter
 
             var waitStart = System.Diagnostics.Stopwatch.GetTimestamp();
             var fence = target.Fence;
-            Check(
-                _vk.WaitForFences(_device, 1, &fence, true, ulong.MaxValue),
-                $"vkWaitForFences(queue visibility: {_activeGuestQueue.Name})");
+
+            // Diagnostic-only: wait in bounded chunks instead of ulong.MaxValue
+            // so a fence that GPU submission never actually signals (e.g. a
+            // MoltenVK quirk, or a queued guest action whose command buffer
+            // was never submitted) shows up as a clear, repeating log line
+            // instead of a silent, permanent hang on this thread. The overall
+            // wait is unchanged: on VK_TIMEOUT we log and keep waiting.
+            const ulong ChunkTimeoutNanoseconds = 3_000_000_000UL;
+            Result waitResult;
+            var chunk = 0;
+            while ((waitResult = _vk.WaitForFences(_device, 1, &fence, true, ChunkTimeoutNanoseconds))
+                   == Result.Timeout)
+            {
+                chunk++;
+                var elapsedMs = (System.Diagnostics.Stopwatch.GetTimestamp() - waitStart) *
+                    1000.0 / System.Diagnostics.Stopwatch.Frequency;
+                Console.Error.WriteLine(
+                    $"[LOADER][WARN] vk.queue_visibility_stall queue={_activeGuestQueue.Name} " +
+                    $"submission={_activeGuestQueue.SubmissionId} target_timeline={targetTimeline} " +
+                    $"completed_timeline={_completedTimeline} chunk={chunk} elapsed_ms={elapsedMs:F0} " +
+                    "-- vkWaitForFences has not returned; the GPU fence for this submission " +
+                    "was never signaled.");
+            }
+
+            Check(waitResult, $"vkWaitForFences(queue visibility: {_activeGuestQueue.Name})");
             CollectCompletedGuestSubmissions(waitForOldest: false);
             var waitedMs = (System.Diagnostics.Stopwatch.GetTimestamp() - waitStart) *
                 1000.0 / System.Diagnostics.Stopwatch.Frequency;


### PR DESCRIPTION
<!--
Copyright (C) 2026 SharpEmu Emulator Project
SPDX-License-Identifier: GPL-2.0-or-later
-->

## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Checklist
By submitting this PR, you confirm that:

- [x] I have read `CONTRIBUTING.md`.
- [x] I tested my changes.
- [ ] I wrote this description myself and did not copy AI-generated explanations.
- [x] I listed the game(s) I tested, if applicable.

> This PR description was drafted with AI assistance (research, tracing, and writeup). I reviewed it, understand every line of the change, and can explain/maintain it. Leaving that box unchecked rather than claiming otherwise.

## Summary

- `WakeBlockedThreads` only checked `thread.BlockWaiter` before marking a parked thread Ready. Threads blocked via the other registration overload (`BlockResumeHandler`/`BlockWakeHandler`, used by `sceKernelWaitEventFlag`) have `BlockWaiter == null`, so that check was silently skipped and the thread got marked Ready without ever confirming its wait condition (event-flag pattern) was actually satisfied. It resumed still unsatisfied.
- `open()` (`wuCroIGjt2g`) and `fstat()` (`mqQMh1zPPT8`) called straight into the Orbis-convention `KernelOpenUnderscore`/`KernelFstat` without converting the result to the POSIX ABI on failure, same issue already documented and handled for `stat`/`PosixStat` a few lines above. A failed `open()` returned the raw Orbis error code (`ORBIS_GEN2_ERROR_NOT_FOUND` = `0x80020002`) directly in RAX instead of -1 with errno set, so a caller checking `fd == -1` missed the failure and went on to call `fstat`/`lseek`/`close`/`read` with that value as the file descriptor.
- Bonus: made the Vulkan queue-visibility fence wait in `VulkanVideoPresenter` bounded (chunked retries with a log line) instead of an unconditional `vkWaitForFences(..., ulong.MaxValue)`, so a submission whose fence never actually signals shows up as a clear repeating log line instead of a silent, permanent hang. Purely diagnostic, the wait still continues past a logged timeout exactly like before.

## Test plan

Tested on macOS (Apple Silicon, Rosetta 2) against **Arcade Game Zone [PPSA19015]**, a Unity/IL2CPP title, in combination with the exception-delivery fix from #253:

- Before the event-flag fix: hard stall at import 81408, every time, with a thread parked on `sceKernelWaitEventFlag` never getting woken despite its condition being met.
- With it: the game gets past multiple GC stop-the-world cycles, initializes the full Unity job system (`Job.worker 0-12`, `Background Job.worker 0-15`, FMOD audio, `GfxFlipThread`, `UnityGfxDeviceWorker`), and renders real frames (splash + first gameplay frame at 1920x1080).
- Before the open/fstat fix: once past the deadlock, the process hit an unrecovered SIGSEGV (fault address 0x0) a bit further in, traced to a failed `open()` on a savedata path whose bogus "successful" return value (the raw Orbis error code) got passed straight into `fstat` as a file descriptor.
- With it: that crash is gone; the failure is now reported through errno like real POSIX `open`/`fstat` and the caller's own error handling takes over correctly.

Left a detailed writeup of a further, still-open issue (a semaphore-count corruption on repeated GC cycles, matching a point already raised in review on #253) as a comment there rather than attempting a blind fix, since properly fixing it needs the interrupt-and-retry redesign already outlined by the reviewer and touches CPU-context redirection machinery I don't have full context on.
