### PR TITLE
logging: populate host CPU, GPU, and RAM on macOS

### DIFF
--- a/src/SharpEmu.Logging/HostSystemInfo.cs
+++ b/src/SharpEmu.Logging/HostSystemInfo.cs
@@ -26,6 +26,15 @@ public static class HostSystemInfo
 
     private static string GetCpuName()
     {
+        if (OperatingSystem.IsMacOS())
+        {
+            var brand = GetSysctlString("machdep.cpu.brand_string");
+            if (!string.IsNullOrWhiteSpace(brand))
+            {
+                return $"{brand} ({Environment.ProcessorCount} logical processors)";
+            }
+        }
+
         if (!OperatingSystem.IsWindows())
         {
             return $"{Environment.ProcessorCount} logical processors";
@@ -58,6 +67,11 @@ public static class HostSystemInfo
 
     private static string GetPreferredGpuName()
     {
+        if (OperatingSystem.IsMacOS())
+        {
+            return GetMetalDeviceName() ?? "unknown";
+        }
+
         if (!OperatingSystem.IsWindows())
         {
             return "unknown";
@@ -124,28 +138,97 @@ public static class HostSystemInfo
 
     private static string GetMemoryDescription()
     {
-        if (OperatingSystem.IsWindows())
+        // Reports the cgroup/job-object limit when the process is constrained,
+        // which is the figure that actually bounds the emulator.
+        var totalBytes = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+        if (totalBytes <= 0)
         {
-            try
-            {
-                var status = new MemoryStatusEx
-                {
-                    dwLength = (uint)Marshal.SizeOf<MemoryStatusEx>(),
-                };
-                if (GlobalMemoryStatusEx(ref status))
-                {
-                    var megabytes = status.ullTotalPhys / (1024 * 1024);
-                    var gigabytes = status.ullTotalPhys / (1024d * 1024 * 1024);
-                    return $"{megabytes:N0} MB ({gigabytes:N1} GB)";
-                }
-            }
-            catch (Exception)
-            {
-                // Hardware information is diagnostic only.
-            }
+            return "unknown";
         }
 
-        return "unknown";
+        var megabytes = totalBytes / (1024 * 1024);
+        var gigabytes = totalBytes / (1024d * 1024 * 1024);
+        return $"{megabytes:N0} MB ({gigabytes:N1} GB)";
+    }
+
+    /// <summary>
+    /// Names the system default Metal device, or null when unavailable.
+    /// </summary>
+    /// <remarks>
+    /// Metal is the only version-stable way to name an Apple GPU: no sysctl
+    /// exposes it, and the Vulkan presenter that also knows the name lives
+    /// downstream of this assembly and initializes long after the startup
+    /// banner is emitted. Like the Windows path, this reports the host's
+    /// preferred GPU, which on a multi-GPU Mac need not be the device the
+    /// presenter later selects; that one is logged separately as
+    /// "Vulkan device: ...".
+    /// </remarks>
+    private static string? GetMetalDeviceName()
+    {
+        try
+        {
+            var device = MTLCreateSystemDefaultDevice();
+            if (device == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            try
+            {
+                var name = objc_msgSend(device, sel_registerName("name"));
+                if (name == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                var utf8 = objc_msgSend(name, sel_registerName("UTF8String"));
+                return utf8 == IntPtr.Zero ? null : Marshal.PtrToStringUTF8(utf8);
+            }
+            finally
+            {
+                // MTLCreateSystemDefaultDevice returns a +1 retained device.
+                objc_msgSend(device, sel_registerName("release"));
+            }
+        }
+        catch (Exception)
+        {
+            // Hardware information is diagnostic only.
+            return null;
+        }
+    }
+
+    /// <summary>Reads a string sysctl by name, or null when unavailable.</summary>
+    private static string? GetSysctlString(string name)
+    {
+        try
+        {
+            nuint length = 0;
+            if (sysctlbyname(name, IntPtr.Zero, ref length, IntPtr.Zero, 0) != 0 || length == 0)
+            {
+                return null;
+            }
+
+            var buffer = Marshal.AllocHGlobal((int)length);
+            try
+            {
+                if (sysctlbyname(name, buffer, ref length, IntPtr.Zero, 0) != 0)
+                {
+                    return null;
+                }
+
+                // length counts the trailing NUL, which PtrToStringUTF8 must not include.
+                return Marshal.PtrToStringUTF8(buffer, (int)length - 1);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+        catch (Exception)
+        {
+            // Hardware information is diagnostic only.
+            return null;
+        }
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
@@ -163,25 +246,19 @@ public static class HostSystemInfo
         public string? DeviceKey;
     }
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-    private struct MemoryStatusEx
-    {
-        public uint dwLength;
-        public uint dwMemoryLoad;
-        public ulong ullTotalPhys;
-        public ulong ullAvailPhys;
-        public ulong ullTotalPageFile;
-        public ulong ullAvailPageFile;
-        public ulong ullTotalVirtual;
-        public ulong ullAvailVirtual;
-        public ulong ullAvailExtendedVirtual;
-    }
-
     [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool EnumDisplayDevices(string? deviceName, uint deviceNum, ref DisplayDevice displayDevice, uint flags);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GlobalMemoryStatusEx(ref MemoryStatusEx buffer);
+    [DllImport("libc", SetLastError = true)]
+    private static extern int sysctlbyname(string name, IntPtr oldp, ref nuint oldlenp, IntPtr newp, nuint newlen);
+
+    [DllImport("/System/Library/Frameworks/Metal.framework/Metal")]
+    private static extern IntPtr MTLCreateSystemDefaultDevice();
+
+    [DllImport("/usr/lib/libobjc.dylib")]
+    private static extern IntPtr sel_registerName(string name);
+
+    [DllImport("/usr/lib/libobjc.dylib")]
+    private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector);
 }

--- a/tests/SharpEmu.Libs.Tests/Logging/HostSystemInfoTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Logging/HostSystemInfoTests.cs
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Logging;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Logging;
+
+public sealed class HostSystemInfoTests
+{
+    [Fact]
+    public void MemoryDescriptionIsResolvedOnEverySupportedHost()
+    {
+        // GC.GetGCMemoryInfo reports total memory on all supported platforms, so
+        // "unknown" here means the query regressed rather than that the host is exotic.
+        Assert.Matches(@"^[\d,]+ MB \([\d.]+ GB\)$", GetMemoryField(HostSystemInfo.Summary));
+    }
+
+    [Fact]
+    public void CpuNameIsNeverBlank()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(HostSystemInfo.CpuName));
+    }
+
+    [Fact]
+    public void SummaryReportsEveryField()
+    {
+        var summary = HostSystemInfo.Summary;
+        Assert.StartsWith("Host hardware: CPU: ", summary);
+        Assert.Contains("; GPU: ", summary);
+        Assert.Contains("; RAM: ", summary);
+        Assert.EndsWith(".", summary);
+    }
+
+    [Fact]
+    public void MacOsResolvesTheCpuBrandRatherThanTheCoreCountFallback()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        // The bare fallback carries no model name; sysctl must supply one.
+        Assert.DoesNotMatch(@"^\d+ logical processors$", HostSystemInfo.CpuName);
+        Assert.Contains("logical processors", HostSystemInfo.CpuName);
+    }
+
+    [Fact]
+    public void MacOsResolvesTheGpuName()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        Assert.NotEqual("unknown", HostSystemInfo.GpuName);
+        Assert.False(string.IsNullOrWhiteSpace(HostSystemInfo.GpuName));
+    }
+
+    [Fact]
+    public void GpuNameIsStableAcrossCalls()
+    {
+        // The Metal device is retained and released on every miss; a leak or a
+        // double-release would surface as a differing or empty second answer.
+        Assert.Equal(HostSystemInfo.GpuName, HostSystemInfo.GpuName);
+    }
+
+    private static string GetMemoryField(string summary)
+    {
+        const string Marker = "; RAM: ";
+        var start = summary.IndexOf(Marker, StringComparison.Ordinal) + Marker.Length;
+        return summary[start..].TrimEnd('.');
+    }
+}


### PR DESCRIPTION
<!--
TODO: description goes here, in your own words.

The raw material is at the bottom of this body under "Notes". It is facts, not
prose - rewrite it, don't paste it, then delete the Notes section and this
comment before merging.
-->

## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Checklist
By submitting this PR, you confirm that:

- [ ] I have read `CONTRIBUTING.md`.
- [ ] I tested my changes.
- [ ] I wrote this description myself and did not copy AI-generated explanations.
- [ ] I listed the game(s) I tested, if applicable.

---

## Notes (raw material — delete before merge)

**Files touched**
- `src/SharpEmu.Logging/HostSystemInfo.cs`
- `tests/SharpEmu.Libs.Tests/Logging/HostSystemInfoTests.cs` (new)

**What each field now uses on macOS**
- CPU → `sysctl machdep.cpu.brand_string`
- GPU → Metal, `MTLCreateSystemDefaultDevice` + `name` (device released after read)
- RAM → `GC.GetGCMemoryInfo().TotalAvailableMemoryBytes`, replacing the Windows-only `GlobalMemoryStatusEx` path; same call now serves every platform

**Log line before → after** (Apple M1 Max)
```
Host hardware: CPU: 10 logical processors; GPU: unknown; RAM: unknown.
Host hardware: CPU: Apple M1 Max (10 logical processors); GPU: Apple M1 Max; RAM: 65,536 MB (64.0 GB).
```

**Verification**
- Host: Apple M1 Max, macOS 26.5.2 (Darwin 25.5.0), `osx-x64` self-contained publish under Rosetta 2
- Game: Dead Cells [PPSA15552] — reaches the startup banner; crashes later for unrelated reasons (see #328), banner is emitted long before that
- RAM figure cross-checked against `hw.memsize` = 68719476736 bytes = 64 GiB ✓
- CPU brand survives Rosetta: process is x86_64 but sysctl still returns `Apple M1 Max`
- Full suite: 257 tests pass (224 Libs + 33 SourceGenerators)
- Not verified: Intel Mac, multi-GPU Mac, Windows/Linux regression (CI covers the latter)

**Known limitations worth stating**
- GPU reports the *system default* Metal device. On a multi-GPU Mac that need not be the device the Vulkan presenter later selects — that one is logged separately as `Vulkan device: ...`. Same semantics as the existing Windows path.
- `GC.GetGCMemoryInfo` reports the cgroup / job-object limit when the process is constrained, not physical RAM. Deliberate: that's the figure that actually bounds the emulator.
- Metal is used only to *name* the GPU. No rendering dependency is introduced; the presenter is still Vulkan/MoltenVK.
