### PR TITLE
[Agc] Implement fused shader half exports

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -78,6 +78,7 @@ public static partial class AgcExports
     private const uint SpiShaderPgmHiLs = 0x149;
     private const uint SpiShaderPgmLoGs = 0x8A;
     private const uint SpiShaderPgmHiGs = 0x8B;
+    private const uint SpiShaderPgmChksumGs = 0x80;
     private const uint SpiPsInputEna = 0x1B3;
     private const uint SpiPsInputAddr = 0x1B4;
     private const uint ComputePgmLo = 0x20C;
@@ -173,6 +174,16 @@ public static partial class AgcExports
     private const ulong ShaderNumOutputSemanticsOffset = 0x56;
     private const ulong ShaderTypeOffset = 0x5A;
     private const ulong ShaderNumShRegistersOffset = 0x5C;
+    private const int ShaderStructBytes = 0x60;
+    private const ulong FusedShaderImageAlignment = 4;
+    private const byte ComputeShaderType = 0;
+    private const byte PsShaderType = 1;
+    private const byte GsShaderType = 2;
+    private const byte HsShaderType = 3;
+    private const byte GsFrontShaderType = 4;
+    private const byte HsFrontShaderType = 5;
+    private const byte GsBackShaderType = 6;
+    private const byte HsBackShaderType = 7;
     private const ulong CommandBufferCursorUpOffset = 0x10;
     private const ulong CommandBufferCursorDownOffset = 0x18;
     private const ulong CommandBufferCallbackOffset = 0x20;
@@ -180,6 +191,8 @@ public static partial class AgcExports
     private const ulong CommandBufferReservedDwOffset = 0x30;
     private const ulong ShaderSpecialGeCntlOffset = 0x00;
     private const ulong ShaderSpecialVgtShaderStagesEnOffset = 0x08;
+    private const uint VgtShaderStagesHsW32EnBit = 1u << 21;
+    private const uint VgtShaderStagesGsW32EnBit = 1u << 22;
     private const ulong ShaderSpecialVgtGsOutPrimTypeOffset = 0x20;
     private const ulong ShaderSpecialGeUserVgprEnOffset = 0x28;
     private const uint CbSetShRegisterRangeMarker = 0x6875000D;
@@ -705,6 +718,177 @@ public static partial class AgcExports
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
+
+    // NID captured from shipped titles; the friendly name collides with a real catalog symbol of a different NID. Rename pending AGC API confirmation.
+    #pragma warning disable SHEM004
+    [SysAbiExport(
+        Nid = "dolOmWH+huQ",
+        ExportName = "sceAgcGetFusedShaderSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int GetFusedShaderSize(CpuContext ctx)
+    {
+        var destinationAddress = ctx[CpuRegister.Rdi];
+        var frontAddress = ctx[CpuRegister.Rsi];
+        var backAddress = ctx[CpuRegister.Rdx];
+        if (destinationAddress == 0 || frontAddress == 0 || backAddress == 0)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        if (!TryReadByte(ctx, frontAddress + ShaderTypeOffset, out var frontType) ||
+            !TryReadByte(ctx, backAddress + ShaderTypeOffset, out var backType) ||
+            !TryReadByte(ctx, backAddress + ShaderNumShRegistersOffset, out var registerCount))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        if (!IsFusedShaderHalfPair(frontType, backType))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        if (!ctx.TryWriteUInt64(destinationAddress, registerCount * 8UL) ||
+            !ctx.TryWriteUInt64(destinationAddress + 8, FusedShaderImageAlignment))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAgc(
+            $"agc.get_fused_shader_size front=0x{frontAddress:X16} back=0x{backAddress:X16} " +
+            $"types={frontType}/{backType} registers={registerCount}");
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+    #pragma warning restore SHEM004
+
+    // NID captured from shipped titles; the friendly name collides with a real catalog symbol of a different NID. Rename pending AGC API confirmation.
+    #pragma warning disable SHEM004
+    [SysAbiExport(
+        Nid = "fd5Bp5tGTgo",
+        ExportName = "sceAgcFuseShaderHalves",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int FuseShaderHalves(CpuContext ctx)
+    {
+        var fusedAddress = ctx[CpuRegister.Rdi];
+        var frontAddress = ctx[CpuRegister.Rsi];
+        var backAddress = ctx[CpuRegister.Rdx];
+        var scratchAddress = ctx[CpuRegister.Rcx];
+        if (fusedAddress == 0 || frontAddress == 0 || backAddress == 0)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        if (!TryReadByte(ctx, frontAddress + ShaderTypeOffset, out var frontType) ||
+            !TryReadByte(ctx, backAddress + ShaderTypeOffset, out var backType))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        if (!IsFusedShaderHalfPair(frontType, backType))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        if (!TryReadUInt64(ctx, frontAddress + ShaderSpecialsOffset, out var frontSpecialsAddress) ||
+            !TryReadUInt64(ctx, backAddress + ShaderSpecialsOffset, out var backSpecialsAddress))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        var isGeometryPair = frontType == GsFrontShaderType;
+        if (frontSpecialsAddress != 0 && backSpecialsAddress != 0)
+        {
+            if (!TryReadUInt32(ctx, frontSpecialsAddress + ShaderSpecialVgtShaderStagesEnOffset + sizeof(uint), out var frontStages) ||
+                !TryReadUInt32(ctx, backSpecialsAddress + ShaderSpecialVgtShaderStagesEnOffset + sizeof(uint), out var backStages))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+
+            var waveSizeBit = isGeometryPair ? VgtShaderStagesGsW32EnBit : VgtShaderStagesHsW32EnBit;
+            if (((frontStages ^ backStages) & waveSizeBit) != 0)
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+            }
+        }
+
+        if (!TryReadUInt64(ctx, backAddress + ShaderShRegistersOffset, out var backRegistersAddress) ||
+            !TryReadByte(ctx, backAddress + ShaderNumShRegistersOffset, out var registerCount) ||
+            !TryReadUInt64(ctx, frontAddress + ShaderCodeOffset, out var frontCodeAddress))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        Span<byte> header = stackalloc byte[ShaderStructBytes];
+        if (!ctx.Memory.TryRead(backAddress, header) ||
+            !ctx.Memory.TryWrite(fusedAddress, header))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        var fusedRegistersAddress = backRegistersAddress;
+        if (scratchAddress != 0 && backRegistersAddress != 0 && registerCount != 0)
+        {
+            Span<byte> registers = stackalloc byte[registerCount * 8];
+            if (!ctx.Memory.TryRead(backRegistersAddress, registers) ||
+                !ctx.Memory.TryWrite(scratchAddress, registers))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+
+            fusedRegistersAddress = scratchAddress;
+        }
+
+        if (!TryWriteByte(ctx, fusedAddress + ShaderTypeOffset, isGeometryPair ? GsShaderType : HsShaderType) ||
+            !ctx.TryWriteUInt64(fusedAddress + ShaderUserDataOffset, 0) ||
+            !ctx.TryWriteUInt64(fusedAddress + ShaderShRegistersOffset, fusedRegistersAddress))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        if (isGeometryPair)
+        {
+            if (!TryReadUInt64(ctx, frontAddress + ShaderShRegistersOffset, out var frontRegistersAddress) ||
+                !TryReadByte(ctx, frontAddress + ShaderNumShRegistersOffset, out var frontRegisterCount))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+
+            for (var occurrence = 0; occurrence < 2; occurrence++)
+            {
+                if (!TryFindShaderRegister(ctx, fusedRegistersAddress, registerCount, SpiShaderPgmChksumGs, occurrence, out var fusedEntry) ||
+                    !TryFindShaderRegister(ctx, frontRegistersAddress, frontRegisterCount, SpiShaderPgmChksumGs, occurrence, out var frontEntry))
+                {
+                    continue;
+                }
+
+                if (!TryReadUInt32(ctx, frontEntry + sizeof(uint), out var checksum) ||
+                    !TryWriteUInt32(ctx, fusedEntry + sizeof(uint), checksum))
+                {
+                    return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+                }
+            }
+        }
+
+        if (!PatchFusedProgramAddress(
+                ctx,
+                fusedRegistersAddress,
+                registerCount,
+                isGeometryPair ? SpiShaderPgmLoEs : SpiShaderPgmLoLs,
+                frontCodeAddress))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAgc(
+            $"agc.fuse_shader_halves fused=0x{fusedAddress:X16} front=0x{frontAddress:X16} " +
+            $"back=0x{backAddress:X16} scratch=0x{scratchAddress:X16} types={frontType}/{backType} " +
+            $"registers={registerCount} code=0x{frontCodeAddress:X16}");
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+    #pragma warning restore SHEM004
 
     [SysAbiExport(
         Nid = "vcmNN+AAXnY",
@@ -10074,20 +10258,20 @@ public static partial class AgcExports
 
         var expectedLo = shaderType switch
         {
-            0 => ComputePgmLo,
-            1 => SpiShaderPgmLoPs,
-            2 or 6 => SpiShaderPgmLoEs,
-            4 => SpiShaderPgmLoGs,
-            7 => SpiShaderPgmLoLs,
+            ComputeShaderType => ComputePgmLo,
+            PsShaderType => SpiShaderPgmLoPs,
+            GsShaderType or GsBackShaderType => SpiShaderPgmLoEs,
+            GsFrontShaderType => SpiShaderPgmLoGs,
+            HsBackShaderType => SpiShaderPgmLoLs,
             _ => 0u,
         };
         var expectedHi = shaderType switch
         {
-            0 => ComputePgmHi,
-            1 => SpiShaderPgmHiPs,
-            2 or 6 => SpiShaderPgmHiEs,
-            4 => SpiShaderPgmHiGs,
-            7 => SpiShaderPgmHiLs,
+            ComputeShaderType => ComputePgmHi,
+            PsShaderType => SpiShaderPgmHiPs,
+            GsShaderType or GsBackShaderType => SpiShaderPgmHiEs,
+            GsFrontShaderType => SpiShaderPgmHiGs,
+            HsBackShaderType => SpiShaderPgmHiLs,
             _ => 0u,
         };
         if (expectedLo == 0 || loRegister != expectedLo || hiRegister != expectedHi)
@@ -10103,7 +10287,7 @@ public static partial class AgcExports
     }
 
     private static bool IsEsGeometryShaderType(byte shaderType) =>
-        shaderType is 2 or 6;
+        shaderType is GsShaderType or GsBackShaderType;
 
     private static int SetIndirectPatchAddress(CpuContext ctx, string registerSpace)
     {
@@ -10312,6 +10496,82 @@ public static partial class AgcExports
 
         return TryWriteUInt32(ctx, destinationAddress, offset) &&
                TryWriteUInt32(ctx, destinationAddress + sizeof(uint), value);
+    }
+
+    private static bool IsFusedShaderHalfPair(byte frontType, byte backType) =>
+        (frontType == GsFrontShaderType && backType == GsBackShaderType) ||
+        (frontType == HsFrontShaderType && backType == HsBackShaderType);
+
+    private static bool TryFindShaderRegister(
+        CpuContext ctx,
+        ulong registersAddress,
+        int registerCount,
+        uint registerOffset,
+        int occurrence,
+        out ulong entryAddress)
+    {
+        if (registersAddress != 0)
+        {
+            for (var index = 0; index < registerCount; index++)
+            {
+                var address = registersAddress + (ulong)index * 8;
+                if (!TryReadUInt32(ctx, address, out var current) || current != registerOffset)
+                {
+                    continue;
+                }
+
+                if (occurrence == 0)
+                {
+                    entryAddress = address;
+                    return true;
+                }
+
+                occurrence--;
+            }
+        }
+
+        entryAddress = 0;
+        return false;
+    }
+
+    // A missing or unpaired lo/hi register is not an error: the retail library
+    // leaves absent registers untouched, unlike the create-time patch which
+    // requires them.
+    private static bool PatchFusedProgramAddress(
+        CpuContext ctx,
+        ulong registersAddress,
+        int registerCount,
+        uint loRegisterOffset,
+        ulong codeAddress)
+    {
+        if (!TryFindShaderRegister(ctx, registersAddress, registerCount, loRegisterOffset, 0, out var loEntry))
+        {
+            TraceAgc($"agc.fuse_shader_halves.pgm_absent lo=0x{loRegisterOffset:X} regs=0x{registersAddress:X16}");
+            return true;
+        }
+
+        var hiEntry = loEntry + 8;
+        if (hiEntry >= registersAddress + (ulong)registerCount * 8 ||
+            !TryReadUInt32(ctx, hiEntry, out var hiOffset) ||
+            hiOffset != loRegisterOffset + 1)
+        {
+            TraceAgc($"agc.fuse_shader_halves.pgm_unpaired lo=0x{loRegisterOffset:X} regs=0x{registersAddress:X16}");
+            return true;
+        }
+
+        if (!TryReadUInt32(ctx, hiEntry + sizeof(uint), out var hiValue))
+        {
+            return false;
+        }
+
+        return TryWriteUInt32(ctx, loEntry + sizeof(uint), (uint)(codeAddress >> 8)) &&
+               TryWriteUInt32(ctx, hiEntry + sizeof(uint), (hiValue & 0xFFFF_FF00u) | (uint)((codeAddress >> 40) & 0xFFUL));
+    }
+
+    private static bool TryWriteByte(CpuContext ctx, ulong address, byte value)
+    {
+        Span<byte> buffer = [value];
+        return ctx.Memory.TryWrite(address, buffer);
     }
 
     private static bool RelocatePointerField(CpuContext ctx, ulong fieldAddress)

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcFusedShaderTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcFusedShaderTests.cs
@@ -1,0 +1,330 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+// sceAgcGetFusedShaderSize (dolOmWH+huQ) and sceAgcFuseShaderHalves (fd5Bp5tGTgo)
+// join a GS or HS front/back shader half pair into one shader: the fused header
+// is the back half retyped, the back half's SH registers become the fused
+// register image, and the front half contributes its program address
+// (SPI_SHADER_PGM_LO/HI_ES) and checksum registers.
+public sealed class AgcFusedShaderTests
+{
+    private const ulong BaseAddress = 0x1_0000_0000;
+    private const int MemorySize = 0x4000;
+
+    private const ulong FrontShader = BaseAddress + 0x0000;
+    private const ulong BackShader = BaseAddress + 0x0100;
+    private const ulong FusedShader = BaseAddress + 0x0200;
+    private const ulong FrontRegisters = BaseAddress + 0x0300;
+    private const ulong BackRegisters = BaseAddress + 0x0400;
+    private const ulong FrontSpecials = BaseAddress + 0x0500;
+    private const ulong BackSpecials = BaseAddress + 0x0600;
+    private const ulong Scratch = BaseAddress + 0x0700;
+    private const ulong SizeResult = BaseAddress + 0x0800;
+
+    private const ulong ShaderUserDataOffset = 0x08;
+    private const ulong ShaderCodeOffset = 0x10;
+    private const ulong ShaderShRegistersOffset = 0x20;
+    private const ulong ShaderSpecialsOffset = 0x28;
+    private const ulong ShaderTypeOffset = 0x5A;
+    private const ulong ShaderNumShRegistersOffset = 0x5C;
+
+    private const byte GsFront = 4;
+    private const byte HsFront = 5;
+    private const byte GsBack = 6;
+    private const byte HsBack = 7;
+
+    private const ulong FrontCode = 0x0000_1234_5678_9A00;
+
+    [Fact]
+    public void GetFusedShaderSize_GsPair_ReportsBackRegisterBytes()
+    {
+        var (memory, ctx) = CreateGsPair();
+
+        ctx[CpuRegister.Rdi] = SizeResult;
+        ctx[CpuRegister.Rsi] = FrontShader;
+        ctx[CpuRegister.Rdx] = BackShader;
+        var result = AgcExports.GetFusedShaderSize(ctx);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(5UL * 8UL, ReadUInt64(memory, SizeResult));
+        Assert.Equal(4UL, ReadUInt64(memory, SizeResult + 8));
+    }
+
+    [Fact]
+    public void GetFusedShaderSize_MismatchedHalves_Rejects()
+    {
+        var (memory, ctx) = CreateGsPair();
+        WriteByte(memory, BackShader + ShaderTypeOffset, HsBack);
+
+        ctx[CpuRegister.Rdi] = SizeResult;
+        ctx[CpuRegister.Rsi] = FrontShader;
+        ctx[CpuRegister.Rdx] = BackShader;
+        var result = AgcExports.GetFusedShaderSize(ctx);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT, result);
+        Assert.Equal(0UL, ReadUInt64(memory, SizeResult));
+    }
+
+    [Fact]
+    public void FuseShaderHalves_GsPairWithScratch_BuildsFusedShader()
+    {
+        var (memory, ctx) = CreateGsPair();
+
+        ctx[CpuRegister.Rdi] = FusedShader;
+        ctx[CpuRegister.Rsi] = FrontShader;
+        ctx[CpuRegister.Rdx] = BackShader;
+        ctx[CpuRegister.Rcx] = Scratch;
+        var result = AgcExports.FuseShaderHalves(ctx);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+
+        // Fused header is the back half with type kGs, cleared user data, and
+        // registers relocated to the scratch image.
+        Assert.Equal(2, ReadByte(memory, FusedShader + ShaderTypeOffset));
+        Assert.Equal(0UL, ReadUInt64(memory, FusedShader + ShaderUserDataOffset));
+        Assert.Equal(Scratch, ReadUInt64(memory, FusedShader + ShaderShRegistersOffset));
+        Assert.Equal(5, ReadByte(memory, FusedShader + ShaderNumShRegistersOffset));
+        Assert.Equal(
+            ReadUInt64(memory, BackShader + ShaderCodeOffset),
+            ReadUInt64(memory, FusedShader + ShaderCodeOffset));
+
+        // The back half's own register image is untouched.
+        Assert.Equal(0x1111_1111u, ReadUInt32(memory, BackRegisters + 4));
+
+        // Scratch image: LO_ES points at the front code, HI_ES keeps its upper
+        // bits, both checksum occurrences carry the front half's values.
+        Assert.Equal(0xC8u, ReadUInt32(memory, Scratch + 0));
+        Assert.Equal(0x3456_789Au, ReadUInt32(memory, Scratch + 4));
+        Assert.Equal(0xC9u, ReadUInt32(memory, Scratch + 8));
+        Assert.Equal(0xAABB_CC12u, ReadUInt32(memory, Scratch + 12));
+        Assert.Equal(0xAAAA_0001u, ReadUInt32(memory, Scratch + 20));
+        Assert.Equal(0xBBBB_0002u, ReadUInt32(memory, Scratch + 28));
+        Assert.Equal(0x5555_5555u, ReadUInt32(memory, Scratch + 36));
+    }
+
+    [Fact]
+    public void FuseShaderHalves_NoScratch_PatchesBackRegistersInPlace()
+    {
+        var (memory, ctx) = CreateGsPair();
+
+        ctx[CpuRegister.Rdi] = FusedShader;
+        ctx[CpuRegister.Rsi] = FrontShader;
+        ctx[CpuRegister.Rdx] = BackShader;
+        ctx[CpuRegister.Rcx] = 0;
+        var result = AgcExports.FuseShaderHalves(ctx);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(BackRegisters, ReadUInt64(memory, FusedShader + ShaderShRegistersOffset));
+        Assert.Equal(0x3456_789Au, ReadUInt32(memory, BackRegisters + 4));
+        Assert.Equal(0xAABB_CC12u, ReadUInt32(memory, BackRegisters + 12));
+    }
+
+    [Fact]
+    public void FuseShaderHalves_WaveSizeMismatch_Rejects()
+    {
+        var (memory, ctx) = CreateGsPair();
+        WriteUInt32(memory, BackSpecials + 0x08 + 4, 0u);
+
+        ctx[CpuRegister.Rdi] = FusedShader;
+        ctx[CpuRegister.Rsi] = FrontShader;
+        ctx[CpuRegister.Rdx] = BackShader;
+        ctx[CpuRegister.Rcx] = Scratch;
+        var result = AgcExports.FuseShaderHalves(ctx);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT, result);
+        Assert.Equal(0, ReadByte(memory, FusedShader + ShaderTypeOffset));
+    }
+
+    [Fact]
+    public void FuseShaderHalves_HsPair_PatchesLoLs()
+    {
+        var (memory, ctx) = CreateGsPair();
+        WriteByte(memory, FrontShader + ShaderTypeOffset, HsFront);
+        WriteByte(memory, BackShader + ShaderTypeOffset, HsBack);
+        WriteUInt32(memory, BackRegisters + 0, 0x148u);
+        WriteUInt32(memory, BackRegisters + 8, 0x149u);
+
+        ctx[CpuRegister.Rdi] = FusedShader;
+        ctx[CpuRegister.Rsi] = FrontShader;
+        ctx[CpuRegister.Rdx] = BackShader;
+        ctx[CpuRegister.Rcx] = Scratch;
+        var result = AgcExports.FuseShaderHalves(ctx);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(3, ReadByte(memory, FusedShader + ShaderTypeOffset));
+        Assert.Equal(0x3456_789Au, ReadUInt32(memory, Scratch + 4));
+        // Checksum grafting is a geometry-pair behavior; the HS image keeps its own values.
+        Assert.Equal(0x1111_0001u, ReadUInt32(memory, Scratch + 20));
+    }
+
+    [Fact]
+    public void FuseShaderHalves_MissingSpecials_SkipsWaveSizeGate()
+    {
+        var (memory, ctx) = CreateGsPair();
+        // The divergence the mismatch test rejects passes when a half lacks specials.
+        WriteUInt64(memory, FrontShader + ShaderSpecialsOffset, 0);
+        WriteUInt32(memory, BackSpecials + 0x08 + 4, 0u);
+
+        ctx[CpuRegister.Rdi] = FusedShader;
+        ctx[CpuRegister.Rsi] = FrontShader;
+        ctx[CpuRegister.Rdx] = BackShader;
+        ctx[CpuRegister.Rcx] = Scratch;
+        var result = AgcExports.FuseShaderHalves(ctx);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(2, ReadByte(memory, FusedShader + ShaderTypeOffset));
+    }
+
+    [Fact]
+    public void FuseShaderHalves_ProgramRegisterAbsent_LeavesImageUntouched()
+    {
+        var (memory, ctx) = CreateGsPair();
+        WriteByte(memory, FrontShader + ShaderTypeOffset, HsFront);
+        WriteByte(memory, BackShader + ShaderTypeOffset, HsBack);
+
+        ctx[CpuRegister.Rdi] = FusedShader;
+        ctx[CpuRegister.Rsi] = FrontShader;
+        ctx[CpuRegister.Rdx] = BackShader;
+        ctx[CpuRegister.Rcx] = Scratch;
+        var result = AgcExports.FuseShaderHalves(ctx);
+
+        // No LO_LS entry in the back image: the fuse still succeeds and the
+        // scratch copy stays verbatim.
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(3, ReadByte(memory, FusedShader + ShaderTypeOffset));
+        Assert.Equal(0x1111_1111u, ReadUInt32(memory, Scratch + 4));
+        Assert.Equal(0xAABB_CC77u, ReadUInt32(memory, Scratch + 12));
+    }
+
+    [Fact]
+    public void FuseShaderHalves_UnpairedProgramRegister_LeavesImageUntouched()
+    {
+        var (memory, ctx) = CreateGsPair();
+        WriteByte(memory, FrontShader + ShaderTypeOffset, HsFront);
+        WriteByte(memory, BackShader + ShaderTypeOffset, HsBack);
+        WriteUInt32(memory, BackRegisters + 0, 0x148u);
+
+        ctx[CpuRegister.Rdi] = FusedShader;
+        ctx[CpuRegister.Rsi] = FrontShader;
+        ctx[CpuRegister.Rdx] = BackShader;
+        ctx[CpuRegister.Rcx] = Scratch;
+        var result = AgcExports.FuseShaderHalves(ctx);
+
+        // LO_LS is present but the next entry is not HI_LS, so the patch is skipped.
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(0x1111_1111u, ReadUInt32(memory, Scratch + 4));
+    }
+
+    [Fact]
+    public void FuseShaderHalves_ProgramRegisterAtImageEnd_LeavesImageUntouched()
+    {
+        var (memory, ctx) = CreateGsPair();
+        WriteByte(memory, FrontShader + ShaderTypeOffset, HsFront);
+        WriteByte(memory, BackShader + ShaderTypeOffset, HsBack);
+        WriteUInt32(memory, BackRegisters + 4 * 8, 0x148u);
+
+        ctx[CpuRegister.Rdi] = FusedShader;
+        ctx[CpuRegister.Rsi] = FrontShader;
+        ctx[CpuRegister.Rdx] = BackShader;
+        ctx[CpuRegister.Rcx] = Scratch;
+        var result = AgcExports.FuseShaderHalves(ctx);
+
+        // The hi half of the pair would sit past the register image.
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(0x5555_5555u, ReadUInt32(memory, Scratch + 36));
+    }
+
+    private static (FakeCpuMemory Memory, CpuContext Ctx) CreateGsPair()
+    {
+        var memory = new FakeCpuMemory(BaseAddress, MemorySize);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+
+        WriteByte(memory, FrontShader + ShaderTypeOffset, GsFront);
+        WriteUInt64(memory, FrontShader + ShaderCodeOffset, FrontCode);
+        WriteUInt64(memory, FrontShader + ShaderShRegistersOffset, FrontRegisters);
+        WriteUInt64(memory, FrontShader + ShaderSpecialsOffset, FrontSpecials);
+        WriteByte(memory, FrontShader + ShaderNumShRegistersOffset, 4);
+
+        WriteByte(memory, BackShader + ShaderTypeOffset, GsBack);
+        WriteUInt64(memory, BackShader + ShaderCodeOffset, 0x0000_0BAD_F00D_BE00);
+        WriteUInt64(memory, BackShader + ShaderShRegistersOffset, BackRegisters);
+        WriteUInt64(memory, BackShader + ShaderSpecialsOffset, BackSpecials);
+        WriteUInt64(memory, BackShader + ShaderUserDataOffset, 0xDEAD_BEEF);
+        WriteByte(memory, BackShader + ShaderNumShRegistersOffset, 5);
+
+        // Back image: ES program address pair, two checksum slots, one bystander.
+        WriteRegister(memory, BackRegisters, 0, 0xC8u, 0x1111_1111u);
+        WriteRegister(memory, BackRegisters, 1, 0xC9u, 0xAABB_CC77u);
+        WriteRegister(memory, BackRegisters, 2, 0x80u, 0x1111_0001u);
+        WriteRegister(memory, BackRegisters, 3, 0x80u, 0x1111_0002u);
+        WriteRegister(memory, BackRegisters, 4, 0x10u, 0x5555_5555u);
+
+        // Front image: GS RSRC pair as shipped, then the checksum values to graft.
+        WriteRegister(memory, FrontRegisters, 0, 0x8Au, 0x0123_4567u);
+        WriteRegister(memory, FrontRegisters, 1, 0x8Bu, 0x89AB_CDEFu);
+        WriteRegister(memory, FrontRegisters, 2, 0x80u, 0xAAAA_0001u);
+        WriteRegister(memory, FrontRegisters, 3, 0x80u, 0xBBBB_0002u);
+
+        // VGT_SHADER_STAGES_EN register pairs with the GS wave32 enable bit set on both halves.
+        WriteUInt32(memory, FrontSpecials + 0x08, 0x1F1u);
+        WriteUInt32(memory, FrontSpecials + 0x08 + 4, 1u << 22);
+        WriteUInt32(memory, BackSpecials + 0x08, 0x1F1u);
+        WriteUInt32(memory, BackSpecials + 0x08 + 4, 1u << 22);
+
+        return (memory, ctx);
+    }
+
+    private static void WriteRegister(FakeCpuMemory memory, ulong array, int index, uint offset, uint value)
+    {
+        WriteUInt32(memory, array + (ulong)index * 8, offset);
+        WriteUInt32(memory, array + (ulong)index * 8 + 4, value);
+    }
+
+    private static void WriteByte(FakeCpuMemory memory, ulong address, byte value)
+    {
+        Span<byte> buffer = [value];
+        Assert.True(memory.TryWrite(address, buffer));
+    }
+
+    private static void WriteUInt32(FakeCpuMemory memory, ulong address, uint value)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
+        Assert.True(memory.TryWrite(address, buffer));
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+        Assert.True(memory.TryWrite(address, buffer));
+    }
+
+    private static byte ReadByte(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> buffer = stackalloc byte[1];
+        Assert.True(memory.TryRead(address, buffer));
+        return buffer[0];
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        Assert.True(memory.TryRead(address, buffer));
+        return BinaryPrimitives.ReadUInt32LittleEndian(buffer);
+    }
+
+    private static ulong ReadUInt64(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        Assert.True(memory.TryRead(address, buffer));
+        return BinaryPrimitives.ReadUInt64LittleEndian(buffer);
+    }
+}


### PR DESCRIPTION
## What this adds

Two libSceAgc NIDs captured from shipped titles, following the existing captured-NID convention (`23LRUSvYu1M`, `HV4j+E0MBHE`, `V++UgBtQhn0`):

- `dolOmWH+huQ` as `sceAgcGetFusedShaderSize`: reports the byte size of the back half's SH register image (count x 8, align 4).
- `fd5Bp5tGTgo` as `sceAgcFuseShaderHalves`: joins a GS or HS front/back shader half pair into one shader. The fused header is the back half retyped to kGs/kHs with cleared user data; the back half's SH registers are copied into caller scratch when provided (patched in place otherwise); the front half donates its program address (SPI_SHADER_PGM_LO/HI_ES for GS, LO/HI_LS for HS, hi keeps its upper 24 bits) and, for GS pairs, both SPI_SHADER_PGM_CHKSUM_GS occurrences.

## Why

libSceAgc ships geometry and tessellation shaders as front/back half pairs that the runtime joins at load time; the emulator implements shader creation but had no join, so both NIDs were unresolved. A title that fuses shaders then works with a garbage fused struct: the size query returns nothing, the caller passes a null scratch pointer, and every pipeline built from the pair inherits the garbage. Any Gen5 title running fused geometry pipelines goes through these two calls; Astro Bot (#11) is the first observed consumer, with 33 GS pairs fused during boot.

## How

- Semantics follow KytyPS5's reverse-engineered `agc.cpp` (`GraphicsUnknownGetFusedShaderSize` / `GraphicsUnknownFuseShaderHalves`), cross-checked against this title: shader struct offsets match the ones `sceAgcCreateShader` already uses, and a traced run shows the game allocating scratch at exactly the size the query reports (10 registers -> 0x50-byte strides) and passing type 4/6 pairs.
- The true symbol names are unknown: both flat `sceAgc*` names and the catalog's mangled `sce::Agc::{getFusedShaderSize,fuseShaderHalves}` signatures hash to different NIDs (checked against scripts/ps5_names.txt and generated mangling variants), so the exports carry the same captured-NID comment and SHEM004 suppression as the existing trio. The catalog lists both flat names, and the NID derivation assigns them `nApJjpKNBl4` and `nQT5kYLv0cg`, so the real catalog demonstrably uses these names for other symbols.
- Every fuse-specific behavior is taken from the KytyPS5 routines: the VGT_SHADER_STAGES_EN wave-size gate (GS_W32_EN bit 22 and HS_W32_EN bit 21 per the public GFX10 register headers, so the gate is both halves agreeing on wave32 mode; skipped when either half lacks specials), the program-address patch preserving the hi register's upper 24 bits (the create-time patch owns the whole dword), a missing or unpaired lo/hi register being left untouched instead of failing like the create-time patch (traced as `pgm_absent`/`pgm_unpaired` so a skipped patch leaves a breadcrumb), and the two-occurrence CHKSUM_GS graft (images carry the register twice with distinct values, so the copy is positional rather than copy-all-matches; the register image is searched by offset rather than assuming array position).
- The create-time patch's shader-type switch and IsEsGeometryShaderType now share the named type constants this change introduces instead of repeating the raw values.
- Not addressed here: the GS-phase program pointer (0x88/0x89) of the back half is never rebased to an absolute address (create only patches the first register pair, 0xC8/0xC9). The draw path currently consumes only the ES pointer, which the fuse sets to the front half's code, so this only matters once the GPU learns to run the GS phase itself.

## Verification

- 10 new tests cover the size query, pair-type rejection, the fused header fields (retype, cleared user data, relocated register image), scratch and in-place register flows, hi-register bit preservation, checksum grafting on GS pairs and its absence on HS pairs, wave-size mismatch rejection and its skip when a half lacks specials, and the leave-untouched patch paths (program register absent, unpaired, or at the image end).
- Full `SharpEmu.Libs.Tests` suite passes (220 tests).
- Astro Bot: all 33 boot-time fuses succeed with well-formed inputs (`types=4/6 registers=10`), and a traced run confirms the game consumes the size query: it allocates scratch blocks at exactly the reported size (0x50-byte strides) and passes them to the fuse call, where the unresolved stub previously left it passing null. The title still parks at its splash afterwards for unrelated reasons (it never issues its first draw), tracked in #11.