### PR TITLE
[VideoOut] Rank integrated GPUs above software rasterizers

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -2219,6 +2219,47 @@ internal static unsafe class VulkanVideoPresenter
         target is not null &&
         (state.TestEnable || state.WriteEnable || state.ClearEnable);
 
+    /// <summary>
+    /// Ranks a Vulkan candidate; the highest score presents. SHARPEMU_VK_DEVICE
+    /// pins an adapter by name substring and overrides the ranking entirely.
+    /// </summary>
+    /// <remarks>
+    /// Discrete parts outrank integrated because an integrated AMD driver
+    /// access-violates inside vkCreateGraphicsPipelines while compiling some
+    /// translated guest shaders (#97). That penalty must not extend below
+    /// <see cref="PhysicalDeviceType.Cpu"/>, which is a software rasterizer
+    /// (Mesa's lavapipe, SwiftShader): rendering the guest on the CPU is slower
+    /// than any real GPU by orders of magnitude, so it stays the last resort.
+    /// MoltenVK also reports every Apple Silicon GPU as integrated, which would
+    /// otherwise lose to a software device on those hosts.
+    /// </remarks>
+    internal static int ScorePhysicalDevice(
+        PhysicalDeviceProperties properties,
+        string name,
+        string? deviceOverride)
+    {
+        if (!string.IsNullOrWhiteSpace(deviceOverride))
+        {
+            return name.Contains(deviceOverride, StringComparison.OrdinalIgnoreCase) ? 1000 : -1000;
+        }
+
+        var score = properties.DeviceType switch
+        {
+            PhysicalDeviceType.DiscreteGpu => 300,
+            PhysicalDeviceType.VirtualGpu => 100,
+            PhysicalDeviceType.IntegratedGpu => 50,
+            PhysicalDeviceType.Cpu => -100,
+            _ => 10,
+        };
+
+        if (properties.VendorID == NvidiaVendorId)
+        {
+            score += 500;
+        }
+
+        return score;
+    }
+
     private readonly record struct Presentation(
         byte[]? Pixels,
         uint Width,
@@ -3198,33 +3239,6 @@ internal static unsafe class VulkanVideoPresenter
                 $"[LOADER][INFO] Vulkan device: {selectedName} ({selected.DeviceType})");
             VideoOutExports.SetSelectedGpuName(selectedName);
             _window.Title = VideoOutExports.GetWindowTitle();
-        }
-
-        private static int ScorePhysicalDevice(
-            PhysicalDeviceProperties properties,
-            string name,
-            string? deviceOverride)
-        {
-            if (!string.IsNullOrWhiteSpace(deviceOverride))
-            {
-                return name.Contains(deviceOverride, StringComparison.OrdinalIgnoreCase) ? 1000 : -1000;
-            }
-
-            var score = properties.DeviceType switch
-            {
-                PhysicalDeviceType.DiscreteGpu => 300,
-                PhysicalDeviceType.VirtualGpu => 100,
-                PhysicalDeviceType.Cpu => 50,
-                PhysicalDeviceType.IntegratedGpu => -100,
-                _ => 10,
-            };
-
-            if (properties.VendorID == NvidiaVendorId)
-            {
-                score += 500;
-            }
-
-            return score;
         }
 
         private void LoadComputeDeviceLimits()

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanPhysicalDeviceScoreTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanPhysicalDeviceScoreTests.cs
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.VideoOut;
+using Silk.NET.Vulkan;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VulkanPhysicalDeviceScoreTests
+{
+    private const uint NvidiaVendorId = 0x10DE;
+    private const uint AmdVendorId = 0x1002;
+
+    private static int Score(PhysicalDeviceType type, uint vendorId = AmdVendorId) =>
+        VulkanVideoPresenter.ScorePhysicalDevice(
+            new PhysicalDeviceProperties { DeviceType = type, VendorID = vendorId },
+            "test device",
+            deviceOverride: null);
+
+    [Theory]
+    [InlineData(PhysicalDeviceType.DiscreteGpu)]
+    [InlineData(PhysicalDeviceType.VirtualGpu)]
+    [InlineData(PhysicalDeviceType.IntegratedGpu)]
+    [InlineData(PhysicalDeviceType.Other)]
+    public void EveryRealDeviceOutranksASoftwareRasterizer(PhysicalDeviceType type)
+    {
+        // A Cpu-type device is lavapipe/SwiftShader. Losing to it means the guest
+        // renders in software while a real GPU sits idle -- the #325 regression.
+        Assert.True(Score(type) > Score(PhysicalDeviceType.Cpu));
+    }
+
+    [Fact]
+    public void DiscreteStillOutranksIntegrated()
+    {
+        // #97: the integrated AMD driver crashes compiling translated guest shaders.
+        Assert.True(Score(PhysicalDeviceType.DiscreteGpu) > Score(PhysicalDeviceType.IntegratedGpu));
+    }
+
+    [Fact]
+    public void NvidiaOutranksAnyOtherDiscreteGpu()
+    {
+        Assert.True(
+            Score(PhysicalDeviceType.DiscreteGpu, NvidiaVendorId) >
+            Score(PhysicalDeviceType.DiscreteGpu, AmdVendorId));
+    }
+
+    [Fact]
+    public void AppleSiliconGpuBeatsSoftwareEvenThoughMoltenVkReportsItIntegrated()
+    {
+        // MoltenVK tags every Apple Silicon GPU as integrated; on those hosts the
+        // integrated score is the only thing standing between the guest and lavapipe.
+        Assert.True(Score(PhysicalDeviceType.IntegratedGpu) > Score(PhysicalDeviceType.Cpu));
+    }
+
+    [Fact]
+    public void DeviceOverrideSelectsMatchingNameAndRejectsOthers()
+    {
+        var properties = new PhysicalDeviceProperties
+        {
+            DeviceType = PhysicalDeviceType.Cpu,
+            VendorID = AmdVendorId,
+        };
+
+        // An explicit pin wins over the type ranking, even for a software device.
+        var pinned = VulkanVideoPresenter.ScorePhysicalDevice(properties, "llvmpipe (LLVM 17)", "llvmpipe");
+        var rejected = VulkanVideoPresenter.ScorePhysicalDevice(properties, "llvmpipe (LLVM 17)", "RTX 4090");
+
+        Assert.True(pinned > Score(PhysicalDeviceType.DiscreteGpu, NvidiaVendorId));
+        Assert.True(rejected < Score(PhysicalDeviceType.Cpu));
+    }
+}


### PR DESCRIPTION
<!--
TODO: description goes here, in your own words.

Raw material is at the bottom under "Notes". It is facts, not prose - rewrite it,
don't paste it, then delete the Notes section and this comment before merging.
-->

Fixes #325

## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Checklist
By submitting this PR, you confirm that:

- [x] I have read `CONTRIBUTING.md`.
- [ ] I tested my changes.
- [x] I wrote this description myself and did not copy AI-generated explanations.
- [x] I listed the game(s) I tested, if applicable.

---

## Notes (raw material — delete before merge)

**The bug**
- `ScorePhysicalDevice` scored `Cpu` = 50, `IntegratedGpu` = -100 → a software rasterizer outranked every integrated GPU.
- #97 set the -100 deliberately (integrated AMD driver access-violates in `vkCreateGraphicsPipelines` compiling translated guest shaders). Its rule: integrated is chosen only when nothing else can present. A `Cpu`-type device counts as "something else" — that's the hole.

**Impact**
- Linux, integrated-only host: Mesa's lavapipe enumerates as `Cpu` → wins → guest software-renders, no warning. Reads as an emulator perf problem, not a device-selection one.
- Apple Silicon: MoltenVK reports Apple GPUs as `IntegratedGpu`. Wins today only because it's the sole candidate (`bestScore` starts at `int.MinValue`). One `Cpu`-type ICD away from the same fate.

**The change**
- `IntegratedGpu` 50, `Cpu` -100. Everything else unchanged.
- Discrete still beats integrated by 250 (750 for NVIDIA) → #97's hybrid-laptop behaviour is not altered. Only the software-vs-integrated comparison flips.
- `ScorePhysicalDevice` moved from the private nested `Presenter` to the outer class as `internal`, so it's reachable from `SharpEmu.Libs.Tests` (which already has `InternalsVisibleTo`). Mirrors the existing `ShouldAttachGuestDepth` precedent. No behaviour change from the move — the call site is unchanged.

**Verification**
- New `VulkanPhysicalDeviceScoreTests` (8 cases). Confirmed they *fail* on the old ordering — reverted the two values and got exactly 3 failures (`IntegratedGpu`, `Other`, and the Apple Silicon case) while the #97 discrete-beats-integrated, NVIDIA, and `SHARPEMU_VK_DEVICE` override tests still passed. Restored → all 8 pass.
- Full suite green.
- Real run, Apple M1 Max / macOS 26.5.2 / `osx-x64` under Rosetta 2, Dead Cells [PPSA15552]:
  - before: `Vulkan candidate: Apple M1 Max (IntegratedGpu) score=-100`
  - after: `Vulkan candidate: Apple M1 Max (IntegratedGpu) score=50`
  - same device selected, `VideoOut ready: 2560x1440`, first frame presented.

**Not verified**
- The lavapipe scenario itself — no integrated-only Linux host with a software ICD available here. That half is reasoned from the scoring code; the fix follows regardless, since it only reorders.
- Hybrid-graphics laptop (the #97 hardware). Argument that it's unaffected is arithmetic, not a test run.
