### PR TITLE
[CPU] Name the extension an unrecoverable illegal instruction needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,18 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 > [!NOTE]  
 > SharpEmu supports Windows x64, Linux x64, and macOS x64. Apple Silicon Macs
-> can run the macOS x64 build through Rosetta 2.
+> can run the macOS x64 build through Rosetta 2, with the instruction-set caveat
+> below.
+
+> [!IMPORTANT]  
+> **Apple Silicon (Rosetta 2) has an instruction-set ceiling.** Guest code runs
+> natively rather than through an interpreter, so it executes on whatever the
+> host provides. Rosetta 2 implements up to SSE4.2 and does not implement SSE4a,
+> AVX, AVX2, or BMI1/BMI2, while the PS5's CPU has all of them. SharpEmu
+> emulates the scalar BMI/ABM instructions in software, but a title that reaches
+> SSE4a or AVX vector code aborts with an illegal instruction; the log names the
+> opcode and the extension it needed. Intel Macs are limited by their own CPU in
+> the same way. This is independent of GPU and game — see #328.
 
 > [!WARNING]  
 > SharpEmu is an experimental PS5 emulator developed from scratch in C#. The current focus is on accuracy and infrastructure setup rather than game-specific compatibility.

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
@@ -211,6 +211,10 @@ public sealed partial class DirectExecutionBackend
 			{
 				Console.Error.WriteLine("[LOADER][INFO]   RIP symbol: " + symbol);
 			}
+			if (exceptionCode == StatusIllegalInstruction)
+			{
+				LogUnsupportedInstructionTrace(rip);
+			}
 			Console.Error.WriteLine($"[LOADER][INFO]   RAX: 0x{rax:X16}");
 			Console.Error.WriteLine($"[LOADER][INFO]   RBX: 0x{rbx:X16}");
 			Console.Error.WriteLine($"[LOADER][INFO]   RCX: 0x{rcx:X16}");

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.IllegalInstruction.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.IllegalInstruction.cs
@@ -194,6 +194,28 @@ public sealed partial class DirectExecutionBackend
         }
     }
 
+    // Reached only once TryRecoverIllegalInstruction has declined: either the opcode is outside the
+    // BMI/ABM set modelled above, or the host lacks an extension nothing here emulates. Without this
+    // the reader gets a bare #UD dump and has to decode the bytes at RIP by hand to learn why. Iced
+    // already knows which extension each opcode needs, so name it. Rosetta 2 is the common case: it
+    // stops at SSE4.2, so the PS5's Zen 2 vector code (SSE4a, AVX, AVX2) lands here.
+    private unsafe void LogUnsupportedInstructionTrace(ulong rip)
+    {
+        if (!TryReadFaultingInstruction(rip, out var instruction))
+        {
+            return;
+        }
+
+        Console.Error.WriteLine("[LOADER][INFO]   " + DescribeUnsupportedInstruction(in instruction));
+        Console.Error.Flush();
+    }
+
+    // Iced reports at least one CPUID feature for every opcode it decodes, and the caller only
+    // reaches here with a decoded one.
+    internal static string DescribeUnsupportedInstruction(in Instruction instruction) =>
+        $"Unsupported instruction: {instruction.Mnemonic} " +
+        $"(requires {string.Join("+", instruction.CpuidFeatures)}; host does not implement it)";
+
     private unsafe bool TryReadFaultingInstruction(ulong rip, out Instruction instruction)
     {
         // Try the full instruction window first, then shrink so a fault near the end of a mapped

--- a/tests/SharpEmu.Libs.Tests/Cpu/UnsupportedInstructionDescriptionTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/UnsupportedInstructionDescriptionTests.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Iced.Intel;
+using SharpEmu.Core.Cpu.Native;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+public sealed class UnsupportedInstructionDescriptionTests
+{
+    private static string Describe(byte[] code)
+    {
+        var decoder = Decoder.Create(64, new ByteArrayCodeReader(code));
+        decoder.Decode(out var instruction);
+        return DirectExecutionBackend.DescribeUnsupportedInstruction(in instruction);
+    }
+
+    [Fact]
+    public void NamesSse4aForTheInstructionDeadCellsFaultsOn()
+    {
+        // Verbatim bytes at the faulting RIP of PPSA15552 under Rosetta 2 (#328):
+        // extrq xmm1, 0x28, 0. SSE4a is AMD-only, so no Apple/Intel host implements it.
+        var description = Describe([0x66, 0x0F, 0x78, 0xC1, 0x28, 0x00]);
+
+        Assert.Equal(
+            "Unsupported instruction: Extrq (requires SSE4A; host does not implement it)",
+            description);
+    }
+
+    [Fact]
+    public void NamesAvx2ForTheInstructionFollowingIt()
+    {
+        // vpblendd xmm0, xmm0, xmm1, 2 -- six bytes past the extrq above.
+        var description = Describe([0xC4, 0xE3, 0x79, 0x02, 0xC1, 0x02]);
+
+        Assert.Contains("Vpblendd", description);
+        Assert.Contains("AVX2", description);
+    }
+
+    [Fact]
+    public void NamesTheExtensionForAnInstructionTheBmiFallbackAlreadyEmulates()
+    {
+        // pdep rax, rbx, rcx -- recovered by TryRecoverIllegalInstruction, so it
+        // never reaches this path in practice; proves the naming is not SSE-specific.
+        var description = Describe([0xC4, 0xE2, 0xE3, 0xF5, 0xC1]);
+
+        Assert.Contains("Pdep", description);
+        Assert.Contains("BMI2", description);
+    }
+
+}


### PR DESCRIPTION
<!--
TODO: description goes here, in your own words.

Raw material is at the bottom under "Notes". It is facts, not prose - rewrite it,
don't paste it, then delete the Notes section and this comment before merging.
-->

Refs #328

## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Checklist
By submitting this PR, you confirm that:

- [ ] I have read `CONTRIBUTING.md`.
- [ ] I tested my changes.
- [ ] I wrote this description myself and did not copy AI-generated explanations.
- [ ] I listed the game(s) I tested, if applicable.

---

## Notes (raw material — delete before merge)

**Scope: diagnostics only.** No recovery behaviour changes, no README change. This does not fix #328 — it makes the failure identify itself.

**The gap**
- `TryRecoverIllegalInstruction` emulates the register-only BMI/ABM forms and returns false for anything else.
- On false, the #UD dump prints RIP + registers but not the opcode. Learning what the host refused means resolving the guest address through the SELF container and disassembling by hand.
- Iced already decodes the instruction during the recovery attempt, and already knows which extension each opcode needs (`Instruction.CpuidFeatures`). It was just never reported.

**The change**
- `DescribeUnsupportedInstruction` — mnemonic + required CPUID feature(s).
- `LogUnsupportedInstructionTrace` — reuses the existing `TryReadFaultingInstruction` (which already handles the shrinking decode window near page boundaries), logs one line.
- Called from the #UD dump next to `RIP symbol:`, the existing precedent for RIP-derived detail. Runs only after `TryRecoverIllegalInstruction` has declined, so emulated instructions are unaffected.
- Naming is host- and extension-agnostic: it comes from Iced, not a hardcoded list, so it names whatever a given host is missing.

**Worked example**
- Before: bare exit 132, no explanation.
- After: `Unsupported instruction: Extrq (requires SSE4A; host does not implement it)`
- This is literally how #328 was identified.

**Verification**
- Real run, Apple M1 Max / macOS 26.5.2 / `osx-x64` under Rosetta 2, Dead Cells [PPSA15552]. Line appears in the dump, exit still 132, faulting RIP `0x80030C6ED`, deterministic across runs.
- Instruction independently confirmed with capstone against the bytes at that RIP: `66 0f 78 c1 28 00` -> `extrq xmm1, 0x28, 0`, group `sse4a`.
- New `UnsupportedInstructionDescriptionTests` (3 cases): SSE4a, AVX2, BMI2 — the BMI2 case shows the naming isn't SSE-specific.
- Full suite green (213 + 33).

**Revised since first posting**
- An earlier revision of this PR also changed the README, adding a note that Rosetta 2 has an instruction-set ceiling and cannot execute AVX/AVX2. **That was wrong** and the hunk is dropped. Rosetta 2 executes AVX and AVX2 correctly; it reports them as absent in both CPUID and `sysctl`, but the instructions run. The claim came from reading the feature flags and never testing them. SSE4a is the only extension that actually faults. See the correction on #328.

**Judgement calls worth a reviewer's eye**
- Feature names come from Iced's `CpuidFeature` enum, so they render uppercase (`SSE4A`, `AVX2`) while mnemonics render Pascal (`Extrq`). Cosmetically inconsistent; left alone rather than hand-mapped.
- The decode runs twice on this path (once in the recovery attempt, once here). Only on the dying path, so not worth caching.
- No guard for an empty `CpuidFeatures` array — Iced always returns at least one for a decoded opcode, and the caller rejects `Code.INVALID` first.
