### PR TITLE
[VideoOut] Fix ScorePhysicalDevice: CPU rasterizer should not outrank integrated GPU

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -3214,7 +3214,11 @@ internal static unsafe class VulkanVideoPresenter
             {
                 PhysicalDeviceType.DiscreteGpu => 300,
                 PhysicalDeviceType.VirtualGpu => 100,
-                PhysicalDeviceType.Cpu => 50,
+                // Integrated GPU penalised to -100 as a workaround for
+                // an AMD driver crash in vkCreateGraphicsPipelines (#97).
+                // The CPU (software rasterizer) is placed below even that
+                // so no real GPU ever loses to Lavapipe / SwiftShader / WARP.
+                PhysicalDeviceType.Cpu => -200,
                 PhysicalDeviceType.IntegratedGpu => -100,
                 _ => 10,
             };


### PR DESCRIPTION
Drops `PhysicalDeviceType.Cpu` from 50 to -200 so software rasterizers (Lavapipe, SwiftShader, WARP) never outrank a real GPU.

**Before:** `Cpu (50) > Unknown (10) > IntegratedGpu (-100)` — a software renderer would beat any integrated GPU, including M-series Apple Silicon GPUs. On headless Linux hosts with only an iGPU + Lavapipe, the emulator silently picks software rendering.

**After:** `DiscreteGpu (300) > VirtualGpu (100) > Unknown (10) > IntegratedGpu (-100) > Cpu (-200)` — no real GPU loses to software. The Intel/AMD integrated-GPU penalty from #97 is preserved.

## Related issue
Closes #325

## Validation
- Build: 0 warnings, 0 errors
- Full suite: 243/243 passed
