### PR TITLE
[Kernel] Return largest span from sceKernelAvailableDirectMemorySize

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -2459,7 +2459,20 @@ public static partial class KernelMemoryCompatExports
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
             }
 
-            if (!TryFindAvailableDirectMemorySpanLocked(searchStart, searchEnd, alignment, out var candidate, out var rangeAvailable))
+            bool foundSpan;
+            ulong candidate;
+            ulong rangeAvailable;
+            lock (_memoryGate)
+            {
+                foundSpan = TryFindAvailableDirectMemorySpanLocked(
+                    searchStart,
+                    searchEnd,
+                    alignment,
+                    out candidate,
+                    out rangeAvailable);
+            }
+
+            if (!foundSpan)
             {
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
             }
@@ -5909,9 +5922,12 @@ public static partial class KernelMemoryCompatExports
             var gapEnd = Math.Min(allocation.Start, effectiveEnd);
             if (candidate < gapEnd)
             {
-                spanStart = candidate;
-                spanLength = gapEnd - candidate;
-                return true;
+                var candidateLength = gapEnd - candidate;
+                if (candidateLength > spanLength)
+                {
+                    spanStart = candidate;
+                    spanLength = candidateLength;
+                }
             }
 
             if (allocation.Start >= effectiveEnd)
@@ -5922,12 +5938,20 @@ public static partial class KernelMemoryCompatExports
             candidate = AlignUp(Math.Max(candidate, allocationEnd), alignment);
             if (candidate >= effectiveEnd)
             {
-                return false;
+                break;
             }
         }
 
-        spanStart = candidate;
-        spanLength = effectiveEnd - candidate;
+        if (candidate < effectiveEnd)
+        {
+            var candidateLength = effectiveEnd - candidate;
+            if (candidateLength > spanLength)
+            {
+                spanStart = candidate;
+                spanLength = candidateLength;
+            }
+        }
+
         return spanLength != 0;
     }
 

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelMemoryCompatExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelMemoryCompatExportsTests.cs
@@ -9,8 +9,20 @@ using Xunit;
 
 namespace SharpEmu.Libs.Tests.Kernel;
 
+[CollectionDefinition(KernelMemoryCompatStateCollection.Name, DisableParallelization = true)]
+public sealed class KernelMemoryCompatStateCollection
+{
+    public const string Name = "KernelMemoryCompatState";
+}
+
+[Collection(KernelMemoryCompatStateCollection.Name)]
 public sealed class KernelMemoryCompatExportsTests
 {
+    private const ulong GuestMemoryBase = 0x1_0000_0000;
+    private const ulong AllocationOutAddress = GuestMemoryBase + 0x100;
+    private const ulong SpanStartOutAddress = GuestMemoryBase + 0x108;
+    private const ulong SpanSizeOutAddress = GuestMemoryBase + 0x110;
+
     [Fact]
     public void PosixStat_MissingFileReturnsMinusOne()
     {
@@ -62,5 +74,94 @@ public sealed class KernelMemoryCompatExportsTests
         {
             CultureInfo.CurrentCulture = previousCulture;
         }
+    }
+
+    [Fact]
+    public void AvailableDirectMemorySize_FragmentedRangeReturnsLargestAlignedSpan()
+    {
+        const ulong firstAllocationStart = 0x0020_0000;
+        const ulong firstAllocationLength = 0x0020_0000;
+        const ulong secondAllocationStart = 0x00C0_0000;
+        const ulong secondAllocationLength = 0x0040_0000;
+        var context = new CpuContext(new FakeCpuMemory(GuestMemoryBase, 0x1000), Generation.Gen5);
+
+        try
+        {
+            AllocateDirectMemory(context, firstAllocationStart, firstAllocationLength);
+            AllocateDirectMemory(context, secondAllocationStart, secondAllocationLength);
+
+            QueryAvailableDirectMemory(context, 0, 0x0100_0000, 0x4000);
+
+            Assert.True(context.TryReadUInt64(SpanStartOutAddress, out var spanStart));
+            Assert.True(context.TryReadUInt64(SpanSizeOutAddress, out var spanSize));
+            Assert.Equal(0x0040_0000UL, spanStart);
+            Assert.Equal(0x0080_0000UL, spanSize);
+        }
+        finally
+        {
+            ReleaseDirectMemory(context, firstAllocationStart, firstAllocationLength);
+            ReleaseDirectMemory(context, secondAllocationStart, secondAllocationLength);
+        }
+    }
+
+    [Fact]
+    public void AvailableDirectMemorySize_AppliesAlignmentBeforeComparingSpans()
+    {
+        const ulong allocationStart = 0x0070_0000;
+        const ulong allocationLength = 0x0010_0000;
+        var context = new CpuContext(new FakeCpuMemory(GuestMemoryBase, 0x1000), Generation.Gen5);
+
+        try
+        {
+            AllocateDirectMemory(context, allocationStart, allocationLength);
+
+            QueryAvailableDirectMemory(context, 0x0010_0000, 0x00C0_0000, 0x0040_0000);
+
+            Assert.True(context.TryReadUInt64(SpanStartOutAddress, out var spanStart));
+            Assert.True(context.TryReadUInt64(SpanSizeOutAddress, out var spanSize));
+            Assert.Equal(0x0080_0000UL, spanStart);
+            Assert.Equal(0x0040_0000UL, spanSize);
+        }
+        finally
+        {
+            ReleaseDirectMemory(context, allocationStart, allocationLength);
+        }
+    }
+
+    private static void AllocateDirectMemory(CpuContext context, ulong start, ulong length)
+    {
+        context[CpuRegister.Rdi] = start;
+        context[CpuRegister.Rsi] = start + length;
+        context[CpuRegister.Rdx] = length;
+        context[CpuRegister.Rcx] = 0x4000;
+        context[CpuRegister.R8] = 0;
+        context[CpuRegister.R9] = AllocationOutAddress;
+
+        Assert.Equal(0, KernelMemoryCompatExports.KernelAllocateDirectMemory(context));
+        Assert.True(context.TryReadUInt64(AllocationOutAddress, out var allocatedAddress));
+        Assert.Equal(start, allocatedAddress);
+    }
+
+    private static void QueryAvailableDirectMemory(
+        CpuContext context,
+        ulong searchStart,
+        ulong searchEnd,
+        ulong alignment)
+    {
+        context[CpuRegister.Rdi] = searchStart;
+        context[CpuRegister.Rsi] = searchEnd;
+        context[CpuRegister.Rdx] = alignment;
+        context[CpuRegister.Rcx] = SpanStartOutAddress;
+        context[CpuRegister.R8] = SpanSizeOutAddress;
+
+        Assert.Equal(0, KernelMemoryCompatExports.KernelAvailableDirectMemorySize(context));
+    }
+
+    private static void ReleaseDirectMemory(CpuContext context, ulong start, ulong length)
+    {
+        context[CpuRegister.Rdi] = start;
+        context[CpuRegister.Rsi] = length;
+
+        Assert.Equal(0, KernelMemoryCompatExports.KernelReleaseDirectMemory(context));
     }
 }


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Checklist
By submitting this PR, you confirm that:

- [x] I have read `CONTRIBUTING.md`.
- [x] I tested my changes.
- [ ] I wrote this description myself and did not copy AI-generated explanations.
- [x] I listed the game(s) I tested, if applicable.

## What this changes

- Updates `sceKernelAvailableDirectMemorySize` to return the largest aligned free span instead of the first available gap.
- Keeps the lower address span when multiple gaps have the same size.
- Protects the direct memory scan with the existing memory lock.
- Adds regression tests for fragmented ranges and alignment adjusted comparisons.
- Leaves fixed size direct memory allocation behavior unchanged.

## Why this is needed

The previous first gap behavior could return a small fragment even when a much larger range was available later. Games may align the returned size before creating a memory pool, which can turn a small fragment into a zero length allocation.

This was observed in Devil May Cry 5 Special Edition, where the returned `0x1B8000` span was aligned down to zero. With this change, the game receives the larger available range, successfully completes the allocation, and advances past the original crash.

The largest span behavior is also consistent with the public shadPS4 and fpPS4 implementations.

- shadPS4:
  https://github.com/shadps4-emu/shadPS4/blob/bfc1a588c258cc124a0d59c0e08ee9d0d984a556/src/core/memory.cpp#L1172-L1216
- fpPS4:
  https://github.com/red-prig/fpPS4/blob/04cefd43e6fddd1ab033e7980cd356d14c964905/kernel/mm_adr_direct.pas#L528-L581

The SharpEmu implementation and regression tests were written independently using its existing memory model.

## Games Tested

- Devil May Cry 5 Special Edition — PPSA01442, v01.002.000
- The affected allocation succeeds and execution advances past the original `0x80546E824` fault.

- Resident Evil Village — PPSA01556, v01.002.000
- Behavior remains unchanged before its existing crash, providing an additional regression check.

Release build completed with 0 warnings and 0 errors. All 245 tests passed.