### PR TITLE
CI: Validate synthetic SPIR-V with pinned SPIRV-Tools

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -159,6 +159,11 @@ jobs:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
       PUBLISH_DIR: ${{ github.workspace }}/artifacts/publish/${{ matrix.rid }}
       RELEASE_DIR: ${{ github.workspace }}/artifacts/release
+      SPIRV_HEADERS_COMMIT: ad9184e76a66b1001c29db9b0a3e87f646c64de0
+      # SpirvModuleBuilder emits SPIR-V 1.5 and VulkanVideoPresenter requests Vulkan 1.2.
+      SPIRV_TARGET_ENV: vulkan1.2
+      SPIRV_TOOLS_COMMIT: 0539c81f69a3daeb706fd3477dca61435b475156
+      SPIRV_TOOLS_VERSION: v2026.2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -182,6 +187,34 @@ jobs:
       # path handling, so a cross-platform generation regression surfaces here.
       - name: Run tests
         run: dotnet test SharpEmu.slnx -c Release --no-build --verbosity normal
+
+      - name: Build pinned SPIRV-Tools
+        if: matrix.rid == 'linux-x64'
+        run: |
+          git clone --no-checkout --filter=blob:none https://github.com/KhronosGroup/SPIRV-Tools.git "$RUNNER_TEMP/spirv-tools"
+          git -C "$RUNNER_TEMP/spirv-tools" checkout --detach "$SPIRV_TOOLS_COMMIT"
+          test "$(git -C "$RUNNER_TEMP/spirv-tools" rev-parse HEAD)" = "$SPIRV_TOOLS_COMMIT"
+
+          git clone --no-checkout --filter=blob:none https://github.com/KhronosGroup/SPIRV-Headers.git "$RUNNER_TEMP/spirv-tools/external/spirv-headers"
+          git -C "$RUNNER_TEMP/spirv-tools/external/spirv-headers" checkout --detach "$SPIRV_HEADERS_COMMIT"
+          test "$(git -C "$RUNNER_TEMP/spirv-tools/external/spirv-headers" rev-parse HEAD)" = "$SPIRV_HEADERS_COMMIT"
+
+          cmake -S "$RUNNER_TEMP/spirv-tools" -B "$RUNNER_TEMP/spirv-tools-build" \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DSPIRV_SKIP_TESTS=ON \
+            -DSPIRV_WERROR=OFF
+          cmake --build "$RUNNER_TEMP/spirv-tools-build" --target spirv-val
+
+      - name: Generate and validate synthetic SPIR-V
+        if: matrix.rid == 'linux-x64'
+        run: |
+          dotnet run --project tools/SharpEmu.Tools.ShaderDump/SharpEmu.Tools.ShaderDump.csproj -c Release -- artifacts/shader-dump
+          scripts/validate-synthetic-spirv.sh \
+            "$RUNNER_TEMP/spirv-tools-build/tools/spirv-val" \
+            "$SPIRV_TOOLS_VERSION" \
+            "$SPIRV_TARGET_ENV" \
+            artifacts/shader-dump
 
       - name: Publish ${{ matrix.rid }} CLI
         run: dotnet publish src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r ${{ matrix.rid }} --self-contained true --no-restore -p:PublishDir="$PUBLISH_DIR"

--- a/scripts/validate-synthetic-spirv.sh
+++ b/scripts/validate-synthetic-spirv.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 SharpEmu Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: $0 <spirv-val> <expected-version> <target-env> <module-directory>" >&2
+  exit 2
+fi
+
+validator=$1
+expected_version=$2
+target_env=$3
+module_directory=$4
+
+if [ ! -x "$validator" ]; then
+  echo "SPIR-V validator is not executable: $validator" >&2
+  exit 2
+fi
+
+if [ ! -d "$module_directory" ]; then
+  echo "SPIR-V module directory does not exist: $module_directory" >&2
+  exit 2
+fi
+
+validator_version="$("$validator" --version | head -n 1)"
+if [[ "$validator_version" != *"SPIRV-Tools $expected_version"* ]]; then
+  echo "unexpected SPIRV-Tools version: $validator_version (expected $expected_version)" >&2
+  exit 2
+fi
+
+echo "Validator: $validator_version"
+echo "Target environment: $target_env"
+
+mapfile -d '' modules < <(find "$module_directory" -type f -name '*.spv' -print0 | sort -z)
+if [ "${#modules[@]}" -eq 0 ]; then
+  echo "no SPIR-V modules found in $module_directory" >&2
+  exit 1
+fi
+
+failures=0
+for module in "${modules[@]}"; do
+  echo "Validating module: $module"
+  if ! "$validator" --target-env "$target_env" "$module"; then
+    echo "SPIR-V validation failed: $module" >&2
+    failures=1
+  fi
+done
+
+if [ "$failures" -ne 0 ]; then
+  exit 1
+fi
+
+echo "Validated ${#modules[@]} synthetic SPIR-V modules."


### PR DESCRIPTION
<!--
Copyright (C) 2026 SharpEmu Emulator Project
SPDX-License-Identifier: GPL-2.0-or-later
-->

## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Checklist
By submitting this PR, you confirm that:

- [x] I have read `CONTRIBUTING.md`.
- [x] I tested my changes.
- [-] I wrote this description myself and did not copy AI-generated explanations.
- [ ] I listed the game(s) I tested, if applicable.

  ## Summary

  - Build SPIRV-Tools v2026.2 from the exact SPIRV-Tools and SPIRV-Headers commits in the Linux runner's temporary directory.
  - Generate every synthetic ShaderDump module and validate all 23 `.spv` files with `spirv-val --target-env vulkan1.2`.
  - Fail CI with the exact module path and the validator diagnostic when any generated module is invalid.

  ## Scope / Boundaries

  - Touches the existing Linux CI job and adds one reusable validation script.
  - SPIR-V 1.5 and Vulkan 1.2 are derived from the current `SpirvModuleBuilder` and `VulkanVideoPresenter` contracts.
  - SPIRV-Tools is pinned to `v2026.2` / `0539c81f69a3daeb706fd3477dca61435b475156`.
  - SPIRV-Headers is pinned to `ad9184e76a66b1001c29db9b0a3e87f646c64de0`, matching the SPIRV-Tools dependency contract.
  - Generated modules and tool build outputs remain temporary or ignored; no generated blobs are committed.
  - Shader semantics, GPU/game validation, releases, and broad CI restructuring remain unchanged.
  - Merge and closure are not requested by this PR.

  ## Validation

  - `dotnet restore SharpEmu.slnx` — passed with .NET SDK 10.0.103.
  - `dotnet build SharpEmu.slnx -c Release --no-restore` — passed with 0 warnings and 0 errors.
  - `dotnet test SharpEmu.slnx -c Release --no-build --verbosity normal` — passed, 243/243 tests.
  - ShaderDump plus `scripts/validate-synthetic-spirv.sh ... v2026.2 vulkan1.2` — passed for all 23 generated modules.
  - Controlled truncated module — rejected with exit code 1, the exact filename, and a SPIRV-Tools diagnostic.
  - `reuse lint` — compliant with 0 missing licenses.
  - `git diff --check`, `bash -n scripts/validate-synthetic-spirv.sh`, and YAML parsing — passed.
  - GitHub Actions run `29581429134` — REUSE, Windows, Linux, macOS, pinned SPIRV-Tools build, and synthetic SPIR-V validation passed on commit `c10598834e393907c320a5e9ffbf63c0832d0ce8`.
  - Games tested: not applicable; this is synthetic, CPU-only CI validation.
  - Manual PM validation: review and edit this description and checklist before publishing.

  ## Security / Privacy

  - No sensitive surfaces are touched.
  - Public source dependencies are pinned to exact commits.
  - Generated shaders and dependency build artifacts remain temporary.
  - No firmware, keys, decrypted assets, game data, or proprietary PlayStation material is included.