### PR TITLE
Generalize the SSE4a EXTRQ patch to any scratch register (fixes #328)

### DIFF
--- a/src/SharpEmu.Core/Cpu/Emulation/Sse4aExtrqRewriter.cs
+++ b/src/SharpEmu.Core/Cpu/Emulation/Sse4aExtrqRewriter.cs
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Core.Cpu.Emulation;
+
+/// <summary>
+/// Rewrites the AMD SSE4a EXTRQ idiom that Sony's toolchain emits for the PS5's Zen 2 cores into an
+/// equivalent SSE4.1 sequence at load time.
+///
+/// SSE4a is an AMD-only extension; Intel has never shipped it. When the direct-execution backend runs
+/// the guest natively, the <c>extrq</c> opcode raises #UD on any Intel host (and on Rosetta 2), while
+/// the AVX/AVX2 code around it runs fine. The particular shape the toolchain produces is a fixed-width
+/// bit extract followed immediately by a <c>vpblendd</c> that folds the extracted dword back into
+/// <c>xmm0</c>. This class recognises that pair and produces a <c>pextrb</c>/<c>pinsrd</c> replacement
+/// with the same observable effect, which the backend patches over the guest bytes before first run.
+///
+/// The matcher is pure and works on plain byte spans so the encoding can be unit-tested on its own; the
+/// unsafe page-protection and instruction-cache plumbing stays in the backend adapter.
+/// </summary>
+public static class Sse4aExtrqRewriter
+{
+    /// <summary>Byte length of both the recognised idiom and its replacement. They are the same size,
+    /// so the patch is an in-place overwrite with no relocation.</summary>
+    public const int SequenceLength = 12;
+
+    /// <summary>
+    /// Matches
+    /// <code>
+    ///   66 0F 78 /0 28 00      extrq    xmmN, 0x28, 0
+    ///   C4 E3 79 02 C0|N 02    vpblendd xmm0, xmm0, xmmN, 2
+    /// </code>
+    /// for any scratch register <c>xmmN</c> (N in 0..7) and, on a match, writes
+    /// <code>
+    ///   66 0F 3A 14 (N&lt;&lt;3) 04   pextrb eax, xmmN, 4
+    ///   66 0F 3A 22 C0 01           pinsrd xmm0, eax, 1
+    /// </code>
+    /// into <paramref name="replacement"/>.
+    ///
+    /// Why these two instructions are equivalent: <c>extrq xmmN, 0x28, 0</c> keeps the low 40 bits of
+    /// <c>xmmN</c> and zeroes the rest, so the second dword <c>vpblendd</c> then copies into
+    /// <c>xmm0</c> is just byte 4 of the original <c>xmmN</c>, zero-extended. <c>pextrb</c> reads that
+    /// same byte into EAX and <c>pinsrd</c> drops it into dword lane 1 of <c>xmm0</c>. The extract
+    /// length (0x28) and index (0) are matched exactly rather than decoded, because the replacement's
+    /// byte offset of 4 is only the right answer for that specific field.
+    ///
+    /// Unlike the original, the replacement clobbers EAX instead of <c>xmmN</c>. That trade already
+    /// existed in the hand-written patch this generalises; the toolchain only uses <c>xmmN</c> here as a
+    /// throwaway for the extract, so nothing downstream depends on it.
+    /// </summary>
+    /// <param name="source">Guest bytes at the candidate instruction. Only the first
+    /// <see cref="SequenceLength"/> bytes are inspected.</param>
+    /// <param name="replacement">Destination for the replacement encoding. Written only on a match, and
+    /// must be at least <see cref="SequenceLength"/> bytes.</param>
+    /// <returns><see langword="true"/> with <paramref name="replacement"/> filled when the idiom is
+    /// recognised; otherwise <see langword="false"/> with <paramref name="replacement"/> left alone.</returns>
+    public static bool TryRewrite(ReadOnlySpan<byte> source, Span<byte> replacement)
+    {
+        if (source.Length < SequenceLength || replacement.Length < SequenceLength)
+        {
+            return false;
+        }
+
+        // extrq xmmN, 0x28, 0. The ModRM byte must have mod=11 and reg=000 (reg is the /0 opcode
+        // extension for this encoding, not an operand); the low three bits select the register.
+        if (source[0] != 0x66 || source[1] != 0x0F || source[2] != 0x78 ||
+            (source[3] & 0xF8) != 0xC0 || source[4] != 0x28 || source[5] != 0x00)
+        {
+            return false;
+        }
+
+        var register = source[3] & 0x07;
+
+        // vpblendd xmm0, xmm0, xmmN, 2 (VEX.128.66.0F3A.W0). Destination and first source are fixed to
+        // xmm0 by the C4 E3 79 prefix and the reg=000 field; the second source register (ModRM rm) has
+        // to be the same xmmN the extract just wrote, or this isn't the idiom.
+        if (source[6] != 0xC4 || source[7] != 0xE3 || source[8] != 0x79 || source[9] != 0x02 ||
+            source[10] != (0xC0 | register) || source[11] != 0x02)
+        {
+            return false;
+        }
+
+        // pextrb eax, xmmN, 4
+        replacement[0] = 0x66;
+        replacement[1] = 0x0F;
+        replacement[2] = 0x3A;
+        replacement[3] = 0x14;
+        replacement[4] = (byte)(0xC0 | (register << 3));
+        replacement[5] = 0x04;
+        // pinsrd xmm0, eax, 1
+        replacement[6] = 0x66;
+        replacement[7] = 0x0F;
+        replacement[8] = 0x3A;
+        replacement[9] = 0x22;
+        replacement[10] = 0xC0;
+        replacement[11] = 0x01;
+        return true;
+    }
+}

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using SharpEmu.Core.Cpu;
+using SharpEmu.Core.Cpu.Emulation;
 using SharpEmu.Core.Loader;
 using SharpEmu.Core.Memory;
 using SharpEmu.HLE;
@@ -2492,28 +2493,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private unsafe bool TryPatchSse4aExtrqBlend(nint address, byte* source)
 	{
-		// Rosetta does not implement AMD SSE4a EXTRQ. This exact sequence masks
-		// xmm2 to its low 40 bits, then copies the resulting second dword into
-		// xmm0. PEXTRB/PINSRD provides the same observable result in 12 bytes:
-		// extract source byte 4 and insert the zero-extended value into lane 1.
-		ReadOnlySpan<byte> pattern =
-		[
-			0x66, 0x0F, 0x78, 0xC2, 0x28, 0x00,
-			0xC4, 0xE3, 0x79, 0x02, 0xC2, 0x02,
-		];
-		for (var i = 0; i < pattern.Length; i++)
+		// AMD SSE4a EXTRQ faults with #UD on Intel hosts and under Rosetta. The recognition and the
+		// SSE4.1 replacement encoding live in Sse4aExtrqRewriter so they can be unit-tested without
+		// executable memory; the register the toolchain picks for the extract varies between titles
+		// (xmm1 in PPSA15552, xmm2 elsewhere), which the rewriter now handles.
+		var window = new ReadOnlySpan<byte>(source, Sse4aExtrqRewriter.SequenceLength);
+		Span<byte> replacement = stackalloc byte[Sse4aExtrqRewriter.SequenceLength];
+		if (!Sse4aExtrqRewriter.TryRewrite(window, replacement))
 		{
-			if (source[i] != pattern[i])
-			{
-				return false;
-			}
+			return false;
 		}
 
-		ReadOnlySpan<byte> replacement =
-		[
-			0x66, 0x0F, 0x3A, 0x14, 0xD0, 0x04,
-			0x66, 0x0F, 0x3A, 0x22, 0xC0, 0x01,
-		];
 		uint oldProtect = 0;
 		if (!VirtualProtect((void*)address, (nuint)replacement.Length, 64u, &oldProtect))
 		{

--- a/tests/SharpEmu.Libs.Tests/Cpu/Sse4aExtrqRewriterTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/Sse4aExtrqRewriterTests.cs
@@ -1,0 +1,134 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Emulation;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+// Covers the load-time rewrite of the AMD SSE4a EXTRQ idiom into SSE4.1 PEXTRB/PINSRD. The expected
+// bytes were assembled by hand from the instruction encodings, so a regression in either the match or
+// the replacement shows up here without needing a host that actually lacks SSE4a.
+public sealed class Sse4aExtrqRewriterTests
+{
+    // extrq xmmN, 0x28, 0 ; vpblendd xmm0, xmm0, xmmN, 2
+    private static byte[] Idiom(int register) =>
+    [
+        0x66, 0x0F, 0x78, (byte)(0xC0 | register), 0x28, 0x00,
+        0xC4, 0xE3, 0x79, 0x02, (byte)(0xC0 | register), 0x02,
+    ];
+
+    // pextrb eax, xmmN, 4 ; pinsrd xmm0, eax, 1
+    private static byte[] Replacement(int register) =>
+    [
+        0x66, 0x0F, 0x3A, 0x14, (byte)(0xC0 | (register << 3)), 0x04,
+        0x66, 0x0F, 0x3A, 0x22, 0xC0, 0x01,
+    ];
+
+    // Before this fix the patch was hard-coded to xmm2. Keeping that exact case pinned makes sure the
+    // generalisation didn't quietly change the encoding that already shipped and worked.
+    [Fact]
+    public void Xmm2_StillRewritesToTheOriginalHandWrittenBytes()
+    {
+        var replacement = new byte[Sse4aExtrqRewriter.SequenceLength];
+        var matched = Sse4aExtrqRewriter.TryRewrite(Idiom(2), replacement);
+
+        Assert.True(matched);
+        Assert.Equal(
+            new byte[] { 0x66, 0x0F, 0x3A, 0x14, 0xD0, 0x04, 0x66, 0x0F, 0x3A, 0x22, 0xC0, 0x01 },
+            replacement);
+    }
+
+    // The regression itself: Dead Cells (PPSA15552) emits the identical idiom against xmm1, which the
+    // old fixed pattern missed by one byte, so the opcode reached the CPU and #UD'd.
+    [Fact]
+    public void Xmm1_IsNowRewritten()
+    {
+        var replacement = new byte[Sse4aExtrqRewriter.SequenceLength];
+        var matched = Sse4aExtrqRewriter.TryRewrite(Idiom(1), replacement);
+
+        Assert.True(matched);
+        // pextrb reads from xmm1, so its ModRM reg field is 001 -> 0xC8.
+        Assert.Equal(
+            new byte[] { 0x66, 0x0F, 0x3A, 0x14, 0xC8, 0x04, 0x66, 0x0F, 0x3A, 0x22, 0xC0, 0x01 },
+            replacement);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    [InlineData(7)]
+    public void AnyScratchRegister_ExtractsFromThatSameRegister(int register)
+    {
+        var replacement = new byte[Sse4aExtrqRewriter.SequenceLength];
+        var matched = Sse4aExtrqRewriter.TryRewrite(Idiom(register), replacement);
+
+        Assert.True(matched);
+        Assert.Equal(Replacement(register), replacement);
+    }
+
+    // If the extract and the blend name different registers it isn't the toolchain idiom, and rewriting
+    // it would silently read from the wrong xmm.
+    [Fact]
+    public void MismatchedExtractAndBlendRegisters_AreRejected()
+    {
+        var bytes = Idiom(1);
+        bytes[10] = 0xC2; // extract xmm1 but blend xmm2
+
+        Assert.False(Sse4aExtrqRewriter.TryRewrite(bytes, new byte[Sse4aExtrqRewriter.SequenceLength]));
+    }
+
+    // The replacement's byte offset (4) is only correct for length 0x28 / index 0, so a different
+    // extract field must not match.
+    [Fact]
+    public void DifferentExtractField_IsRejected()
+    {
+        var bytes = Idiom(1);
+        bytes[4] = 0x20; // length 32 instead of 40
+
+        Assert.False(Sse4aExtrqRewriter.TryRewrite(bytes, new byte[Sse4aExtrqRewriter.SequenceLength]));
+    }
+
+    // reg != 000 in the ModRM is a different /r opcode extension, not EXTRQ.
+    [Fact]
+    public void NonZeroModRmRegField_IsRejected()
+    {
+        var bytes = Idiom(1);
+        bytes[3] = 0xC9; // mod=11, reg=001, rm=001
+
+        Assert.False(Sse4aExtrqRewriter.TryRewrite(bytes, new byte[Sse4aExtrqRewriter.SequenceLength]));
+    }
+
+    [Fact]
+    public void UnrelatedBytes_AreRejected()
+    {
+        var bytes = new byte[Sse4aExtrqRewriter.SequenceLength];
+        Assert.False(Sse4aExtrqRewriter.TryRewrite(bytes, new byte[Sse4aExtrqRewriter.SequenceLength]));
+    }
+
+    [Fact]
+    public void ShortInput_IsRejectedWithoutReading()
+    {
+        Assert.False(Sse4aExtrqRewriter.TryRewrite(Idiom(1).AsSpan(0, 11), new byte[Sse4aExtrqRewriter.SequenceLength]));
+    }
+
+    // A non-match must not scribble into the caller's buffer; the backend reuses one stack buffer per
+    // scan position and only writes to guest memory when the return value is true.
+    [Fact]
+    public void NoMatch_LeavesReplacementBufferUntouched()
+    {
+        var replacement = new byte[Sse4aExtrqRewriter.SequenceLength];
+        for (var i = 0; i < replacement.Length; i++)
+        {
+            replacement[i] = 0xAB;
+        }
+
+        Assert.False(Sse4aExtrqRewriter.TryRewrite(new byte[Sse4aExtrqRewriter.SequenceLength], replacement));
+        Assert.All(replacement, b => Assert.Equal(0xAB, b));
+    }
+}


### PR DESCRIPTION
## What this fixes

`DirectExecutionBackend.TryPatchSse4aExtrqBlend` rewrites the AMD-only `extrq` + `vpblendd` idiom that Sony's toolchain emits, because SSE4a isn't implemented on Intel hosts or under Rosetta and the raw opcode raises #UD there. #328 points out that the matcher hard-codes the scratch register to `xmm2`:

```
66 0F 78 C2 28 00     extrq    xmm2, 0x28, 0
C4 E3 79 02 C2 02     vpblendd xmm0, xmm0, xmm2, 2
```

Dead Cells (PPSA15552) emits the identical idiom but against `xmm1` (`...C1...`), so the pattern misses by one byte per instruction, the `extrq` reaches the CPU, and the game dies with SIGILL right after the first frame. The `Patched ... 0 SSE4a EXTRQ blends` line in the startup log is the giveaway.

## The change

I moved the pattern match and the replacement encoding out of the backend into a small pure class, `Sse4aExtrqRewriter`, that reads the register straight out of the ModRM byte instead of comparing it against a literal. For register N it emits:

```
66 0F 3A 14 (C0|N<<3) 04   pextrb eax, xmmN, 4
66 0F 3A 22 C0 01          pinsrd xmm0, eax, 1
```

The equivalence is the one the original patch already relied on: `extrq xmmN, 0x28, 0` keeps the low 40 bits of `xmmN` and zeroes the rest, so the second dword `vpblendd` folds into `xmm0` is just byte 4 of the original `xmmN`, zero-extended. `pextrb`/`pinsrd` reproduce exactly that, using EAX as scratch (the toolchain only uses `xmmN` as a throwaway for the extract, so nothing downstream reads it back).

A couple of deliberate limits:

- The extract field (`0x28` length, `0` index) is still matched literally rather than decoded, because the byte-4 offset in the replacement is only the right answer for that specific field. A different extract width would need different replacement math, so it's safer not to match it at all.
- Only the scratch register is generalized. Destination/first-source stay pinned to `xmm0` and the blend mask to `2`, and there's still no REX prefix, so this doesn't widen what gets rewritten beyond the one idiom the toolchain emits (xmm0–7) — it just stops caring which of those registers it landed in.

The unsafe `VirtualProtect`/write/`FlushInstructionCache` plumbing stays in the backend; only the decision moved out, which is what makes it testable.

## How I verified it

- New unit tests in `Sse4aExtrqRewriterTests`. They pin the xmm2 case to the exact bytes the old hand-written patch produced (so the refactor is provably byte-identical for the case that already shipped), cover the xmm1 regression and all eight registers, and check that mismatched / short / malformed input is rejected.
- Cross-checked the raw bytes through Iced's disassembler: the inputs decode to `extrq xmmN, 28h, 0` / `vpblendd xmm0, xmm0, xmmN, 2` and the outputs to `pextrb eax, xmmN, 4` / `pinsrd xmm0, eax, 1` for N = 1, 2, 7.
- `dotnet build` and the full `dotnet test` run are clean (226 tests in the Libs suite, +16 from this change).

What I could not do: I don't have the game or an Intel / Rosetta machine, so I haven't watched PPSA15552 boot past the fault end to end. If anyone who can reproduce #328 is able to confirm the log now shows a non-zero `SSE4a EXTRQ blends` count and the SIGILL is gone, that would close the loop.


**Note:** this hasn't been tested in-game. I don't have PPSA15552 or an Intel/Rosetta machine, so the verification is at the unit-test and instruction-encoding level only (see above). If someone who can reproduce #328 confirms the SIGILL is gone in-game, that closes the loop.

Fixes #328.
