### PR TITLE
[VideoOut] Scope the AMD integrated-GPU penalty to Windows

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -271,6 +271,51 @@ internal static unsafe class VulkanVideoPresenter
     private static bool _presenterCloseRequested;
     private const string DebugUtilsExtensionName = "VK_EXT_debug_utils";
     private const uint NvidiaVendorId = 0x10DE;
+    private const uint AmdVendorId = 0x1002;
+
+    // Ranks a Vulkan physical device for automatic selection. Pure policy, kept
+    // beside the vendor IDs it uses and callable in isolation for tests (#325).
+    internal static int ScorePhysicalDevice(
+        PhysicalDeviceProperties properties,
+        string name,
+        string? deviceOverride)
+    {
+        if (!string.IsNullOrWhiteSpace(deviceOverride))
+        {
+            return name.Contains(deviceOverride, StringComparison.OrdinalIgnoreCase) ? 1000 : -1000;
+        }
+
+        var score = properties.DeviceType switch
+        {
+            PhysicalDeviceType.DiscreteGpu => 300,
+            PhysicalDeviceType.VirtualGpu => 100,
+            // A real integrated GPU (Intel, Apple/MoltenVK, Qualcomm, ...) still
+            // beats a software rasterizer; #97's crash was AMD's integrated
+            // driver specifically, penalized below.
+            PhysicalDeviceType.IntegratedGpu => 50,
+            // Software rasterizers such as Mesa lavapipe present as Cpu: a
+            // fallback only, chosen when no hardware GPU can present.
+            PhysicalDeviceType.Cpu => 20,
+            _ => 10,
+        };
+
+        if (properties.VendorID == NvidiaVendorId)
+        {
+            score += 500;
+        }
+
+        // #97: AMD's integrated driver access-violates inside
+        // vkCreateGraphicsPipelines while compiling some translated shaders, so
+        // keep AMD iGPUs as the true last resort - below even software
+        // rendering, chosen only when nothing else can present.
+        if (properties.DeviceType == PhysicalDeviceType.IntegratedGpu &&
+            properties.VendorID == AmdVendorId)
+        {
+            score = -100;
+        }
+
+        return score;
+    }
     private const string PortabilityEnumerationExtensionName = "VK_KHR_portability_enumeration";
     private const string PortabilitySubsetExtensionName = "VK_KHR_portability_subset";
     private const int GlfwPlatformHint = 0x00050003;
@@ -3198,33 +3243,6 @@ internal static unsafe class VulkanVideoPresenter
                 $"[LOADER][INFO] Vulkan device: {selectedName} ({selected.DeviceType})");
             VideoOutExports.SetSelectedGpuName(selectedName);
             _window.Title = VideoOutExports.GetWindowTitle();
-        }
-
-        private static int ScorePhysicalDevice(
-            PhysicalDeviceProperties properties,
-            string name,
-            string? deviceOverride)
-        {
-            if (!string.IsNullOrWhiteSpace(deviceOverride))
-            {
-                return name.Contains(deviceOverride, StringComparison.OrdinalIgnoreCase) ? 1000 : -1000;
-            }
-
-            var score = properties.DeviceType switch
-            {
-                PhysicalDeviceType.DiscreteGpu => 300,
-                PhysicalDeviceType.VirtualGpu => 100,
-                PhysicalDeviceType.Cpu => 50,
-                PhysicalDeviceType.IntegratedGpu => -100,
-                _ => 10,
-            };
-
-            if (properties.VendorID == NvidiaVendorId)
-            {
-                score += 500;
-            }
-
-            return score;
         }
 
         private void LoadComputeDeviceLimits()

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -272,9 +272,10 @@ internal static unsafe class VulkanVideoPresenter
     private const string DebugUtilsExtensionName = "VK_EXT_debug_utils";
     private const uint NvidiaVendorId = 0x10DE;
     private const uint AmdVendorId = 0x1002;
+    // Other GPU PCI vendor IDs, for reference when adding future rules:
+    // Intel 0x8086, Qualcomm 0x5143, ARM 0x13B5, Apple 0x106B, Microsoft (software) 0x1414.
+    private const int LastResortPenalty = 1000;
 
-    // Ranks a Vulkan physical device for automatic selection. Pure policy, kept
-    // beside the vendor IDs it uses and callable in isolation for tests (#325).
     internal static int ScorePhysicalDevice(
         PhysicalDeviceProperties properties,
         string name,
@@ -289,12 +290,7 @@ internal static unsafe class VulkanVideoPresenter
         {
             PhysicalDeviceType.DiscreteGpu => 300,
             PhysicalDeviceType.VirtualGpu => 100,
-            // A real integrated GPU (Intel, Apple/MoltenVK, Qualcomm, ...) still
-            // beats a software rasterizer; #97's crash was AMD's integrated
-            // driver specifically, penalized below.
             PhysicalDeviceType.IntegratedGpu => 50,
-            // Software rasterizers such as Mesa lavapipe present as Cpu: a
-            // fallback only, chosen when no hardware GPU can present.
             PhysicalDeviceType.Cpu => 20,
             _ => 10,
         };
@@ -304,17 +300,23 @@ internal static unsafe class VulkanVideoPresenter
             score += 500;
         }
 
-        // #97: AMD's integrated driver access-violates inside
-        // vkCreateGraphicsPipelines while compiling some translated shaders, so
-        // keep AMD iGPUs as the true last resort - below even software
-        // rendering, chosen only when nothing else can present.
-        if (properties.DeviceType == PhysicalDeviceType.IntegratedGpu &&
-            properties.VendorID == AmdVendorId)
-        {
-            score = -100;
-        }
+        score -= ComputeDevicePenalty(properties, OperatingSystem.IsWindows());
 
         return score;
+    }
+
+    internal static int ComputeDevicePenalty(PhysicalDeviceProperties properties, bool isWindows)
+    {
+        var penalty = 0;
+
+        if (isWindows &&
+            properties.DeviceType == PhysicalDeviceType.IntegratedGpu &&
+            properties.VendorID == AmdVendorId)
+        {
+            penalty += LastResortPenalty;
+        }
+
+        return penalty;
     }
     private const string PortabilityEnumerationExtensionName = "VK_KHR_portability_enumeration";
     private const string PortabilitySubsetExtensionName = "VK_KHR_portability_subset";

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -273,8 +273,16 @@ internal static unsafe class VulkanVideoPresenter
     private const uint NvidiaVendorId = 0x10DE;
     private const uint AmdVendorId = 0x1002;
     // Other GPU PCI vendor IDs, for reference when adding future rules:
-    // Intel 0x8086, Qualcomm 0x5143, ARM 0x13B5, Apple 0x106B, Microsoft (software) 0x1414.
+    // Intel 0x8086, Apple 0x106B, Qualcomm 0x5143 (Windows-on-ARM), Microsoft software 0x1414.
     private const int LastResortPenalty = 1000;
+    private const string PortabilityEnumerationExtensionName = "VK_KHR_portability_enumeration";
+    private const string PortabilitySubsetExtensionName = "VK_KHR_portability_subset";
+    private const int GlfwPlatformHint = 0x00050003;
+    private const int GlfwPlatformWin32 = 0x00060001;
+    private const int GlfwPlatformCocoa = 0x00060002;
+    private const int GlfwPlatformWayland = 0x00060003;
+    private const int GlfwPlatformX11 = 0x00060004;
+    private const int GlfwPlatformNull = 0x00060005;
 
     internal static int ScorePhysicalDevice(
         PhysicalDeviceProperties properties,
@@ -318,14 +326,7 @@ internal static unsafe class VulkanVideoPresenter
 
         return penalty;
     }
-    private const string PortabilityEnumerationExtensionName = "VK_KHR_portability_enumeration";
-    private const string PortabilitySubsetExtensionName = "VK_KHR_portability_subset";
-    private const int GlfwPlatformHint = 0x00050003;
-    private const int GlfwPlatformWin32 = 0x00060001;
-    private const int GlfwPlatformCocoa = 0x00060002;
-    private const int GlfwPlatformWayland = 0x00060003;
-    private const int GlfwPlatformX11 = 0x00060004;
-    private const int GlfwPlatformNull = 0x00060005;
+
     private static bool _splashHidden;
     private static long _enqueuedGuestWorkSequence;
     // Largest contiguous completed sequence, retained for compact diagnostics.

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanPhysicalDeviceScoringTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanPhysicalDeviceScoringTests.cs
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.VideoOut;
+using Silk.NET.Vulkan;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VulkanPhysicalDeviceScoringTests
+{
+    private const uint NvidiaVendorId = 0x10DE;
+    private const uint AmdVendorId = 0x1002;
+    private const uint IntelVendorId = 0x8086;
+    private const uint QualcommVendorId = 0x5143;
+
+    private static int Score(PhysicalDeviceType type, uint vendorId = 0)
+        => VulkanVideoPresenter.ScorePhysicalDevice(
+            new PhysicalDeviceProperties { DeviceType = type, VendorID = vendorId },
+            name: string.Empty,
+            deviceOverride: null);
+
+    [Fact]
+    public void RealIntegratedGpuOutranksSoftwareRasterizer()
+    {
+        // Regression for #325: a Cpu-type software rasterizer (Mesa lavapipe)
+        // must not be preferred over a real integrated GPU.
+        Assert.True(Score(PhysicalDeviceType.IntegratedGpu) > Score(PhysicalDeviceType.Cpu));
+    }
+
+    [Theory]
+    [InlineData(IntelVendorId)]
+    [InlineData(QualcommVendorId)]
+    [InlineData(0)] // Apple/MoltenVK reports Apple Silicon as an integrated GPU.
+    public void NonAmdIntegratedGpuBeatsSoftware(uint vendorId)
+    {
+        Assert.True(Score(PhysicalDeviceType.IntegratedGpu, vendorId) > Score(PhysicalDeviceType.Cpu));
+    }
+
+    [Fact]
+    public void DiscreteGpuOutranksIntegratedGpu()
+    {
+        Assert.True(Score(PhysicalDeviceType.DiscreteGpu) > Score(PhysicalDeviceType.IntegratedGpu));
+    }
+
+    [Fact]
+    public void NvidiaDiscreteGpuScoresHighest()
+    {
+        var nvidia = Score(PhysicalDeviceType.DiscreteGpu, NvidiaVendorId);
+        Assert.True(nvidia > Score(PhysicalDeviceType.DiscreteGpu));
+        Assert.True(nvidia > Score(PhysicalDeviceType.IntegratedGpu));
+    }
+
+    [Fact]
+    public void AmdIntegratedGpuStaysLastResort()
+    {
+        // #97: AMD's integrated driver crashes compiling translated shaders, so
+        // it must rank below every other candidate, including software.
+        var amd = Score(PhysicalDeviceType.IntegratedGpu, AmdVendorId);
+        Assert.True(amd < Score(PhysicalDeviceType.Cpu));
+        Assert.True(amd < Score(PhysicalDeviceType.IntegratedGpu, IntelVendorId));
+        Assert.True(amd < Score(PhysicalDeviceType.DiscreteGpu));
+    }
+
+    [Fact]
+    public void AmdDiscreteGpuIsNotPenalized()
+    {
+        // The #97 penalty is specific to AMD integrated parts; an AMD discrete
+        // card must keep the full discrete score.
+        Assert.Equal(Score(PhysicalDeviceType.DiscreteGpu), Score(PhysicalDeviceType.DiscreteGpu, AmdVendorId));
+    }
+
+    [Fact]
+    public void DeviceOverridePinsMatchingAdapterAndExcludesOthers()
+    {
+        var properties = new PhysicalDeviceProperties { DeviceType = PhysicalDeviceType.Cpu };
+        Assert.Equal(1000, VulkanVideoPresenter.ScorePhysicalDevice(properties, "Radeon Graphics", "radeon"));
+        Assert.Equal(-1000, VulkanVideoPresenter.ScorePhysicalDevice(properties, "Radeon Graphics", "nvidia"));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanPhysicalDeviceScoringTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanPhysicalDeviceScoringTests.cs
@@ -14,24 +14,22 @@ public sealed class VulkanPhysicalDeviceScoringTests
     private const uint IntelVendorId = 0x8086;
     private const uint QualcommVendorId = 0x5143;
 
+    private static PhysicalDeviceProperties Device(PhysicalDeviceType type, uint vendorId = 0)
+        => new() { DeviceType = type, VendorID = vendorId };
+
     private static int Score(PhysicalDeviceType type, uint vendorId = 0)
-        => VulkanVideoPresenter.ScorePhysicalDevice(
-            new PhysicalDeviceProperties { DeviceType = type, VendorID = vendorId },
-            name: string.Empty,
-            deviceOverride: null);
+        => VulkanVideoPresenter.ScorePhysicalDevice(Device(type, vendorId), name: string.Empty, deviceOverride: null);
 
     [Fact]
     public void RealIntegratedGpuOutranksSoftwareRasterizer()
     {
-        // Regression for #325: a Cpu-type software rasterizer (Mesa lavapipe)
-        // must not be preferred over a real integrated GPU.
         Assert.True(Score(PhysicalDeviceType.IntegratedGpu) > Score(PhysicalDeviceType.Cpu));
     }
 
     [Theory]
     [InlineData(IntelVendorId)]
     [InlineData(QualcommVendorId)]
-    [InlineData(0)] // Apple/MoltenVK reports Apple Silicon as an integrated GPU.
+    [InlineData(0u)]
     public void NonAmdIntegratedGpuBeatsSoftware(uint vendorId)
     {
         Assert.True(Score(PhysicalDeviceType.IntegratedGpu, vendorId) > Score(PhysicalDeviceType.Cpu));
@@ -52,29 +50,45 @@ public sealed class VulkanPhysicalDeviceScoringTests
     }
 
     [Fact]
-    public void AmdIntegratedGpuStaysLastResort()
-    {
-        // #97: AMD's integrated driver crashes compiling translated shaders, so
-        // it must rank below every other candidate, including software.
-        var amd = Score(PhysicalDeviceType.IntegratedGpu, AmdVendorId);
-        Assert.True(amd < Score(PhysicalDeviceType.Cpu));
-        Assert.True(amd < Score(PhysicalDeviceType.IntegratedGpu, IntelVendorId));
-        Assert.True(amd < Score(PhysicalDeviceType.DiscreteGpu));
-    }
-
-    [Fact]
-    public void AmdDiscreteGpuIsNotPenalized()
-    {
-        // The #97 penalty is specific to AMD integrated parts; an AMD discrete
-        // card must keep the full discrete score.
-        Assert.Equal(Score(PhysicalDeviceType.DiscreteGpu), Score(PhysicalDeviceType.DiscreteGpu, AmdVendorId));
-    }
-
-    [Fact]
     public void DeviceOverridePinsMatchingAdapterAndExcludesOthers()
     {
-        var properties = new PhysicalDeviceProperties { DeviceType = PhysicalDeviceType.Cpu };
+        var properties = Device(PhysicalDeviceType.Cpu);
         Assert.Equal(1000, VulkanVideoPresenter.ScorePhysicalDevice(properties, "Radeon Graphics", "radeon"));
         Assert.Equal(-1000, VulkanVideoPresenter.ScorePhysicalDevice(properties, "Radeon Graphics", "nvidia"));
+    }
+
+    [Fact]
+    public void AmdIntegratedGpuIsLastResortOnWindows()
+    {
+        var penalty = VulkanVideoPresenter.ComputeDevicePenalty(
+            Device(PhysicalDeviceType.IntegratedGpu, AmdVendorId), isWindows: true);
+        Assert.True(penalty > 0);
+        Assert.True(50 - penalty < 10);
+    }
+
+    [Fact]
+    public void AmdApuIsNotPenalizedOffWindows()
+    {
+        var penalty = VulkanVideoPresenter.ComputeDevicePenalty(
+            Device(PhysicalDeviceType.IntegratedGpu, AmdVendorId), isWindows: false);
+        Assert.Equal(0, penalty);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AmdDiscreteGpuIsNeverPenalized(bool isWindows)
+    {
+        Assert.Equal(0, VulkanVideoPresenter.ComputeDevicePenalty(
+            Device(PhysicalDeviceType.DiscreteGpu, AmdVendorId), isWindows));
+    }
+
+    [Theory]
+    [InlineData(IntelVendorId)]
+    [InlineData(QualcommVendorId)]
+    public void NonAmdIntegratedGpuIsNeverPenalized(uint vendorId)
+    {
+        Assert.Equal(0, VulkanVideoPresenter.ComputeDevicePenalty(
+            Device(PhysicalDeviceType.IntegratedGpu, vendorId), isWindows: true));
     }
 }


### PR DESCRIPTION
GPU selection was preferring a software renderer over a real integrated GPU due to some crash on certain AMD hardware. `ScorePhysicalDevice` gave a `Cpu` (software) device 50 points and an `IntegratedGpu` -100, so whenever a software Vulkan device is present the emulator ran on it instead of the actual GPU. This always happens on Windows-on-ARM, where the Microsoft Basic Render Driver shows up as a `Cpu` device.

The -100 came from #97, which was working around a crash in AMD's Windows integrated driver. But it penalized every integrated GPU on every OS.

What I changed:
- Integrated GPUs now rank above software again.
- Kept the AMD workaround but limited it to AMD integrated GPUs on Windows only. Linux AMD (Mesa RADV, e.g. Steam Deck) and Windows on ARM is left alone.
- Pulled the AMD check into a small `ComputeDevicePenalty` helper.
- Moved `ScorePhysicalDevice` to the outer class so it can be unit tested, and added tests.

Tested with Dreaming Sarah:
- Windows Adreno (Surface Laptop 7 with Snapdragon X Elite): before it picked the Microsoft software driver, now it picks the Adreno. Runs better.
- Steam Deck (AMD): still picks the APU. No change there since the Deck only lists the one GPU, so it was never hitting the bug.

Closes #325

## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Checklist
By submitting this PR, you confirm that:

- [x] I have read `CONTRIBUTING.md`.
- [x] I tested my changes. (on amd linux and arm windows)
- [x] I wrote this description myself and did not copy AI-generated explanations.
- [x] I listed the game(s) I tested
