### PR TITLE
Rank software rasterizers below every real GPU in device selection (fixes #325)

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -271,6 +271,22 @@ internal static unsafe class VulkanVideoPresenter
     private static bool _presenterCloseRequested;
     private const string DebugUtilsExtensionName = "VK_EXT_debug_utils";
     private const uint NvidiaVendorId = 0x10DE;
+
+    // Base ranking used when picking a Vulkan adapter, before the vendor bonus in ScorePhysicalDevice.
+    // A software rasterizer (Mesa lavapipe and similar ICDs enumerate as Cpu) has to rank below every
+    // real GPU. #97 pushed integrated GPUs down to -100 so they are only chosen as a last resort among
+    // real devices; Cpu sits below even that, so an integrated GPU still wins whenever both are present.
+    // Cpu stays above the int.MinValue seed in the selection loop, so it is still picked when it is the
+    // only adapter that can present.
+    internal static int ScoreDeviceType(PhysicalDeviceType deviceType) => deviceType switch
+    {
+        PhysicalDeviceType.DiscreteGpu => 300,
+        PhysicalDeviceType.VirtualGpu => 100,
+        PhysicalDeviceType.IntegratedGpu => -100,
+        PhysicalDeviceType.Cpu => -200,
+        _ => 10,
+    };
+
     private const string PortabilityEnumerationExtensionName = "VK_KHR_portability_enumeration";
     private const string PortabilitySubsetExtensionName = "VK_KHR_portability_subset";
     private const int GlfwPlatformHint = 0x00050003;
@@ -3210,14 +3226,7 @@ internal static unsafe class VulkanVideoPresenter
                 return name.Contains(deviceOverride, StringComparison.OrdinalIgnoreCase) ? 1000 : -1000;
             }
 
-            var score = properties.DeviceType switch
-            {
-                PhysicalDeviceType.DiscreteGpu => 300,
-                PhysicalDeviceType.VirtualGpu => 100,
-                PhysicalDeviceType.Cpu => 50,
-                PhysicalDeviceType.IntegratedGpu => -100,
-                _ => 10,
-            };
+            var score = ScoreDeviceType(properties.DeviceType);
 
             if (properties.VendorID == NvidiaVendorId)
             {

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanDeviceScoringTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanDeviceScoringTests.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Silk.NET.Vulkan;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+// Locks in the physical-device type ranking used to pick a Vulkan adapter. The regression these guard
+// against is a software rasterizer (Cpu) outscoring a real integrated GPU, which would silently drop
+// the emulator into software rendering on integrated-only hosts (Mesa lavapipe, Apple Silicon).
+public sealed class VulkanDeviceScoringTests
+{
+    [Fact]
+    public void IntegratedGpu_RanksAboveSoftwareRasterizer()
+    {
+        Assert.True(
+            VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.IntegratedGpu) >
+            VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.Cpu));
+    }
+
+    [Fact]
+    public void EveryRealDeviceType_OutranksSoftwareRasterizer()
+    {
+        var cpu = VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.Cpu);
+        Assert.True(VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.DiscreteGpu) > cpu);
+        Assert.True(VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.VirtualGpu) > cpu);
+        Assert.True(VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.IntegratedGpu) > cpu);
+        Assert.True(VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.Other) > cpu);
+    }
+
+    [Fact]
+    public void DiscreteGpu_RanksHighest()
+    {
+        var discrete = VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.DiscreteGpu);
+        Assert.True(discrete > VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.VirtualGpu));
+        Assert.True(discrete > VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.IntegratedGpu));
+        Assert.True(discrete > VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.Cpu));
+    }
+
+    // Even at the bottom of the ranking, a Cpu device must beat the int.MinValue seed the selection loop
+    // starts from, so software rendering is still chosen when it is the only adapter that can present.
+    [Fact]
+    public void SoftwareRasterizer_StaysSelectableAsLastResort()
+    {
+        Assert.True(VulkanVideoPresenter.ScoreDeviceType(PhysicalDeviceType.Cpu) > int.MinValue);
+    }
+}


### PR DESCRIPTION
## What this fixes

`ScorePhysicalDevice` in `VulkanVideoPresenter` ranked a software CPU rasterizer above a real integrated GPU:

```csharp
PhysicalDeviceType.DiscreteGpu   => 300,
PhysicalDeviceType.VirtualGpu    => 100,
PhysicalDeviceType.Cpu           => 50,
PhysicalDeviceType.IntegratedGpu => -100,
_ => 10,
```

#97 introduced the `-100` for integrated GPUs on purpose — to keep hybrid-graphics laptops off an integrated AMD driver that access-violates inside `vkCreateGraphicsPipelines` — with the rule "an integrated GPU is only chosen when nothing else can present." The gap is that a `Cpu` device *is* something else that can present: it scores 50 and beats a real integrated GPU at -100.

Where that bites:

- **Integrated-only Linux hosts.** Mesa's lavapipe enumerates as `VK_PHYSICAL_DEVICE_TYPE_CPU`. If the only real GPU is Intel/AMD integrated, SharpEmu picks lavapipe (50) over the iGPU (-100) and silently software-renders — which just looks like the emulator being slow.
- **Apple Silicon.** MoltenVK reports the GPU as `IntegratedGpu`, so it scores -100 and only wins today because it happens to be the sole candidate (`bestScore` seeds at `int.MinValue`). Any `Cpu`-type ICD showing up next to it would displace it.

## The change

I pulled the device-type ranking out of `ScorePhysicalDevice` into a small `ScoreDeviceType` helper and put `Cpu` below `IntegratedGpu` (`-200`):

```csharp
PhysicalDeviceType.DiscreteGpu   => 300,
PhysicalDeviceType.VirtualGpu    => 100,
PhysicalDeviceType.IntegratedGpu => -100,
PhysicalDeviceType.Cpu           => -200,
_ => 10,
```

I deliberately left `IntegratedGpu` at exactly `-100` rather than reshuffling the whole table, so #97's intent is untouched: integrated GPUs stay a last resort among *real* devices. All this does is make a software rasterizer rank below them. `Cpu` is still above the `int.MinValue` seed, so it's still selected when it's genuinely the only adapter that can present (e.g. a headless CI box with only lavapipe) — software rendering stays a fallback, it just stops being a *preferred* one.

The NVIDIA vendor bonus and the `SHARPEMU_VK_DEVICE` override path are unchanged. I moved the ranking to a helper so it can be unit-tested without a live Vulkan instance.

## How I verified it

- New `VulkanDeviceScoringTests` covering the ranking: integrated outranks Cpu, every real device type outranks Cpu, discrete stays highest, and Cpu still beats `int.MinValue` so it remains selectable as a last resort.
- `dotnet build` + full `dotnet test` clean.

I haven't run this on an actual integrated-only lavapipe host or on Apple Silicon — I don't have either set up — so the verification is at the ranking / unit-test level, not a live device-selection run.

## Checklist

By submitting this PR, you confirm that:

- [x] I have read `CONTRIBUTING.md`.
- [x] I tested my changes.
- [x] I wrote this description myself and did not copy AI-generated explanations.
- [ ] I listed the game(s) I tested, if applicable. (not game-specific — this is device selection; not run in-game, see above)

Fixes #325.
