### PR TITLE
[Test] Pin V_READLANE scalar destination encodings

### DIFF
--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
@@ -1872,8 +1872,9 @@ public static class Gen5ShaderTranslator
                 destinations = [Gen5Operand.Vector(word & 0xFF)];
                 if (opcode == "VReadlaneB32")
                 {
-                    // The scalar destination lives in the low vdst byte (bits 0-7);
-                    // bits 8-14 are the VOP3B carry-out sdst, which readlane lacks.
+                    // V_READLANE uses the VOP3A vdst byte even though the
+                    // destination register is scalar. Bits 8-14 are the
+                    // distinct sdst field used by VOP3B encodings.
                     destinations = [Gen5Operand.Scalar(word & 0xFF)];
                 }
                 var isVop3B = IsVop3BOpcode((word >> 16) & 0x3FF);

--- a/tests/SharpEmu.Libs.Tests/ShaderCompiler/Gen5ShaderTranslatorTests.cs
+++ b/tests/SharpEmu.Libs.Tests/ShaderCompiler/Gen5ShaderTranslatorTests.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.ShaderCompiler;
+
+public sealed class Gen5ShaderTranslatorTests
+{
+    private const ulong ProgramAddress = 0x1_0000_0000;
+
+    [Theory]
+    [InlineData(0xD7600005u, 5u)]
+    [InlineData(0xD7600065u, 101u)]
+    public void VReadlaneB32DecodesScalarDestinationFromVdstByte(
+        uint instructionWord,
+        uint expectedDestination)
+    {
+        var memory = new FakeCpuMemory(ProgramAddress, 0x100);
+        Span<byte> code = stackalloc byte[3 * sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(code, instructionWord);
+        BinaryPrimitives.WriteUInt32LittleEndian(code[sizeof(uint)..], 0x02000501u);
+        BinaryPrimitives.WriteUInt32LittleEndian(code[(2 * sizeof(uint))..], 0xBF810000u);
+        Assert.True(memory.TryWrite(ProgramAddress, code));
+
+        var context = new CpuContext(memory, Generation.Gen5);
+        Assert.True(
+            Gen5ShaderTranslator.TryDecodeProgram(
+                context,
+                ProgramAddress,
+                out var program,
+                out var error),
+            error);
+
+        var instruction = Assert.Single(
+            program.Instructions,
+            static item => item.Opcode == "VReadlaneB32");
+        Assert.Equal(Gen5ShaderEncoding.Vop3, instruction.Encoding);
+
+        var destination = Assert.Single(instruction.Destinations);
+        Assert.Equal(Gen5OperandKind.ScalarRegister, destination.Kind);
+        Assert.Equal(expectedDestination, destination.Value);
+
+        Assert.Equal(Gen5OperandKind.VectorRegister, instruction.Sources[0].Kind);
+        Assert.Equal(1u, instruction.Sources[0].Value);
+        Assert.Equal(Gen5OperandKind.ScalarRegister, instruction.Sources[1].Kind);
+        Assert.Equal(2u, instruction.Sources[1].Value);
+    }
+}


### PR DESCRIPTION
## Change description

## What changed

Adds regression tests for two known LLVM `V_READLANE_B32` encodings targeting `s5` and `s101`. This PR does not change production decoding; the decoder fix was already merged in #262.

## Why

The tests pin the VOP3A `VDST` encoding and guard against the scalar-destination regression returning in future decoder changes.

## Validation

- 2 focused `Gen5ShaderTranslatorTests` passed using synthetic public encodings.
- The full build and test suite passed.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
