### PR TITLE
[SystemService] Write notice skip flag as one byte

### DIFF
--- a/src/SharpEmu.Libs/SystemService/SystemServiceExports.cs
+++ b/src/SharpEmu.Libs/SystemService/SystemServiceExports.cs
@@ -38,8 +38,8 @@ public static class SystemServiceExports
         }
 
         // No system notice screen to skip in the emulator; report "do not skip".
-        Span<byte> flagBytes = stackalloc byte[sizeof(int)];
-        BinaryPrimitives.WriteInt32LittleEndian(flagBytes, 0);
+        Span<byte> flagBytes = stackalloc byte[1];
+        flagBytes[0] = 0;
         return ctx.Memory.TryWrite(flagAddress, flagBytes)
             ? ctx.SetReturn(0)
             : ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);

--- a/tests/SharpEmu.Libs.Tests/SystemService/SystemServiceExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/SystemService/SystemServiceExportsTests.cs
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.SystemService;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.SystemService;
+
+public sealed class SystemServiceExportsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+
+    [Fact]
+    public void GetNoticeScreenSkipFlagWritesOneByteAtMemoryBoundary()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 1);
+        var context = new CpuContext(memory, Generation.Gen5);
+        Assert.True(memory.TryWrite(MemoryBase, new byte[] { 0xA5 }));
+        context[CpuRegister.Rdi] = MemoryBase;
+
+        Assert.Equal(0, SystemServiceExports.SystemServiceGetNoticeScreenSkipFlag(context));
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+
+        Span<byte> flag = stackalloc byte[1];
+        Assert.True(memory.TryRead(MemoryBase, flag));
+        Assert.Equal(0, flag[0]);
+    }
+}


### PR DESCRIPTION
## Change description

## What changed

Writes the Gen5 notice-screen skip flag as one byte and adds a boundary test that detects writes past the output.

## Why

The caller provides a one-byte flag. The previous four-byte write could fault or overwrite adjacent guest memory.

## Validation

- 1 focused SystemService regression test passed.
- The full build and test suite passed.


## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

