### PR TITLE
[CPU] Preserve full guest callback return values

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.NativeWorker.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.NativeWorker.cs
@@ -62,7 +62,7 @@ public sealed partial class DirectExecutionBackend
 		if (worker is null)
 		{
 			TlsSetValue(_hostRspSlotTlsIndex, (nint)hostRspSlot);
-			return CallNativeEntry(entryStub);
+			return unchecked((int)CallNativeEntry(entryStub));
 		}
 		try
 		{

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -871,10 +871,22 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		return *(ulong*)((byte*)contextRecord + offset);
 	}
 
-	private unsafe static int CallNativeEntry(void* entry)
+	private unsafe static ulong CallNativeEntry(void* entry)
 	{
-		var nativeEntry = (delegate* unmanaged[Cdecl]<int>)entry;
+		var nativeEntry = (delegate* unmanaged[Cdecl]<ulong>)entry;
 		return nativeEntry();
+	}
+
+	private static void StoreCompletedGuestNativeReturn(CpuContext context, ulong returnValue)
+	{
+		context[CpuRegister.Rax] = returnValue;
+	}
+
+	private static bool ShouldTraceGuestCallbackReturn(string name)
+	{
+		var filter = Environment.GetEnvironmentVariable("SHARPEMU_TRACE_GUEST_CALLBACK_RETURNS");
+		return string.Equals(filter, "1", StringComparison.Ordinal) ||
+			(!string.IsNullOrWhiteSpace(filter) && name.Contains(filter, StringComparison.Ordinal));
 	}
 
 	private unsafe static void WriteCtxU64(void* contextRecord, int offset, ulong value)
@@ -5078,7 +5090,14 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					reason = LastError ?? "guest thread forced exit";
 					return GuestNativeCallExitReason.ForcedExit;
 				}
-				reason = $"returned 0x{nativeReturn:X8}";
+				if (ShouldTraceGuestCallbackReturn(name))
+				{
+					Console.Error.WriteLine(
+						$"[LOADER][TRACE] guest_native.return name='{name}' " +
+						$"native=0x{nativeReturn:X16} context=0x{context[CpuRegister.Rax]:X16}");
+				}
+				StoreCompletedGuestNativeReturn(context, nativeReturn);
+				reason = $"returned 0x{nativeReturn:X16}";
 				return GuestNativeCallExitReason.Returned;
 			}
 			catch (AccessViolationException ex)
@@ -5233,7 +5252,14 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					reason = LastError ?? "guest thread forced exit";
 					return GuestNativeCallExitReason.ForcedExit;
 				}
-				reason = $"returned 0x{nativeReturn:X8}";
+				if (ShouldTraceGuestCallbackReturn(name))
+				{
+					Console.Error.WriteLine(
+						$"[LOADER][TRACE] guest_native.return name='{name}' " +
+						$"native=0x{nativeReturn:X16} context=0x{context[CpuRegister.Rax]:X16}");
+				}
+				StoreCompletedGuestNativeReturn(context, nativeReturn);
+				reason = $"returned 0x{nativeReturn:X16}";
 				return GuestNativeCallExitReason.Returned;
 			}
 			catch (AccessViolationException ex)
@@ -5552,7 +5578,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			int num6 = -1;
 			try
 			{
-				num6 = CallNativeEntry(ptr);
+				num6 = unchecked((int)CallNativeEntry(ptr));
 				Console.Error.WriteLine($"[LOADER][INFO] Guest returned: {num6}");
 				// A host stop has already invalidated the session. Draining guest
 				// continuations here can re-enter a blocked HLE call after its owner

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -5578,6 +5578,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			int num6 = -1;
 			try
 			{
+				// The process entry point returns an int exit status. Guest callbacks
+				// and continuations preserve the full-width RAX value in the paths above.
 				num6 = unchecked((int)CallNativeEntry(ptr));
 				Console.Error.WriteLine($"[LOADER][INFO] Guest returned: {num6}");
 				// A host stop has already invalidated the session. Draining guest

--- a/tests/SharpEmu.Libs.Tests/Cpu/GuestNativeReturnTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/GuestNativeReturnTests.cs
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using SharpEmu.Core.Cpu.Native;
+using SharpEmu.HLE;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+public sealed class GuestNativeReturnTests
+{
+    private const ulong GuestPointer = 0x0000_0071_CAFE_BA00;
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static ulong ReturnGuestPointer() => GuestPointer;
+
+    [Fact]
+    public unsafe void NativeEntryAndCompletedContextPreserveFullPointerReturn()
+    {
+        var nativeEntry = typeof(DirectExecutionBackend).GetMethod(
+            "CallNativeEntry",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(nativeEntry);
+        Assert.Equal(typeof(ulong), nativeEntry.ReturnType);
+        var target = (delegate* unmanaged[Cdecl]<ulong>)&ReturnGuestPointer;
+        var boxedTarget = Pointer.Box((void*)target, typeof(void*));
+        Assert.Equal(GuestPointer, Assert.IsType<ulong>(nativeEntry.Invoke(null, [boxedTarget])));
+
+        var storeReturn = typeof(DirectExecutionBackend).GetMethod(
+            "StoreCompletedGuestNativeReturn",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(storeReturn);
+
+        var context = new CpuContext(new FakeCpuMemory(0x1_0000, 0x1000), Generation.Gen5);
+        storeReturn.Invoke(null, [context, GuestPointer]);
+
+        Assert.Equal(GuestPointer, context[CpuRegister.Rax]);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Cpu/GuestNativeReturnTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/GuestNativeReturnTests.cs
@@ -20,19 +20,19 @@ public sealed class GuestNativeReturnTests
     [Fact]
     public unsafe void NativeEntryAndCompletedContextPreserveFullPointerReturn()
     {
-        var nativeEntry = typeof(DirectExecutionBackend).GetMethod(
-            "CallNativeEntry",
-            BindingFlags.Static | BindingFlags.NonPublic);
-        Assert.NotNull(nativeEntry);
+        var nativeEntry = Assert.IsAssignableFrom<MethodInfo>(
+            typeof(DirectExecutionBackend).GetMethod(
+                "CallNativeEntry",
+                BindingFlags.Static | BindingFlags.NonPublic));
         Assert.Equal(typeof(ulong), nativeEntry.ReturnType);
         var target = (delegate* unmanaged[Cdecl]<ulong>)&ReturnGuestPointer;
         var boxedTarget = Pointer.Box((void*)target, typeof(void*));
         Assert.Equal(GuestPointer, Assert.IsType<ulong>(nativeEntry.Invoke(null, [boxedTarget])));
 
-        var storeReturn = typeof(DirectExecutionBackend).GetMethod(
-            "StoreCompletedGuestNativeReturn",
-            BindingFlags.Static | BindingFlags.NonPublic);
-        Assert.NotNull(storeReturn);
+        var storeReturn = Assert.IsAssignableFrom<MethodInfo>(
+            typeof(DirectExecutionBackend).GetMethod(
+                "StoreCompletedGuestNativeReturn",
+                BindingFlags.Static | BindingFlags.NonPublic));
 
         var context = new CpuContext(new FakeCpuMemory(0x1_0000, 0x1000), Generation.Gen5);
         storeReturn.Invoke(null, [context, GuestPointer]);


### PR DESCRIPTION
## Change description

## What changed

Preserves the complete 64-bit `RAX` value returned by guest callbacks through the native-worker execution path.

## Why

The callback result was narrowed before being returned, truncating values that use the upper 32 bits.

## Validation

- 1 focused callback-return regression test passed.
- The full build and test suite passed.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

