### PR TITLE
[Vulkan] Remove unused per-draw descriptor allocation

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -5560,8 +5560,6 @@ internal static unsafe class VulkanVideoPresenter
             ShaderStageFlags stageFlags)
         {
             var textureCount = resources.Textures.Length;
-            var sampledImageCount = resources.Textures.Count(texture => !texture.IsStorage);
-            var storageImageCount = textureCount - sampledImageCount;
             var globalBufferCount = resources.GlobalMemoryBuffers.Length;
             var bindingCount = textureCount + (globalBufferCount == 0 ? 0 : 1);
             var layout = GetOrCreateDescriptorLayout(resources, stageFlags, bindingCount);
@@ -5574,38 +5572,6 @@ internal static unsafe class VulkanVideoPresenter
             }
 
             var setLayout = layout.DescriptorSetLayout;
-
-            var poolSizes = new DescriptorPoolSize[
-                (sampledImageCount == 0 ? 0 : 1) +
-                (storageImageCount == 0 ? 0 : 1) +
-                (globalBufferCount == 0 ? 0 : 1)];
-            var poolSizeIndex = 0;
-            if (sampledImageCount != 0)
-            {
-                poolSizes[poolSizeIndex++] = new DescriptorPoolSize
-                {
-                    Type = DescriptorType.CombinedImageSampler,
-                    DescriptorCount = (uint)sampledImageCount,
-                };
-            }
-
-            if (storageImageCount != 0)
-            {
-                poolSizes[poolSizeIndex++] = new DescriptorPoolSize
-                {
-                    Type = DescriptorType.StorageImage,
-                    DescriptorCount = (uint)storageImageCount,
-                };
-            }
-
-            if (globalBufferCount != 0)
-            {
-                poolSizes[poolSizeIndex] = new DescriptorPoolSize
-                {
-                    Type = DescriptorType.StorageBuffer,
-                    DescriptorCount = (uint)globalBufferCount,
-                };
-            }
 
             if (_recycledDescriptorPools.TryPop(out var recycledPool))
             {


### PR DESCRIPTION
## What changed

Removed the unused descriptor-pool sizing block from `CreateTranslatedDescriptorResources`.

The presenter used to count sampled and storage images, allocate a `DescriptorPoolSize[]`, and populate it for every descriptor-bearing draw or dispatch. That result was never passed to Vulkan. Pool creation already uses the generic fixed-size block below it, and recycled pools bypass creation entirely.

This removes one managed array allocation and the texture-counting pass from the hot path without changing descriptor layouts, pool sizes, Vulkan commands, or guest-visible behavior.

## Testing

- `dotnet build SharpEmu.slnx -c Release --no-restore` — 0 warnings, 0 errors
- `dotnet test SharpEmu.slnx -c Release --no-build --verbosity normal` — 243 passed
- Game testing: N/A; this does not change rendering behavior. Keeping the PR as a draft until the automated gameplay runner checks it.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
