### PR TITLE
[AvPlayer] Match Gen5 stream and video frame ABI

### DIFF
--- a/src/SharpEmu.Libs/AvPlayer/AvPlayerExports.cs
+++ b/src/SharpEmu.Libs/AvPlayer/AvPlayerExports.cs
@@ -17,11 +17,23 @@ public static class AvPlayerExports
     private const int FrameBufferCount = 3;
     private const int FrameInfoSize = 40;
     private const int FrameInfoExSize = 104;
-    private const int StreamInfoSize = 40;
+    private const int Gen4StreamInfoSize = 40;
+    private const int Gen5StreamInfoSize = 32;
+    private const int Gen5StreamInfoExSize = 104;
     private const int MaxGuestPathLength = 4096;
+    private const ulong Gen4InitExAutoStartOffset = 0xA8;
+    private const ulong Gen5InitExAutoStartOffset = 0x74;
+    private const ulong Gen5PostInitVideoDecoderOffset = 0x8;
+    private const uint Gen5VideoDecoderSoftware2 = 1;
     private static readonly object StateGate = new();
     private static readonly Dictionary<ulong, PlayerState> Players = new();
     private static int _traceCount;
+
+    internal readonly record struct VideoFrameLayout(
+        int Width,
+        int Height,
+        int Pitch,
+        int BufferSize);
 
     private sealed class PlayerState : IDisposable
     {
@@ -31,6 +43,7 @@ public static class AvPlayerExports
         public ulong AllocateTextureCallback { get; init; }
         public ulong EventObject { get; init; }
         public ulong EventCallback { get; init; }
+        public bool UseVideoDecoderSoftware2 { get; set; }
         public string? SourcePath { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
@@ -54,6 +67,7 @@ public static class AvPlayerExports
         public int NextGuestBuffer { get; set; }
         public ulong LastGuestBuffer { get; set; }
         public long NextFrameIndex { get; set; }
+        public int VideoFramesDelivered { get; set; }
         public ulong AudioBufferBase { get; set; }
         public int NextAudioBuffer { get; set; }
         public long NextAudioFrameIndex { get; set; }
@@ -107,6 +121,7 @@ public static class AvPlayerExports
             Dispose();
             PlaybackClock.Reset();
             NextFrameIndex = 0;
+            VideoFramesDelivered = 0;
             NextAudioFrameIndex = 0;
             EndOfStream = false;
         }
@@ -156,12 +171,53 @@ public static class AvPlayerExports
         var dataAddress = ctx[CpuRegister.Rsi];
         lock (StateGate)
         {
-            return SetReturn(
-                ctx,
-                handle != 0 && dataAddress != 0 && Players.ContainsKey(handle)
-                    ? 0
-                    : InvalidParameters);
+            if (handle == 0 || dataAddress == 0 ||
+                !Players.TryGetValue(handle, out var player))
+            {
+                return SetReturn(ctx, InvalidParameters);
+            }
+
+            if ((ctx.TargetGeneration & Generation.Gen5) == 0)
+            {
+                return SetReturn(ctx, 0);
+            }
+            if (!TryReadGen5PostInitVideoDecoder(
+                    ctx,
+                    dataAddress,
+                    out var videoDecoderType,
+                    out var useVideoDecoderSoftware2))
+            {
+                return SetReturn(ctx, InvalidParameters);
+            }
+
+            player.UseVideoDecoderSoftware2 = useVideoDecoderSoftware2;
+            Console.Error.WriteLine(
+                $"[AVPLAYER][INFO] post_init handle=0x{handle:X16} " +
+                $"video_decoder_type={videoDecoderType} software2={(player.UseVideoDecoderSoftware2 ? 1 : 0)}");
+            return SetReturn(ctx, 0);
         }
+    }
+
+    internal static bool TryReadGen5PostInitVideoDecoder(
+        CpuContext ctx,
+        ulong dataAddress,
+        out uint videoDecoderType,
+        out bool useVideoDecoderSoftware2)
+    {
+        if ((ctx.TargetGeneration & Generation.Gen5) == 0 ||
+            dataAddress == 0 ||
+            !TryReadUInt32(
+                ctx,
+                dataAddress + Gen5PostInitVideoDecoderOffset,
+                out videoDecoderType))
+        {
+            videoDecoderType = 0;
+            useVideoDecoderSoftware2 = false;
+            return false;
+        }
+
+        useVideoDecoderSoftware2 = videoDecoderType == Gen5VideoDecoderSoftware2;
+        return true;
     }
 
     [SysAbiExport(
@@ -186,7 +242,7 @@ public static class AvPlayerExports
             Players.Add(handle, new PlayerState
             {
                 Handle = handle,
-                AutoStart = TryReadByte(ctx, initDataAddress + 164, out var autoStart) && autoStart != 0,
+                AutoStart = TryReadInitExAutoStart(ctx, initDataAddress, out var autoStart) && autoStart,
                 AllocatorObject = TryReadUInt64(ctx, initDataAddress + 8, out var allocatorObject) ? allocatorObject : 0,
                 AllocateTextureCallback = TryReadUInt64(ctx, initDataAddress + 32, out var allocateTexture) ? allocateTexture : 0,
                 EventObject = TryReadUInt64(ctx, initDataAddress + 88, out var eventObject) ? eventObject : 0,
@@ -194,7 +250,12 @@ public static class AvPlayerExports
             });
         }
 
-        Trace($"init_ex handle=0x{handle:X16} alloc_texture=0x{Players[handle].AllocateTextureCallback:X16}");
+        TryReadUInt64(ctx, initDataAddress, out var initDataSize);
+        Trace(
+            $"init_ex handle=0x{handle:X16} " +
+            $"alloc_texture=0x{Players[handle].AllocateTextureCallback:X16} " +
+            $"generation={ctx.TargetGeneration} size={initDataSize} " +
+            $"auto_start={(Players[handle].AutoStart ? 1 : 0)}");
         return SetReturn(ctx, 0);
     }
 
@@ -386,7 +447,25 @@ public static class AvPlayerExports
         ExportName = "sceAvPlayerEnableStream",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libSceAvPlayer")]
-    public static int AvPlayerEnableStream(CpuContext ctx) => ValidatePlayer(ctx);
+    public static int AvPlayerEnableStream(CpuContext ctx)
+    {
+        var handle = ctx[CpuRegister.Rdi];
+        var streamIndex = unchecked((uint)ctx[CpuRegister.Rsi]);
+        lock (StateGate)
+        {
+            if (!Players.TryGetValue(handle, out var player))
+            {
+                return SetReturn(ctx, InvalidParameters);
+            }
+            if (player.SourcePath is null || streamIndex > 1)
+            {
+                return SetReturn(ctx, OperationFailed);
+            }
+
+            Trace($"enable_stream handle=0x{handle:X16} index={streamIndex}");
+            return SetReturn(ctx, 0);
+        }
+    }
 
     [SysAbiExport(
         Nid = "k-q+xOxdc3E",
@@ -404,7 +483,8 @@ public static class AvPlayerExports
         ExportName = "sceAvPlayerGetStreamInfoEx",
         Target = Generation.Gen5,
         LibraryName = "libSceAvPlayer")]
-    public static int AvPlayerSetDecoderMode(CpuContext ctx) => ValidatePlayer(ctx);
+    public static int AvPlayerGetStreamInfoEx(CpuContext ctx) =>
+        GetStreamInfo(ctx, extended: true);
 
     [SysAbiExport(
         Nid = "XC9wM+xULz8",
@@ -555,9 +635,17 @@ public static class AvPlayerExports
         LibraryName = "libSceAvPlayer")]
     public static int AvPlayerStreamCount(CpuContext ctx)
     {
+        var handle = ctx[CpuRegister.Rdi];
         lock (StateGate)
         {
-            return SetReturn(ctx, Players.ContainsKey(ctx[CpuRegister.Rdi]) ? 2 : InvalidParameters);
+            if (!Players.TryGetValue(handle, out var player))
+            {
+                return SetReturn(ctx, InvalidParameters);
+            }
+
+            var count = player.SourcePath is null ? 0 : 2;
+            Trace($"stream_count handle=0x{handle:X16} count={count}");
+            return SetReturn(ctx, count);
         }
     }
 
@@ -566,41 +654,152 @@ public static class AvPlayerExports
         ExportName = "sceAvPlayerGetStreamInfo",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libSceAvPlayer")]
-    public static int AvPlayerGetStreamInfo(CpuContext ctx)
+    public static int AvPlayerGetStreamInfo(CpuContext ctx) =>
+        GetStreamInfo(ctx, extended: false);
+
+    private static int GetStreamInfo(CpuContext ctx, bool extended)
     {
         var streamIndex = unchecked((uint)ctx[CpuRegister.Rsi]);
         var infoAddress = ctx[CpuRegister.Rdx];
         lock (StateGate)
         {
             if (!Players.TryGetValue(ctx[CpuRegister.Rdi], out var player) ||
-                streamIndex > 1 || infoAddress == 0 || player.Width <= 0 || player.Height <= 0)
+                infoAddress == 0)
+            {
+                return SetReturn(ctx, InvalidParameters);
+            }
+            if (player.SourcePath is null || streamIndex > 1 ||
+                player.Width <= 0 || player.Height <= 0)
+            {
+                return SetReturn(ctx, OperationFailed);
+            }
+
+            if (!TryWriteStreamInfo(
+                    ctx,
+                    infoAddress,
+                    streamIndex,
+                    player.Width,
+                    player.Height,
+                    player.FramesPerSecond,
+                    player.DurationMilliseconds,
+                    extended,
+                    out var size,
+                    player.UseVideoDecoderSoftware2))
             {
                 return SetReturn(ctx, InvalidParameters);
             }
 
-            Span<byte> info = stackalloc byte[StreamInfoSize];
-            info.Clear();
-            BinaryPrimitives.WriteUInt32LittleEndian(info[0..], streamIndex); // 0=video, 1=audio
-            if (streamIndex == 0)
-            {
-                BinaryPrimitives.WriteUInt32LittleEndian(info[8..], checked((uint)player.Width));
-                BinaryPrimitives.WriteUInt32LittleEndian(info[12..], checked((uint)player.Height));
-                BinaryPrimitives.WriteSingleLittleEndian(info[16..], (float)player.Width / player.Height);
-            }
-            else
-            {
-                BinaryPrimitives.WriteUInt16LittleEndian(info[8..], 2);
-                BinaryPrimitives.WriteUInt32LittleEndian(info[12..], 48_000);
-            }
-            BinaryPrimitives.WriteUInt64LittleEndian(info[24..], player.DurationMilliseconds);
-            if (!ctx.Memory.TryWrite(infoAddress, info))
-            {
-                return SetReturn(ctx, InvalidParameters);
-            }
-
+            var type = GetStreamType(ctx.TargetGeneration, streamIndex);
+            Trace(
+                $"stream_info handle=0x{player.Handle:X16} index={streamIndex} " +
+                $"type={type} extended={(extended ? 1 : 0)} size={size}");
             return SetReturn(ctx, 0);
         }
     }
+
+    internal static bool TryWriteStreamInfo(
+        CpuContext ctx,
+        ulong infoAddress,
+        uint streamIndex,
+        int width,
+        int height,
+        double framesPerSecond,
+        ulong durationMilliseconds,
+        bool extended,
+        out int size,
+        bool useVideoDecoderSoftware2 = true)
+    {
+        size = 0;
+        if (infoAddress == 0 || streamIndex > 1 || width <= 0 || height <= 0)
+        {
+            return false;
+        }
+
+        var gen5 = (ctx.TargetGeneration & Generation.Gen5) != 0;
+        if (extended && !gen5)
+        {
+            return false;
+        }
+
+        size = extended
+            ? Gen5StreamInfoExSize
+            : gen5
+                ? Gen5StreamInfoSize
+                : Gen4StreamInfoSize;
+        Span<byte> storage = stackalloc byte[Gen5StreamInfoExSize];
+        var info = storage[..size];
+        info.Clear();
+
+        var typeOffset = extended ? sizeof(ulong) : 0;
+        var detailsOffset = extended ? 16 : 8;
+        var durationOffset = extended ? 96 : 24;
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            info[typeOffset..],
+            GetStreamType(ctx.TargetGeneration, streamIndex));
+        if (extended)
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(info, Gen5StreamInfoExSize);
+        }
+
+        if (streamIndex == 0)
+        {
+            var layoutWidth = width;
+            var layoutHeight = height;
+            var layoutPitch = width;
+            if (gen5)
+            {
+                var layout = GetVideoFrameLayout(
+                    ctx.TargetGeneration,
+                    width,
+                    height,
+                    useVideoDecoderSoftware2,
+                    extended);
+                layoutWidth = layout.Width;
+                layoutHeight = layout.Height;
+                layoutPitch = layout.Pitch;
+            }
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                info[detailsOffset..],
+                checked((uint)layoutWidth));
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                info[(detailsOffset + sizeof(uint))..],
+                checked((uint)layoutHeight));
+            BinaryPrimitives.WriteSingleLittleEndian(
+                info[(detailsOffset + 2 * sizeof(uint))..],
+                (float)width / height);
+            if (extended)
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(
+                    info[(detailsOffset + 36)..],
+                    checked((uint)layoutPitch));
+                info[detailsOffset + 40] = 8;
+                info[detailsOffset + 41] = 8;
+                BinaryPrimitives.WriteDoubleLittleEndian(
+                    info[(detailsOffset + 48)..],
+                    framesPerSecond);
+            }
+        }
+        else
+        {
+            BinaryPrimitives.WriteUInt16LittleEndian(info[detailsOffset..], 2);
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                info[(detailsOffset + sizeof(uint))..],
+                48_000);
+        }
+
+        info[detailsOffset + 12] = (byte)'u';
+        info[detailsOffset + 13] = (byte)'n';
+        info[detailsOffset + 14] = (byte)'d';
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            info[durationOffset..],
+            durationMilliseconds);
+        return ctx.Memory.TryWrite(infoAddress, info);
+    }
+
+    private static uint GetStreamType(Generation generation, uint streamIndex) =>
+        (generation & Generation.Gen5) != 0
+            ? streamIndex + 1 // Gen5: Unknown=0, Video=1, Audio=2.
+            : streamIndex;    // Gen4: Video=0, Audio=1.
 
     private static int AddSource(CpuContext ctx, string guestPath)
     {
@@ -682,6 +881,22 @@ public static class AvPlayerExports
                 return SetReturn(ctx, 0);
             }
 
+            player.VideoFramesDelivered++;
+            if (player.VideoFramesDelivered == 1)
+            {
+                var layout = GetVideoFrameLayout(
+                    ctx.TargetGeneration,
+                    player.Width,
+                    player.Height,
+                    player.UseVideoDecoderSoftware2,
+                    extended);
+                Console.Error.WriteLine(
+                    $"[AVPLAYER][INFO] first_video_frame handle=0x{player.Handle:X16} " +
+                    $"ex={(extended ? 1 : 0)} ts={timestamp} data=0x{player.LastGuestBuffer:X16} " +
+                    $"source={player.Width}x{player.Height} software2={(player.UseVideoDecoderSoftware2 ? 1 : 0)} " +
+                    $"pitch={layout.Pitch} " +
+                    $"buffer_size={player.GuestBufferStride}");
+            }
             Trace($"video_frame handle=0x{player.Handle:X16} ex={extended} ts={timestamp} data=0x{player.LastGuestBuffer:X16}");
             return SetReturn(ctx, 1);
         }
@@ -884,9 +1099,13 @@ public static class AvPlayerExports
             return false;
         }
 
-        var alignedWidth = AlignUp(player.Width, 16);
-        var alignedHeight = AlignUp(player.Height, 16);
-        var bufferStride = checked(alignedWidth * alignedHeight * 3 / 2);
+        var layout = GetVideoFrameLayout(
+            ctx.TargetGeneration,
+            player.Width,
+            player.Height,
+            player.UseVideoDecoderSoftware2,
+            extended);
+        var bufferStride = layout.BufferSize;
         if (player.GuestBuffers[0] == 0)
         {
             if (!AllocateGuestVideoBuffers(ctx, player, bufferStride))
@@ -897,21 +1116,20 @@ public static class AvPlayerExports
         }
 
         var frameData = player.RawFrame;
-        if (!extended && (alignedWidth != player.Width || alignedHeight != player.Height))
+        if (layout.Pitch != player.Width || layout.Height != player.Height)
         {
-            player.PaddedFrame ??= new byte[bufferStride];
-            player.PaddedFrame.AsSpan().Clear();
-            for (var row = 0; row < player.Height; row++)
+            if (player.PaddedFrame is null || player.PaddedFrame.Length != bufferStride)
             {
-                player.RawFrame.AsSpan(row * player.Width, player.Width)
-                    .CopyTo(player.PaddedFrame.AsSpan(row * alignedWidth, player.Width));
+                player.PaddedFrame = new byte[bufferStride];
             }
-            var rawChromaOffset = player.Width * player.Height;
-            var paddedChromaOffset = alignedWidth * alignedHeight;
-            for (var row = 0; row < player.Height / 2; row++)
+            if (!TryCopyNv12Frame(
+                    player.RawFrame,
+                    player.PaddedFrame,
+                    player.Width,
+                    player.Height,
+                    layout))
             {
-                player.RawFrame.AsSpan(rawChromaOffset + (row * player.Width), player.Width)
-                    .CopyTo(player.PaddedFrame.AsSpan(paddedChromaOffset + (row * alignedWidth), player.Width));
+                return false;
             }
             frameData = player.PaddedFrame;
         }
@@ -924,22 +1142,130 @@ public static class AvPlayerExports
             return false;
         }
 
+        return TryWriteVideoFrameInfo(
+            ctx,
+            infoAddress,
+            bufferAddress,
+            timestamp,
+            player.Width,
+            player.Height,
+            layout,
+            player.FramesPerSecond,
+            extended);
+    }
+
+    internal static bool TryWriteVideoFrameInfo(
+        CpuContext ctx,
+        ulong infoAddress,
+        ulong bufferAddress,
+        ulong timestamp,
+        int sourceWidth,
+        int sourceHeight,
+        VideoFrameLayout layout,
+        double framesPerSecond,
+        bool extended)
+    {
         Span<byte> info = extended
             ? stackalloc byte[FrameInfoExSize]
             : stackalloc byte[FrameInfoSize];
         info.Clear();
         BinaryPrimitives.WriteUInt64LittleEndian(info[0..], bufferAddress);
         BinaryPrimitives.WriteUInt64LittleEndian(info[16..], timestamp);
-        BinaryPrimitives.WriteUInt32LittleEndian(info[24..], checked((uint)(extended ? player.Width : alignedWidth)));
-        BinaryPrimitives.WriteUInt32LittleEndian(info[28..], checked((uint)(extended ? player.Height : alignedHeight)));
-        BinaryPrimitives.WriteSingleLittleEndian(info[32..], 1.0f);
+        BinaryPrimitives.WriteUInt32LittleEndian(info[24..], checked((uint)layout.Width));
+        BinaryPrimitives.WriteUInt32LittleEndian(info[28..], checked((uint)layout.Height));
+        BinaryPrimitives.WriteSingleLittleEndian(
+            info[32..],
+            (ctx.TargetGeneration & Generation.Gen5) != 0
+                ? (float)sourceWidth / sourceHeight
+                : 1.0f);
         if (extended)
         {
-            BinaryPrimitives.WriteUInt32LittleEndian(info[60..], checked((uint)player.Width));
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                info[48..],
+                checked((uint)(layout.Pitch - sourceWidth)));
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                info[56..],
+                checked((uint)(layout.Height - sourceHeight)));
+            BinaryPrimitives.WriteUInt32LittleEndian(info[60..], checked((uint)layout.Pitch));
             info[64] = 8;
             info[65] = 8;
+            if ((ctx.TargetGeneration & Generation.Gen5) != 0)
+            {
+                BinaryPrimitives.WriteDoubleLittleEndian(info[72..], framesPerSecond);
+            }
         }
         return ctx.Memory.TryWrite(infoAddress, info);
+    }
+
+    internal static VideoFrameLayout GetVideoFrameLayout(
+        Generation generation,
+        int sourceWidth,
+        int sourceHeight,
+        bool useVideoDecoderSoftware2,
+        bool extended = false)
+    {
+        if (sourceWidth <= 0 || sourceHeight <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(sourceWidth),
+                "Video dimensions must be positive.");
+        }
+
+        var gen5 = (generation & Generation.Gen5) != 0;
+        var alignedWidth = AlignUp(sourceWidth, 16);
+        var alignedHeight = AlignUp(sourceHeight, 16);
+        var width = gen5
+            ? useVideoDecoderSoftware2 ? sourceWidth : alignedWidth
+            : extended ? sourceWidth : alignedWidth;
+        var height = gen5
+            ? useVideoDecoderSoftware2 ? sourceHeight : alignedHeight
+            : extended ? sourceHeight : alignedHeight;
+        var pitch = gen5 ? AlignUp(width, 256) : width;
+        var bufferSize = gen5
+            ? checked(pitch * height * 3 / 2)
+            : checked(alignedWidth * alignedHeight * 3 / 2);
+        return new VideoFrameLayout(
+            width,
+            height,
+            pitch,
+            bufferSize);
+    }
+
+    internal static bool TryCopyNv12Frame(
+        ReadOnlySpan<byte> source,
+        Span<byte> destination,
+        int sourceWidth,
+        int sourceHeight,
+        VideoFrameLayout layout)
+    {
+        var sourceSize = (long)sourceWidth * sourceHeight * 3 / 2;
+        if (sourceWidth <= 0 || sourceHeight <= 0 ||
+            (sourceWidth & 1) != 0 || (sourceHeight & 1) != 0 ||
+            layout.Width < sourceWidth || layout.Height < sourceHeight ||
+            layout.Pitch < sourceWidth ||
+            sourceSize > source.Length ||
+            destination.Length < layout.BufferSize)
+        {
+            return false;
+        }
+
+        destination[..layout.BufferSize].Clear();
+        for (var row = 0; row < sourceHeight; row++)
+        {
+            source.Slice(row * sourceWidth, sourceWidth)
+                .CopyTo(destination.Slice(row * layout.Pitch, sourceWidth));
+        }
+
+        var sourceChromaOffset = sourceWidth * sourceHeight;
+        var destinationChromaOffset = layout.Pitch * layout.Height;
+        for (var row = 0; row < sourceHeight / 2; row++)
+        {
+            source.Slice(sourceChromaOffset + (row * sourceWidth), sourceWidth)
+                .CopyTo(destination.Slice(
+                    destinationChromaOffset + (row * layout.Pitch),
+                    sourceWidth));
+        }
+        return true;
     }
 
     private static bool AllocateGuestVideoBuffers(CpuContext ctx, PlayerState player, int bufferSize)
@@ -1196,6 +1522,28 @@ public static class AvPlayerExports
             return false;
         }
         value = buffer[0];
+        return true;
+    }
+
+    internal static bool TryReadInitExAutoStart(
+        CpuContext ctx,
+        ulong initDataAddress,
+        out bool autoStart)
+    {
+        // Gen5's InitDataEx places auto_start immediately after debug_level;
+        // Gen4's compact priority/affinity layout places it after the output
+        // framebuffer count. The old shared +0xA4 read was Gen4's framebuffer
+        // count, not either ABI's auto_start field.
+        var offset = (ctx.TargetGeneration & Generation.Gen5) != 0
+            ? Gen5InitExAutoStartOffset
+            : Gen4InitExAutoStartOffset;
+        if (!TryReadByte(ctx, initDataAddress + offset, out var value))
+        {
+            autoStart = false;
+            return false;
+        }
+
+        autoStart = value != 0;
         return true;
     }
 

--- a/src/SharpEmu.Libs/AvPlayer/AvPlayerExports.cs
+++ b/src/SharpEmu.Libs/AvPlayer/AvPlayerExports.cs
@@ -191,8 +191,8 @@ public static class AvPlayerExports
             }
 
             player.UseVideoDecoderSoftware2 = useVideoDecoderSoftware2;
-            Console.Error.WriteLine(
-                $"[AVPLAYER][INFO] post_init handle=0x{handle:X16} " +
+            Trace(
+                $"post_init handle=0x{handle:X16} " +
                 $"video_decoder_type={videoDecoderType} software2={(player.UseVideoDecoderSoftware2 ? 1 : 0)}");
             return SetReturn(ctx, 0);
         }
@@ -890,8 +890,8 @@ public static class AvPlayerExports
                     player.Height,
                     player.UseVideoDecoderSoftware2,
                     extended);
-                Console.Error.WriteLine(
-                    $"[AVPLAYER][INFO] first_video_frame handle=0x{player.Handle:X16} " +
+                Trace(
+                    $"first_video_frame handle=0x{player.Handle:X16} " +
                     $"ex={(extended ? 1 : 0)} ts={timestamp} data=0x{player.LastGuestBuffer:X16} " +
                     $"source={player.Width}x{player.Height} software2={(player.UseVideoDecoderSoftware2 ? 1 : 0)} " +
                     $"pitch={layout.Pitch} " +

--- a/tests/SharpEmu.Libs.Tests/AvPlayer/AvPlayerInitDataTests.cs
+++ b/tests/SharpEmu.Libs.Tests/AvPlayer/AvPlayerInitDataTests.cs
@@ -1,0 +1,121 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.AvPlayer;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.AvPlayer;
+
+public sealed class AvPlayerInitDataTests
+{
+    private const ulong InitDataAddress = 0x1_0000;
+    private const ulong PostInitDataAddress = 0x1_1000;
+
+    [Fact]
+    public void Gen5InitExReadsAutoStartFromGen5Layout()
+    {
+        var memory = new FakeCpuMemory(InitDataAddress, 0x1000);
+        Assert.True(memory.TryWrite(InitDataAddress + 0x74, [1]));
+        Assert.True(memory.TryWrite(InitDataAddress + 0xA4, [0]));
+        Assert.True(memory.TryWrite(InitDataAddress + 0xA8, [0]));
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Assert.True(
+            AvPlayerExports.TryReadInitExAutoStart(
+                context,
+                InitDataAddress,
+                out var autoStart));
+        Assert.True(autoStart);
+
+        Assert.True(memory.TryWrite(InitDataAddress + 0x74, [0]));
+        Assert.True(memory.TryWrite(InitDataAddress + 0xA4, [1]));
+        Assert.True(
+            AvPlayerExports.TryReadInitExAutoStart(
+                context,
+                InitDataAddress,
+                out autoStart));
+        Assert.False(autoStart);
+    }
+
+    [Fact]
+    public void Gen4InitExReadsAutoStartFromGen4Layout()
+    {
+        var memory = new FakeCpuMemory(InitDataAddress, 0x1000);
+        Assert.True(memory.TryWrite(InitDataAddress + 0x74, [0]));
+        Assert.True(memory.TryWrite(InitDataAddress + 0xA4, [1]));
+        Assert.True(memory.TryWrite(InitDataAddress + 0xA8, [1]));
+        var context = new CpuContext(memory, Generation.Gen4);
+
+        Assert.True(
+            AvPlayerExports.TryReadInitExAutoStart(
+                context,
+                InitDataAddress,
+                out var autoStart));
+        Assert.True(autoStart);
+
+        Assert.True(memory.TryWrite(InitDataAddress + 0x74, [1]));
+        Assert.True(memory.TryWrite(InitDataAddress + 0xA8, [0]));
+        Assert.True(
+            AvPlayerExports.TryReadInitExAutoStart(
+                context,
+                InitDataAddress,
+                out autoStart));
+        Assert.False(autoStart);
+    }
+
+    [Fact]
+    public void UnreadableInitExAutoStartIsReportedAsFalse()
+    {
+        var memory = new FakeCpuMemory(InitDataAddress, 0x20);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Assert.False(
+            AvPlayerExports.TryReadInitExAutoStart(
+                context,
+                InitDataAddress,
+                out var autoStart));
+        Assert.False(autoStart);
+    }
+
+    [Fact]
+    public void Gen5PostInitReadsSoftware2FromGen5Layout()
+    {
+        var memory = new FakeCpuMemory(InitDataAddress, 0x2000);
+        WriteUInt32(memory, PostInitDataAddress + 4, 3);
+        WriteUInt32(memory, PostInitDataAddress + 8, 1);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Assert.True(
+            AvPlayerExports.TryReadGen5PostInitVideoDecoder(
+                context,
+                PostInitDataAddress,
+                out var decoderType,
+                out var software2));
+        Assert.Equal(1u, decoderType);
+        Assert.True(software2);
+    }
+
+    [Fact]
+    public void PostInitRejectsUnreadableGenerationSpecificDecoderField()
+    {
+        var memory = new FakeCpuMemory(PostInitDataAddress, 8);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Assert.False(
+            AvPlayerExports.TryReadGen5PostInitVideoDecoder(
+                context,
+                PostInitDataAddress,
+                out var decoderType,
+                out var software2));
+        Assert.Equal(0u, decoderType);
+        Assert.False(software2);
+    }
+
+    private static void WriteUInt32(FakeCpuMemory memory, ulong address, uint value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/AvPlayer/AvPlayerStreamInfoTests.cs
+++ b/tests/SharpEmu.Libs.Tests/AvPlayer/AvPlayerStreamInfoTests.cs
@@ -1,0 +1,231 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.AvPlayer;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.AvPlayer;
+
+public sealed class AvPlayerStreamInfoTests
+{
+    private const ulong InfoAddress = 0x2_0000;
+
+    [Fact]
+    public void Gen5BasicVideoInfoUsesThirtyTwoByteLayoutAndVideoType()
+    {
+        var memory = new FakeCpuMemory(InfoAddress, 32);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Assert.True(
+            AvPlayerExports.TryWriteStreamInfo(
+                context,
+                InfoAddress,
+                streamIndex: 0,
+                width: 1920,
+                height: 1080,
+                framesPerSecond: 30,
+                durationMilliseconds: 16_333,
+                extended: false,
+                out var size));
+        Assert.Equal(32, size);
+
+        var info = Read(memory, size);
+        Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(info));
+        Assert.Equal(1920u, BinaryPrimitives.ReadUInt32LittleEndian(info[8..]));
+        Assert.Equal(1080u, BinaryPrimitives.ReadUInt32LittleEndian(info[12..]));
+        Assert.Equal(16_333ul, BinaryPrimitives.ReadUInt64LittleEndian(info[24..]));
+    }
+
+    [Fact]
+    public void Gen5BasicAudioInfoUsesAudioType()
+    {
+        var memory = new FakeCpuMemory(InfoAddress, 32);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Assert.True(
+            AvPlayerExports.TryWriteStreamInfo(
+                context,
+                InfoAddress,
+                streamIndex: 1,
+                width: 1920,
+                height: 1080,
+                framesPerSecond: 30,
+                durationMilliseconds: 16_333,
+                extended: false,
+                out var size));
+
+        var info = Read(memory, size);
+        Assert.Equal(2u, BinaryPrimitives.ReadUInt32LittleEndian(info));
+        Assert.Equal(2, BinaryPrimitives.ReadUInt16LittleEndian(info[8..]));
+        Assert.Equal(48_000u, BinaryPrimitives.ReadUInt32LittleEndian(info[12..]));
+    }
+
+    [Fact]
+    public void Gen5BasicInfoDoesNotOverwriteTrailingCallerMemory()
+    {
+        var memory = new FakeCpuMemory(InfoAddress, 40);
+        Assert.True(memory.TryWrite(InfoAddress + 32, Enumerable.Repeat((byte)0xA5, 8).ToArray()));
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Assert.True(
+            AvPlayerExports.TryWriteStreamInfo(
+                context,
+                InfoAddress,
+                streamIndex: 0,
+                width: 1920,
+                height: 1080,
+                framesPerSecond: 30,
+                durationMilliseconds: 16_333,
+                extended: false,
+                out var size));
+        Assert.Equal(32, size);
+
+        var bytes = Read(memory, 40);
+        Assert.All(bytes[32..], value => Assert.Equal(0xA5, value));
+    }
+
+    [Fact]
+    public void Gen4BasicInfoRetainsFortyByteLayoutAndTypeValues()
+    {
+        var memory = new FakeCpuMemory(InfoAddress, 40);
+        var context = new CpuContext(memory, Generation.Gen4);
+
+        Assert.True(
+            AvPlayerExports.TryWriteStreamInfo(
+                context,
+                InfoAddress,
+                streamIndex: 0,
+                width: 1920,
+                height: 1080,
+                framesPerSecond: 60,
+                durationMilliseconds: 5_000,
+                extended: false,
+                out var size,
+                useVideoDecoderSoftware2: false));
+        Assert.Equal(40, size);
+
+        var info = Read(memory, size);
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(info));
+        Assert.Equal(1920u, BinaryPrimitives.ReadUInt32LittleEndian(info[8..]));
+        Assert.Equal(1080u, BinaryPrimitives.ReadUInt32LittleEndian(info[12..]));
+        Assert.Equal(5_000ul, BinaryPrimitives.ReadUInt64LittleEndian(info[24..]));
+        Assert.Equal(0ul, BinaryPrimitives.ReadUInt64LittleEndian(info[32..]));
+    }
+
+    [Fact]
+    public void Gen5ExtendedInfoWritesSizeTypeDetailsAndDuration()
+    {
+        var memory = new FakeCpuMemory(InfoAddress, 104);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Assert.True(
+            AvPlayerExports.TryWriteStreamInfo(
+                context,
+                InfoAddress,
+                streamIndex: 0,
+                width: 1920,
+                height: 1080,
+                framesPerSecond: 59.94,
+                durationMilliseconds: 20_000,
+                extended: true,
+                out var size));
+        Assert.Equal(104, size);
+
+        var info = Read(memory, size);
+        Assert.Equal(104ul, BinaryPrimitives.ReadUInt64LittleEndian(info));
+        Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(info[8..]));
+        Assert.Equal(1920u, BinaryPrimitives.ReadUInt32LittleEndian(info[16..]));
+        Assert.Equal(1080u, BinaryPrimitives.ReadUInt32LittleEndian(info[20..]));
+        Assert.Equal(2048u, BinaryPrimitives.ReadUInt32LittleEndian(info[52..]));
+        Assert.Equal(8, info[56]);
+        Assert.Equal(8, info[57]);
+        Assert.Equal(59.94, BinaryPrimitives.ReadDoubleLittleEndian(info[64..]), 3);
+        Assert.Equal(20_000ul, BinaryPrimitives.ReadUInt64LittleEndian(info[96..]));
+    }
+
+    [Fact]
+    public void Gen5ExtendedAudioInfoUsesAudioTypeAndDetails()
+    {
+        var memory = new FakeCpuMemory(InfoAddress, 104);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Assert.True(
+            AvPlayerExports.TryWriteStreamInfo(
+                context,
+                InfoAddress,
+                streamIndex: 1,
+                width: 1920,
+                height: 1080,
+                framesPerSecond: 30,
+                durationMilliseconds: 16_333,
+                extended: true,
+                out var size));
+
+        var info = Read(memory, size);
+        Assert.Equal(104ul, BinaryPrimitives.ReadUInt64LittleEndian(info));
+        Assert.Equal(2u, BinaryPrimitives.ReadUInt32LittleEndian(info[8..]));
+        Assert.Equal(2, BinaryPrimitives.ReadUInt16LittleEndian(info[16..]));
+        Assert.Equal(48_000u, BinaryPrimitives.ReadUInt32LittleEndian(info[20..]));
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(info[24..]));
+        Assert.Equal(16_333ul, BinaryPrimitives.ReadUInt64LittleEndian(info[96..]));
+    }
+
+    [Fact]
+    public void ExtendedStreamInfoExportRegistersForGen5Only()
+    {
+        var gen5Manager = new ModuleManager();
+        gen5Manager.RegisterExports(
+            SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen5));
+        Assert.True(gen5Manager.TryGetExport("ctTAcF5DiKQ", out var export));
+        Assert.Equal("sceAvPlayerGetStreamInfoEx", export.Name);
+        Assert.Equal("libSceAvPlayer", export.LibraryName);
+
+        var gen4Manager = new ModuleManager();
+        gen4Manager.RegisterExports(
+            SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen4));
+        Assert.False(gen4Manager.TryGetExport("ctTAcF5DiKQ", out _));
+    }
+
+    [Fact]
+    public void StreamInfoWritePreservesMemoryFaultAndGenerationValidation()
+    {
+        var shortMemory = new FakeCpuMemory(InfoAddress, 31);
+        var gen5 = new CpuContext(shortMemory, Generation.Gen5);
+        Assert.False(
+            AvPlayerExports.TryWriteStreamInfo(
+                gen5,
+                InfoAddress,
+                streamIndex: 0,
+                width: 1920,
+                height: 1080,
+                framesPerSecond: 30,
+                durationMilliseconds: 1,
+                extended: false,
+                out var size));
+        Assert.Equal(32, size);
+
+        var gen4Memory = new FakeCpuMemory(InfoAddress, 104);
+        var gen4 = new CpuContext(gen4Memory, Generation.Gen4);
+        Assert.False(
+            AvPlayerExports.TryWriteStreamInfo(
+                gen4,
+                InfoAddress,
+                streamIndex: 0,
+                width: 1920,
+                height: 1080,
+                framesPerSecond: 30,
+                durationMilliseconds: 1,
+                extended: true,
+                out size));
+        Assert.Equal(0, size);
+    }
+
+    private static byte[] Read(FakeCpuMemory memory, int size)
+    {
+        var bytes = new byte[size];
+        Assert.True(memory.TryRead(InfoAddress, bytes));
+        return bytes;
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/AvPlayer/AvPlayerVideoFrameLayoutTests.cs
+++ b/tests/SharpEmu.Libs.Tests/AvPlayer/AvPlayerVideoFrameLayoutTests.cs
@@ -1,0 +1,191 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.AvPlayer;
+using System.Buffers.Binary;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.AvPlayer;
+
+public sealed class AvPlayerVideoFrameLayoutTests
+{
+    [Theory]
+    [InlineData(Generation.Gen5, true, false, 1920, 1080, 2048, 0x32A000)]
+    [InlineData(Generation.Gen5, false, true, 1920, 1088, 2048, 0x330000)]
+    [InlineData(Generation.Gen4, false, false, 1920, 1088, 1920, 0x2FD000)]
+    [InlineData(Generation.Gen4, true, true, 1920, 1080, 1920, 0x2FD000)]
+    public void LayoutMatchesGenerationAndDecoderContract(
+        Generation generation,
+        bool software2,
+        bool extended,
+        int expectedWidth,
+        int expectedHeight,
+        int expectedPitch,
+        int expectedSize)
+    {
+        var layout = AvPlayerExports.GetVideoFrameLayout(
+            generation,
+            sourceWidth: 1920,
+            sourceHeight: 1080,
+            useVideoDecoderSoftware2: software2,
+            extended: extended);
+
+        Assert.Equal(expectedWidth, layout.Width);
+        Assert.Equal(expectedHeight, layout.Height);
+        Assert.Equal(expectedPitch, layout.Pitch);
+        Assert.Equal(expectedSize, layout.BufferSize);
+    }
+
+    [Fact]
+    public void Gen5Nv12CopyPadsLumaAndChromaRowsToPitch()
+    {
+        var layout = AvPlayerExports.GetVideoFrameLayout(
+            Generation.Gen5,
+            sourceWidth: 4,
+            sourceHeight: 2,
+            useVideoDecoderSoftware2: true);
+        var source = Enumerable.Range(1, 12).Select(value => (byte)value).ToArray();
+        var destination = Enumerable.Repeat((byte)0xA5, layout.BufferSize).ToArray();
+
+        Assert.True(
+            AvPlayerExports.TryCopyNv12Frame(
+                source,
+                destination,
+                sourceWidth: 4,
+                sourceHeight: 2,
+                layout: layout));
+
+        Assert.Equal(source[0..4], destination[0..4]);
+        Assert.Equal(source[4..8], destination[layout.Pitch..(layout.Pitch + 4)]);
+        var chromaOffset = layout.Pitch * layout.Height;
+        Assert.Equal(source[8..12], destination[chromaOffset..(chromaOffset + 4)]);
+        Assert.All(destination[4..layout.Pitch], value => Assert.Equal(0, value));
+        Assert.All(
+            destination[(layout.Pitch + 4)..chromaOffset],
+            value => Assert.Equal(0, value));
+        Assert.All(
+            destination[(chromaOffset + 4)..layout.BufferSize],
+            value => Assert.Equal(0, value));
+    }
+
+    [Fact]
+    public void DefaultDecoderPlacesChromaAfterAlignedLumaHeight()
+    {
+        var layout = AvPlayerExports.GetVideoFrameLayout(
+            Generation.Gen4,
+            sourceWidth: 4,
+            sourceHeight: 2,
+            useVideoDecoderSoftware2: false);
+        var source = Enumerable.Range(1, 12).Select(value => (byte)value).ToArray();
+        var destination = Enumerable.Repeat((byte)0xA5, layout.BufferSize).ToArray();
+
+        Assert.True(
+            AvPlayerExports.TryCopyNv12Frame(
+                source,
+                destination,
+                sourceWidth: 4,
+                sourceHeight: 2,
+                layout: layout));
+
+        var chromaOffset = layout.Pitch * layout.Height;
+        Assert.Equal(source[8..12], destination[chromaOffset..(chromaOffset + 4)]);
+        Assert.All(
+            destination[(layout.Pitch * 2)..chromaOffset],
+            value => Assert.Equal(0, value));
+    }
+
+    [Fact]
+    public void Gen5ExtendedFrameInfoUsesExactLayoutAndPreservesTrailingMemory()
+    {
+        const ulong infoAddress = 0x2_0000;
+        var memory = new FakeCpuMemory(infoAddress, 112);
+        Assert.True(memory.TryWrite(infoAddress + 104, Enumerable.Repeat((byte)0xA5, 8).ToArray()));
+        var context = new CpuContext(memory, Generation.Gen5);
+        var layout = AvPlayerExports.GetVideoFrameLayout(
+            Generation.Gen5,
+            sourceWidth: 1920,
+            sourceHeight: 1080,
+            useVideoDecoderSoftware2: true);
+
+        Assert.True(
+            AvPlayerExports.TryWriteVideoFrameInfo(
+                context,
+                infoAddress,
+                bufferAddress: 0x1234_5678,
+                timestamp: 42,
+                sourceWidth: 1920,
+                sourceHeight: 1080,
+                layout: layout,
+                framesPerSecond: 29.97,
+                extended: true));
+
+        var info = new byte[112];
+        Assert.True(memory.TryRead(infoAddress, info));
+        Assert.Equal(0x1234_5678ul, BinaryPrimitives.ReadUInt64LittleEndian(info));
+        Assert.Equal(42ul, BinaryPrimitives.ReadUInt64LittleEndian(info[16..]));
+        Assert.Equal(1920u, BinaryPrimitives.ReadUInt32LittleEndian(info[24..]));
+        Assert.Equal(1080u, BinaryPrimitives.ReadUInt32LittleEndian(info[28..]));
+        Assert.Equal(128u, BinaryPrimitives.ReadUInt32LittleEndian(info[48..]));
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(info[56..]));
+        Assert.Equal(2048u, BinaryPrimitives.ReadUInt32LittleEndian(info[60..]));
+        Assert.Equal(8, info[64]);
+        Assert.Equal(8, info[65]);
+        Assert.Equal(29.97, BinaryPrimitives.ReadDoubleLittleEndian(info[72..]), 3);
+        Assert.All(info[104..], value => Assert.Equal(0xA5, value));
+    }
+
+    [Fact]
+    public void Gen4ExtendedFrameInfoPreservesLegacySourceLayout()
+    {
+        const ulong infoAddress = 0x2_0000;
+        var memory = new FakeCpuMemory(infoAddress, 104);
+        var context = new CpuContext(memory, Generation.Gen4);
+        var layout = AvPlayerExports.GetVideoFrameLayout(
+            Generation.Gen4,
+            sourceWidth: 1920,
+            sourceHeight: 1080,
+            useVideoDecoderSoftware2: false,
+            extended: true);
+
+        Assert.True(
+            AvPlayerExports.TryWriteVideoFrameInfo(
+                context,
+                infoAddress,
+                bufferAddress: 0x1234,
+                timestamp: 7,
+                sourceWidth: 1920,
+                sourceHeight: 1080,
+                layout: layout,
+                framesPerSecond: 30,
+                extended: true));
+
+        var info = new byte[104];
+        Assert.True(memory.TryRead(infoAddress, info));
+        Assert.Equal(1920u, BinaryPrimitives.ReadUInt32LittleEndian(info[24..]));
+        Assert.Equal(1080u, BinaryPrimitives.ReadUInt32LittleEndian(info[28..]));
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(info[48..]));
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(info[56..]));
+        Assert.Equal(1920u, BinaryPrimitives.ReadUInt32LittleEndian(info[60..]));
+        Assert.Equal(0d, BinaryPrimitives.ReadDoubleLittleEndian(info[72..]));
+        Assert.Equal(0x2FD000, layout.BufferSize);
+    }
+
+    [Fact]
+    public void Nv12CopyRejectsShortDestination()
+    {
+        var layout = AvPlayerExports.GetVideoFrameLayout(
+            Generation.Gen5,
+            sourceWidth: 4,
+            sourceHeight: 2,
+            useVideoDecoderSoftware2: true);
+
+        Assert.False(
+            AvPlayerExports.TryCopyNv12Frame(
+                new byte[12],
+                new byte[layout.BufferSize - 1],
+                sourceWidth: 4,
+                sourceHeight: 2,
+                layout: layout));
+    }
+}


### PR DESCRIPTION
## Change description

## What changed

Uses generation-specific AvPlayer initialization and stream layouts, reports Gen5 metadata at the correct offsets and widths, and produces Gen5 video frames with the expected plane layout.

## Why

Reusing older-generation structure assumptions caused Gen5 callers to read incorrect stream metadata and video buffers.

## Overlap

PR #316 contains related NV12 work inside a larger rendering change. This PR isolates the complete AvPlayer ABI contract with dedicated coverage and does not depend on the rendering stack.

## Validation

- 22 focused AvPlayer ABI and layout tests passed.
- The full build and test suite passed.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).


