### PR TITLE
[VM] Unify POSIX host memory state

### DIFF
--- a/src/SharpEmu.HLE/Host/Posix/PosixHostMemory.cs
+++ b/src/SharpEmu.HLE/Host/Posix/PosixHostMemory.cs
@@ -24,9 +24,11 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
     private const uint PAGE_NOACCESS = 0x01;
     private const uint PAGE_READONLY = 0x02;
     private const uint PAGE_READWRITE = 0x04;
+    private const uint PAGE_WRITECOPY = 0x08;
     private const uint PAGE_EXECUTE = 0x10;
     private const uint PAGE_EXECUTE_READ = 0x20;
     private const uint PAGE_EXECUTE_READWRITE = 0x40;
+    private const uint PAGE_EXECUTE_WRITECOPY = 0x80;
 
     private const ulong PageSize = 0x1000;
 
@@ -48,6 +50,11 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
             (nuint)size,
             MEM_COMMIT | MEM_RESERVE,
             ToNativeProtection(protection));
+    }
+
+    internal void* AllocateRaw(void* desiredAddress, nuint size, uint allocationType, uint protection)
+    {
+        return Posix.Alloc(desiredAddress, size, allocationType, protection);
     }
 
     public ulong Reserve(ulong desiredAddress, ulong size, HostPageProtection protection)
@@ -145,13 +152,15 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
         _ => throw new ArgumentOutOfRangeException(nameof(protection), protection, null),
     };
 
-    private static HostPageProtection ToHostProtection(uint protection) => protection switch
+    private static HostPageProtection ToHostProtection(uint protection) => (protection & 0xFF) switch
     {
         PAGE_READONLY => HostPageProtection.ReadOnly,
         PAGE_READWRITE => HostPageProtection.ReadWrite,
+        PAGE_WRITECOPY => HostPageProtection.ReadWrite,
         PAGE_EXECUTE => HostPageProtection.Execute,
         PAGE_EXECUTE_READ => HostPageProtection.ReadExecute,
         PAGE_EXECUTE_READWRITE => HostPageProtection.ReadWriteExecute,
+        PAGE_EXECUTE_WRITECOPY => HostPageProtection.ExecuteWriteCopy,
         _ => HostPageProtection.NoAccess,
     };
 
@@ -396,12 +405,39 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
                 if (TryFindRegionLocked(pageAddress, out var region))
                 {
                     // Win32 VirtualQuery reports a run of pages sharing the
-                    // same protection, so stop the run where it changes.
-                    var protect = region.ProtectAt(pageAddress);
-                    var runEnd = pageAddress + PageSize;
-                    while (runEnd < region.End && region.ProtectAt(runEnd) == protect)
+                    // same protection, so stop the run where it changes. Do
+                    // not walk the whole mapping page-by-page here: PS5 GPU
+                    // apertures can span hundreds of GiB, while protection
+                    // overrides are sparse.
+                    var pageProtects = region.PageProtects;
+                    uint protect;
+                    ulong runEnd;
+                    if (pageProtects is null || pageProtects.Count == 0)
                     {
-                        runEnd += PageSize;
+                        protect = region.DefaultProtect;
+                        runEnd = region.End;
+                    }
+                    else if (pageProtects.TryGetValue(pageAddress, out protect))
+                    {
+                        runEnd = pageAddress + PageSize;
+                        while (runEnd < region.End &&
+                            pageProtects.TryGetValue(runEnd, out var nextProtect) &&
+                            nextProtect == protect)
+                        {
+                            runEnd += PageSize;
+                        }
+                    }
+                    else
+                    {
+                        protect = region.DefaultProtect;
+                        runEnd = region.End;
+                        foreach (var overrideAddress in pageProtects.Keys)
+                        {
+                            if (overrideAddress > pageAddress && overrideAddress < runEnd)
+                            {
+                                runEnd = overrideAddress;
+                            }
+                        }
                     }
 
                     info.BaseAddress = pageAddress;
@@ -509,14 +545,16 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
 
         private static int ToPosixProtect(uint win32Protect)
         {
-            return win32Protect switch
+            // Modifier bits such as PAGE_GUARD are retained in the shadow
+            // table for raw Query round-trips but do not change POSIX access.
+            return (win32Protect & 0xFF) switch
             {
                 PAGE_NOACCESS => PROT_NONE,
                 PAGE_READONLY => PROT_READ,
-                PAGE_READWRITE => PROT_READ | PROT_WRITE,
+                PAGE_READWRITE or PAGE_WRITECOPY => PROT_READ | PROT_WRITE,
                 PAGE_EXECUTE => PROT_READ | PROT_EXEC,
                 PAGE_EXECUTE_READ => PROT_READ | PROT_EXEC,
-                PAGE_EXECUTE_READWRITE => PROT_READ | PROT_WRITE | PROT_EXEC,
+                PAGE_EXECUTE_READWRITE or PAGE_EXECUTE_WRITECOPY => PROT_READ | PROT_WRITE | PROT_EXEC,
                 _ => PROT_READ | PROT_WRITE
             };
         }

--- a/src/SharpEmu.HLE/HostMemory.cs
+++ b/src/SharpEmu.HLE/HostMemory.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Runtime.InteropServices;
+using SharpEmu.HLE.Host;
+using SharpEmu.HLE.Host.Posix;
 
 namespace SharpEmu.HLE;
 
@@ -52,7 +54,23 @@ public static unsafe class HostMemory
             return Win32VirtualAlloc(address, size, allocationType, protect);
         }
 
-        return Posix.Alloc(address, size, allocationType, protect);
+        if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            // Native guest execution is x64-only, but architecture-neutral
+            // tests and tooling still use the compatibility facade on ARM64.
+            return Posix.Alloc(address, size, allocationType, protect);
+        }
+
+        if (allocationType is not (MEM_COMMIT or MEM_RESERVE or (MEM_COMMIT | MEM_RESERVE)))
+        {
+            return null;
+        }
+
+        // Keep the Win32-style raw protection word intact for Query callers.
+        // The typed interface intentionally normalizes it, so the compatibility
+        // facade uses the raw entry point on the same process-wide POSIX backend.
+        var memory = (PosixHostMemory)HostPlatform.Current.Memory;
+        return memory.AllocateRaw(address, size, allocationType, protect);
     }
 
     public static bool Free(void* address, nuint size, uint freeType)
@@ -62,7 +80,14 @@ public static unsafe class HostMemory
             return Win32VirtualFree(address, size, freeType);
         }
 
-        return Posix.Free(address, size, freeType);
+        if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            return Posix.Free(address, size, freeType);
+        }
+
+        _ = size;
+        _ = freeType;
+        return HostPlatform.Current.Memory.Free(unchecked((ulong)address));
     }
 
     public static bool Protect(void* address, nuint size, uint newProtect, out uint oldProtect)
@@ -72,7 +97,16 @@ public static unsafe class HostMemory
             return Win32VirtualProtect(address, size, newProtect, out oldProtect);
         }
 
-        return Posix.Protect(address, size, newProtect, out oldProtect);
+        if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            return Posix.Protect(address, size, newProtect, out oldProtect);
+        }
+
+        return HostPlatform.Current.Memory.ProtectRaw(
+            unchecked((ulong)address),
+            (ulong)size,
+            newProtect,
+            out oldProtect);
     }
 
     public static nuint Query(void* address, out BasicInfo info)
@@ -82,7 +116,28 @@ public static unsafe class HostMemory
             return Win32VirtualQuery(address, out info, (nuint)sizeof(BasicInfo));
         }
 
-        return Posix.Query(address, out info);
+        if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            return Posix.Query(address, out info);
+        }
+
+        if (!HostPlatform.Current.Memory.Query(unchecked((ulong)address), out var region))
+        {
+            info = default;
+            return 0;
+        }
+
+        info = new BasicInfo
+        {
+            BaseAddress = region.BaseAddress,
+            AllocationBase = region.AllocationBase,
+            AllocationProtect = region.RawAllocationProtection,
+            RegionSize = region.RegionSize,
+            State = region.RawState,
+            Protect = region.RawProtection,
+            Type = region.State == HostRegionState.Free ? 0 : MEM_PRIVATE,
+        };
+        return (nuint)sizeof(BasicInfo);
     }
 
     public static void FlushInstructionCache(void* address, nuint size)
@@ -93,10 +148,14 @@ public static unsafe class HostMemory
             return;
         }
 
-        // The emulator only executes x86-64 guest code, so a non-Windows host
-        // is either x86-64 (including Rosetta 2 translation) with a coherent
-        // instruction cache, or would need sys_icache_invalidate for a future
-        // arm64 recompiler. Nothing to do today.
+        if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            // The ARM64 process never executes guest code directly. Preserve
+            // the compatibility facade's historical no-op for test/tooling use.
+            return;
+        }
+
+        HostPlatform.Current.Memory.FlushInstructionCache(unchecked((ulong)address), (ulong)size);
     }
 
     [DllImport("kernel32.dll", EntryPoint = "VirtualAlloc", SetLastError = true)]

--- a/tests/SharpEmu.Libs.Tests/Memory/PosixHostMemoryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Memory/PosixHostMemoryTests.cs
@@ -2,19 +2,165 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Runtime.InteropServices;
+using SharpEmu.Core.Memory;
+using SharpEmu.HLE;
 using SharpEmu.HLE.Host;
 using SharpEmu.HLE.Host.Posix;
 using Xunit;
 
 namespace SharpEmu.Libs.Tests.Memory;
 
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class PosixHostMemoryStateCollection
+{
+    public const string Name = "PosixHostMemoryState";
+}
+
+[Collection(PosixHostMemoryStateCollection.Name)]
 public sealed unsafe class PosixHostMemoryTests
 {
     private const int ProtRead = 0x1;
     private const int ProtWrite = 0x2;
     private const int MapPrivate = 0x02;
     private const int MapAnonymousDarwin = 0x1000;
+    private const uint PageExecuteWriteCopy = 0x80;
+    private const uint PageGuard = 0x100;
     private static readonly nint MapFailed = -1;
+
+    [Fact]
+    public void LegacyFacadeAndProcessBackendShareMappings()
+    {
+        if (!SupportsNativePosixBackend())
+        {
+            return;
+        }
+
+        var size = checked((nuint)Environment.SystemPageSize);
+        var backend = HostPlatform.Current.Memory;
+        var facadeAddress = HostMemory.Alloc(
+            null,
+            size,
+            HostMemory.MEM_RESERVE | HostMemory.MEM_COMMIT,
+            HostMemory.PAGE_READWRITE);
+        Assert.NotEqual(0UL, (ulong)facadeAddress);
+
+        var facadeFreed = false;
+        try
+        {
+            Assert.True(backend.Query((ulong)facadeAddress, out var facadeRegion));
+            Assert.Equal(HostRegionState.Committed, facadeRegion.State);
+            Assert.Equal((ulong)facadeAddress, facadeRegion.AllocationBase);
+            Assert.True(backend.Protect(
+                (ulong)facadeAddress,
+                (ulong)size,
+                HostPageProtection.ReadOnly,
+                out var facadeOldProtection));
+            Assert.Equal(HostMemory.PAGE_READWRITE, facadeOldProtection);
+            Assert.True(backend.Free((ulong)facadeAddress));
+            facadeFreed = true;
+        }
+        finally
+        {
+            if (!facadeFreed)
+            {
+                _ = HostMemory.Free(facadeAddress, 0, HostMemory.MEM_RELEASE);
+            }
+        }
+
+        var backendAddress = backend.Allocate(0, (ulong)size, HostPageProtection.ReadWrite);
+        Assert.NotEqual(0UL, backendAddress);
+
+        var backendFreed = false;
+        try
+        {
+            Assert.NotEqual(0U, HostMemory.Query((void*)backendAddress, out var backendRegion));
+            Assert.Equal(backendAddress, backendRegion.AllocationBase);
+            Assert.Equal(HostMemory.MEM_COMMIT, backendRegion.State);
+            Assert.True(HostMemory.Protect(
+                (void*)backendAddress,
+                size,
+                HostMemory.PAGE_READONLY,
+                out var backendOldProtection));
+            Assert.Equal(HostMemory.PAGE_READWRITE, backendOldProtection);
+            Assert.True(HostMemory.Free((void*)backendAddress, 0, HostMemory.MEM_RELEASE));
+            backendFreed = true;
+        }
+        finally
+        {
+            if (!backendFreed)
+            {
+                _ = backend.Free(backendAddress);
+            }
+        }
+    }
+
+    [Fact]
+    public void LegacyFacadePreservesRawAllocationProtection()
+    {
+        if (!SupportsNativePosixBackend())
+        {
+            return;
+        }
+
+        var size = checked((nuint)Environment.SystemPageSize);
+        var rawProtection = PageExecuteWriteCopy | PageGuard;
+        var address = HostMemory.Alloc(
+            null,
+            size,
+            HostMemory.MEM_RESERVE | HostMemory.MEM_COMMIT,
+            rawProtection);
+        Assert.NotEqual(0UL, (ulong)address);
+
+        try
+        {
+            Assert.True(HostPlatform.Current.Memory.Query((ulong)address, out var region));
+            Assert.Equal(HostPageProtection.ExecuteWriteCopy, region.Protection);
+            Assert.Equal(rawProtection, region.RawProtection);
+            Assert.Equal(rawProtection, region.RawAllocationProtection);
+
+            Assert.NotEqual(0U, HostMemory.Query(address, out var facadeInfo));
+            Assert.Equal(rawProtection, facadeInfo.Protect);
+            Assert.Equal(rawProtection, facadeInfo.AllocationProtect);
+        }
+        finally
+        {
+            Assert.True(HostMemory.Free(address, 0, HostMemory.MEM_RELEASE));
+        }
+    }
+
+    [Fact]
+    public void DefaultPhysicalMemoryUsesProcessBackendForExactMappings()
+    {
+        if (!SupportsNativePosixBackend())
+        {
+            return;
+        }
+
+        const int maxAttempts = 16;
+        var size = checked((ulong)Environment.SystemPageSize);
+        var backend = HostPlatform.Current.Memory;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            var candidate = backend.Allocate(0, size, HostPageProtection.ReadWrite);
+            Assert.NotEqual(0UL, candidate);
+            Assert.True(backend.Free(candidate));
+
+            using var memory = new PhysicalVirtualMemory();
+            if (!memory.TryAllocateAtExact(candidate, size, executable: false, out var actualAddress))
+            {
+                continue;
+            }
+
+            Assert.Equal(candidate, actualAddress);
+            Assert.True(backend.Query(candidate, out var region));
+            Assert.Equal(HostRegionState.Committed, region.State);
+            Assert.Equal(candidate, region.AllocationBase);
+            Assert.True(memory.TryWrite(candidate, [0x5A]));
+            return;
+        }
+
+        Assert.Fail($"Could not reclaim any of {maxAttempts} released candidate mappings exactly.");
+    }
 
     [Fact]
     public void ExactAllocationDoesNotReplaceUntrackedDarwinMapping()
@@ -59,4 +205,8 @@ public sealed unsafe class PosixHostMemoryTests
 
     [DllImport("libc", SetLastError = true)]
     private static extern int munmap(nint addr, nuint length);
+
+    private static bool SupportsNativePosixBackend() =>
+        !OperatingSystem.IsWindows() &&
+        RuntimeInformation.ProcessArchitecture == Architecture.X64;
 }


### PR DESCRIPTION
## Change description

## What changed

Gives each POSIX host-memory instance one authoritative region table and routes allocation, protection, lookup, and release through it.

## Why

Region state was split between static and instance-owned collections, allowing different host-memory objects to observe inconsistent ownership and lifecycle data.

## Validation

- 4 focused POSIX host-memory tests passed.
- The full build and test suite passed.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

