### PR TITLE
[ShaderCompiler] Match integer vertex input interfaces

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -8514,7 +8514,32 @@ internal static unsafe class VulkanVideoPresenter
                 (17, 0) => Format.R5G5B5A1UnormPack16,
                 (19, 0) => Format.R4G4B4A4UnormPack16,
                 (34, 7) => Format.E5B9G9R9UfloatPack32,
-                _ => ToVkFloatVertexFormat(componentCount),
+                _ => Gen5VertexInputFormat.ResolveKind(numberFormat) switch
+                {
+                    Gen5VertexInputKind.Uint => ToVkUnsignedVertexFormat(componentCount),
+                    Gen5VertexInputKind.Sint => ToVkSignedVertexFormat(componentCount),
+                    _ => ToVkFloatVertexFormat(componentCount),
+                },
+            };
+
+        private static Format ToVkUnsignedVertexFormat(uint componentCount) =>
+            componentCount switch
+            {
+                1 => Format.R32Uint,
+                2 => Format.R32G32Uint,
+                3 => Format.R32G32B32Uint,
+                4 => Format.R32G32B32A32Uint,
+                _ => Format.R32Uint,
+            };
+
+        private static Format ToVkSignedVertexFormat(uint componentCount) =>
+            componentCount switch
+            {
+                1 => Format.R32Sint,
+                2 => Format.R32G32Sint,
+                3 => Format.R32G32B32Sint,
+                4 => Format.R32G32B32A32Sint,
+                _ => Format.R32Sint,
             };
 
         private static Format ToVkFloatVertexFormat(uint componentCount) =>

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -305,7 +305,8 @@ public static partial class Gen5SpirvTranslator
         private readonly record struct SpirvVertexInput(
             uint Variable,
             uint Type,
-            uint ComponentCount);
+            uint ComponentCount,
+            Gen5VertexInputKind Kind);
 
         private readonly record struct SpirvPixelOutput(
             uint Variable,
@@ -1266,12 +1267,18 @@ public static partial class Gen5SpirvTranslator
         {
             foreach (var input in _evaluation.VertexInputs ?? [])
             {
+                var kind = Gen5VertexInputFormat.ResolveKind(input.NumberFormat);
+                var componentType = kind switch
+                {
+                    Gen5VertexInputKind.Uint => _uintType,
+                    Gen5VertexInputKind.Sint => _intType,
+                    _ => _floatType,
+                };
                 var type = input.ComponentCount switch
                 {
-                    1u => _floatType,
-                    2u => _vec2Type,
-                    3u => _vec3Type,
-                    4u => _vec4Type,
+                    1u => componentType,
+                    >= 2u and <= 4u =>
+                        _module.TypeVector(componentType, input.ComponentCount),
                     _ => 0u,
                 };
                 if (type == 0)
@@ -1293,7 +1300,8 @@ public static partial class Gen5SpirvTranslator
                     new SpirvVertexInput(
                         variable,
                         type,
-                        input.ComponentCount));
+                        input.ComponentCount,
+                        kind));
                 _interfaces.Add(variable);
             }
         }
@@ -3167,16 +3175,25 @@ public static partial class Gen5SpirvTranslator
             }
 
             var loaded = Load(input.Type, input.Variable);
+            var componentType = input.Kind switch
+            {
+                Gen5VertexInputKind.Uint => _uintType,
+                Gen5VertexInputKind.Sint => _intType,
+                _ => _floatType,
+            };
             for (uint component = 0; component < control.DwordCount; component++)
             {
                 var value = input.ComponentCount == 1
                     ? loaded
                     : _module.AddInstruction(
                         SpirvOp.CompositeExtract,
-                        _floatType,
+                        componentType,
                         loaded,
                         component);
-                StoreV(control.VectorData + component, Bitcast(_uintType, value));
+                var raw = input.Kind == Gen5VertexInputKind.Uint
+                    ? value
+                    : Bitcast(_uintType, value);
+                StoreV(control.VectorData + component, raw);
             }
 
             return true;

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderIr.cs
@@ -49,6 +49,24 @@ public enum Gen5PixelOutputKind
     Sint,
 }
 
+public enum Gen5VertexInputKind
+{
+    Float,
+    Uint,
+    Sint,
+}
+
+public static class Gen5VertexInputFormat
+{
+    public static Gen5VertexInputKind ResolveKind(uint numberFormat) =>
+        numberFormat switch
+        {
+            4 => Gen5VertexInputKind.Uint,
+            5 => Gen5VertexInputKind.Sint,
+            _ => Gen5VertexInputKind.Float,
+        };
+}
+
 public readonly record struct Gen5PixelOutputBinding(
     uint GuestSlot,
     uint HostLocation,

--- a/tests/SharpEmu.Libs.Tests/ShaderCompiler/Gen5VertexInputSpirvTests.cs
+++ b/tests/SharpEmu.Libs.Tests/ShaderCompiler/Gen5VertexInputSpirvTests.cs
@@ -1,0 +1,234 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Text;
+using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.ShaderCompiler;
+
+public sealed class Gen5VertexInputSpirvTests
+{
+    [Theory]
+    [InlineData(0u, Gen5VertexInputKind.Float)]
+    [InlineData(1u, Gen5VertexInputKind.Float)]
+    [InlineData(2u, Gen5VertexInputKind.Float)]
+    [InlineData(3u, Gen5VertexInputKind.Float)]
+    [InlineData(4u, Gen5VertexInputKind.Uint)]
+    [InlineData(5u, Gen5VertexInputKind.Sint)]
+    [InlineData(6u, Gen5VertexInputKind.Float)]
+    [InlineData(7u, Gen5VertexInputKind.Float)]
+    [InlineData(9u, Gen5VertexInputKind.Float)]
+    public void NumberFormatResolvesVertexInterfaceKind(
+        uint numberFormat,
+        Gen5VertexInputKind expectedKind)
+    {
+        Assert.Equal(expectedKind, Gen5VertexInputFormat.ResolveKind(numberFormat));
+    }
+
+    [Theory]
+    [InlineData(0u, SpirvOp.TypeFloat, 0u, true)]
+    [InlineData(2u, SpirvOp.TypeFloat, 0u, true)]
+    [InlineData(4u, SpirvOp.TypeInt, 0u, false)]
+    [InlineData(5u, SpirvOp.TypeInt, 1u, true)]
+    [InlineData(7u, SpirvOp.TypeFloat, 0u, true)]
+    [InlineData(9u, SpirvOp.TypeFloat, 0u, true)]
+    public void VertexInterfaceTypeMatchesNumberFormatAndPreservesRawVgprBits(
+        uint numberFormat,
+        SpirvOp expectedScalarType,
+        uint expectedSignedness,
+        bool expectsBitcast)
+    {
+        var program = CreateVertexFetchProgram();
+        var state = new Gen5ShaderState(program, new uint[16], Metadata: null);
+        Gen5VertexInputBinding[] vertexInputs =
+        [
+            new(
+                Pc: 0,
+                Location: 2,
+                ComponentCount: 2,
+                DataFormat: 4,
+                NumberFormat: numberFormat,
+                BaseAddress: 0,
+                Stride: 2 * sizeof(uint),
+                OffsetBytes: 0,
+                Data: new byte[2 * sizeof(uint)],
+                DataLength: 2 * sizeof(uint),
+                DataPooled: false),
+        ];
+        var evaluation = new Gen5ShaderEvaluation(
+            new uint[256],
+            new uint[256],
+            Array.Empty<Gen5ImageBinding>(),
+            Array.Empty<Gen5GlobalMemoryBinding>(),
+            VertexInputs: vertexInputs);
+
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileVertexShader(
+                state,
+                evaluation,
+                out var shader,
+                out var error),
+            error);
+
+        var instructions = ParseInstructions(shader.Spirv);
+        var attributeVariable = FindNamedId(instructions, "attr2");
+        var pointerType = Assert.Single(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.Variable &&
+                instruction.Operands[1] == attributeVariable).Operands[0];
+        var scalarType = ResolveScalarType(instructions, pointerType);
+        Assert.Equal(expectedScalarType, scalarType.Opcode);
+        Assert.Equal(32u, scalarType.Operands[1]);
+        if (expectedScalarType == SpirvOp.TypeInt)
+        {
+            Assert.Equal(expectedSignedness, scalarType.Operands[2]);
+        }
+
+        var attributeLoad = Assert.Single(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.Load &&
+                instruction.Operands[2] == attributeVariable);
+        var loadedId = attributeLoad.Operands[1];
+        var scalarTypeId = scalarType.Operands[0];
+        var extracts = instructions
+            .Where(instruction =>
+                instruction.Opcode == SpirvOp.CompositeExtract &&
+                instruction.Operands[2] == loadedId)
+            .ToArray();
+        Assert.Equal(2, extracts.Length);
+        Assert.All(extracts, extract => Assert.Equal(scalarTypeId, extract.Operands[0]));
+        Assert.All(
+            extracts,
+            extract =>
+                Assert.Equal(
+                    expectsBitcast,
+                    instructions.Any(instruction =>
+                        instruction.Opcode == SpirvOp.Bitcast &&
+                        instruction.Operands[2] == extract.Operands[1])));
+    }
+
+    private static Gen5ShaderProgram CreateVertexFetchProgram() =>
+        new(
+            Address: 0x1000,
+            Instructions:
+            [
+                new Gen5ShaderInstruction(
+                    Pc: 0,
+                    Encoding: Gen5ShaderEncoding.Mubuf,
+                    Opcode: "BufferLoadFormatXy",
+                    Words: [],
+                    Sources: [],
+                    Destinations: [Gen5Operand.Vector(0), Gen5Operand.Vector(1)],
+                    Control: new Gen5BufferMemoryControl(
+                        DwordCount: 2,
+                        VectorAddress: 0,
+                        VectorData: 0,
+                        ScalarResource: 0,
+                        OffsetBytes: 0,
+                        IndexEnabled: false,
+                        OffsetEnabled: false,
+                        Glc: false,
+                        Slc: false)),
+                new Gen5ShaderInstruction(
+                    Pc: 4,
+                    Encoding: Gen5ShaderEncoding.Sopp,
+                    Opcode: "SEndpgm",
+                    Words: [0xBF810000u],
+                    Sources: [],
+                    Destinations: [],
+                    Control: null),
+            ]);
+
+    private static IReadOnlyList<SpirvInstruction> ParseInstructions(byte[] spirv)
+    {
+        Assert.True(spirv.Length >= 5 * sizeof(uint));
+        Assert.Equal(0, spirv.Length % sizeof(uint));
+        var words = new uint[spirv.Length / sizeof(uint)];
+        for (var index = 0; index < words.Length; index++)
+        {
+            words[index] = BinaryPrimitives.ReadUInt32LittleEndian(
+                spirv.AsSpan(index * sizeof(uint), sizeof(uint)));
+        }
+
+        var instructions = new List<SpirvInstruction>();
+        for (var index = 5; index < words.Length;)
+        {
+            var wordCount = checked((int)(words[index] >> 16));
+            Assert.True(wordCount > 0);
+            Assert.True(index + wordCount <= words.Length);
+            var opcode = (SpirvOp)(words[index] & 0xFFFF);
+            instructions.Add(
+                new SpirvInstruction(
+                    opcode,
+                    words.AsSpan(index + 1, wordCount - 1).ToArray()));
+            index += wordCount;
+        }
+
+        return instructions;
+    }
+
+    private static uint FindNamedId(
+        IReadOnlyList<SpirvInstruction> instructions,
+        string name) =>
+        Assert.Single(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.Name &&
+                DecodeString(instruction.Operands.AsSpan(1)) == name).Operands[0];
+
+    private static SpirvInstruction ResolveScalarType(
+        IReadOnlyList<SpirvInstruction> instructions,
+        uint pointerType)
+    {
+        var pointer = Assert.Single(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.TypePointer &&
+                instruction.Operands[0] == pointerType);
+        var pointeeType = pointer.Operands[2];
+        var pointee = Assert.Single(
+            instructions,
+            instruction =>
+                instruction.Operands.Length > 0 &&
+                instruction.Operands[0] == pointeeType &&
+                instruction.Opcode is SpirvOp.TypeInt or SpirvOp.TypeFloat or SpirvOp.TypeVector);
+        if (pointee.Opcode != SpirvOp.TypeVector)
+        {
+            return pointee;
+        }
+
+        var componentType = pointee.Operands[1];
+        return Assert.Single(
+            instructions,
+            instruction =>
+                instruction.Operands.Length > 0 &&
+                instruction.Operands[0] == componentType &&
+                instruction.Opcode is SpirvOp.TypeInt or SpirvOp.TypeFloat);
+    }
+
+    private static string DecodeString(ReadOnlySpan<uint> words)
+    {
+        var bytes = new byte[words.Length * sizeof(uint)];
+        for (var index = 0; index < words.Length; index++)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                bytes.AsSpan(index * sizeof(uint), sizeof(uint)),
+                words[index]);
+        }
+
+        var terminator = Array.IndexOf(bytes, (byte)0);
+        return Encoding.UTF8.GetString(
+            bytes,
+            0,
+            terminator >= 0 ? terminator : bytes.Length);
+    }
+
+    private sealed record SpirvInstruction(
+        SpirvOp Opcode,
+        uint[] Operands);
+}


### PR DESCRIPTION
## Change description

## What changed

Preserves signed and unsigned integer vertex attribute types in shader IR, emits matching SPIR-V inputs, and selects compatible Vulkan vertex formats.

## Why

Integer guest attributes were declared as floating-point shader inputs, creating a pipeline/interface type mismatch.

## Overlap

PR #316 includes related renderer/compiler changes in a much larger bundle. This PR isolates integer vertex-interface agreement with dedicated tests.

## Validation

- 15 focused vertex-input interface tests passed.
- The full build and test suite passed.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

