### PR TITLE
[AudioOut2] Fix output buffer widths

### DIFF
--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -120,8 +120,8 @@ public static class AudioOut2Exports
         }
 
         // The second argument is a pointer to one uint64_t, not a larger memory-info
-        // structure. Writing past these eight bytes corrupts callers that keep the
-        // output in a stack slot (including GTA V's saved stack canary).
+        // structure. Writing past these eight bytes can corrupt adjacent caller state
+        // when the output occupies a tightly packed stack slot.
         return ctx.TryWriteUInt64(outMemorySizeAddress, AudioOut2ContextMemorySize)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
@@ -245,8 +245,8 @@ public static class AudioOut2Exports
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        // Both outputs are uint32_t values. GTA V places the level output four
-        // bytes before its stack canary, so an eight-byte write corrupts it.
+        // Both outputs are uint32_t values. Writing eight bytes to the level output
+        // can corrupt adjacent caller state.
         if (outQueueLevelAddress != 0 && !ctx.TryWriteUInt32(outQueueLevelAddress, 0))
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);

--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -17,6 +17,7 @@ public static class AudioOut2Exports
     private const int AudioOut2ContextParamSize = 0x40;
     private const int AudioOut2ContextMemorySize = 0x10000;
     private const int AudioOut2ContextMemoryAlignment = 0x10000;
+    private const uint SpeakerArrayMemorySize = 0x10000;
     private static long _nextContextHandle = 1;
     private static long _nextUserHandle = 1;
     private static int _nextPortId;
@@ -112,20 +113,16 @@ public static class AudioOut2Exports
     public static int AudioOut2ContextQueryMemory(CpuContext ctx)
     {
         var paramAddress = ctx[CpuRegister.Rdi];
-        var memoryInfoAddress = ctx[CpuRegister.Rsi];
-        if (paramAddress == 0 || memoryInfoAddress == 0)
+        var outMemorySizeAddress = ctx[CpuRegister.Rsi];
+        if (paramAddress == 0 || outMemorySizeAddress == 0)
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        Span<byte> memoryInfo = stackalloc byte[0x20];
-        memoryInfo.Clear();
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x00..], AudioOut2ContextMemorySize);
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x08..], AudioOut2ContextMemoryAlignment);
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x10..], AudioOut2ContextMemorySize);
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x18..], AudioOut2ContextMemoryAlignment);
-
-        return ctx.Memory.TryWrite(memoryInfoAddress, memoryInfo)
+        // The second argument is a pointer to one uint64_t, not a larger memory-info
+        // structure. Writing past these eight bytes corrupts callers that keep the
+        // output in a stack slot (including GTA V's saved stack canary).
+        return ctx.TryWriteUInt64(outMemorySizeAddress, AudioOut2ContextMemorySize)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
     }
@@ -240,11 +237,26 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2ContextGetQueueLevel(CpuContext ctx)
     {
-        // The advance path paces synchronously, so the queue is always drained.
-        var levelAddress = ctx[CpuRegister.Rsi];
-        if (levelAddress != 0)
+        var handle = ctx[CpuRegister.Rdi];
+        var outQueueLevelAddress = ctx[CpuRegister.Rsi];
+        var outQueueAvailableAddress = ctx[CpuRegister.Rdx];
+        if (handle == 0)
         {
-            _ = TryWriteUInt64(ctx, levelAddress, 0);
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        // Both outputs are uint32_t values. GTA V places the level output four
+        // bytes before its stack canary, so an eight-byte write corrupts it.
+        if (outQueueLevelAddress != 0 && !ctx.TryWriteUInt32(outQueueLevelAddress, 0))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        // Nothing is queued to real hardware: report an empty queue with room
+        // available so submitters keep flowing.
+        if (outQueueAvailableAddress != 0 && !ctx.TryWriteUInt32(outQueueAvailableAddress, 4))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
         return SetReturn(ctx, 0);

--- a/tests/SharpEmu.Libs.Tests/Audio/AudioOut2ExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Audio/AudioOut2ExportsTests.cs
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Audio;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Audio;
+
+public sealed class AudioOut2ExportsTests
+{
+    private const ulong Base = 0x1_0000_0000;
+    private const ulong ParamAddress = Base + 0x100;
+    private const ulong OutMemorySizeAddress = Base + 0x200;
+    private const ulong OutQueueLevelAddress = Base + 0x300;
+    private const ulong OutQueueAvailableAddress = Base + 0x400;
+
+    private readonly FakeCpuMemory _memory = new(Base, 0x1000);
+    private readonly CpuContext _ctx;
+
+    public AudioOut2ExportsTests()
+    {
+        _ctx = new CpuContext(_memory, Generation.Gen5);
+    }
+
+    [Fact]
+    public void ContextQueryMemory_WritesOnlyEightByteSizeOutput()
+    {
+        Span<byte> canary = stackalloc byte[24];
+        canary.Fill(0xA5);
+        Assert.True(_memory.TryWrite(OutMemorySizeAddress + 8, canary));
+
+        _ctx[CpuRegister.Rdi] = ParamAddress;
+        _ctx[CpuRegister.Rsi] = OutMemorySizeAddress;
+
+        Assert.Equal(0, AudioOut2Exports.AudioOut2ContextQueryMemory(_ctx));
+        Assert.True(_ctx.TryReadUInt64(OutMemorySizeAddress, out var memorySize));
+        Assert.Equal(0x10000UL, memorySize);
+
+        Span<byte> canaryAfterCall = stackalloc byte[24];
+        Assert.True(_memory.TryRead(OutMemorySizeAddress + 8, canaryAfterCall));
+        Assert.True(canary.SequenceEqual(canaryAfterCall));
+    }
+
+    [Fact]
+    public void ContextGetQueueLevel_WritesTwoFourByteOutputsWithoutTouchingCanary()
+    {
+        const ulong canary = 0xC0DE_C0DE_CAFE_BA00;
+        Assert.True(_ctx.TryWriteUInt64(OutQueueLevelAddress + 4, canary));
+
+        _ctx[CpuRegister.Rdi] = 1;
+        _ctx[CpuRegister.Rsi] = OutQueueLevelAddress;
+        _ctx[CpuRegister.Rdx] = OutQueueAvailableAddress;
+
+        Assert.Equal(0, AudioOut2Exports.AudioOut2ContextGetQueueLevel(_ctx));
+        Assert.True(_ctx.TryReadUInt32(OutQueueLevelAddress, out var queueLevel));
+        Assert.True(_ctx.TryReadUInt32(OutQueueAvailableAddress, out var queueAvailable));
+        Assert.True(_ctx.TryReadUInt64(OutQueueLevelAddress + 4, out var canaryAfterCall));
+        Assert.Equal(0U, queueLevel);
+        Assert.Equal(4U, queueAvailable);
+        Assert.Equal(canary, canaryAfterCall);
+    }
+}


### PR DESCRIPTION
## Change description

## What changed

Writes the AudioOut2 context size as one 64-bit value and queue level/availability as two 32-bit values. Boundary tests verify that adjacent guest memory is untouched.

## Why

The previous wider writes could corrupt caller state when outputs were placed in tightly packed stack slots.

## Overlap

This is the tested, AudioOut2-only extraction of the width fixes in PR #195. PR #366 adds separate speaker-array exports and is complementary.

## Validation

- 2 focused AudioOut2 boundary tests passed.
- The full build and test suite passed.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).


