### PR TITLE
[SaveData] Preserve mounted save and transaction contracts

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -214,6 +214,22 @@ public static partial class KernelMemoryCompatExports
         }
     }
 
+    public static bool UnregisterGuestPathMount(string guestMountPoint)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(guestMountPoint);
+
+        var normalizedMountPoint = NormalizeGuestStatCachePath(guestMountPoint);
+        if (normalizedMountPoint is null || normalizedMountPoint == "/")
+        {
+            throw new ArgumentException("Guest mount point must name a directory.", nameof(guestMountPoint));
+        }
+
+        lock (_guestMountGate)
+        {
+            return _guestMounts.Remove(normalizedMountPoint);
+        }
+    }
+
     internal static bool TryAllocateHleData(
         CpuContext ctx,
         ulong length,

--- a/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
@@ -12,13 +12,21 @@ namespace SharpEmu.Libs.SaveData;
 public static class SaveDataExports
 {
     private const int OrbisSaveDataErrorParameter = unchecked((int)0x809F0000);
+    private const int OrbisSaveDataErrorBusy = unchecked((int)0x809F0003);
+    private const int OrbisSaveDataErrorNotMounted = unchecked((int)0x809F0004);
     private const int OrbisSaveDataErrorExists = unchecked((int)0x809F0007);
     private const int OrbisSaveDataErrorNotFound = unchecked((int)0x809F0008);
     private const int OrbisSaveDataErrorInternal = unchecked((int)0x809F000B);
     private const int OrbisSaveDataErrorMemoryNotReady = unchecked((int)0x809F0012);
+    private const int OrbisSaveDataErrorMountFull = unchecked((int)0x809F000C);
     private const int SaveDataTitleIdSize = 10;
     private const int SaveDataDirNameSize = 32;
     private const int SaveDataParamSize = 0x530;
+    private const int SaveDataParamTitleOffset = 0x00;
+    private const int SaveDataParamSubTitleOffset = 0x80;
+    private const int SaveDataParamDetailOffset = 0x100;
+    private const int SaveDataParamUserParamOffset = 0x500;
+    private const int SaveDataParamMtimeOffset = 0x508;
     private const int SaveDataSearchInfoSize = 0x30;
     private const ulong ResultHitNumOffset = 0x00;
     private const ulong ResultDirNamesOffset = 0x08;
@@ -33,17 +41,29 @@ public static class SaveDataExports
     private const int MountResultSize = 0x40;
     // Emulator guard against corrupt or misread sizes, not a platform limit.
     private const ulong SaveDataMemoryMaxSize = 64UL * 1024 * 1024;
+    private const int MaxMountPoints = 16;
     private static readonly object _stateGate = new();
     private static readonly object _memoryGate = new();
-    private static readonly HashSet<int> _preparedTransactionResources = [];
+    private static readonly Dictionary<int, string> _preparedTransactionResources = [];
+    private static readonly Dictionary<string, string> _mountedSavePaths = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly StringComparison _hostPathComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
     private static string? _titleId;
 
     public static void ConfigureApplicationInfo(string? titleId)
     {
         lock (_stateGate)
         {
+            foreach (var mountPoint in _mountedSavePaths.Keys)
+            {
+                KernelMemoryCompatExports.UnregisterGuestPathMount(mountPoint);
+            }
+
             _titleId = string.IsNullOrWhiteSpace(titleId) ? null : SanitizePathSegment(titleId.Trim());
             _preparedTransactionResources.Clear();
+            _mountedSavePaths.Clear();
+            _nextTransactionResource = 0;
         }
     }
 
@@ -181,8 +201,7 @@ public static class SaveDataExports
             !ctx.TryReadUInt64(mountAddress + 0x10, out var blocks) ||
             !ctx.TryReadUInt64(mountAddress + 0x18, out var systemBlocks) ||
             !TryReadUInt32(ctx, mountAddress + 0x20, out var mountMode) ||
-            !TryReadUInt32(ctx, mountAddress + 0x24, out var resource) ||
-            !TryReadUInt32(ctx, mountAddress + 0x28, out var mode) ||
+            !TryReadInt32(ctx, mountAddress + 0x28, out var resource) ||
             dirNameAddress == 0 ||
             !TryReadFixedAscii(ctx, dirNameAddress, SaveDataDirNameSize, out var dirName))
         {
@@ -196,46 +215,80 @@ public static class SaveDataExports
 
         try
         {
-            var titleId = ResolveConfiguredTitleId();
-            var savePath = Path.Combine(
-                ResolveTitleSaveRoot(userId, titleId),
-                SanitizePathSegment(dirName));
-            var existed = Directory.Exists(savePath);
-            var create = (mountMode & MountModeCreate) != 0;
-            var createIfMissing = (mountMode & MountModeCreate2) != 0;
-
-            if (!existed && !create && !createIfMissing)
+            lock (_stateGate)
             {
-                return SetReturn(ctx, OrbisSaveDataErrorNotFound);
+                var titleId = ResolveConfiguredTitleId();
+                if (!TryResolveSavePath(userId, titleId, dirName, out var savePath))
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorParameter);
+                }
+
+                if (_mountedSavePaths.Values.Any(
+                        mountedPath => string.Equals(mountedPath, savePath, _hostPathComparison)))
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorBusy);
+                }
+
+                string? mountPoint = null;
+                for (var index = 0; index < MaxMountPoints; index++)
+                {
+                    var candidate = $"/savedata{index}";
+                    if (!_mountedSavePaths.ContainsKey(candidate))
+                    {
+                        mountPoint = candidate;
+                        break;
+                    }
+                }
+
+                if (mountPoint is null)
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorMountFull);
+                }
+
+                var existed = Directory.Exists(savePath);
+                var create = (mountMode & MountModeCreate) != 0;
+                var createIfMissing = (mountMode & MountModeCreate2) != 0;
+
+                if (!existed && !create && !createIfMissing)
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorNotFound);
+                }
+
+                if (existed && create)
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorExists);
+                }
+
+                var created = false;
+                if (!existed)
+                {
+                    Directory.CreateDirectory(savePath);
+                    created = true;
+                }
+
+                Span<byte> result = stackalloc byte[MountResultSize];
+                result.Clear();
+                WriteAscii(result[..16], mountPoint);
+                BinaryPrimitives.WriteUInt32LittleEndian(result[0x1C..], created ? 1u : 0u);
+                if (!ctx.Memory.TryWrite(resultAddress, result))
+                {
+                    if (created)
+                    {
+                        Directory.Delete(savePath, recursive: true);
+                    }
+
+                    return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+                }
+
+                KernelMemoryCompatExports.RegisterGuestPathMount(mountPoint, savePath);
+                _mountedSavePaths[mountPoint] = savePath;
+
+                TraceSaveData(
+                    $"mount3 user={userId} title={titleId} dir={dirName} blocks={blocks} " +
+                    $"system_blocks={systemBlocks} mount_mode=0x{mountMode:X} resource={resource} " +
+                    $"mount_point={mountPoint} created={!existed} root='{savePath}'");
+                return SetReturn(ctx, 0);
             }
-
-            if (existed && create)
-            {
-                return SetReturn(ctx, OrbisSaveDataErrorExists);
-            }
-
-            if (!existed)
-            {
-                Directory.CreateDirectory(savePath);
-            }
-
-            const string mountPoint = "/savedata0";
-            KernelMemoryCompatExports.RegisterGuestPathMount(mountPoint, savePath);
-
-            Span<byte> result = stackalloc byte[MountResultSize];
-            result.Clear();
-            WriteAscii(result[..16], mountPoint);
-            BinaryPrimitives.WriteUInt32LittleEndian(result[0x1C..], createIfMissing && !existed ? 1u : 0u);
-            if (!ctx.Memory.TryWrite(resultAddress, result))
-            {
-                return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
-            }
-
-            TraceSaveData(
-                $"mount3 user={userId} title={titleId} dir={dirName} blocks={blocks} " +
-                $"system_blocks={systemBlocks} mount_mode=0x{mountMode:X} resource={resource} mode={mode} " +
-                $"mount_point={mountPoint} created={!existed} root='{savePath}'");
-            return SetReturn(ctx, 0);
         }
         catch (IOException)
         {
@@ -251,6 +304,116 @@ public static class SaveDataExports
         }
     }
 
+    [SysAbiExport(
+        Nid = "85zul--eGXs",
+        ExportName = "sceSaveDataSetParam",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceSaveData")]
+    public static int SaveDataSetParam(CpuContext ctx)
+    {
+        var mountPointAddress = ctx[CpuRegister.Rdi];
+        var paramType = unchecked((uint)ctx[CpuRegister.Rsi]);
+        var paramAddress = ctx[CpuRegister.Rdx];
+        var paramSize = ctx[CpuRegister.Rcx];
+        if (mountPointAddress == 0 || paramAddress == 0 || paramType > 4)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+
+        if (!TryReadFixedAscii(ctx, mountPointAddress, 16, out var mountPoint))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        var fieldCapacity = paramType switch
+        {
+            0 => SaveDataParamSize,
+            1 or 2 => 128,
+            3 => 1024,
+            4 => sizeof(uint),
+            _ => 0,
+        };
+        var inputSize = paramType is 1 or 2 or 3
+            ? checked((int)Math.Min(paramSize, (ulong)fieldCapacity))
+            : fieldCapacity;
+        if (inputSize == 0 ||
+            (paramType is 0 or 4 && paramSize < (ulong)fieldCapacity))
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+
+        try
+        {
+            lock (_stateGate)
+            {
+                if (!_mountedSavePaths.TryGetValue(mountPoint, out var savePath))
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorNotMounted);
+                }
+
+                var input = new byte[inputSize];
+                if (!ctx.Memory.TryRead(paramAddress, input))
+                {
+                    return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+                }
+
+                if (paramType is 1 or 2 or 3 && !input.Contains((byte)0))
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorParameter);
+                }
+
+                var loadStatus = TryLoadSavedParam(savePath, out var param);
+                if (loadStatus is SavedParamLoadStatus.Invalid or SavedParamLoadStatus.Error)
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorInternal);
+                }
+
+                param ??= CreateDefaultParam(savePath);
+                switch (paramType)
+                {
+                    case 0:
+                        input.AsSpan(SaveDataParamTitleOffset, 128)
+                            .CopyTo(param.AsSpan(SaveDataParamTitleOffset, 128));
+                        input.AsSpan(SaveDataParamSubTitleOffset, 128)
+                            .CopyTo(param.AsSpan(SaveDataParamSubTitleOffset, 128));
+                        input.AsSpan(SaveDataParamDetailOffset, 1024)
+                            .CopyTo(param.AsSpan(SaveDataParamDetailOffset, 1024));
+                        input.AsSpan(SaveDataParamUserParamOffset, sizeof(uint))
+                            .CopyTo(param.AsSpan(SaveDataParamUserParamOffset, sizeof(uint)));
+                        param.AsSpan(0x504, sizeof(uint)).Clear();
+                        param.AsSpan(0x510).Clear();
+                        break;
+                    case 1:
+                        ReplaceParamField(param, SaveDataParamTitleOffset, 128, input);
+                        break;
+                    case 2:
+                        ReplaceParamField(param, SaveDataParamSubTitleOffset, 128, input);
+                        break;
+                    case 3:
+                        ReplaceParamField(param, SaveDataParamDetailOffset, 1024, input);
+                        break;
+                    case 4:
+                        input.CopyTo(param, SaveDataParamUserParamOffset);
+                        break;
+                }
+
+                SetSavedParamMtime(param, DateTime.UtcNow);
+                WriteSavedParam(savePath, param);
+                TraceSaveData(
+                    $"set_param mount_point={mountPoint} type={paramType} size={inputSize} root='{savePath}'");
+                return SetReturn(ctx, 0);
+            }
+        }
+        catch (IOException)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorInternal);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorInternal);
+        }
+    }
+
     private static int _nextTransactionResource;
     [SysAbiExport(
         Nid = "gjRZNnw0JPE",
@@ -259,39 +422,17 @@ public static class SaveDataExports
         LibraryName = "libSceSaveData")]
     public static int SaveDataCreateTransactionResource(CpuContext ctx)
     {
-        var userId = unchecked((int)ctx[CpuRegister.Rdi]);
-        var reserved = ctx[CpuRegister.Rsi];
-
-        var id = (uint)Interlocked.Increment(ref _nextTransactionResource);
-
-        // The resource-out pointer's argument slot varies by SDK revision: some
-        // callers pass it in rdx, others in rcx (a 4-arg form where rdx holds a
-        // count/flag). Void Terrarium passes rdx=0x1 (not a pointer) and the
-        // real out-pointer in rcx. Probe the plausible candidates and write the
-        // handle to the first writable one instead of faulting on a bad rdx.
-        // This is a stub-level create (matches shadPS4's return-OK semantics);
-        // never return MEMORY_FAULT for it, or the guest treats savedata init as
-        // failed and never advances.
-        var resourceAddress = 0UL;
-        foreach (var candidate in new[]
-                 {
-                     ctx[CpuRegister.Rdx],
-                     ctx[CpuRegister.Rcx],
-                     ctx[CpuRegister.R8],
-                     ctx[CpuRegister.R9],
-                 })
+        var memorySize = ctx[CpuRegister.Rdi];
+        int resource;
+        lock (_stateGate)
         {
-            if (candidate != 0 && TryWriteUInt32(ctx, candidate, id))
-            {
-                resourceAddress = candidate;
-                break;
-            }
+            resource = ++_nextTransactionResource;
         }
 
         TraceSaveData(
-            $"create_transaction_resource user={userId} reserved=0x{reserved:X} resource_addr=0x{resourceAddress:X} id={id}");
+            $"create_transaction_resource memory_size=0x{memorySize:X} resource={resource}");
 
-        return SetReturn(ctx, 0);
+        return SetReturn(ctx, resource);
     }
 
     [SysAbiExport(
@@ -318,10 +459,62 @@ public static class SaveDataExports
         LibraryName = "libSceSaveData")]
     public static int SaveDataUmount2(CpuContext ctx)
     {
-        // Unmounting a save directory always succeeds in the stub filesystem;
-        // returning an error here makes the game's save flow stall before it
-        // hands control to the title/gameplay state.
-        TraceSaveData($"umount2 user={unchecked((int)ctx[CpuRegister.Rdi])}");
+        var mode = unchecked((uint)ctx[CpuRegister.Rdi]);
+        // Async backup completion events are not modeled by this focused
+        // persistence layer; retain the mode for diagnostics without guessing
+        // an event-queue contract.
+        var mountPointAddress = ctx[CpuRegister.Rsi];
+        if (mountPointAddress == 0)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+
+        if (!TryReadFixedAscii(ctx, mountPointAddress, 16, out var mountPoint))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        if (string.IsNullOrWhiteSpace(mountPoint))
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+
+        try
+        {
+            lock (_stateGate)
+            {
+                if (!_mountedSavePaths.TryGetValue(mountPoint, out var savePath))
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorNotMounted);
+                }
+
+                if (!TryRefreshSavedParamMtime(savePath))
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorInternal);
+                }
+
+                var preparedResources = _preparedTransactionResources
+                    .Where(entry => string.Equals(entry.Value, savePath, _hostPathComparison))
+                    .Select(entry => entry.Key)
+                    .ToArray();
+                foreach (var resource in preparedResources)
+                {
+                    _preparedTransactionResources.Remove(resource);
+                }
+                _mountedSavePaths.Remove(mountPoint);
+                KernelMemoryCompatExports.UnregisterGuestPathMount(mountPoint);
+            }
+        }
+        catch (IOException)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorInternal);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorInternal);
+        }
+
+        TraceSaveData($"umount2 mode=0x{mode:X} mount_point={mountPoint}");
         return SetReturn(ctx, 0);
     }
 
@@ -380,7 +573,7 @@ public static class SaveDataExports
             }
 
             var info = new DirectoryInfo(directory);
-            entries.Add(new SaveEntry(name, directory, info.LastWriteTimeUtc));
+            entries.Add(new SaveEntry(name, directory, ResolveSaveMtimeUtc(directory, info.LastWriteTimeUtc)));
         }
 
         return entries;
@@ -390,6 +583,7 @@ public static class SaveDataExports
     {
         IOrderedEnumerable<SaveEntry> sorted = sortKey switch
         {
+            1 => entries.OrderBy(entry => ResolveSaveUserParam(entry.Path)),
             3 => entries.OrderBy(entry => entry.LastWriteUtc),
             _ => entries.OrderBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase),
         };
@@ -405,13 +599,147 @@ public static class SaveDataExports
 
     private static bool TryWriteParam(CpuContext ctx, ulong address, SaveEntry entry)
     {
-        var param = new byte[SaveDataParamSize];
-        WriteAscii(param.AsSpan(0x00, 128), "Saved Data");
-        WriteAscii(param.AsSpan(0x100, 1024), entry.Name);
-        BinaryPrimitives.WriteInt64LittleEndian(
-            param.AsSpan(0x508, sizeof(long)),
-            new DateTimeOffset(entry.LastWriteUtc).ToUnixTimeSeconds());
+        var param = LoadSavedParam(entry.Path);
+        if (param is null)
+        {
+            param = CreateDefaultParam(entry.Path);
+            SetSavedParamMtime(param, entry.LastWriteUtc);
+        }
+
         return ctx.Memory.TryWrite(address, param);
+    }
+
+    private static byte[]? LoadSavedParam(string savePath)
+    {
+        return TryLoadSavedParam(savePath, out var param) == SavedParamLoadStatus.Loaded
+            ? param
+            : null;
+    }
+
+    private static SavedParamLoadStatus TryLoadSavedParam(string savePath, out byte[]? param)
+    {
+        param = null;
+        var metadataPath = ResolveParamMetadataPath(savePath);
+        if (!File.Exists(metadataPath))
+        {
+            return SavedParamLoadStatus.Missing;
+        }
+
+        try
+        {
+            var loaded = File.ReadAllBytes(metadataPath);
+            if (loaded.Length != SaveDataParamSize)
+            {
+                return SavedParamLoadStatus.Invalid;
+            }
+
+            param = loaded;
+            return SavedParamLoadStatus.Loaded;
+        }
+        catch (IOException)
+        {
+            return SavedParamLoadStatus.Error;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return SavedParamLoadStatus.Error;
+        }
+    }
+
+    private static byte[] CreateDefaultParam(string savePath)
+    {
+        var param = new byte[SaveDataParamSize];
+        WriteAscii(param.AsSpan(SaveDataParamTitleOffset, 128), "Saved Data");
+        var mtime = Directory.Exists(savePath)
+            ? Directory.GetLastWriteTimeUtc(savePath)
+            : DateTime.UtcNow;
+        BinaryPrimitives.WriteInt64LittleEndian(
+            param.AsSpan(SaveDataParamMtimeOffset, sizeof(long)),
+            new DateTimeOffset(mtime).ToUnixTimeSeconds());
+        return param;
+    }
+
+    private static string ResolveParamMetadataPath(string savePath)
+    {
+        var titleRoot = Directory.GetParent(savePath)?.FullName ?? ResolveSaveDataRoot();
+        var dirName = Path.GetFileName(Path.TrimEndingDirectorySeparator(savePath));
+        return Path.Combine(titleRoot, "sce_params", $"{dirName}.bin");
+    }
+
+    private static void WriteSavedParam(string savePath, byte[] param)
+    {
+        var metadataPath = ResolveParamMetadataPath(savePath);
+        var metadataRoot = Path.GetDirectoryName(metadataPath)!;
+        Directory.CreateDirectory(metadataRoot);
+        var temporaryPath = Path.Combine(
+            metadataRoot,
+            $".{Path.GetFileName(metadataPath)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            File.WriteAllBytes(temporaryPath, param);
+            File.Move(temporaryPath, metadataPath, overwrite: true);
+        }
+        finally
+        {
+            File.Delete(temporaryPath);
+        }
+    }
+
+    private static bool TryRefreshSavedParamMtime(string savePath)
+    {
+        var loadStatus = TryLoadSavedParam(savePath, out var param);
+        if (loadStatus is SavedParamLoadStatus.Invalid or SavedParamLoadStatus.Error)
+        {
+            return false;
+        }
+
+        param ??= CreateDefaultParam(savePath);
+        SetSavedParamMtime(param, DateTime.UtcNow);
+        WriteSavedParam(savePath, param);
+        return true;
+    }
+
+    private static void SetSavedParamMtime(byte[] param, DateTime mtimeUtc)
+    {
+        BinaryPrimitives.WriteInt64LittleEndian(
+            param.AsSpan(SaveDataParamMtimeOffset, sizeof(long)),
+            new DateTimeOffset(mtimeUtc).ToUnixTimeSeconds());
+    }
+
+    private static DateTime ResolveSaveMtimeUtc(string savePath, DateTime fallback)
+    {
+        var param = LoadSavedParam(savePath);
+        if (param is null)
+        {
+            return fallback;
+        }
+
+        var seconds = BinaryPrimitives.ReadInt64LittleEndian(
+            param.AsSpan(SaveDataParamMtimeOffset, sizeof(long)));
+        try
+        {
+            return DateTimeOffset.FromUnixTimeSeconds(seconds).UtcDateTime;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return fallback;
+        }
+    }
+
+    private static int ResolveSaveUserParam(string savePath)
+    {
+        var param = LoadSavedParam(savePath);
+        return param is null
+            ? 0
+            : BinaryPrimitives.ReadInt32LittleEndian(
+                param.AsSpan(SaveDataParamUserParamOffset, sizeof(int)));
+    }
+
+    private static void ReplaceParamField(byte[] param, int offset, int length, byte[] value)
+    {
+        var field = param.AsSpan(offset, length);
+        field.Clear();
+        value.AsSpan(0, Math.Min(value.Length, field.Length)).CopyTo(field);
     }
 
     private static bool TryWriteSearchInfo(CpuContext ctx, ulong address, SaveEntry entry)
@@ -475,7 +803,34 @@ public static class SaveDataExports
     }
 
     private static string ResolveTitleSaveRoot(int userId, string titleId) =>
-        Path.Combine(ResolveSaveDataRoot(), userId.ToString(), SanitizePathSegment(titleId));
+        Path.GetFullPath(Path.Combine(ResolveSaveDataRoot(), userId.ToString(), SanitizePathSegment(titleId)));
+
+    private static bool TryResolveSavePath(int userId, string titleId, string dirName, out string savePath)
+    {
+        savePath = string.Empty;
+        if (!IsGuestPathSegment(titleId) || !IsGuestPathSegment(dirName))
+        {
+            return false;
+        }
+
+        var titleRoot = ResolveTitleSaveRoot(userId, titleId);
+        var candidate = Path.GetFullPath(Path.Combine(titleRoot, SanitizePathSegment(dirName)));
+        var rootWithSeparator = Path.TrimEndingDirectorySeparator(titleRoot) + Path.DirectorySeparatorChar;
+        if (!candidate.StartsWith(rootWithSeparator, _hostPathComparison))
+        {
+            return false;
+        }
+
+        savePath = candidate;
+        return true;
+    }
+
+    private static bool IsGuestPathSegment(string value) =>
+        !string.IsNullOrWhiteSpace(value) &&
+        !string.Equals(value, ".", StringComparison.Ordinal) &&
+        !string.Equals(value, "..", StringComparison.Ordinal) &&
+        !value.Contains('/') &&
+        !value.Contains('\\');
 
     private static string ResolveSaveDataMemoryPath(int userId) =>
         Path.Combine(ResolveTitleSaveRoot(userId, ResolveConfiguredTitleId()), "sce_sdmemory", "memory.dat");
@@ -529,7 +884,7 @@ public static class SaveDataExports
     {
         var invalid = Path.GetInvalidFileNameChars();
         var sanitized = new string(value.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray());
-        return string.IsNullOrWhiteSpace(sanitized) ? "default" : sanitized;
+        return string.IsNullOrWhiteSpace(sanitized) || sanitized is "." or ".." ? "default" : sanitized;
     }
 
     private static bool TryReadFixedAscii(CpuContext ctx, ulong address, int length, out string value)
@@ -631,6 +986,14 @@ public static class SaveDataExports
 
     private readonly record struct SaveEntry(string Name, string Path, DateTime LastWriteUtc);
 
+    private enum SavedParamLoadStatus
+    {
+        Missing,
+        Loaded,
+        Invalid,
+        Error,
+    }
+
     [SysAbiExport(
         Nid = "sDCBrmc61XU",
         ExportName = "sceSaveDataPrepare",
@@ -639,13 +1002,15 @@ public static class SaveDataExports
     public static int SaveDataPrepare(CpuContext ctx)
     {
         var mountPointAddress = ctx[CpuRegister.Rdi];
-        var resource = unchecked((int)ctx[CpuRegister.Rdx]);
-        if (mountPointAddress == 0)
+        var paramAddress = ctx[CpuRegister.Rsi];
+        if (mountPointAddress == 0 || paramAddress == 0)
         {
             return ctx.SetReturn(OrbisSaveDataErrorParameter);
         }
 
-        if (!TryReadFixedAscii(ctx, mountPointAddress, 16, out var mountPoint))
+        if (!TryReadFixedAscii(ctx, mountPointAddress, 16, out var mountPoint) ||
+            !TryReadInt32(ctx, paramAddress, out var resource) ||
+            !TryReadUInt32(ctx, paramAddress + sizeof(int), out var prepareMode))
         {
             return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
@@ -657,13 +1022,16 @@ public static class SaveDataExports
 
         lock (_stateGate)
         {
-            if (resource != 0)
+            if (!_mountedSavePaths.TryGetValue(mountPoint, out var savePath))
             {
-                _preparedTransactionResources.Add(resource);
+                return ctx.SetReturn(OrbisSaveDataErrorNotMounted);
             }
+
+            _preparedTransactionResources[resource] = savePath;
         }
 
-        TraceSaveData($"prepare mount_point={mountPoint} resource={resource}");
+        TraceSaveData(
+            $"prepare mount_point={mountPoint} resource={resource} prepare_mode=0x{prepareMode:X}");
         return ctx.SetReturn(0);
     }
 
@@ -680,12 +1048,44 @@ public static class SaveDataExports
             return ctx.SetReturn(OrbisSaveDataErrorParameter);
         }
 
-        lock (_stateGate)
+        if (!TryReadInt32(ctx, commitAddress, out var resource) ||
+            !TryReadUInt32(ctx, commitAddress + sizeof(int), out var commitMode))
         {
-            _preparedTransactionResources.Clear();
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
-        TraceSaveData($"commit commit=0x{commitAddress:X16}");
+        // Async backup completion events are deliberately deferred until the
+        // save-data event lifecycle is implemented and observed independently.
+
+        var committed = false;
+        try
+        {
+            lock (_stateGate)
+            {
+                if (_preparedTransactionResources.TryGetValue(resource, out var savePath))
+                {
+                    if (!TryRefreshSavedParamMtime(savePath))
+                    {
+                        return ctx.SetReturn(OrbisSaveDataErrorInternal);
+                    }
+
+                    _preparedTransactionResources.Remove(resource);
+                    committed = true;
+                }
+            }
+        }
+        catch (IOException)
+        {
+            return ctx.SetReturn(OrbisSaveDataErrorInternal);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return ctx.SetReturn(OrbisSaveDataErrorInternal);
+        }
+
+        TraceSaveData(
+            $"commit resource={resource} commit_mode=0x{commitMode:X} " +
+            $"prepared={(committed ? 1 : 0)} commit=0x{commitAddress:X16}");
         return ctx.SetReturn(0);
     }
 

--- a/tests/SharpEmu.Libs.Tests/SaveData/SaveDataExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/SaveData/SaveDataExportsTests.cs
@@ -1,0 +1,570 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using SharpEmu.Libs.SaveData;
+using System.Buffers.Binary;
+using System.Text;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.SaveData;
+
+[CollectionDefinition("SaveDataState", DisableParallelization = true)]
+public sealed class SaveDataStateCollection
+{
+    public const string Name = "SaveDataState";
+}
+
+[Collection(SaveDataStateCollection.Name)]
+public sealed class SaveDataExportsTests : IDisposable
+{
+    private const int SaveDataErrorNotMounted = unchecked((int)0x809F0004);
+    private const int SaveDataErrorParameter = unchecked((int)0x809F0000);
+    private const int SaveDataErrorBusy = unchecked((int)0x809F0003);
+    private const int SaveDataErrorMountFull = unchecked((int)0x809F000C);
+    private const int SaveDataErrorInternal = unchecked((int)0x809F000B);
+    private const int MemoryFault = (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong MountAddress = MemoryBase + 0x100;
+    private const ulong DirNameAddress = MemoryBase + 0x200;
+    private const ulong MountResultAddress = MemoryBase + 0x300;
+    private const ulong SecondMountAddress = MemoryBase + 0x400;
+    private const ulong SecondDirNameAddress = MemoryBase + 0x500;
+    private const ulong SecondMountResultAddress = MemoryBase + 0x600;
+    private const ulong ParamAddress = MemoryBase + 0x1000;
+    private const ulong SearchCondAddress = MemoryBase + 0x2000;
+    private const ulong SearchResultAddress = MemoryBase + 0x2100;
+    private const ulong SearchDirNamesAddress = MemoryBase + 0x2200;
+    private const ulong SearchParamsAddress = MemoryBase + 0x2300;
+    private readonly string? _originalSaveRoot;
+    private readonly string _saveRoot;
+    private readonly FakeCpuMemory _memory = new(MemoryBase, 0x10000);
+    private readonly CpuContext _context;
+
+    public SaveDataExportsTests()
+    {
+        _originalSaveRoot = Environment.GetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR");
+        _saveRoot = Path.Combine(Path.GetTempPath(), $"sharpemu-savedata-{Guid.NewGuid():N}");
+        Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", _saveRoot);
+        SaveDataExports.ConfigureApplicationInfo("PPSA03525");
+        _context = new CpuContext(_memory, Generation.Gen5);
+    }
+
+    [Fact]
+    public void CreateTransactionResource_ReturnsHandleWithoutWritingNonArguments()
+    {
+        var candidateAddresses = new[]
+        {
+            MemoryBase + 0x100,
+            MemoryBase + 0x200,
+            MemoryBase + 0x300,
+            MemoryBase + 0x400,
+        };
+        var sentinel = new byte[] { 0xA5, 0x5A, 0xC3, 0x3C };
+        foreach (var address in candidateAddresses)
+        {
+            Assert.True(_memory.TryWrite(address, sentinel));
+        }
+
+        _context[CpuRegister.Rdi] = 0xC0000;
+        _context[CpuRegister.Rdx] = candidateAddresses[0];
+        _context[CpuRegister.Rcx] = candidateAddresses[1];
+        _context[CpuRegister.R8] = candidateAddresses[2];
+        _context[CpuRegister.R9] = candidateAddresses[3];
+
+        Assert.Equal(1, SaveDataExports.SaveDataCreateTransactionResource(_context));
+        Assert.Equal(1UL, _context[CpuRegister.Rax]);
+
+        foreach (var address in candidateAddresses)
+        {
+            var actual = new byte[sentinel.Length];
+            Assert.True(_memory.TryRead(address, actual));
+            Assert.Equal(sentinel, actual);
+        }
+    }
+
+    [Fact]
+    public void CreateTransactionResource_AllocatesMonotonicHandlesAndResetsPerApplication()
+    {
+        _context[CpuRegister.Rdi] = 0x1000;
+        Assert.Equal(1, SaveDataExports.SaveDataCreateTransactionResource(_context));
+        Assert.Equal(2, SaveDataExports.SaveDataCreateTransactionResource(_context));
+
+        SaveDataExports.ConfigureApplicationInfo("PPSA00000");
+
+        Assert.Equal(1, SaveDataExports.SaveDataCreateTransactionResource(_context));
+    }
+
+    [Fact]
+    public void SetParam_TitleFieldPersistsOutsideMountedSaveAndFeedsSearch()
+    {
+        MountSave("slot0");
+        Assert.EndsWith(
+            Path.Combine("PPSA03525", "slot0", "data.bin"),
+            KernelMemoryCompatExports.ResolveGuestPath("/savedata0/data.bin"));
+
+        var title = new byte[128];
+        Encoding.ASCII.GetBytes("Grand Theft Auto: San Andreas\0").CopyTo(title, 0);
+        Assert.True(_memory.TryWrite(ParamAddress, title));
+        _context[CpuRegister.Rdi] = MountResultAddress;
+        _context[CpuRegister.Rsi] = 1;
+        _context[CpuRegister.Rdx] = ParamAddress;
+        _context[CpuRegister.Rcx] = (ulong)title.Length;
+        Assert.Equal(0, SaveDataExports.SaveDataSetParam(_context));
+
+        var metadataPath = Path.Combine(
+            _saveRoot,
+            "1",
+            "PPSA03525",
+            "sce_params",
+            "slot0.bin");
+        var stored = File.ReadAllBytes(metadataPath);
+        Assert.Equal(0x530, stored.Length);
+        Assert.Equal(title, stored[..128]);
+        Assert.False(File.Exists(Path.Combine(_saveRoot, "1", "PPSA03525", "slot0", "slot0.bin")));
+
+        Span<byte> condition = stackalloc byte[0x20];
+        condition.Clear();
+        BinaryPrimitives.WriteInt32LittleEndian(condition, 1);
+        Assert.True(_memory.TryWrite(SearchCondAddress, condition));
+        Span<byte> result = stackalloc byte[0x28];
+        result.Clear();
+        BinaryPrimitives.WriteUInt64LittleEndian(result[0x08..], SearchDirNamesAddress);
+        BinaryPrimitives.WriteUInt32LittleEndian(result[0x10..], 1);
+        BinaryPrimitives.WriteUInt64LittleEndian(result[0x18..], SearchParamsAddress);
+        Assert.True(_memory.TryWrite(SearchResultAddress, result));
+        _context[CpuRegister.Rdi] = SearchCondAddress;
+        _context[CpuRegister.Rsi] = SearchResultAddress;
+        Assert.Equal(0, SaveDataExports.SaveDataDirNameSearch(_context));
+        var searched = new byte[0x530];
+        Assert.True(_memory.TryRead(SearchParamsAddress, searched));
+        Assert.Equal(title, searched[..128]);
+
+        _context[CpuRegister.Rdi] = 0;
+        _context[CpuRegister.Rsi] = MountResultAddress;
+        Assert.Equal(0, SaveDataExports.SaveDataUmount2(_context));
+        Assert.Equal(
+            "/savedata0/data.bin",
+            KernelMemoryCompatExports.ResolveGuestPath("/savedata0/data.bin"));
+        _context[CpuRegister.Rdi] = MountResultAddress;
+        _context[CpuRegister.Rsi] = 1;
+        _context[CpuRegister.Rdx] = ParamAddress;
+        _context[CpuRegister.Rcx] = (ulong)title.Length;
+        Assert.Equal(SaveDataErrorNotMounted, SaveDataExports.SaveDataSetParam(_context));
+    }
+
+    [Fact]
+    public void SetParam_StringFieldRequiresNullWithinDeclaredSize()
+    {
+        MountSave("slot0");
+        Assert.True(_memory.TryWrite(ParamAddress, Enumerable.Repeat((byte)'A', 128).ToArray()));
+        _context[CpuRegister.Rdi] = MountResultAddress;
+        _context[CpuRegister.Rsi] = 1;
+        _context[CpuRegister.Rdx] = ParamAddress;
+        _context[CpuRegister.Rcx] = 128;
+
+        Assert.Equal(SaveDataErrorParameter, SaveDataExports.SaveDataSetParam(_context));
+    }
+
+    [Fact]
+    public void Mount3_AllocatesDistinctMountPointsForConcurrentSaves()
+    {
+        var first = MountSave("slot0");
+        var second = MountSave(
+            "slot1",
+            SecondMountAddress,
+            SecondDirNameAddress,
+            SecondMountResultAddress);
+
+        Assert.Equal("/savedata0", first);
+        Assert.Equal("/savedata1", second);
+        Assert.EndsWith(
+            Path.Combine("slot0", "data.bin"),
+            KernelMemoryCompatExports.ResolveGuestPath("/savedata0/data.bin"));
+        Assert.EndsWith(
+            Path.Combine("slot1", "data.bin"),
+            KernelMemoryCompatExports.ResolveGuestPath("/savedata1/data.bin"));
+    }
+
+    [Fact]
+    public void Mount3_RejectsSaveThatIsAlreadyMounted()
+    {
+        MountSave("slot0");
+        _memory.WriteCString(SecondDirNameAddress, "slot0");
+        WriteMountRequest(SecondMountAddress, SecondDirNameAddress);
+        _context[CpuRegister.Rdi] = SecondMountAddress;
+        _context[CpuRegister.Rsi] = SecondMountResultAddress;
+
+        Assert.Equal(SaveDataErrorBusy, SaveDataExports.SaveDataMount3(_context));
+        Assert.Equal("/savedata0", ReadFixedAscii(MountResultAddress, 16));
+        Assert.Equal(string.Empty, ReadFixedAscii(SecondMountResultAddress, 16));
+    }
+
+    [Fact]
+    public void Mount3_ReturnsMountFullAfterAllSlotsAreAllocated()
+    {
+        for (var index = 0; index < 16; index++)
+        {
+            var mountAddress = MemoryBase + 0x3000UL + (ulong)(index * 0x100);
+            var dirNameAddress = mountAddress + 0x40;
+            var resultAddress = mountAddress + 0x80;
+            Assert.Equal(
+                $"/savedata{index}",
+                MountSave($"slot{index}", mountAddress, dirNameAddress, resultAddress));
+        }
+
+        var overflowMountAddress = MemoryBase + 0x4000;
+        var overflowDirNameAddress = overflowMountAddress + 0x40;
+        var overflowResultAddress = overflowMountAddress + 0x80;
+        _memory.WriteCString(overflowDirNameAddress, "overflow");
+        WriteMountRequest(overflowMountAddress, overflowDirNameAddress);
+        _context[CpuRegister.Rdi] = overflowMountAddress;
+        _context[CpuRegister.Rsi] = overflowResultAddress;
+
+        Assert.Equal(SaveDataErrorMountFull, SaveDataExports.SaveDataMount3(_context));
+    }
+
+    [Fact]
+    public void Mount3_FaultingResultRollsBackNewDirectory()
+    {
+        _memory.WriteCString(DirNameAddress, "rollback");
+        WriteMountRequest(MountAddress, DirNameAddress);
+        _context[CpuRegister.Rdi] = MountAddress;
+        _context[CpuRegister.Rsi] = MemoryBase + 0x10000;
+
+        Assert.Equal(MemoryFault, SaveDataExports.SaveDataMount3(_context));
+        Assert.False(Directory.Exists(Path.Combine(_saveRoot, "1", "PPSA03525", "rollback")));
+    }
+
+    [Fact]
+    public void Mount3_CreateModeReportsCreatedStatus()
+    {
+        _memory.WriteCString(DirNameAddress, "created");
+        WriteMountRequest(MountAddress, DirNameAddress, mountMode: 1u << 2);
+        _context[CpuRegister.Rdi] = MountAddress;
+        _context[CpuRegister.Rsi] = MountResultAddress;
+
+        Assert.Equal(0, SaveDataExports.SaveDataMount3(_context));
+
+        Span<byte> status = stackalloc byte[sizeof(uint)];
+        Assert.True(_memory.TryRead(MountResultAddress + 0x1C, status));
+        Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(status));
+    }
+
+    [Fact]
+    public void Umount2_ValidatesPointerAndPreservesLiveMountOnUnknownName()
+    {
+        MountSave("slot0");
+
+        _context[CpuRegister.Rdi] = 0xA5;
+        _context[CpuRegister.Rsi] = 0;
+        Assert.Equal(SaveDataErrorParameter, SaveDataExports.SaveDataUmount2(_context));
+        _context[CpuRegister.Rsi] = MemoryBase + 0x10000;
+        Assert.Equal(MemoryFault, SaveDataExports.SaveDataUmount2(_context));
+        _memory.WriteCString(DirNameAddress, "/savedata9");
+        _context[CpuRegister.Rsi] = DirNameAddress;
+        Assert.Equal(SaveDataErrorNotMounted, SaveDataExports.SaveDataUmount2(_context));
+        Assert.EndsWith(
+            Path.Combine("slot0", "data.bin"),
+            KernelMemoryCompatExports.ResolveGuestPath("/savedata0/data.bin"));
+    }
+
+    [Fact]
+    public void SetParam_AllIgnoresOutputFieldsAndUmountRefreshesMtime()
+    {
+        MountSave("slot0");
+        var input = Enumerable.Repeat((byte)0xA5, 0x530).ToArray();
+        input.AsSpan(0, 0x500).Clear();
+        Encoding.ASCII.GetBytes("Synthetic save\0").CopyTo(input, 0);
+        BinaryPrimitives.WriteInt32LittleEndian(input.AsSpan(0x500), 42);
+        BinaryPrimitives.WriteInt64LittleEndian(input.AsSpan(0x508), 1);
+        Assert.True(_memory.TryWrite(ParamAddress, input));
+        _context[CpuRegister.Rdi] = MountResultAddress;
+        _context[CpuRegister.Rsi] = 0;
+        _context[CpuRegister.Rdx] = ParamAddress;
+        _context[CpuRegister.Rcx] = (ulong)input.Length;
+
+        Assert.Equal(0, SaveDataExports.SaveDataSetParam(_context));
+        var metadataPath = GetMetadataPath("slot0");
+        var stored = File.ReadAllBytes(metadataPath);
+        Assert.Equal("Synthetic save", Encoding.ASCII.GetString(stored, 0, 14));
+        Assert.Equal(42, BinaryPrimitives.ReadInt32LittleEndian(stored.AsSpan(0x500)));
+        Assert.True(BinaryPrimitives.ReadInt64LittleEndian(stored.AsSpan(0x508)) > 1);
+        Assert.All(stored[0x510..], value => Assert.Equal(0, value));
+
+        BinaryPrimitives.WriteInt64LittleEndian(stored.AsSpan(0x508), 2);
+        File.WriteAllBytes(metadataPath, stored);
+        _context[CpuRegister.Rdi] = 0;
+        _context[CpuRegister.Rsi] = MountResultAddress;
+        Assert.Equal(0, SaveDataExports.SaveDataUmount2(_context));
+
+        stored = File.ReadAllBytes(metadataPath);
+        Assert.True(BinaryPrimitives.ReadInt64LittleEndian(stored.AsSpan(0x508)) > 2);
+    }
+
+    [Fact]
+    public void Commit_RefreshesOnlyThePreparedSave()
+    {
+        MountSave("slot0");
+        MountSave(
+            "slot1",
+            SecondMountAddress,
+            SecondDirNameAddress,
+            SecondMountResultAddress);
+        SetUserParam(MountResultAddress, 7);
+        SetUserParam(SecondMountResultAddress, 8);
+        var firstMetadataPath = GetMetadataPath("slot0");
+        var secondMetadataPath = GetMetadataPath("slot1");
+        var first = File.ReadAllBytes(firstMetadataPath);
+        var second = File.ReadAllBytes(secondMetadataPath);
+        BinaryPrimitives.WriteInt64LittleEndian(first.AsSpan(0x508), 3);
+        BinaryPrimitives.WriteInt64LittleEndian(second.AsSpan(0x508), 4);
+        File.WriteAllBytes(firstMetadataPath, first);
+        File.WriteAllBytes(secondMetadataPath, second);
+
+        const int resource = 17;
+        var prepareAddress = MemoryBase + 0x2800;
+        var commitAddress = MemoryBase + 0x2840;
+        WriteTransactionParam(prepareAddress, resource, mode: 0x12);
+        _context[CpuRegister.Rdi] = MountResultAddress;
+        _context[CpuRegister.Rsi] = prepareAddress;
+        Assert.Equal(0, SaveDataExports.SaveDataPrepare(_context));
+        WriteTransactionParam(commitAddress, resource, mode: 0x34);
+        _context[CpuRegister.Rdi] = commitAddress;
+
+        Assert.Equal(0, SaveDataExports.SaveDataCommit(_context));
+
+        first = File.ReadAllBytes(firstMetadataPath);
+        second = File.ReadAllBytes(secondMetadataPath);
+        Assert.True(BinaryPrimitives.ReadInt64LittleEndian(first.AsSpan(0x508)) > 3);
+        Assert.Equal(4, BinaryPrimitives.ReadInt64LittleEndian(second.AsSpan(0x508)));
+
+        BinaryPrimitives.WriteInt64LittleEndian(first.AsSpan(0x508), 5);
+        File.WriteAllBytes(firstMetadataPath, first);
+        WriteTransactionParam(commitAddress, resource: 99, mode: 0);
+        _context[CpuRegister.Rdi] = commitAddress;
+        Assert.Equal(0, SaveDataExports.SaveDataCommit(_context));
+        first = File.ReadAllBytes(firstMetadataPath);
+        Assert.Equal(5, BinaryPrimitives.ReadInt64LittleEndian(first.AsSpan(0x508)));
+    }
+
+    [Fact]
+    public void PrepareAndCommit_ValidateGuestParameterPointers()
+    {
+        MountSave("slot0");
+        _context[CpuRegister.Rdi] = MountResultAddress;
+        _context[CpuRegister.Rsi] = 0;
+        Assert.Equal(SaveDataErrorParameter, SaveDataExports.SaveDataPrepare(_context));
+        _context[CpuRegister.Rsi] = MemoryBase + 0x10000;
+        Assert.Equal(MemoryFault, SaveDataExports.SaveDataPrepare(_context));
+
+        _context[CpuRegister.Rdi] = 0;
+        Assert.Equal(SaveDataErrorParameter, SaveDataExports.SaveDataCommit(_context));
+        _context[CpuRegister.Rdi] = MemoryBase + 0x10000;
+        Assert.Equal(MemoryFault, SaveDataExports.SaveDataCommit(_context));
+    }
+
+    [Fact]
+    public void Umount_DoesNotOverwriteMalformedMetadata()
+    {
+        MountSave("slot0");
+        var metadataPath = GetMetadataPath("slot0");
+        Directory.CreateDirectory(Path.GetDirectoryName(metadataPath)!);
+        var malformed = new byte[] { 0xA5, 0x5A, 0xC3 };
+        File.WriteAllBytes(metadataPath, malformed);
+        _context[CpuRegister.Rdi] = 0;
+        _context[CpuRegister.Rsi] = MountResultAddress;
+
+        Assert.Equal(SaveDataErrorInternal, SaveDataExports.SaveDataUmount2(_context));
+        Assert.Equal(malformed, File.ReadAllBytes(metadataPath));
+        Assert.EndsWith(
+            Path.Combine("slot0", "data.bin"),
+            KernelMemoryCompatExports.ResolveGuestPath("/savedata0/data.bin"));
+    }
+
+    [Fact]
+    public void Commit_PreservesMalformedMetadataAndCanRetryPreparedResource()
+    {
+        MountSave("slot0");
+        SetUserParam(MountResultAddress, 9);
+        var metadataPath = GetMetadataPath("slot0");
+        var valid = File.ReadAllBytes(metadataPath);
+        const int resource = 23;
+        var prepareAddress = MemoryBase + 0x2800;
+        var commitAddress = MemoryBase + 0x2840;
+        WriteTransactionParam(prepareAddress, resource, mode: 0);
+        _context[CpuRegister.Rdi] = MountResultAddress;
+        _context[CpuRegister.Rsi] = prepareAddress;
+        Assert.Equal(0, SaveDataExports.SaveDataPrepare(_context));
+
+        var malformed = new byte[] { 0x11, 0x22, 0x33 };
+        File.WriteAllBytes(metadataPath, malformed);
+        WriteTransactionParam(commitAddress, resource, mode: 0);
+        _context[CpuRegister.Rdi] = commitAddress;
+        Assert.Equal(SaveDataErrorInternal, SaveDataExports.SaveDataCommit(_context));
+        Assert.Equal(malformed, File.ReadAllBytes(metadataPath));
+
+        BinaryPrimitives.WriteInt64LittleEndian(valid.AsSpan(0x508), 6);
+        File.WriteAllBytes(metadataPath, valid);
+        Assert.Equal(0, SaveDataExports.SaveDataCommit(_context));
+        valid = File.ReadAllBytes(metadataPath);
+        Assert.True(BinaryPrimitives.ReadInt64LittleEndian(valid.AsSpan(0x508)) > 6);
+    }
+
+    [Fact]
+    public void Umount_MissingMetadataPersistsCanonicalSearchDefaults()
+    {
+        MountSave("slot0");
+        _context[CpuRegister.Rdi] = 0;
+        _context[CpuRegister.Rsi] = MountResultAddress;
+        Assert.Equal(0, SaveDataExports.SaveDataUmount2(_context));
+
+        Span<byte> condition = stackalloc byte[0x20];
+        condition.Clear();
+        BinaryPrimitives.WriteInt32LittleEndian(condition, 1);
+        Assert.True(_memory.TryWrite(SearchCondAddress, condition));
+        Span<byte> result = stackalloc byte[0x28];
+        result.Clear();
+        BinaryPrimitives.WriteUInt64LittleEndian(result[0x08..], SearchDirNamesAddress);
+        BinaryPrimitives.WriteUInt32LittleEndian(result[0x10..], 1);
+        BinaryPrimitives.WriteUInt64LittleEndian(result[0x18..], SearchParamsAddress);
+        Assert.True(_memory.TryWrite(SearchResultAddress, result));
+        _context[CpuRegister.Rdi] = SearchCondAddress;
+        _context[CpuRegister.Rsi] = SearchResultAddress;
+
+        Assert.Equal(0, SaveDataExports.SaveDataDirNameSearch(_context));
+        Assert.Equal("Saved Data", ReadFixedAscii(SearchParamsAddress, 128));
+        Assert.Equal(string.Empty, ReadFixedAscii(SearchParamsAddress + 0x100, 1024));
+    }
+
+    [Fact]
+    public void SetParam_UnknownMountPrecedesFaultingDataPointer()
+    {
+        _memory.WriteCString(DirNameAddress, "/savedata9");
+        _context[CpuRegister.Rdi] = DirNameAddress;
+        _context[CpuRegister.Rsi] = 1;
+        _context[CpuRegister.Rdx] = MemoryBase + 0x10000;
+        _context[CpuRegister.Rcx] = 128;
+
+        Assert.Equal(SaveDataErrorNotMounted, SaveDataExports.SaveDataSetParam(_context));
+    }
+
+    [Fact]
+    public void DirNameSearch_SortsByPersistedUserParam()
+    {
+        MountSave("alpha");
+        MountSave(
+            "beta",
+            SecondMountAddress,
+            SecondDirNameAddress,
+            SecondMountResultAddress);
+        SetUserParam(MountResultAddress, 20);
+        SetUserParam(SecondMountResultAddress, 10);
+
+        Span<byte> condition = stackalloc byte[0x20];
+        condition.Clear();
+        BinaryPrimitives.WriteInt32LittleEndian(condition, 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(condition[0x18..], 1);
+        Assert.True(_memory.TryWrite(SearchCondAddress, condition));
+        Span<byte> result = stackalloc byte[0x28];
+        result.Clear();
+        BinaryPrimitives.WriteUInt64LittleEndian(result[0x08..], SearchDirNamesAddress);
+        BinaryPrimitives.WriteUInt32LittleEndian(result[0x10..], 2);
+        Assert.True(_memory.TryWrite(SearchResultAddress, result));
+        _context[CpuRegister.Rdi] = SearchCondAddress;
+        _context[CpuRegister.Rsi] = SearchResultAddress;
+
+        Assert.Equal(0, SaveDataExports.SaveDataDirNameSearch(_context));
+        Assert.Equal("beta", ReadFixedAscii(SearchDirNamesAddress, 32));
+        Assert.Equal("alpha", ReadFixedAscii(SearchDirNamesAddress + 32, 32));
+    }
+
+    [Fact]
+    public void SetParam_ExportsForBothGenerations()
+    {
+        foreach (var generation in new[] { Generation.Gen4, Generation.Gen5 })
+        {
+            var manager = new ModuleManager();
+            manager.RegisterExports(SharpEmu.Generated.SysAbiExportRegistry.CreateExports(generation));
+
+            Assert.True(manager.TryGetExport("85zul--eGXs", out var export));
+            Assert.Equal("sceSaveDataSetParam", export.Name);
+            Assert.Equal("libSceSaveData", export.LibraryName);
+        }
+    }
+
+    public void Dispose()
+    {
+        SaveDataExports.ConfigureApplicationInfo(null);
+        Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", _originalSaveRoot);
+        if (Directory.Exists(_saveRoot))
+        {
+            Directory.Delete(_saveRoot, recursive: true);
+        }
+    }
+
+    private string MountSave(
+        string dirName,
+        ulong mountAddress = MountAddress,
+        ulong dirNameAddress = DirNameAddress,
+        ulong resultAddress = MountResultAddress)
+    {
+        _memory.WriteCString(dirNameAddress, dirName);
+        WriteMountRequest(mountAddress, dirNameAddress);
+
+        _context[CpuRegister.Rdi] = mountAddress;
+        _context[CpuRegister.Rsi] = resultAddress;
+        Assert.Equal(0, SaveDataExports.SaveDataMount3(_context));
+        return ReadFixedAscii(resultAddress, 16);
+    }
+
+    private void WriteMountRequest(
+        ulong mountAddress,
+        ulong dirNameAddress,
+        uint mountMode = 1u << 5)
+    {
+        Span<byte> mount = stackalloc byte[0x30];
+        mount.Clear();
+        BinaryPrimitives.WriteInt32LittleEndian(mount, 1);
+        BinaryPrimitives.WriteUInt64LittleEndian(mount[0x08..], dirNameAddress);
+        BinaryPrimitives.WriteUInt64LittleEndian(mount[0x10..], 96);
+        BinaryPrimitives.WriteUInt32LittleEndian(mount[0x20..], mountMode);
+        Assert.True(_memory.TryWrite(mountAddress, mount));
+    }
+
+    private void SetUserParam(ulong mountPointAddress, int value)
+    {
+        Span<byte> param = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32LittleEndian(param, value);
+        Assert.True(_memory.TryWrite(ParamAddress, param));
+        _context[CpuRegister.Rdi] = mountPointAddress;
+        _context[CpuRegister.Rsi] = 4;
+        _context[CpuRegister.Rdx] = ParamAddress;
+        _context[CpuRegister.Rcx] = sizeof(int);
+        Assert.Equal(0, SaveDataExports.SaveDataSetParam(_context));
+    }
+
+    private void WriteTransactionParam(ulong address, int resource, uint mode)
+    {
+        Span<byte> param = stackalloc byte[8];
+        BinaryPrimitives.WriteInt32LittleEndian(param, resource);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[sizeof(int)..], mode);
+        Assert.True(_memory.TryWrite(address, param));
+    }
+
+    private string GetMetadataPath(string dirName) => Path.Combine(
+        _saveRoot,
+        "1",
+        "PPSA03525",
+        "sce_params",
+        $"{dirName}.bin");
+
+    private string ReadFixedAscii(ulong address, int length)
+    {
+        var bytes = new byte[length];
+        Assert.True(_memory.TryRead(address, bytes));
+        var end = Array.IndexOf(bytes, (byte)0);
+        return Encoding.ASCII.GetString(bytes, 0, end < 0 ? bytes.Length : end);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/SaveData/SaveDataExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/SaveData/SaveDataExportsTests.cs
@@ -47,7 +47,7 @@ public sealed class SaveDataExportsTests : IDisposable
         _originalSaveRoot = Environment.GetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR");
         _saveRoot = Path.Combine(Path.GetTempPath(), $"sharpemu-savedata-{Guid.NewGuid():N}");
         Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", _saveRoot);
-        SaveDataExports.ConfigureApplicationInfo("PPSA03525");
+        SaveDataExports.ConfigureApplicationInfo("PPSA00001");
         _context = new CpuContext(_memory, Generation.Gen5);
     }
 
@@ -101,7 +101,7 @@ public sealed class SaveDataExportsTests : IDisposable
     {
         MountSave("slot0");
         Assert.EndsWith(
-            Path.Combine("PPSA03525", "slot0", "data.bin"),
+            Path.Combine("PPSA00001", "slot0", "data.bin"),
             KernelMemoryCompatExports.ResolveGuestPath("/savedata0/data.bin"));
 
         var title = new byte[128];
@@ -116,13 +116,13 @@ public sealed class SaveDataExportsTests : IDisposable
         var metadataPath = Path.Combine(
             _saveRoot,
             "1",
-            "PPSA03525",
+            "PPSA00001",
             "sce_params",
             "slot0.bin");
         var stored = File.ReadAllBytes(metadataPath);
         Assert.Equal(0x530, stored.Length);
         Assert.Equal(title, stored[..128]);
-        Assert.False(File.Exists(Path.Combine(_saveRoot, "1", "PPSA03525", "slot0", "slot0.bin")));
+        Assert.False(File.Exists(Path.Combine(_saveRoot, "1", "PPSA00001", "slot0", "slot0.bin")));
 
         Span<byte> condition = stackalloc byte[0x20];
         condition.Clear();
@@ -234,7 +234,7 @@ public sealed class SaveDataExportsTests : IDisposable
         _context[CpuRegister.Rsi] = MemoryBase + 0x10000;
 
         Assert.Equal(MemoryFault, SaveDataExports.SaveDataMount3(_context));
-        Assert.False(Directory.Exists(Path.Combine(_saveRoot, "1", "PPSA03525", "rollback")));
+        Assert.False(Directory.Exists(Path.Combine(_saveRoot, "1", "PPSA00001", "rollback")));
     }
 
     [Fact]
@@ -556,7 +556,7 @@ public sealed class SaveDataExportsTests : IDisposable
     private string GetMetadataPath(string dirName) => Path.Combine(
         _saveRoot,
         "1",
-        "PPSA03525",
+        "PPSA00001",
         "sce_params",
         $"{dirName}.bin");
 


### PR DESCRIPTION
## Change description

## What changed

Persists mounted save parameters, models transaction handles and prepared-save commits, enforces distinct mount slots, and rolls back failed mount results.

## Why

Several SaveData operations were treated as stateless calls, so output faults or unmounts could leave inconsistent metadata, handles, or filesystem state.

## Overlap

PR #281 contains related metadata/search behavior. This PR adds the mounted lifecycle and transaction guarantees; #281's separate delete and traversal coverage remains complementary.

## Validation

- 19 focused SaveData tests passed using temporary synthetic directories.
- The full build and test suite passed.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).


