### PR TITLE
[Pthread] Round positive condition waits up

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -1307,7 +1307,9 @@ public static class KernelPthreadCompatExports
                 }
 
                 var remaining = GetRemainingTimeout(deadline);
-                if (remaining <= TimeSpan.Zero || !Monitor.Wait(state.SyncRoot, remaining))
+                var waitMilliseconds = GetCondMonitorWaitMilliseconds(remaining);
+                if (waitMilliseconds == 0 ||
+                    !Monitor.Wait(state.SyncRoot, waitMilliseconds))
                 {
                     CompleteCondWaiterLocked(state, waiter, timedOut: true);
                     break;
@@ -1633,6 +1635,18 @@ public static class KernelPthreadCompatExports
         }
 
         return TimeSpan.FromSeconds(remainingTicks / (double)Stopwatch.Frequency);
+    }
+
+    internal static int GetCondMonitorWaitMilliseconds(TimeSpan remaining)
+    {
+        if (remaining <= TimeSpan.Zero)
+        {
+            return 0;
+        }
+
+        return (int)Math.Min(
+            int.MaxValue,
+            Math.Max(1d, Math.Ceiling(remaining.TotalMilliseconds)));
     }
 
     private static int NormalizeMutexType(int type)

--- a/tests/SharpEmu.Libs.Tests/Pthread/PthreadCondSemanticsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Pthread/PthreadCondSemanticsTests.cs
@@ -14,6 +14,21 @@ namespace SharpEmu.Libs.Tests.Pthread;
 // See issue #113.
 public sealed class PthreadCondSemanticsTests
 {
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 1)]
+    [InlineData(TimeSpan.TicksPerMillisecond, 1)]
+    [InlineData(TimeSpan.TicksPerMillisecond + 1, 2)]
+    public void Timedwait_HostFallbackRoundsPositiveWaitUp(
+        long remainingTicks,
+        int expectedMilliseconds)
+    {
+        Assert.Equal(
+            expectedMilliseconds,
+            KernelPthreadCompatExports.GetCondMonitorWaitMilliseconds(
+                TimeSpan.FromTicks(remainingTicks)));
+    }
+
     [Fact]
     public void PthreadCondState_DoesNotHavePendingSignals()
     {


### PR DESCRIPTION
## Change description

## What changed

Rounds every positive condition-variable timeout up to at least one host millisecond and caps oversized waits at the host API limit.

## Why

Sub-millisecond guest waits were truncated to zero and treated as immediate timeouts.

## Validation

- 6 focused timeout-boundary tests passed.
- The full build and test suite passed.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

