### PR TITLE
[AGC] Keep DCB completion on its guest queue

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -2946,12 +2946,28 @@ public static partial class AgcExports
         // guest-memory writes have finished. Put the notification on that same
         // logical graphics queue instead of approximating completion with a
         // timer, which can wake Unity while its upload data is still stale.
-        if (VulkanVideoPresenter.SubmitOrderedGuestAction(
+        if (EnqueueSubmittedDcbCompletion(
+                state.QueueName,
+                submissionId,
                 TriggerCompletionEvents,
-                $"agc submit completion {submissionId}") == 0)
+                VulkanVideoPresenter.SubmitOrderedGuestAction) == 0)
         {
             TriggerCompletionEvents();
         }
+    }
+
+    internal static long EnqueueSubmittedDcbCompletion(
+        string queueName,
+        ulong submissionId,
+        Action completion,
+        Func<Action, string, long> submitOrderedAction)
+    {
+        using var guestQueueScope = VulkanVideoPresenter.EnterGuestQueue(
+            queueName,
+            submissionId);
+        return submitOrderedAction(
+            completion,
+            $"agc submit completion {submissionId}");
     }
 
     // Returns true only when parsing stopped on an unsatisfied WAIT_REG_MEM.

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcSubmissionQueueTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcSubmissionQueueTests.cs
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Reflection;
+using SharpEmu.Libs.Agc;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcSubmissionQueueTests
+{
+    [Fact]
+    public void DcbCompletionStaysBehindEarlierWorkOnTheGraphicsQueue()
+    {
+        const string queueName = "dcb.graphics";
+        const ulong submissionId = 42;
+        var executionOrder = new List<string>();
+        var queuedActions = new Dictionary<string, Queue<Action>>
+        {
+            [queueName] = new Queue<Action>(),
+            [VulkanGuestQueueIdentity.Default.Name] = new Queue<Action>(),
+        };
+        queuedActions[queueName].Enqueue(() => executionOrder.Add("release_mem"));
+
+        VulkanGuestQueueIdentity? capturedQueue = null;
+        var sequence = AgcExports.EnqueueSubmittedDcbCompletion(
+            queueName,
+            submissionId,
+            () => executionOrder.Add("completion"),
+            (action, debugName) =>
+            {
+                Assert.Equal($"agc submit completion {submissionId}", debugName);
+                capturedQueue = GetSubmittingGuestQueue();
+                var targetQueue = capturedQueue ?? VulkanGuestQueueIdentity.Default;
+                queuedActions[targetQueue.Name].Enqueue(action);
+                return 2;
+            });
+
+        Assert.Equal(2, sequence);
+        Assert.Equal(
+            new VulkanGuestQueueIdentity(queueName, submissionId),
+            capturedQueue);
+        Assert.Null(GetSubmittingGuestQueue());
+
+        while (queuedActions[queueName].TryDequeue(out var action))
+        {
+            action();
+        }
+
+        Assert.Equal(["release_mem", "completion"], executionOrder);
+        Assert.Empty(queuedActions[VulkanGuestQueueIdentity.Default.Name]);
+    }
+
+    private static VulkanGuestQueueIdentity? GetSubmittingGuestQueue()
+    {
+        var field = typeof(VulkanVideoPresenter).GetField(
+            "_submittingGuestQueue",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return field.GetValue(null) is VulkanGuestQueueIdentity queue
+            ? queue
+            : null;
+    }
+}


### PR DESCRIPTION
## Summary

- submit each DCB completion callback under the identity of the DCB's guest graphics queue
- keep completion notification behind earlier ordered work such as `RELEASE_MEM`
- restore the ambient queue identity after submission

## Prior art and scope

This touches AGC queueing code also modified by open PRs #198, #208, and #316, but it does not duplicate their patches:

- #198 combines AGC event-queue work with depth/stencil and rasterizer pipeline changes
- #208 combines ordered GPU queues with CPU, shader, HLE, and input work
- #316 is a broad 38-file shader/Vulkan/frame-presentation stack

None of those diffs contains this `SubmitParsedDcb` completion-queue correction or a focused submission-order test. This PR is better isolated for this specific contract: two files, one queue identity helper, and a deterministic test proving `RELEASE_MEM` executes before completion without relying on renderer timing. It is complementary to the broader rendering work and can merge independently.

## Validation

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release --filter FullyQualifiedName~AgcSubmissionQueueTests --verbosity minimal`
  - 1 passed
- `dotnet restore SharpEmu.slnx`
- `dotnet build SharpEmu.slnx -c Release --no-restore`
  - 0 warnings, 0 errors
- `dotnet test SharpEmu.slnx -c Release --no-build --verbosity minimal`
  - SharpEmu.Libs.Tests: 235 passed
  - SharpEmu.SourceGenerators.Tests: 33 passed
- `git diff --check`
