### PR TITLE
[Remoteplay] Add disconnected bootstrap exports

### DIFF
--- a/src/SharpEmu.Libs/Remoteplay/RemoteplayExports.cs
+++ b/src/SharpEmu.Libs/Remoteplay/RemoteplayExports.cs
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+
+namespace SharpEmu.Libs.Remoteplay;
+
+public static class RemoteplayExports
+{
+    private const int RemoteplayConnectionStatusDisconnected = 0;
+
+    [SysAbiExport(
+        Nid = "k1SwgkMSOM8",
+        ExportName = "sceRemoteplayInitialize",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceRemoteplay")]
+    public static int RemoteplayInitialize(CpuContext ctx) => ctx.SetReturn(0);
+
+    [SysAbiExport(
+        Nid = "g3PNjYKWqnQ",
+        ExportName = "sceRemoteplayGetConnectionStatus",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceRemoteplay")]
+    public static int RemoteplayGetConnectionStatus(CpuContext ctx)
+    {
+        var statusAddress = ctx[CpuRegister.Rsi];
+        if (statusAddress == 0)
+        {
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        // There is no remote-play session under emulation.
+        return ctx.TryWriteInt32(statusAddress, RemoteplayConnectionStatusDisconnected)
+            ? ctx.SetReturn(0)
+            : ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Remoteplay/RemoteplayExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Remoteplay/RemoteplayExportsTests.cs
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Remoteplay;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Remoteplay;
+
+public sealed class RemoteplayExportsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong StatusAddress = MemoryBase + 0x100;
+    private const ulong FaultingAddress = 0xDEAD_0000_0000;
+
+    [Fact]
+    public void InitializeAndConnectionStatusExportsAreRegisteredForGen5()
+    {
+        var manager = new ModuleManager();
+        manager.RegisterExports(
+            SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen5));
+
+        Assert.True(manager.TryGetExport("k1SwgkMSOM8", out var initialize));
+        Assert.Equal("sceRemoteplayInitialize", initialize.Name);
+        Assert.True(manager.TryGetExport("g3PNjYKWqnQ", out var getStatus));
+        Assert.Equal("sceRemoteplayGetConnectionStatus", getStatus.Name);
+    }
+
+    [Fact]
+    public void GetConnectionStatusReportsDisconnected()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rsi] = StatusAddress;
+
+        Assert.Equal(0, RemoteplayExports.RemoteplayGetConnectionStatus(context));
+
+        Span<byte> status = stackalloc byte[sizeof(int)];
+        Assert.True(memory.TryRead(StatusAddress, status));
+        Assert.Equal(0, BinaryPrimitives.ReadInt32LittleEndian(status));
+    }
+
+    [Theory]
+    [InlineData(0UL, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT)]
+    [InlineData(FaultingAddress, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT)]
+    public void GetConnectionStatusRejectsInvalidOutput(
+        ulong statusAddress,
+        OrbisGen2Result expected)
+    {
+        var context = new CpuContext(new FakeCpuMemory(MemoryBase, 0x1000), Generation.Gen5);
+        context[CpuRegister.Rsi] = statusAddress;
+
+        Assert.Equal((int)expected, RemoteplayExports.RemoteplayGetConnectionStatus(context));
+    }
+}


### PR DESCRIPTION
## Change description

## What changed

Adds the Gen4/Gen5 Remote Play initialization and connection-status exports and reports the emulator's current disconnected state.

## Why

Titles can query Remote Play during startup even when no Remote Play session exists.

## Overlap

PR #195 contains the same production surface inside a broad boot-compatibility bundle. This PR isolates it with dedicated argument and memory-fault tests.

## Validation

- 4 focused Remote Play tests passed.
- The full build and test suite passed.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).


