### PR TITLE
[SystemService] Add Gen5 notice auto-set disable export

### DIFF
--- a/src/SharpEmu.Libs/SystemService/SystemServiceExports.cs
+++ b/src/SharpEmu.Libs/SystemService/SystemServiceExports.cs
@@ -212,4 +212,11 @@ public static class SystemServiceExports
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libSceSystemService")]
     public static int SystemServiceReportAbnormalTermination(CpuContext ctx) => ctx.SetReturn(0);
+
+    [SysAbiExport(
+        Nid = "8Lo6Zv94aho",
+        ExportName = "sceSystemServiceDisableNoticeScreenSkipFlagAutoSet",
+        Target = Generation.Gen5,
+        LibraryName = "libSceSystemService")]
+    public static int SystemServiceDisableNoticeScreenSkipFlagAutoSet(CpuContext ctx) => ctx.SetReturn(0);
 }

--- a/tests/SharpEmu.Libs.Tests/SystemService/SystemServiceBootstrapExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/SystemService/SystemServiceBootstrapExportsTests.cs
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.SystemService;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.SystemService;
+
+public sealed class SystemServiceBootstrapExportsTests
+{
+    [Fact]
+    public void DisableNoticeScreenSkipFlagAutoSetIsRegisteredOnlyForGen5()
+    {
+        var gen4 = new ModuleManager();
+        gen4.RegisterExports(
+            SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen4));
+        Assert.False(gen4.TryGetExport("8Lo6Zv94aho", out _));
+
+        var gen5 = new ModuleManager();
+        gen5.RegisterExports(
+            SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen5));
+        Assert.True(gen5.TryGetExport("8Lo6Zv94aho", out var export));
+        Assert.Equal("sceSystemServiceDisableNoticeScreenSkipFlagAutoSet", export.Name);
+        Assert.Equal("libSceSystemService", export.LibraryName);
+    }
+
+    [Fact]
+    public void DisableNoticeScreenSkipFlagAutoSetSucceedsWithoutGuestMemory()
+    {
+        var context = new CpuContext(
+            new FakeCpuMemory(0x1_0000_0000, 0x1000),
+            Generation.Gen5);
+
+        Assert.Equal(
+            0,
+            SystemServiceExports.SystemServiceDisableNoticeScreenSkipFlagAutoSet(context));
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+    }
+}


### PR DESCRIPTION
## Change description

## What changed

Adds the Gen5-only `sceSystemServiceDisableNoticeScreenSkipFlagAutoSet` export as a successful no-op.

## Why

The emulator has no notice-screen auto-set state, but Gen5 callers still expect the bootstrap function to exist and succeed.

## Overlap

PR #195 contains the same export without focused behavior coverage. PR #346 changes a different SystemService output-width contract.

## Validation

- 2 focused registration and return-contract tests passed.
- The full build and test suite passed.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

