### PR TITLE
[TLS] Grow startup static reservation safely

### DIFF
--- a/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
+++ b/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
@@ -26,10 +26,6 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
     private const ulong StackSize = 0x0020_0000UL;
     private static readonly ulong TlsBaseAddress = OperatingSystem.IsWindows() ? 0x7FFE_0000_0000UL : 0x6FFE_0000_0000UL;
     private const ulong TlsSize = 0x0001_0000UL;
-    // The static TLS blocks live at negative offsets from the TCB (FreeBSD
-    // amd64 variant II). Keep every host in sync with GuestTlsTemplate's
-    // startup reservation; PS5 modules routinely reach beyond one host page.
-    private const ulong TlsPrefixSize = GuestTlsTemplate.StartupStaticTlsReservation;
     private static readonly ulong BootstrapStubBaseAddress = OperatingSystem.IsWindows() ? 0x7FFD_F000_0000UL : 0x6FFD_F000_0000UL;
     private static readonly ulong BootstrapPayloadBaseAddress = OperatingSystem.IsWindows() ? 0x7FFD_E000_0000UL : 0x6FFD_E000_0000UL;
     private static readonly ulong DynlibFallbackStubBaseAddress = OperatingSystem.IsWindows() ? 0x7FFD_D000_0000UL : 0x6FFD_D000_0000UL;
@@ -347,15 +343,16 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
     private ulong TryMapTlsRegion()
     {
         const ulong tlsStride = 0x0100_0000UL;
+        var tlsPrefixSize = GuestTlsTemplate.GetStartupStaticTlsReservation();
         for (var i = 0; i < 32; i++)
         {
             var candidateBase = TlsBaseAddress - ((ulong)i * tlsStride);
-            var mappedBase = candidateBase - TlsPrefixSize;
+            var mappedBase = candidateBase - tlsPrefixSize;
             try
             {
                 _virtualMemory.Map(
                     mappedBase,
-                    TlsSize + TlsPrefixSize,
+                    TlsSize + tlsPrefixSize,
                     fileOffset: 0,
                     fileData: ReadOnlySpan<byte>.Empty,
                     ProgramHeaderFlags.Read | ProgramHeaderFlags.Write);

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -156,10 +156,6 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private const ulong GuestThreadTlsSize = 0x0001_0000UL;
 
-	// Matches CpuDispatcher.TlsPrefixSize: static TLS blocks sit below the
-	// thread pointer and PS5 modules can reach beyond one host page.
-	private const ulong GuestThreadTlsPrefixSize = GuestTlsTemplate.StartupStaticTlsReservation;
-
 	private const ulong GuestThreadRegionStride = 0x0100_0000UL;
 
 	// Unity titles routinely create more than 64 workers once native plugins,
@@ -4504,11 +4500,12 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		out ulong tlsBase,
 		out string? error)
 	{
+		var tlsPrefixSize = GuestTlsTemplate.GetStartupStaticTlsReservation();
 		for (int i = 0; i < GuestThreadRegionSlots; i++)
 		{
 			var candidateBase = GuestThreadTlsBaseAddress - ((ulong)i * GuestThreadRegionStride);
-			var mappedBase = candidateBase - GuestThreadTlsPrefixSize;
-			var mappedSize = GuestThreadTlsSize + GuestThreadTlsPrefixSize;
+			var mappedBase = candidateBase - tlsPrefixSize;
+			var mappedSize = GuestThreadTlsSize + tlsPrefixSize;
 			if (!IsGuestThreadRegionFree(virtualMemory, mappedBase, mappedSize))
 			{
 				continue;

--- a/src/SharpEmu.HLE/GuestTlsTemplate.cs
+++ b/src/SharpEmu.HLE/GuestTlsTemplate.cs
@@ -14,10 +14,15 @@ namespace SharpEmu.HLE;
 /// </summary>
 public static class GuestTlsTemplate
 {
-    // Must match CpuDispatcher/DirectExecutionBackend's mapped prefix. PS5
-    // modules can require more than one host page of Variant II static TLS;
-    // Dreaming Sarah's startup image, for example, reaches 0x1870 bytes.
-    public const ulong StartupStaticTlsReservation = 0x10000UL;
+    // CpuDispatcher/DirectExecutionBackend map at least this much space below
+    // each thread pointer. Larger Variant II layouts grow the reservation to
+    // the page-aligned size computed from all startup PT_TLS modules.
+    public const ulong MinimumStartupStaticTlsReservation = 0x10000UL;
+    // Thread TLS regions are spaced 16 MiB apart and reserve the top 64 KiB
+    // for the TCB/dynamic area. Keep the static prefix within the remainder
+    // so adjacent worker slots can never overlap.
+    public const ulong MaximumStartupStaticTlsReservation = 0x00FF_0000UL;
+    private const ulong GuestPageSize = 0x1000UL;
     private static readonly object _gate = new();
     private static readonly SortedDictionary<ulong, ModuleTemplate> _modules = new();
     private static readonly Dictionary<ulong, ThreadDtv> _threadDtvs = new();
@@ -102,6 +107,20 @@ public static class GuestTlsTemplate
         get { lock (_gate) { return _staticTlsSize; } }
     }
 
+    /// <summary>
+    /// Returns the page-aligned prefix that must be mapped below a new thread
+    /// pointer for the currently registered Variant II static TLS layout.
+    /// </summary>
+    public static ulong GetStartupStaticTlsReservation()
+    {
+        lock (_gate)
+        {
+            return AlignUp(
+                Math.Max(MinimumStartupStaticTlsReservation, _staticTlsSize),
+                GuestPageSize);
+        }
+    }
+
     /// <summary>Largest PT_TLS alignment required by the registered modules.</summary>
     public static ulong MaximumAlignment
     {
@@ -171,11 +190,11 @@ public static class GuestTlsTemplate
                 memorySize,
                 normalizedAlignment,
                 alignmentBias);
-            if (staticOffset > StartupStaticTlsReservation)
+            if (staticOffset > MaximumStartupStaticTlsReservation)
             {
-                throw new InvalidOperationException(
-                    $"Static TLS requires 0x{staticOffset:X} bytes, but startup maps only " +
-                    $"0x{StartupStaticTlsReservation:X} bytes below the thread pointer.");
+                throw new InvalidDataException(
+                    $"Cumulative PT_TLS size 0x{staticOffset:X} exceeds the supported " +
+                    $"0x{MaximumStartupStaticTlsReservation:X}-byte static reservation.");
             }
             _modules.Add(moduleId, new ModuleTemplate
             {

--- a/tests/SharpEmu.Libs.Tests/Tls/GuestTlsTemplateTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Tls/GuestTlsTemplateTests.cs
@@ -6,6 +6,10 @@ using Xunit;
 
 namespace SharpEmu.Libs.Tests.Tls;
 
+[CollectionDefinition("GuestTlsTemplateState", DisableParallelization = true)]
+public sealed class GuestTlsTemplateStateCollection;
+
+[Collection("GuestTlsTemplateState")]
 public sealed class GuestTlsTemplateTests
 {
     [Fact]
@@ -22,7 +26,111 @@ public sealed class GuestTlsTemplateTests
                 alignment: 0x10);
 
             Assert.Equal(0x1870UL, staticOffset);
-            Assert.True(staticOffset <= GuestTlsTemplate.StartupStaticTlsReservation);
+            Assert.Equal(
+                GuestTlsTemplate.MinimumStartupStaticTlsReservation,
+                GuestTlsTemplate.GetStartupStaticTlsReservation());
+        }
+        finally
+        {
+            GuestTlsTemplate.Reset();
+        }
+    }
+
+    [Fact]
+    public void StartupReservationGrowsPastMinimumAndRoundsToGuestPage()
+    {
+        try
+        {
+            GuestTlsTemplate.Reset();
+
+            var staticOffset = GuestTlsTemplate.RegisterModule(
+                moduleId: 1,
+                initImage: [0x11, 0x22],
+                memorySize: 0x13570,
+                alignment: 0x10);
+
+            Assert.Equal(0x13570UL, staticOffset);
+            Assert.Equal(0x14000UL, GuestTlsTemplate.GetStartupStaticTlsReservation());
+        }
+        finally
+        {
+            GuestTlsTemplate.Reset();
+        }
+    }
+
+    [Fact]
+    public void StartupReservationTracksCumulativeModuleLayout()
+    {
+        try
+        {
+            GuestTlsTemplate.Reset();
+
+            Assert.Equal(
+                0xF000UL,
+                GuestTlsTemplate.RegisterModule(1, [0xA1], 0xF000, 0x1000));
+            Assert.Equal(
+                0x12000UL,
+                GuestTlsTemplate.RegisterModule(2, [0xB2], 0x3000, 0x1000));
+            Assert.Equal(0x12000UL, GuestTlsTemplate.GetStartupStaticTlsReservation());
+        }
+        finally
+        {
+            GuestTlsTemplate.Reset();
+        }
+    }
+
+    [Fact]
+    public void StartupReservationRejectsLayoutsThatWouldOverlapThreadSlots()
+    {
+        try
+        {
+            GuestTlsTemplate.Reset();
+
+            var error = Assert.Throws<InvalidDataException>(() =>
+                GuestTlsTemplate.RegisterModule(
+                    moduleId: 1,
+                    initImage: [],
+                    memorySize: GuestTlsTemplate.MaximumStartupStaticTlsReservation + 1,
+                    alignment: 1));
+
+            Assert.Contains("exceeds the supported", error.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GuestTlsTemplate.Reset();
+        }
+    }
+
+    [Fact]
+    public void SeedThreadBlockUsesExpandedStaticReservation()
+    {
+        try
+        {
+            GuestTlsTemplate.Reset();
+
+            var staticOffset = GuestTlsTemplate.RegisterModule(
+                moduleId: 1,
+                initImage: [0x31, 0x42],
+                memorySize: 0x13570,
+                alignment: 0x10);
+            var reservation = GuestTlsTemplate.GetStartupStaticTlsReservation();
+            const ulong memoryBase = 0x1_0000_0000;
+            var threadPointer = memoryBase + reservation;
+            var memory = new FakeCpuMemory(memoryBase, checked((int)reservation + 0x1000));
+            var context = new CpuContext(memory, Generation.Gen5)
+            {
+                FsBase = threadPointer,
+            };
+
+            GuestTlsTemplate.SeedThreadBlock(context, threadPointer);
+
+            var staticAddress = threadPointer - staticOffset;
+            Span<byte> initialized = stackalloc byte[3];
+            Assert.True(memory.TryRead(staticAddress, initialized));
+            Assert.Equal((byte)0x31, initialized[0]);
+            Assert.Equal((byte)0x42, initialized[1]);
+            Assert.Equal((byte)0x00, initialized[2]);
+            Assert.Equal(staticAddress + 1, GuestTlsTemplate.ResolveAddress(context, 1, 1));
         }
         finally
         {


### PR DESCRIPTION
## Change description

## What changed

Sizes startup and worker TLS prefixes from the registered Variant II layout, page-aligns larger reservations, and rejects layouts that would overlap the next 16 MiB worker slot.

## Why

The fixed 64 KiB reservation was too small for larger static TLS layouts, while unbounded growth could overlap neighboring worker regions.

## Overlap

PR #195 also grows the reservation but does not enforce the worker-slot boundary. This version keeps that invariant and adds focused layout tests.
## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.
## Validation

- 5 focused TLS layout and lookup tests passed.
- The full build and test suite passed.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).


