### PR TITLE
[AudioOut2] Add speaker-array bootstrap exports

### DIFF
--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -185,6 +185,36 @@ public static class AudioOut2Exports
     }
 
     [SysAbiExport(
+        Nid = "G1YOKDJYX2Y",
+        ExportName = "sceAudioOut2GetSpeakerArrayMemorySize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2GetSpeakerArrayMemorySize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0x10000;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "+k91hoTuoA8",
+        ExportName = "sceAudioOut2SpeakerArrayCreate",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2SpeakerArrayCreate(CpuContext ctx)
+    {
+        var outHandleAddress = ctx[CpuRegister.Rdi];
+        if (outHandleAddress == 0)
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        var handle = (ulong)Interlocked.Increment(ref _nextContextHandle);
+        return TryWriteUInt64(ctx, outHandleAddress, handle)
+            ? SetReturn(ctx, 0)
+            : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+    }
+
+    [SysAbiExport(
         Nid = "DxGyV8dtOR8",
         ExportName = "sceAudioOut2ContextBedWrite",
         Target = Generation.Gen5,

--- a/tests/SharpEmu.Libs.Tests/Audio/AudioOut2SpeakerArrayExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Audio/AudioOut2SpeakerArrayExportsTests.cs
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Audio;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Audio;
+
+public sealed class AudioOut2SpeakerArrayExportsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong HandleAddress = MemoryBase + 0x100;
+    private const ulong FaultingAddress = 0xDEAD_0000_0000;
+
+    [Fact]
+    public void SpeakerArrayExportsAreRegisteredForGen5()
+    {
+        var manager = new ModuleManager();
+        manager.RegisterExports(
+            SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen5));
+
+        Assert.True(manager.TryGetExport("G1YOKDJYX2Y", out var getSize));
+        Assert.Equal("sceAudioOut2GetSpeakerArrayMemorySize", getSize.Name);
+        Assert.True(manager.TryGetExport("+k91hoTuoA8", out var create));
+        Assert.Equal("sceAudioOut2SpeakerArrayCreate", create.Name);
+    }
+
+    [Fact]
+    public void GetSpeakerArrayMemorySizeReturnsRequiredSize()
+    {
+        var context = CreateContext();
+
+        Assert.Equal(0, AudioOut2Exports.AudioOut2GetSpeakerArrayMemorySize(context));
+        Assert.Equal(0x10000UL, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void SpeakerArrayCreateWritesNonzeroHandle()
+    {
+        var context = CreateContext();
+        context[CpuRegister.Rdi] = HandleAddress;
+
+        Assert.Equal(0, AudioOut2Exports.AudioOut2SpeakerArrayCreate(context));
+        Assert.True(context.TryReadUInt64(HandleAddress, out var handle));
+        Assert.NotEqual(0UL, handle);
+    }
+
+    [Theory]
+    [InlineData(0UL, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT)]
+    [InlineData(FaultingAddress, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT)]
+    public void SpeakerArrayCreateRejectsInvalidOutput(
+        ulong outputAddress,
+        OrbisGen2Result expected)
+    {
+        var context = CreateContext();
+        context[CpuRegister.Rdi] = outputAddress;
+
+        Assert.Equal((int)expected, AudioOut2Exports.AudioOut2SpeakerArrayCreate(context));
+    }
+
+    private static CpuContext CreateContext() =>
+        new(new FakeCpuMemory(MemoryBase, 0x1000), Generation.Gen5);
+}


### PR DESCRIPTION
### Change description

## What changed

Adds the Gen5 AudioOut2 speaker-array size and creation exports, returns the required 64 KiB allocation size, and creates a validated opaque handle.

## Why

Gen5 startup expects these speaker-array bootstrap functions even before any real speaker-array processing is available.

## Overlap

PR #195 contains the same exports inside a broad compatibility bundle without focused tests. PR #357 fixes separate AudioOut2 output widths.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).


## Validation

- 5 focused speaker-array export tests passed.
- The full build and test suite passed.
