### PR TITLE
[AGC] Consolidate bootstrap, queue, and shader contracts

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -76,8 +76,10 @@ public static partial class AgcExports
     private const uint SpiShaderPgmHiEs = 0xC9;
     private const uint SpiShaderPgmLoLs = 0x148;
     private const uint SpiShaderPgmHiLs = 0x149;
-    private const uint SpiShaderPgmLoGs = 0x8A;
-    private const uint SpiShaderPgmHiGs = 0x8B;
+    private const uint SpiShaderPgmLoGs = 0x88;
+    private const uint SpiShaderPgmHiGs = 0x89;
+    private const uint SpiShaderPgmLoHs = 0x108;
+    private const uint SpiShaderPgmHiHs = 0x109;
     private const uint SpiPsInputEna = 0x1B3;
     private const uint SpiPsInputAddr = 0x1B4;
     private const uint ComputePgmLo = 0x20C;
@@ -570,6 +572,13 @@ public static partial class AgcExports
         Explicit,
     }
 
+    private enum ShaderProgramRegisterPatchResult : byte
+    {
+        Success,
+        InvalidArgument,
+        MemoryFault,
+    }
+
     private readonly record struct RegisteredAgcResource(
         uint Owner,
         ulong Address,
@@ -691,9 +700,15 @@ public static partial class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
-        if (!PatchShaderProgramRegisters(ctx, headerAddress, codeAddress))
+        var patchResult = PatchShaderProgramRegisters(ctx, headerAddress, codeAddress);
+        if (patchResult == ShaderProgramRegisterPatchResult.InvalidArgument)
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        if (patchResult == ShaderProgramRegisterPatchResult.MemoryFault)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
         if (destinationAddress != 0 &&
@@ -10234,24 +10249,16 @@ public static partial class AgcExports
         }
     }
 
-    private static bool PatchShaderProgramRegisters(CpuContext ctx, ulong headerAddress, ulong codeAddress)
+    private static ShaderProgramRegisterPatchResult PatchShaderProgramRegisters(
+        CpuContext ctx,
+        ulong headerAddress,
+        ulong codeAddress)
     {
         if (!TryReadUInt64(ctx, headerAddress + ShaderShRegistersOffset, out var shRegistersAddress) ||
             !TryReadByte(ctx, headerAddress + ShaderTypeOffset, out var shaderType) ||
             !TryReadByte(ctx, headerAddress + ShaderNumShRegistersOffset, out var registerCount))
         {
-            return false;
-        }
-
-        if (shRegistersAddress == 0 || registerCount < 2)
-        {
-            return false;
-        }
-
-        if (!TryReadUInt32(ctx, shRegistersAddress, out var loRegister) ||
-            !TryReadUInt32(ctx, shRegistersAddress + 8, out var hiRegister))
-        {
-            return false;
+            return ShaderProgramRegisterPatchResult.MemoryFault;
         }
 
         var expectedLo = shaderType switch
@@ -10260,6 +10267,7 @@ public static partial class AgcExports
             1 => SpiShaderPgmLoPs,
             2 or 6 => SpiShaderPgmLoEs,
             4 => SpiShaderPgmLoGs,
+            5 => SpiShaderPgmLoHs,
             7 => SpiShaderPgmLoLs,
             _ => 0u,
         };
@@ -10269,19 +10277,76 @@ public static partial class AgcExports
             1 => SpiShaderPgmHiPs,
             2 or 6 => SpiShaderPgmHiEs,
             4 => SpiShaderPgmHiGs,
+            5 => SpiShaderPgmHiHs,
             7 => SpiShaderPgmHiLs,
             _ => 0u,
         };
-        if (expectedLo == 0 || loRegister != expectedLo || hiRegister != expectedHi)
+        if (shRegistersAddress == 0 || registerCount < 2 || expectedLo == 0)
         {
-            TraceCreateShader(0, headerAddress, codeAddress, $"unexpected-registers type={shaderType} lo=0x{loRegister:X8} hi=0x{hiRegister:X8}");
-            return false;
+            TraceCreateShader(
+                0,
+                headerAddress,
+                codeAddress,
+                $"invalid-register-array type={shaderType} count={registerCount} address=0x{shRegistersAddress:X16}");
+            return ShaderProgramRegisterPatchResult.InvalidArgument;
+        }
+
+        ulong loValueAddress = 0;
+        ulong hiValueAddress = 0;
+        uint firstRegister = 0;
+        uint secondRegister = 0;
+        for (var index = 0; index < registerCount; index++)
+        {
+            var entryAddress = shRegistersAddress + ((ulong)index * 8);
+            if (!TryReadUInt32(ctx, entryAddress, out var register))
+            {
+                return ShaderProgramRegisterPatchResult.MemoryFault;
+            }
+
+            if (index == 0)
+            {
+                firstRegister = register;
+            }
+            else if (index == 1)
+            {
+                secondRegister = register;
+            }
+
+            if (register != expectedLo || index + 1 >= registerCount)
+            {
+                continue;
+            }
+
+            var nextEntryAddress = entryAddress + 8;
+            if (!TryReadUInt32(ctx, nextEntryAddress, out var nextRegister))
+            {
+                return ShaderProgramRegisterPatchResult.MemoryFault;
+            }
+
+            if (nextRegister == expectedHi)
+            {
+                loValueAddress = entryAddress + sizeof(uint);
+                hiValueAddress = nextEntryAddress + sizeof(uint);
+                break;
+            }
+        }
+
+        if (loValueAddress == 0 || hiValueAddress == 0)
+        {
+            TraceAgc(
+                $"agc.create_shader header=0x{headerAddress:X16} code=0x{codeAddress:X16} " +
+                $"program-registers-unpatched type={shaderType} count={registerCount} " +
+                $"expected=0x{expectedLo:X8}/0x{expectedHi:X8} " +
+                $"first=0x{firstRegister:X8}/0x{secondRegister:X8}");
+            return ShaderProgramRegisterPatchResult.Success;
         }
 
         var loValue = (uint)((codeAddress >> 8) & 0xFFFF_FFFFUL);
         var hiValue = (uint)((codeAddress >> 40) & 0xFFUL);
-        return TryWriteUInt32(ctx, shRegistersAddress + sizeof(uint), loValue) &&
-               TryWriteUInt32(ctx, shRegistersAddress + 8 + sizeof(uint), hiValue);
+        return TryWriteUInt32(ctx, loValueAddress, loValue) &&
+               TryWriteUInt32(ctx, hiValueAddress, hiValue)
+            ? ShaderProgramRegisterPatchResult.Success
+            : ShaderProgramRegisterPatchResult.MemoryFault;
     }
 
     private static bool IsEsGeometryShaderType(byte shaderType) =>

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -182,7 +182,6 @@ public static partial class AgcExports
     private const ulong ShaderSpecialVgtShaderStagesEnOffset = 0x08;
     private const ulong ShaderSpecialVgtGsOutPrimTypeOffset = 0x20;
     private const ulong ShaderSpecialGeUserVgprEnOffset = 0x28;
-    private const uint CbSetShRegisterRangeMarker = 0x6875000D;
     private static readonly object _submitTraceGate = new();
     private static readonly HashSet<uint> _tracedDcbSizes = new();
     private static readonly HashSet<(ulong Es, ulong Ps, GuestDrawKind Kind)> _tracedShaderTranslations = new();
@@ -1275,10 +1274,7 @@ public static partial class AgcExports
             return ReturnPointer(ctx, 0);
         }
 
-        if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 2, out var markerAddress) ||
-            !TryWriteUInt32(ctx, markerAddress, Pm4(2, ItNop, RZero)) ||
-            !TryWriteUInt32(ctx, markerAddress + 4, CbSetShRegisterRangeMarker) ||
-            !TryAllocateCommandDwords(ctx, commandBufferAddress, valueCount + 2, out var commandAddress) ||
+        if (!TryAllocateCommandDwords(ctx, commandBufferAddress, valueCount + 2, out var commandAddress) ||
             !TryWriteUInt32(ctx, commandAddress, Pm4(valueCount + 2, ItSetShReg, 0)) ||
             !TryWriteUInt32(ctx, commandAddress + 4, offset))
         {

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -3116,12 +3116,28 @@ public static partial class AgcExports
         // guest-memory writes have finished. Put the notification on that same
         // logical graphics queue instead of approximating completion with a
         // timer, which can wake Unity while its upload data is still stale.
-        if (VulkanVideoPresenter.SubmitOrderedGuestAction(
+        if (EnqueueSubmittedDcbCompletion(
+                state.QueueName,
+                submissionId,
                 TriggerCompletionEvents,
-                $"agc submit completion {submissionId}") == 0)
+                VulkanVideoPresenter.SubmitOrderedGuestAction) == 0)
         {
             TriggerCompletionEvents();
         }
+    }
+
+    internal static long EnqueueSubmittedDcbCompletion(
+        string queueName,
+        ulong submissionId,
+        Action completion,
+        Func<Action, string, long> submitOrderedAction)
+    {
+        using var guestQueueScope = VulkanVideoPresenter.EnterGuestQueue(
+            queueName,
+            submissionId);
+        return submitOrderedAction(
+            completion,
+            $"agc submit completion {submissionId}");
     }
 
     // Returns true only when parsing stopped on an unsatisfied WAIT_REG_MEM.

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -552,7 +552,7 @@ public static partial class AgcExports
         public Dictionary<ulong, ComputeImageWriter> ComputeImageWriters { get; } = new();
         public Dictionary<uint, string> ResourceOwners { get; } = new();
         public Dictionary<uint, RegisteredAgcResource> RegisteredResources { get; } = new();
-        public bool ResourceRegistrationInitialized { get; set; }
+        public ResourceRegistrationMode ResourceRegistrationMode { get; set; }
         public ulong ResourceRegistrationMemory { get; set; }
         public ulong ResourceRegistrationMemorySize { get; set; }
         public uint ResourceRegistrationMaxOwners { get; set; }
@@ -562,6 +562,13 @@ public static partial class AgcExports
         public ulong WorkSequence { get; set; }
         public ulong SubmissionSequence { get; set; }
         public bool WaitMonitorRunning { get; set; }
+    }
+
+    private enum ResourceRegistrationMode : byte
+    {
+        None,
+        Implicit,
+        Explicit,
     }
 
     private readonly record struct RegisteredAgcResource(
@@ -934,6 +941,31 @@ public static partial class AgcExports
     }
 
     [SysAbiExport(
+        Nid = "t7PlZ9nt5Lc",
+        ExportName = "sceAgcCbNopGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int CbNopGetSize(CpuContext ctx)
+    {
+        // CbNop writes exactly the requested number of dwords.
+        var dwordCount = (uint)ctx[CpuRegister.Rdi];
+        ctx[CpuRegister.Rax] = (ulong)dwordCount * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "hL7C0IRpWZI",
+        ExportName = "sceAgcCbQueueEndOfPipeActionGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int CbQueueEndOfPipeActionGetSize(CpuContext ctx)
+    {
+        // End-of-pipe actions use an eight-dword release-memory packet.
+        ctx[CpuRegister.Rax] = 8u * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
         Nid = "k3GhuSNmBLU",
         ExportName = "sceAgcCbDispatch",
         Target = Generation.Gen5,
@@ -1128,6 +1160,17 @@ public static partial class AgcExports
         }
 
         return ReturnPointer(ctx, commandAddress);
+    }
+
+    [SysAbiExport(
+        Nid = "ewobAQeMo5k",
+        ExportName = "sceAgcAcbAcquireMemGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int AcbAcquireMemGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 8u * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     [SysAbiExport(
@@ -1345,6 +1388,36 @@ public static partial class AgcExports
         }
 
         TraceAgc($"agc.dcb_reset_queue buf=0x{commandBufferAddress:X16} cmd=0x{commandAddress:X16}");
+        return ReturnPointer(ctx, commandAddress);
+    }
+
+    [SysAbiExport(
+        Nid = "w4-d0n60hdo",
+        ExportName = "sceAgcDcbSetUcRegisterDirect",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbSetUcRegisterDirect(CpuContext ctx)
+    {
+        var commandBufferAddress = ctx[CpuRegister.Rdi];
+        var packedRegister = ctx[CpuRegister.Rsi];
+        var value = (uint)packedRegister;
+        var offset = (uint)(packedRegister >> 32);
+        if (commandBufferAddress == 0 || offset > ushort.MaxValue)
+        {
+            return ReturnPointer(ctx, 0);
+        }
+
+        if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 3, out var commandAddress) ||
+            !TryWriteUInt32(ctx, commandAddress, Pm4(3, ItSetUconfigReg, 0)) ||
+            !TryWriteUInt32(ctx, commandAddress + 4, offset) ||
+            !TryWriteUInt32(ctx, commandAddress + 8, value))
+        {
+            return ReturnPointer(ctx, 0);
+        }
+
+        TraceAgc(
+            $"agc.dcb_set_uc_direct buf=0x{commandBufferAddress:X16} cmd=0x{commandAddress:X16} " +
+            $"offset=0x{offset:X4} value=0x{value:X8}");
         return ReturnPointer(ctx, commandAddress);
     }
 
@@ -1702,6 +1775,17 @@ public static partial class AgcExports
             $"agc.dcb_acquire_mem buf=0x{commandBufferAddress:X16} cmd=0x{commandAddress:X16} " +
             $"engine={engine} cbdb=0x{cbDbOp:X8} gcr=0x{gcrControl:X8} base=0x{baseAddress:X16} size=0x{sizeBytes:X16}");
         return ReturnPointer(ctx, commandAddress);
+    }
+
+    [SysAbiExport(
+        Nid = "-vnlTPPXPrw",
+        ExportName = "sceAgcDcbAcquireMemGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbAcquireMemGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 8u * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     [SysAbiExport(
@@ -2638,6 +2722,34 @@ public static partial class AgcExports
     }
 
     [SysAbiExport(
+        Nid = "XlNp7jzGiPo",
+        ExportName = "sceAgcDriverSetTFRing",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgcDriver")]
+    public static int DriverSetTFRing(CpuContext ctx)
+    {
+        // The tessellation-factor ring is consumed by the hardware scheduler.
+        // Record the registration for diagnostics and accept it under HLE.
+        var ringAddress = ctx[CpuRegister.Rdi];
+        var ringSizeBytes = (uint)ctx[CpuRegister.Rsi];
+        TraceAgc($"agc.driver_set_tf_ring addr=0x{ringAddress:X16} size=0x{ringSizeBytes:X}");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "MM4IZSEYytQ",
+        ExportName = "sceAgcDriverSetHsOffchipParam",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgcDriver")]
+    public static int DriverSetHsOffchipParam(CpuContext ctx)
+    {
+        // Hull-shader off-chip LDS configuration is likewise hardware-only.
+        var param = (uint)ctx[CpuRegister.Rdi];
+        TraceAgc($"agc.driver_set_hs_offchip_param param=0x{param:X8}");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
         Nid = "UglJIZjGssM",
         ExportName = "sceAgcDriverSubmitDcb",
         Target = Generation.Gen5,
@@ -2782,12 +2894,19 @@ public static partial class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryWriteUInt32(ctx, ownerAddress, DefaultAgcOwner))
+        var state = _submittedGpuStates.GetValue(ctx.Memory, static _ => new SubmittedGpuState());
+        uint owner;
+        lock (state.Gate)
+        {
+            owner = state.DefaultOwner;
+        }
+
+        if (!TryWriteUInt32(ctx, ownerAddress, owner))
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
-        TraceAgc($"agc.driver_get_default_owner out=0x{ownerAddress:X16} owner={DefaultAgcOwner}");
+        TraceAgc($"agc.driver_get_default_owner out=0x{ownerAddress:X16} owner={owner}");
         return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
@@ -2798,15 +2917,66 @@ public static partial class AgcExports
     LibraryName = "libSceAgc")]
     public static int DriverRegisterResource(CpuContext ctx)
     {
-        var resourceAddress = ctx[CpuRegister.Rdi];
+        var resourceHandleAddress = ctx[CpuRegister.Rdi];
         var owner = (uint)ctx[CpuRegister.Rsi];
-        var nameAddress = ctx[CpuRegister.Rdx];
-        var type = (uint)ctx[CpuRegister.R8];
-        var flags = (uint)ctx[CpuRegister.R9];
+        var resourceAddress = ctx[CpuRegister.Rdx];
+        var resourceSize = ctx[CpuRegister.Rcx];
+        var nameAddress = ctx[CpuRegister.R8];
+        var type = (uint)ctx[CpuRegister.R9];
+        if (resourceHandleAddress == 0 || resourceAddress == 0 || resourceSize == 0 ||
+            !ctx.TryReadUInt32(ctx[CpuRegister.Rsp] + sizeof(ulong), out var flags) ||
+            !TryReadGuestCString(
+                ctx,
+                nameAddress,
+                ResourceRegistrationMaxNameLength,
+                out var nameBytes))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        var state = _submittedGpuStates.GetValue(ctx.Memory, static _ => new SubmittedGpuState());
+        var resourceName = System.Text.Encoding.UTF8.GetString(nameBytes);
+        uint resourceHandle;
+        lock (state.Gate)
+        {
+            if (state.ResourceRegistrationMode == ResourceRegistrationMode.None ||
+                owner != state.DefaultOwner &&
+                !state.ResourceOwners.ContainsKey(owner))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+            }
+
+            resourceHandle = state.NextResource;
+            while (resourceHandle == 0 || state.RegisteredResources.ContainsKey(resourceHandle))
+            {
+                resourceHandle++;
+                if (resourceHandle == state.NextResource)
+                {
+                    return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+                }
+            }
+
+            if (!TryWriteUInt32(ctx, resourceHandleAddress, resourceHandle))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+
+            state.NextResource = resourceHandle + 1;
+            state.RegisteredResources.Add(
+                resourceHandle,
+                new RegisteredAgcResource(
+                    owner,
+                    resourceAddress,
+                    resourceSize,
+                    resourceName,
+                    type,
+                    flags));
+        }
 
         TraceAgc(
-            $"agc.driver_register_resource resource=0x{resourceAddress:X16} owner={owner} " +
-            $"name=0x{nameAddress:X16} type={type} flags={flags}");
+            $"agc.driver_register_resource handle={resourceHandle} owner={owner} " +
+            $"resource=0x{resourceAddress:X16} bytes=0x{resourceSize:X} " +
+            $"name={resourceName} type={type} flags={flags}");
 
         return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
     }
@@ -10942,6 +11112,28 @@ public static partial class AgcExports
     }
 
     [SysAbiExport(
+        Nid = "QIXCsbipds0",
+        ExportName = "sceAgcDcbRewindGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbRewindGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 2u * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "VEGu4dixjUg",
+        ExportName = "sceAgcDcbJumpGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbJumpGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 4u * sizeof(uint);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
         Nid = "bbFueFP+J4k",
         ExportName = "sceAgcDcbSetPredication",
         Target = Generation.Gen5,
@@ -11092,7 +11284,7 @@ public static partial class AgcExports
         var state = _submittedGpuStates.GetValue(ctx.Memory, static _ => new SubmittedGpuState());
         lock (state.Gate)
         {
-            state.ResourceRegistrationInitialized = true;
+            state.ResourceRegistrationMode = ResourceRegistrationMode.Explicit;
             state.ResourceRegistrationMemory = memoryAddress;
             state.ResourceRegistrationMemorySize = memorySize;
             state.ResourceRegistrationMaxOwners = (uint)ownerCount;
@@ -11148,10 +11340,11 @@ public static partial class AgcExports
 
         var state = _submittedGpuStates.GetValue(ctx.Memory, static _ => new SubmittedGpuState());
         uint owner;
+        var initializedImplicitly = false;
+        var ownerName = System.Text.Encoding.UTF8.GetString(nameBytes);
         lock (state.Gate)
         {
-            if (!state.ResourceRegistrationInitialized ||
-                state.ResourceRegistrationMaxOwners != 0 &&
+            if (state.ResourceRegistrationMaxOwners != 0 &&
                 state.ResourceOwners.Count >= state.ResourceRegistrationMaxOwners)
             {
                 return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
@@ -11167,23 +11360,29 @@ public static partial class AgcExports
                 }
             }
 
-            state.NextOwner = owner + 1;
-            state.ResourceOwners.Add(owner, System.Text.Encoding.UTF8.GetString(nameBytes));
-        }
-
-        if (!ctx.TryWriteUInt32(ownerAddress, owner))
-        {
-            lock (state.Gate)
+            if (!ctx.TryWriteUInt32(ownerAddress, owner))
             {
-                state.ResourceOwners.Remove(owner);
+                return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             }
 
-            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            if (state.ResourceRegistrationMode == ResourceRegistrationMode.None)
+            {
+                state.ResourceRegistrationMode = ResourceRegistrationMode.Implicit;
+                initializedImplicitly = true;
+            }
+
+            state.NextOwner = owner + 1;
+            state.ResourceOwners.Add(owner, ownerName);
+        }
+
+        if (initializedImplicitly)
+        {
+            TraceAgc("agc.driver_register_owner initialized implicit resource registration");
         }
 
         TraceAgc(
             $"agc.driver_register_owner out=0x{ownerAddress:X16} owner={owner} " +
-            $"name={System.Text.Encoding.UTF8.GetString(nameBytes)}");
+            $"name={ownerName}");
         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcBootstrapExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcBootstrapExportsTests.cs
@@ -1,0 +1,440 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcBootstrapExportsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+
+    [Theory]
+    [InlineData("cb-nop", 7, 28)]
+    [InlineData("cb-eop", 0, 32)]
+    [InlineData("acb-acquire", 0, 32)]
+    [InlineData("dcb-acquire", 0, 32)]
+    [InlineData("dcb-rewind", 0, 8)]
+    [InlineData("dcb-jump", 0, 16)]
+    public void PacketSizeQueriesReturnEmittedByteCounts(string export, ulong argument, ulong expected)
+    {
+        var context = new CpuContext(new FakeCpuMemory(MemoryBase, 0x1000), Generation.Gen5);
+        context[CpuRegister.Rdi] = argument;
+
+        var result = export switch
+        {
+            "cb-nop" => AgcExports.CbNopGetSize(context),
+            "cb-eop" => AgcExports.CbQueueEndOfPipeActionGetSize(context),
+            "acb-acquire" => AgcExports.AcbAcquireMemGetSize(context),
+            "dcb-acquire" => AgcExports.DcbAcquireMemGetSize(context),
+            "dcb-rewind" => AgcExports.DcbRewindGetSize(context),
+            "dcb-jump" => AgcExports.DcbJumpGetSize(context),
+            _ => throw new InvalidOperationException(export),
+        };
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(expected, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void DriverHardwareRegistrationsAreAccepted()
+    {
+        var context = new CpuContext(new FakeCpuMemory(MemoryBase, 0x1000), Generation.Gen5);
+
+        context[CpuRegister.Rdi] = 0x3_12B0_0200;
+        context[CpuRegister.Rsi] = 0x3FFF8;
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverSetTFRing(context));
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+
+        context[CpuRegister.Rdi] = 0x1234;
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverSetHsOffchipParam(context));
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void DirectUcRegisterWritesSetUconfigPacketAndAdvancesCursor()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        var commandBufferAddress = MemoryBase + 0x100;
+        var commandAddress = MemoryBase + 0x400;
+
+        WriteUInt64(memory, commandBufferAddress + 0x10, commandAddress);
+        WriteUInt64(memory, commandBufferAddress + 0x18, commandAddress + 0x100);
+        WriteUInt64(memory, commandBufferAddress + 0x20, 0);
+        WriteUInt64(memory, commandBufferAddress + 0x28, 0);
+        WriteUInt32(memory, commandBufferAddress + 0x30, 0);
+
+        context[CpuRegister.Rdi] = commandBufferAddress;
+        context[CpuRegister.Rsi] = (0x1234UL << 32) | 0xDEAD_BEEFUL;
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DcbSetUcRegisterDirect(context));
+        Assert.Equal(commandAddress, context[CpuRegister.Rax]);
+        Assert.Equal(commandAddress + 12, ReadUInt64(memory, commandBufferAddress + 0x10));
+        Assert.Equal(0xC001_7900u, ReadUInt32(memory, commandAddress));
+        Assert.Equal(0x1234u, ReadUInt32(memory, commandAddress + 4));
+        Assert.Equal(0xDEAD_BEEFu, ReadUInt32(memory, commandAddress + 8));
+    }
+
+    [Fact]
+    public void DriverRegisterOwnerSupportsOwnerFirstFlow()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        var nameAddress = memory.WriteCString(MemoryBase + 0x100, "owner-first");
+        var ownerAddress = MemoryBase + 0x200;
+
+        context[CpuRegister.Rdi] = ownerAddress;
+        context[CpuRegister.Rsi] = nameAddress;
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterOwner(context));
+        Assert.Equal(2u, ReadUInt32(memory, ownerAddress));
+    }
+
+    [Fact]
+    public void DriverRegisterOwnerMemoryFaultDoesNotConsumeOwnerOrRegistrationMode()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        var nameAddress = memory.WriteCString(MemoryBase + 0x100, "owner-first");
+
+        context[CpuRegister.Rdi] = MemoryBase + 0x2000;
+        context[CpuRegister.Rsi] = nameAddress;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            AgcExports.DriverRegisterOwner(context));
+
+        var ownerAddress = MemoryBase + 0x200;
+        context[CpuRegister.Rdi] = ownerAddress;
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterOwner(context));
+        Assert.Equal(2u, ReadUInt32(memory, ownerAddress));
+    }
+
+    [Fact]
+    public void ExplicitInitializationReplacesOwnerFirstRegistrationState()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        var ownerAddress = MemoryBase + 0x200;
+        var firstNameAddress = memory.WriteCString(MemoryBase + 0x100, "implicit-owner");
+        var explicitNameAddress = memory.WriteCString(MemoryBase + 0x180, "explicit-owner");
+
+        context[CpuRegister.Rdi] = ownerAddress;
+        context[CpuRegister.Rsi] = firstNameAddress;
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterOwner(context));
+        Assert.Equal(2u, ReadUInt32(memory, ownerAddress));
+
+        context[CpuRegister.Rdi] = MemoryBase + 0x300;
+        context[CpuRegister.Rsi] = 0x1E0;
+        context[CpuRegister.Rdx] = 1;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.DriverInitResourceRegistration(context));
+
+        context[CpuRegister.Rdi] = ownerAddress;
+        context[CpuRegister.Rsi] = explicitNameAddress;
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterOwner(context));
+        Assert.Equal(2u, ReadUInt32(memory, ownerAddress));
+    }
+
+    [Fact]
+    public void DriverRegisterOwnerPreservesExplicitOwnerLimit()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        var firstNameAddress = memory.WriteCString(MemoryBase + 0x100, "first-owner");
+        var secondNameAddress = memory.WriteCString(MemoryBase + 0x180, "second-owner");
+        var ownerAddress = MemoryBase + 0x200;
+
+        context[CpuRegister.Rdi] = MemoryBase + 0x300;
+        context[CpuRegister.Rsi] = 0x1E0;
+        context[CpuRegister.Rdx] = 1;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.DriverInitResourceRegistration(context));
+
+        context[CpuRegister.Rdi] = ownerAddress;
+        context[CpuRegister.Rsi] = firstNameAddress;
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterOwner(context));
+
+        context[CpuRegister.Rdi] = ownerAddress;
+        context[CpuRegister.Rsi] = secondNameAddress;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            AgcExports.DriverRegisterOwner(context));
+    }
+
+    [Fact]
+    public void DriverRegisterResourceUsesSevenArgumentAbiInImplicitModeAndUnregisters()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x2000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        var ownerNameAddress = memory.WriteCString(MemoryBase + 0x100, "implicit-owner");
+        var ownerAddress = MemoryBase + 0x200;
+        var resourceNameAddress = memory.WriteCString(MemoryBase + 0x300, "implicit-resource");
+        var resourceHandleAddress = MemoryBase + 0x400;
+        var stackAddress = MemoryBase + 0x1000;
+
+        context[CpuRegister.Rdi] = ownerAddress;
+        context[CpuRegister.Rsi] = ownerNameAddress;
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterOwner(context));
+        var owner = ReadUInt32(memory, ownerAddress);
+        Assert.Equal(2u, owner);
+
+        WriteUInt32(memory, resourceHandleAddress, 0xCCCCCCCC);
+        ConfigureRegisterResource(
+            context,
+            memory,
+            resourceHandleAddress,
+            owner,
+            resourceAddress: MemoryBase + 0x800,
+            resourceSize: 0x3456,
+            resourceNameAddress,
+            type: 0x55,
+            flags: 0xA5A55A5A,
+            stackAddress);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterResource(context));
+        var resourceHandle = ReadUInt32(memory, resourceHandleAddress);
+        Assert.Equal(1u, resourceHandle);
+
+        context[CpuRegister.Rdi] = resourceHandle;
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverUnregisterResource(context));
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            AgcExports.DriverUnregisterResource(context));
+    }
+
+    [Fact]
+    public void DriverRegisterResourceRequiresARegistrationModeAndRejectsUnknownOwners()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x2000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        var ownerNameAddress = memory.WriteCString(MemoryBase + 0x100, "explicit-owner");
+        var ownerAddress = MemoryBase + 0x200;
+        var resourceNameAddress = memory.WriteCString(MemoryBase + 0x300, "explicit-resource");
+        var resourceHandleAddress = MemoryBase + 0x400;
+        var stackAddress = MemoryBase + 0x1000;
+
+        WriteUInt32(memory, resourceHandleAddress, 0x11111111);
+        ConfigureRegisterResource(
+            context,
+            memory,
+            resourceHandleAddress,
+            owner: 1,
+            resourceAddress: MemoryBase + 0x800,
+            resourceSize: 0x100,
+            resourceNameAddress,
+            type: 3,
+            flags: 4,
+            stackAddress);
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            AgcExports.DriverRegisterResource(context));
+        Assert.Equal(0x11111111u, ReadUInt32(memory, resourceHandleAddress));
+
+        context[CpuRegister.Rdi] = MemoryBase + 0x600;
+        context[CpuRegister.Rsi] = 0x400;
+        context[CpuRegister.Rdx] = 2;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.DriverInitResourceRegistration(context));
+
+        context[CpuRegister.Rdi] = ownerAddress;
+        context[CpuRegister.Rsi] = ownerNameAddress;
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterOwner(context));
+        var owner = ReadUInt32(memory, ownerAddress);
+        Assert.Equal(2u, owner);
+
+        WriteUInt32(memory, resourceHandleAddress, 0x22222222);
+        ConfigureRegisterResource(
+            context,
+            memory,
+            resourceHandleAddress,
+            owner: 99,
+            resourceAddress: MemoryBase + 0x800,
+            resourceSize: 0x100,
+            resourceNameAddress,
+            type: 3,
+            flags: 4,
+            stackAddress);
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            AgcExports.DriverRegisterResource(context));
+        Assert.Equal(0x22222222u, ReadUInt32(memory, resourceHandleAddress));
+
+        ConfigureRegisterResource(
+            context,
+            memory,
+            resourceHandleAddress,
+            owner,
+            resourceAddress: MemoryBase + 0x800,
+            resourceSize: 0x100,
+            resourceNameAddress,
+            type: 3,
+            flags: 4,
+            stackAddress);
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterResource(context));
+        Assert.Equal(1u, ReadUInt32(memory, resourceHandleAddress));
+
+        ConfigureRegisterResource(
+            context,
+            memory,
+            resourceHandleAddress,
+            owner: 1,
+            resourceAddress: MemoryBase + 0x900,
+            resourceSize: 0x200,
+            resourceNameAddress,
+            type: 5,
+            flags: 6,
+            stackAddress);
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterResource(context));
+        Assert.Equal(2u, ReadUInt32(memory, resourceHandleAddress));
+    }
+
+    [Fact]
+    public void DriverRegisterResourceFaultsDoNotConsumeAHandle()
+    {
+        const ulong faultingAddress = 0xDEAD_0000_0000;
+        var memory = new FakeCpuMemory(MemoryBase, 0x2000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        var ownerNameAddress = memory.WriteCString(MemoryBase + 0x100, "fault-owner");
+        var ownerAddress = MemoryBase + 0x200;
+        var resourceNameAddress = memory.WriteCString(MemoryBase + 0x300, "fault-resource");
+        var resourceHandleAddress = MemoryBase + 0x400;
+        var stackAddress = MemoryBase + 0x1000;
+
+        context[CpuRegister.Rdi] = ownerAddress;
+        context[CpuRegister.Rsi] = ownerNameAddress;
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterOwner(context));
+        var owner = ReadUInt32(memory, ownerAddress);
+
+        WriteUInt32(memory, resourceHandleAddress, 0x33333333);
+        ConfigureRegisterResource(
+            context,
+            memory,
+            resourceHandleAddress,
+            owner,
+            resourceAddress: MemoryBase + 0x800,
+            resourceSize: 0x100,
+            resourceNameAddress,
+            type: 7,
+            flags: 8,
+            stackAddress: faultingAddress,
+            writeStackArgument: false);
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            AgcExports.DriverRegisterResource(context));
+        Assert.Equal(0x33333333u, ReadUInt32(memory, resourceHandleAddress));
+
+        ConfigureRegisterResource(
+            context,
+            memory,
+            resourceHandleAddress: faultingAddress,
+            owner,
+            resourceAddress: MemoryBase + 0x800,
+            resourceSize: 0x100,
+            resourceNameAddress,
+            type: 7,
+            flags: 8,
+            stackAddress);
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            AgcExports.DriverRegisterResource(context));
+
+        ConfigureRegisterResource(
+            context,
+            memory,
+            resourceHandleAddress,
+            owner,
+            resourceAddress: MemoryBase + 0x800,
+            resourceSize: 0x100,
+            resourceNameAddress,
+            type: 7,
+            flags: 8,
+            stackAddress);
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverRegisterResource(context));
+        Assert.Equal(1u, ReadUInt32(memory, resourceHandleAddress));
+    }
+
+    [Fact]
+    public void DriverGetDefaultOwnerReflectsRegisteredDefaultOwner()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        var ownerAddress = MemoryBase + 0x100;
+
+        context[CpuRegister.Rdi] = MemoryBase + 0x300;
+        context[CpuRegister.Rsi] = 0x200;
+        context[CpuRegister.Rdx] = 1;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.DriverInitResourceRegistration(context));
+
+        context[CpuRegister.Rdi] = 7;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.DriverRegisterDefaultOwner(context));
+
+        context[CpuRegister.Rdi] = ownerAddress;
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.DriverGetDefaultOwner(context));
+        Assert.Equal(7u, ReadUInt32(memory, ownerAddress));
+    }
+
+    private static void ConfigureRegisterResource(
+        CpuContext context,
+        FakeCpuMemory memory,
+        ulong resourceHandleAddress,
+        uint owner,
+        ulong resourceAddress,
+        ulong resourceSize,
+        ulong resourceNameAddress,
+        uint type,
+        uint flags,
+        ulong stackAddress,
+        bool writeStackArgument = true)
+    {
+        context[CpuRegister.Rdi] = resourceHandleAddress;
+        context[CpuRegister.Rsi] = owner;
+        context[CpuRegister.Rdx] = resourceAddress;
+        context[CpuRegister.Rcx] = resourceSize;
+        context[CpuRegister.R8] = resourceNameAddress;
+        context[CpuRegister.R9] = type;
+        context[CpuRegister.Rsp] = stackAddress;
+        if (writeStackArgument)
+        {
+            WriteUInt32(memory, stackAddress + sizeof(ulong), flags);
+        }
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static void WriteUInt32(FakeCpuMemory memory, ulong address, uint value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static ulong ReadUInt64(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        Assert.True(memory.TryRead(address, bytes));
+        return BinaryPrimitives.ReadUInt64LittleEndian(bytes);
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        Assert.True(memory.TryRead(address, bytes));
+        return BinaryPrimitives.ReadUInt32LittleEndian(bytes);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcShRegisterRangeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcShRegisterRangeTests.cs
@@ -1,0 +1,111 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcShRegisterRangeTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong CommandBufferAddress = MemoryBase + 0x100;
+    private const ulong ValuesAddress = MemoryBase + 0x300;
+    private const ulong CommandAddress = MemoryBase + 0x400;
+
+    [Fact]
+    public void SetShRegisterRangeConsumesOnlyAdvertisedPacketSpace()
+    {
+        var memory = CreateRequest(commandDwordsAvailable: 5);
+        var context = CreateContext(memory);
+
+        _ = AgcExports.CbSetShRegisterRangeDirect(context);
+
+        Assert.Equal(CommandAddress, context[CpuRegister.Rax]);
+        Assert.Equal(
+            CommandAddress + (5 * sizeof(uint)),
+            ReadUInt64(memory, CommandBufferAddress + 0x10));
+        Assert.Equal(0xC003_7600u, ReadUInt32(memory, CommandAddress));
+        Assert.Equal(0x20u, ReadUInt32(memory, CommandAddress + 4));
+        Assert.Equal(0x1111_1111u, ReadUInt32(memory, CommandAddress + 8));
+        Assert.Equal(0x2222_2222u, ReadUInt32(memory, CommandAddress + 12));
+        Assert.Equal(0x3333_3333u, ReadUInt32(memory, CommandAddress + 16));
+    }
+
+    [Fact]
+    public void SetShRegisterRangeShortBufferDoesNotPartiallyConsumeSpace()
+    {
+        var memory = CreateRequest(commandDwordsAvailable: 4);
+        for (ulong offset = 0; offset < 5 * sizeof(uint); offset += sizeof(uint))
+        {
+            WriteUInt32(memory, CommandAddress + offset, 0xA5A5_A5A5);
+        }
+        var context = CreateContext(memory);
+
+        _ = AgcExports.CbSetShRegisterRangeDirect(context);
+
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+        Assert.Equal(CommandAddress, ReadUInt64(memory, CommandBufferAddress + 0x10));
+        for (ulong offset = 0; offset < 5 * sizeof(uint); offset += sizeof(uint))
+        {
+            Assert.Equal(0xA5A5_A5A5u, ReadUInt32(memory, CommandAddress + offset));
+        }
+    }
+
+    private static FakeCpuMemory CreateRequest(ulong commandDwordsAvailable)
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        WriteUInt32(memory, ValuesAddress, 0x1111_1111);
+        WriteUInt32(memory, ValuesAddress + 4, 0x2222_2222);
+        WriteUInt32(memory, ValuesAddress + 8, 0x3333_3333);
+        WriteUInt64(memory, CommandBufferAddress + 0x10, CommandAddress);
+        WriteUInt64(
+            memory,
+            CommandBufferAddress + 0x18,
+            CommandAddress + (commandDwordsAvailable * sizeof(uint)));
+        WriteUInt64(memory, CommandBufferAddress + 0x20, 0);
+        WriteUInt64(memory, CommandBufferAddress + 0x28, 0);
+        WriteUInt32(memory, CommandBufferAddress + 0x30, 0);
+        return memory;
+    }
+
+    private static CpuContext CreateContext(FakeCpuMemory memory)
+    {
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = CommandBufferAddress;
+        context[CpuRegister.Rsi] = 0x20;
+        context[CpuRegister.Rdx] = ValuesAddress;
+        context[CpuRegister.Rcx] = 3;
+        return context;
+    }
+
+    private static void WriteUInt32(FakeCpuMemory memory, ulong address, uint value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        Assert.True(memory.TryRead(address, bytes));
+        return BinaryPrimitives.ReadUInt32LittleEndian(bytes);
+    }
+
+    private static ulong ReadUInt64(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        Assert.True(memory.TryRead(address, bytes));
+        return BinaryPrimitives.ReadUInt64LittleEndian(bytes);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcShaderProgramRegisterTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcShaderProgramRegisterTests.cs
@@ -1,0 +1,156 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcShaderProgramRegisterTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong DestinationAddress = MemoryBase + 0x80;
+    private const ulong HeaderAddress = MemoryBase + 0x100;
+    private const ulong RegistersAddress = MemoryBase + 0x400;
+    private const ulong CodeAddress = 0x0000_1234_5678_9A00;
+
+    [Fact]
+    public void CreateHullShaderPreservesResourceRegistersWithoutProgramPair()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        ConfigureShaderHeader(
+            memory,
+            shaderType: 5,
+            (0x10A, 0xA5A5_A5A5),
+            (0x10B, 0x5A5A_5A5A));
+        var context = CreateContext(memory, DestinationAddress);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.CreateShader(context));
+        Assert.Equal(HeaderAddress, ReadUInt64(memory, DestinationAddress));
+        Assert.Equal(CodeAddress, ReadUInt64(memory, HeaderAddress + 0x10));
+        Assert.Equal(0xA5A5_A5A5u, ReadUInt32(memory, RegistersAddress + 4));
+        Assert.Equal(0x5A5A_5A5Au, ReadUInt32(memory, RegistersAddress + 12));
+    }
+
+    [Fact]
+    public void CreateHullShaderPatchesOnlyActualProgramRegisterPair()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        ConfigureShaderHeader(
+            memory,
+            shaderType: 5,
+            (0x10A, 0xA5A5_A5A5),
+            (0x10B, 0x5A5A_5A5A),
+            (0x108, 0),
+            (0x109, 0));
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.CreateShader(CreateContext(memory, DestinationAddress)));
+        AssertProgramPairPatchedAfterPreservedResources(memory);
+    }
+
+    [Fact]
+    public void CreateGeometryShaderPatchesProgramRegistersInsteadOfResourceRegisters()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        ConfigureShaderHeader(
+            memory,
+            shaderType: 4,
+            (0x8A, 0xA5A5_A5A5),
+            (0x8B, 0x5A5A_5A5A),
+            (0x88, 0),
+            (0x89, 0));
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.CreateShader(CreateContext(memory, destinationAddress: 0)));
+        AssertProgramPairPatchedAfterPreservedResources(memory);
+    }
+
+    [Fact]
+    public void CreateShaderReturnsMemoryFaultForUnreadableRegisterArray()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x410);
+        ConfigureShaderHeader(
+            memory,
+            shaderType: 5,
+            (0x10A, 0xA5A5_A5A5),
+            (0x10B, 0x5A5A_5A5A));
+        WriteByte(memory, HeaderAddress + 0x5C, 3);
+        WriteUInt64(memory, DestinationAddress, 0xDEAD_BEEF_DEAD_BEEF);
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            AgcExports.CreateShader(CreateContext(memory, DestinationAddress)));
+        Assert.Equal(0xDEAD_BEEF_DEAD_BEEFul, ReadUInt64(memory, DestinationAddress));
+    }
+
+    private static CpuContext CreateContext(FakeCpuMemory memory, ulong destinationAddress)
+    {
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = destinationAddress;
+        context[CpuRegister.Rsi] = HeaderAddress;
+        context[CpuRegister.Rdx] = CodeAddress;
+        return context;
+    }
+
+    private static void ConfigureShaderHeader(
+        FakeCpuMemory memory,
+        byte shaderType,
+        params (uint Register, uint Value)[] registers)
+    {
+        WriteUInt32(memory, HeaderAddress, 0x3433_3231);
+        WriteUInt32(memory, HeaderAddress + 4, 0x18);
+        WriteUInt64(memory, HeaderAddress + 0x20, RegistersAddress - (HeaderAddress + 0x20));
+        WriteByte(memory, HeaderAddress + 0x5A, shaderType);
+        WriteByte(memory, HeaderAddress + 0x5C, checked((byte)registers.Length));
+        for (var index = 0; index < registers.Length; index++)
+        {
+            var entryAddress = RegistersAddress + ((ulong)index * 8);
+            WriteUInt32(memory, entryAddress, registers[index].Register);
+            WriteUInt32(memory, entryAddress + 4, registers[index].Value);
+        }
+    }
+
+    private static void AssertProgramPairPatchedAfterPreservedResources(FakeCpuMemory memory)
+    {
+        Assert.Equal(0xA5A5_A5A5u, ReadUInt32(memory, RegistersAddress + 4));
+        Assert.Equal(0x5A5A_5A5Au, ReadUInt32(memory, RegistersAddress + 12));
+        Assert.Equal(0x3456_789Au, ReadUInt32(memory, RegistersAddress + 20));
+        Assert.Equal(0x12u, ReadUInt32(memory, RegistersAddress + 28));
+    }
+
+    private static void WriteByte(FakeCpuMemory memory, ulong address, byte value) =>
+        Assert.True(memory.TryWrite(address, [value]));
+
+    private static void WriteUInt32(FakeCpuMemory memory, ulong address, uint value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        Assert.True(memory.TryRead(address, bytes));
+        return BinaryPrimitives.ReadUInt32LittleEndian(bytes);
+    }
+
+    private static ulong ReadUInt64(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        Assert.True(memory.TryRead(address, bytes));
+        return BinaryPrimitives.ReadUInt64LittleEndian(bytes);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcSubmissionQueueTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcSubmissionQueueTests.cs
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Reflection;
+using SharpEmu.Libs.Agc;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcSubmissionQueueTests
+{
+    [Fact]
+    public void DcbCompletionStaysBehindEarlierWorkOnTheGraphicsQueue()
+    {
+        const string queueName = "dcb.graphics";
+        const ulong submissionId = 42;
+        var executionOrder = new List<string>();
+        var queuedActions = new Dictionary<string, Queue<Action>>
+        {
+            [queueName] = new Queue<Action>(),
+            [VulkanGuestQueueIdentity.Default.Name] = new Queue<Action>(),
+        };
+        queuedActions[queueName].Enqueue(() => executionOrder.Add("release_mem"));
+
+        VulkanGuestQueueIdentity? capturedQueue = null;
+        var sequence = AgcExports.EnqueueSubmittedDcbCompletion(
+            queueName,
+            submissionId,
+            () => executionOrder.Add("completion"),
+            (action, debugName) =>
+            {
+                Assert.Equal($"agc submit completion {submissionId}", debugName);
+                capturedQueue = GetSubmittingGuestQueue();
+                var targetQueue = capturedQueue ?? VulkanGuestQueueIdentity.Default;
+                queuedActions[targetQueue.Name].Enqueue(action);
+                return 2;
+            });
+
+        Assert.Equal(2, sequence);
+        Assert.Equal(
+            new VulkanGuestQueueIdentity(queueName, submissionId),
+            capturedQueue);
+        Assert.Null(GetSubmittingGuestQueue());
+
+        while (queuedActions[queueName].TryDequeue(out var action))
+        {
+            action();
+        }
+
+        Assert.Equal(["release_mem", "completion"], executionOrder);
+        Assert.Empty(queuedActions[VulkanGuestQueueIdentity.Default.Name]);
+    }
+
+    private static VulkanGuestQueueIdentity? GetSubmittingGuestQueue()
+    {
+        var field = typeof(VulkanVideoPresenter).GetField(
+            "_submittingGuestQueue",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return field.GetValue(null) is VulkanGuestQueueIdentity queue
+            ? queue
+            : null;
+    }
+}


### PR DESCRIPTION
### Change description

## What changed

Adds the missing Gen5 AGC bootstrap and registration contracts, preserves submission ordering, emits direct SH ranges at the advertised size, and relocates the actual geometry/hull program-register pair without overwriting resource registers.

## Why

The missing and partially modeled AGC contracts prevented reliable queue setup, resource registration, packet emission, and shader relocation.

## Overlap

This replaces drafts #361, #368, and #369. PR #195 has similar bootstrap work but no AGC-specific tests and relocates the wrong hull-register pair. PRs #198, #208, and #316 remain complementary.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).


## Validation

- 23 focused AGC contract tests passed.
- The full build and test suite passed.
