### PR TITLE
[AGC] Preserve shader resource registers during relocation

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -76,8 +76,10 @@ public static partial class AgcExports
     private const uint SpiShaderPgmHiEs = 0xC9;
     private const uint SpiShaderPgmLoLs = 0x148;
     private const uint SpiShaderPgmHiLs = 0x149;
-    private const uint SpiShaderPgmLoGs = 0x8A;
-    private const uint SpiShaderPgmHiGs = 0x8B;
+    private const uint SpiShaderPgmLoGs = 0x88;
+    private const uint SpiShaderPgmHiGs = 0x89;
+    private const uint SpiShaderPgmLoHs = 0x108;
+    private const uint SpiShaderPgmHiHs = 0x109;
     private const uint SpiPsInputEna = 0x1B3;
     private const uint SpiPsInputAddr = 0x1B4;
     private const uint ComputePgmLo = 0x20C;
@@ -564,6 +566,13 @@ public static partial class AgcExports
         public bool WaitMonitorRunning { get; set; }
     }
 
+    private enum ShaderProgramRegisterPatchResult : byte
+    {
+        Success,
+        InvalidArgument,
+        MemoryFault,
+    }
+
     private readonly record struct RegisteredAgcResource(
         uint Owner,
         ulong Address,
@@ -685,9 +694,15 @@ public static partial class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
-        if (!PatchShaderProgramRegisters(ctx, headerAddress, codeAddress))
+        var patchResult = PatchShaderProgramRegisters(ctx, headerAddress, codeAddress);
+        if (patchResult == ShaderProgramRegisterPatchResult.InvalidArgument)
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        if (patchResult == ShaderProgramRegisterPatchResult.MemoryFault)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
         if (destinationAddress != 0 &&
@@ -10052,24 +10067,16 @@ public static partial class AgcExports
         }
     }
 
-    private static bool PatchShaderProgramRegisters(CpuContext ctx, ulong headerAddress, ulong codeAddress)
+    private static ShaderProgramRegisterPatchResult PatchShaderProgramRegisters(
+        CpuContext ctx,
+        ulong headerAddress,
+        ulong codeAddress)
     {
         if (!TryReadUInt64(ctx, headerAddress + ShaderShRegistersOffset, out var shRegistersAddress) ||
             !TryReadByte(ctx, headerAddress + ShaderTypeOffset, out var shaderType) ||
             !TryReadByte(ctx, headerAddress + ShaderNumShRegistersOffset, out var registerCount))
         {
-            return false;
-        }
-
-        if (shRegistersAddress == 0 || registerCount < 2)
-        {
-            return false;
-        }
-
-        if (!TryReadUInt32(ctx, shRegistersAddress, out var loRegister) ||
-            !TryReadUInt32(ctx, shRegistersAddress + 8, out var hiRegister))
-        {
-            return false;
+            return ShaderProgramRegisterPatchResult.MemoryFault;
         }
 
         var expectedLo = shaderType switch
@@ -10078,6 +10085,7 @@ public static partial class AgcExports
             1 => SpiShaderPgmLoPs,
             2 or 6 => SpiShaderPgmLoEs,
             4 => SpiShaderPgmLoGs,
+            5 => SpiShaderPgmLoHs,
             7 => SpiShaderPgmLoLs,
             _ => 0u,
         };
@@ -10087,19 +10095,76 @@ public static partial class AgcExports
             1 => SpiShaderPgmHiPs,
             2 or 6 => SpiShaderPgmHiEs,
             4 => SpiShaderPgmHiGs,
+            5 => SpiShaderPgmHiHs,
             7 => SpiShaderPgmHiLs,
             _ => 0u,
         };
-        if (expectedLo == 0 || loRegister != expectedLo || hiRegister != expectedHi)
+        if (shRegistersAddress == 0 || registerCount < 2 || expectedLo == 0)
         {
-            TraceCreateShader(0, headerAddress, codeAddress, $"unexpected-registers type={shaderType} lo=0x{loRegister:X8} hi=0x{hiRegister:X8}");
-            return false;
+            TraceCreateShader(
+                0,
+                headerAddress,
+                codeAddress,
+                $"invalid-register-array type={shaderType} count={registerCount} address=0x{shRegistersAddress:X16}");
+            return ShaderProgramRegisterPatchResult.InvalidArgument;
+        }
+
+        ulong loValueAddress = 0;
+        ulong hiValueAddress = 0;
+        uint firstRegister = 0;
+        uint secondRegister = 0;
+        for (var index = 0; index < registerCount; index++)
+        {
+            var entryAddress = shRegistersAddress + ((ulong)index * 8);
+            if (!TryReadUInt32(ctx, entryAddress, out var register))
+            {
+                return ShaderProgramRegisterPatchResult.MemoryFault;
+            }
+
+            if (index == 0)
+            {
+                firstRegister = register;
+            }
+            else if (index == 1)
+            {
+                secondRegister = register;
+            }
+
+            if (register != expectedLo || index + 1 >= registerCount)
+            {
+                continue;
+            }
+
+            var nextEntryAddress = entryAddress + 8;
+            if (!TryReadUInt32(ctx, nextEntryAddress, out var nextRegister))
+            {
+                return ShaderProgramRegisterPatchResult.MemoryFault;
+            }
+
+            if (nextRegister == expectedHi)
+            {
+                loValueAddress = entryAddress + sizeof(uint);
+                hiValueAddress = nextEntryAddress + sizeof(uint);
+                break;
+            }
+        }
+
+        if (loValueAddress == 0 || hiValueAddress == 0)
+        {
+            TraceAgc(
+                $"agc.create_shader header=0x{headerAddress:X16} code=0x{codeAddress:X16} " +
+                $"program-registers-unpatched type={shaderType} count={registerCount} " +
+                $"expected=0x{expectedLo:X8}/0x{expectedHi:X8} " +
+                $"first=0x{firstRegister:X8}/0x{secondRegister:X8}");
+            return ShaderProgramRegisterPatchResult.Success;
         }
 
         var loValue = (uint)((codeAddress >> 8) & 0xFFFF_FFFFUL);
         var hiValue = (uint)((codeAddress >> 40) & 0xFFUL);
-        return TryWriteUInt32(ctx, shRegistersAddress + sizeof(uint), loValue) &&
-               TryWriteUInt32(ctx, shRegistersAddress + 8 + sizeof(uint), hiValue);
+        return TryWriteUInt32(ctx, loValueAddress, loValue) &&
+               TryWriteUInt32(ctx, hiValueAddress, hiValue)
+            ? ShaderProgramRegisterPatchResult.Success
+            : ShaderProgramRegisterPatchResult.MemoryFault;
     }
 
     private static bool IsEsGeometryShaderType(byte shaderType) =>

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcShaderProgramRegisterTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcShaderProgramRegisterTests.cs
@@ -1,0 +1,156 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcShaderProgramRegisterTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong DestinationAddress = MemoryBase + 0x80;
+    private const ulong HeaderAddress = MemoryBase + 0x100;
+    private const ulong RegistersAddress = MemoryBase + 0x400;
+    private const ulong CodeAddress = 0x0000_1234_5678_9A00;
+
+    [Fact]
+    public void CreateHullShaderPreservesResourceRegistersWithoutProgramPair()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        ConfigureShaderHeader(
+            memory,
+            shaderType: 5,
+            (0x10A, 0xA5A5_A5A5),
+            (0x10B, 0x5A5A_5A5A));
+        var context = CreateContext(memory, DestinationAddress);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, AgcExports.CreateShader(context));
+        Assert.Equal(HeaderAddress, ReadUInt64(memory, DestinationAddress));
+        Assert.Equal(CodeAddress, ReadUInt64(memory, HeaderAddress + 0x10));
+        Assert.Equal(0xA5A5_A5A5u, ReadUInt32(memory, RegistersAddress + 4));
+        Assert.Equal(0x5A5A_5A5Au, ReadUInt32(memory, RegistersAddress + 12));
+    }
+
+    [Fact]
+    public void CreateHullShaderPatchesOnlyActualProgramRegisterPair()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        ConfigureShaderHeader(
+            memory,
+            shaderType: 5,
+            (0x10A, 0xA5A5_A5A5),
+            (0x10B, 0x5A5A_5A5A),
+            (0x108, 0),
+            (0x109, 0));
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.CreateShader(CreateContext(memory, DestinationAddress)));
+        AssertProgramPairPatchedAfterPreservedResources(memory);
+    }
+
+    [Fact]
+    public void CreateGeometryShaderPatchesProgramRegistersInsteadOfResourceRegisters()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        ConfigureShaderHeader(
+            memory,
+            shaderType: 4,
+            (0x8A, 0xA5A5_A5A5),
+            (0x8B, 0x5A5A_5A5A),
+            (0x88, 0),
+            (0x89, 0));
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.CreateShader(CreateContext(memory, destinationAddress: 0)));
+        AssertProgramPairPatchedAfterPreservedResources(memory);
+    }
+
+    [Fact]
+    public void CreateShaderReturnsMemoryFaultForUnreadableRegisterArray()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x410);
+        ConfigureShaderHeader(
+            memory,
+            shaderType: 5,
+            (0x10A, 0xA5A5_A5A5),
+            (0x10B, 0x5A5A_5A5A));
+        WriteByte(memory, HeaderAddress + 0x5C, 3);
+        WriteUInt64(memory, DestinationAddress, 0xDEAD_BEEF_DEAD_BEEF);
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            AgcExports.CreateShader(CreateContext(memory, DestinationAddress)));
+        Assert.Equal(0xDEAD_BEEF_DEAD_BEEFul, ReadUInt64(memory, DestinationAddress));
+    }
+
+    private static CpuContext CreateContext(FakeCpuMemory memory, ulong destinationAddress)
+    {
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = destinationAddress;
+        context[CpuRegister.Rsi] = HeaderAddress;
+        context[CpuRegister.Rdx] = CodeAddress;
+        return context;
+    }
+
+    private static void ConfigureShaderHeader(
+        FakeCpuMemory memory,
+        byte shaderType,
+        params (uint Register, uint Value)[] registers)
+    {
+        WriteUInt32(memory, HeaderAddress, 0x3433_3231);
+        WriteUInt32(memory, HeaderAddress + 4, 0x18);
+        WriteUInt64(memory, HeaderAddress + 0x20, RegistersAddress - (HeaderAddress + 0x20));
+        WriteByte(memory, HeaderAddress + 0x5A, shaderType);
+        WriteByte(memory, HeaderAddress + 0x5C, checked((byte)registers.Length));
+        for (var index = 0; index < registers.Length; index++)
+        {
+            var entryAddress = RegistersAddress + ((ulong)index * 8);
+            WriteUInt32(memory, entryAddress, registers[index].Register);
+            WriteUInt32(memory, entryAddress + 4, registers[index].Value);
+        }
+    }
+
+    private static void AssertProgramPairPatchedAfterPreservedResources(FakeCpuMemory memory)
+    {
+        Assert.Equal(0xA5A5_A5A5u, ReadUInt32(memory, RegistersAddress + 4));
+        Assert.Equal(0x5A5A_5A5Au, ReadUInt32(memory, RegistersAddress + 12));
+        Assert.Equal(0x3456_789Au, ReadUInt32(memory, RegistersAddress + 20));
+        Assert.Equal(0x12u, ReadUInt32(memory, RegistersAddress + 28));
+    }
+
+    private static void WriteByte(FakeCpuMemory memory, ulong address, byte value) =>
+        Assert.True(memory.TryWrite(address, [value]));
+
+    private static void WriteUInt32(FakeCpuMemory memory, ulong address, uint value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        Assert.True(memory.TryRead(address, bytes));
+        return BinaryPrimitives.ReadUInt32LittleEndian(bytes);
+    }
+
+    private static ulong ReadUInt64(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        Assert.True(memory.TryRead(address, bytes));
+        return BinaryPrimitives.ReadUInt64LittleEndian(bytes);
+    }
+}


### PR DESCRIPTION
## Summary

- distinguish geometry/hull shader program-address registers from adjacent resource registers
- scan the declared SH-register array for the actual LO/HI pair before relocation
- preserve resource values when the program pair is absent
- distinguish malformed headers from guest-memory faults

## Prior art and scope

Open PR #195 overlaps this shader-creation path, but its hull-shader handling treats `0x10A/0x10B` as the program-address pair. Those are the resource registers exercised here; patching them overwrites guest shader configuration.

This PR uses the program pair `0x108/0x109`, searches the full declared register array rather than assuming the first two entries, and succeeds without mutation when the pair is absent. Four focused tests prove hull and geometry relocation, preservation of adjacent resource values, and memory-fault classification. That makes this version safer and independently reviewable than the untested AGC portion bundled in #195.

Open PRs #198, #208, and #316 touch AGC/rendering code but do not contain this relocation correction or its tests. This PR also does not depend on #367's bootstrap exports.

## Validation

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release --filter FullyQualifiedName~AgcShaderProgramRegisterTests --verbosity minimal`
  - 4 passed
- `dotnet restore SharpEmu.slnx`
- `dotnet build SharpEmu.slnx -c Release --no-restore`
  - 0 warnings, 0 errors
- `dotnet test SharpEmu.slnx -c Release --no-build --verbosity minimal`
  - SharpEmu.Libs.Tests: 238 passed
  - SharpEmu.SourceGenerators.Tests: 33 passed
- `git diff --check`
