### PR TITLE
[ShaderCompiler] Support DS write add-thread-id

### DIFF
--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -682,6 +682,10 @@ public static partial class Gen5SpirvTranslator
             if (UsesSubgroupOperations())
             {
                 _module.AddCapability(SpirvCapability.GroupNonUniform);
+                // Declaring the subgroup lane input also makes initial EXEC/VCC
+                // state use OpGroupNonUniformBallot, regardless of which guest
+                // opcode first required subgroup support.
+                _module.AddCapability(SpirvCapability.GroupNonUniformBallot);
                 if (UsesSubgroupShuffle())
                 {
                     _module.AddCapability(SpirvCapability.GroupNonUniformShuffle);
@@ -692,10 +696,6 @@ public static partial class Gen5SpirvTranslator
                     _module.AddCapability(SpirvCapability.GroupNonUniformVote);
                 }
 
-                if (UsesSubgroupBroadcast() || UsesWaveControl())
-                {
-                    _module.AddCapability(SpirvCapability.GroupNonUniformBallot);
-                }
             }
 
             _glsl = _module.ImportExtInst("GLSL.std.450");
@@ -1813,6 +1813,25 @@ public static partial class Gen5SpirvTranslator
                     var address = GetRawSource(instruction, 0);
                     StoreLds(
                         LdsPointer(address, control.Offset0),
+                        GetRawSource(instruction, 1));
+                    return true;
+                }
+                case "DsWriteAddtidB32":
+                {
+                    if (instruction.Sources.Count < 2)
+                    {
+                        error = "missing LDS add-thread-id write source";
+                        return false;
+                    }
+
+                    // RDNA2 DS_WRITE_ADDTID_B32 has no address VGPR. Its byte
+                    // address is M0[15:0] + {offset1, offset0} + lane * 4.
+                    var m0 = BitwiseAnd(GetRawSource(instruction, 0), UInt(ushort.MaxValue));
+                    var laneOffset = ShiftLeftLogical(GuestWaveLane(), UInt(2));
+                    var address = IAdd(m0, laneOffset);
+                    var instructionOffset = (control.Offset1 << 8) | control.Offset0;
+                    StoreLds(
+                        LdsPointer(address, instructionOffset),
                         GetRawSource(instruction, 1));
                     return true;
                 }
@@ -5285,7 +5304,10 @@ public static partial class Gen5SpirvTranslator
              UsesSubgroupBroadcast() ||
              UsesWaveControl() ||
              _state.Program.Instructions.Any(static instruction =>
-                 instruction.Opcode is "VMbcntLoU32B32" or "VMbcntHiU32B32"));
+                 instruction.Opcode is
+                     "VMbcntLoU32B32" or
+                     "VMbcntHiU32B32" or
+                     "DsWriteAddtidB32"));
 
         private static bool IsWaveMaskOperand(Gen5Operand operand) =>
             operand.Kind == Gen5OperandKind.ScalarRegister &&

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
@@ -1251,6 +1251,7 @@ public static class Gen5ShaderTranslator
             0x37 => "DsRead2B32",
             0x38 => "DsRead2St64B32",
             0x4D => "DsWriteB64",
+            0xB0 => "DsWriteAddtidB32",
             0xDE => "DsWriteB96",
             0xDF => "DsWriteB128",
             0xFE => "DsReadB96",
@@ -1921,6 +1922,10 @@ public static class Gen5ShaderTranslator
                     ((word >> 17) & 1) != 0);
                 sources = opcode switch
                 {
+                    "DsWriteAddtidB32" => [
+                        Gen5Operand.Scalar(124),
+                        Gen5Operand.Vector(vectorData0),
+                    ],
                     "DsWriteB32" => [
                         Gen5Operand.Vector(vectorAddress),
                         Gen5Operand.Vector(vectorData0),

--- a/tests/SharpEmu.Libs.Tests/ShaderCompiler/Gen5DataShareDecodeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/ShaderCompiler/Gen5DataShareDecodeTests.cs
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.ShaderCompiler;
+
+public sealed class Gen5DataShareDecodeTests
+{
+    private const ulong ProgramAddress = 0x1_0000_0000;
+
+    [Fact]
+    public void DsWriteAddtidB32DecodesM0AndDataWithoutAddressVgpr()
+    {
+        var memory = new FakeCpuMemory(ProgramAddress, 0x100);
+        Span<byte> code = stackalloc byte[3 * sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(code, 0xDAC01234u);
+        BinaryPrimitives.WriteUInt32LittleEndian(code[sizeof(uint)..], 0x00002A11u);
+        BinaryPrimitives.WriteUInt32LittleEndian(code[(2 * sizeof(uint))..], 0xBF810000u);
+        Assert.True(memory.TryWrite(ProgramAddress, code));
+
+        var context = new CpuContext(memory, Generation.Gen5);
+        Assert.True(
+            Gen5ShaderTranslator.TryDecodeProgram(
+                context,
+                ProgramAddress,
+                out var program,
+                out var error),
+            error);
+
+        var instruction = Assert.Single(
+            program.Instructions,
+            static item => item.Opcode == "DsWriteAddtidB32");
+        Assert.Equal(Gen5ShaderEncoding.Ds, instruction.Encoding);
+        Assert.Empty(instruction.Destinations);
+
+        var control = Assert.IsType<Gen5DataShareControl>(instruction.Control);
+        Assert.Equal(0x34u, control.Offset0);
+        Assert.Equal(0x12u, control.Offset1);
+        Assert.False(control.Gds);
+
+        Assert.Collection(
+            instruction.Sources,
+            source =>
+            {
+                Assert.Equal(Gen5OperandKind.ScalarRegister, source.Kind);
+                Assert.Equal(124u, source.Value);
+            },
+            source =>
+            {
+                Assert.Equal(Gen5OperandKind.VectorRegister, source.Kind);
+                Assert.Equal(42u, source.Value);
+            });
+        Assert.DoesNotContain(
+            instruction.Sources,
+            static source =>
+                source.Kind == Gen5OperandKind.VectorRegister && source.Value == 17);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/ShaderCompiler/Gen5DataShareSpirvTests.cs
+++ b/tests/SharpEmu.Libs.Tests/ShaderCompiler/Gen5DataShareSpirvTests.cs
@@ -1,0 +1,421 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Text;
+using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.ShaderCompiler;
+
+public sealed class Gen5DataShareSpirvTests
+{
+    [Fact]
+    public void WriteAddtidComputeUsesM0ImmediateAndSubgroupLaneForLdsStore()
+    {
+        var initialScalars = new uint[256];
+        initialScalars[124] = 0xCAFE_0100;
+        var evaluation = CreateEvaluation(initialScalars);
+
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileComputeShader(
+                CreateState(),
+                evaluation,
+                localSizeX: 32,
+                localSizeY: 1,
+                localSizeZ: 1,
+                out var shader,
+                out var error),
+            error);
+
+        var instructions = ParseInstructions(shader.Spirv);
+        Assert.Contains(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.Capability &&
+                instruction.Operands[0] == (uint)SpirvCapability.GroupNonUniformBallot);
+        var subgroupInput = FindBuiltInVariable(
+            instructions,
+            SpirvBuiltIn.SubgroupLocalInvocationId);
+        var subgroupLoads = ResultIds(
+            instructions,
+            SpirvOp.Load,
+            instruction => instruction.Operands[2] == subgroupInput);
+        var lanes = FindBinaryResults(
+            instructions,
+            SpirvOp.BitwiseAnd,
+            subgroupLoads,
+            FindConstantId(instructions, 31));
+        var shiftByTwo = FindBinaryResults(
+            instructions,
+            SpirvOp.BitwiseAnd,
+            new HashSet<uint> { FindConstantId(instructions, 2) },
+            FindConstantId(instructions, 31));
+        var laneOffset = FindBinaryResult(
+            instructions,
+            SpirvOp.ShiftLeftLogical,
+            lanes,
+            shiftByTwo,
+            commutative: false);
+
+        var scalarRegisters = FindNamedId(instructions, "sgpr");
+        var m0Pointers = ResultIds(
+            instructions,
+            SpirvOp.AccessChain,
+            instruction =>
+                instruction.Operands[2] == scalarRegisters &&
+                instruction.Operands[^1] == FindConstantId(instructions, 124));
+        var m0Loads = ResultIds(
+            instructions,
+            SpirvOp.Load,
+            instruction => m0Pointers.Contains(instruction.Operands[2]));
+        var maskedM0 = FindBinaryResult(
+            instructions,
+            SpirvOp.BitwiseAnd,
+            m0Loads,
+            FindConstantId(instructions, ushort.MaxValue));
+
+        var m0AndLane = FindBinaryResult(
+            instructions,
+            SpirvOp.IAdd,
+            new HashSet<uint> { maskedM0 },
+            laneOffset);
+        var byteAddress = FindBinaryResult(
+            instructions,
+            SpirvOp.IAdd,
+            new HashSet<uint> { m0AndLane },
+            FindConstantId(instructions, 0x1234));
+        var dwordAddress = FindBinaryResult(
+            instructions,
+            SpirvOp.ShiftRightLogical,
+            new HashSet<uint> { byteAddress },
+            shiftByTwo,
+            commutative: false);
+        var boundedDwordAddress = FindBinaryResult(
+            instructions,
+            SpirvOp.BitwiseAnd,
+            new HashSet<uint> { dwordAddress },
+            FindConstantId(instructions, 8191));
+
+        var lds = FindNamedId(instructions, "lds");
+        var ldsPointer = Assert.Single(
+            ResultIds(
+                instructions,
+                SpirvOp.AccessChain,
+                instruction =>
+                    instruction.Operands[2] == lds &&
+                    instruction.Operands[^1] == boundedDwordAddress));
+        AssertLdsStoreUsesVector(instructions, ldsPointer, 42);
+        Assert.Equal(
+            SpirvStorageClass.Workgroup,
+            FindVariableStorageClass(instructions, lds));
+    }
+
+    [Fact]
+    public void WriteAddtidWave64UsesLocalInvocationIndexModulo64()
+    {
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileComputeShader(
+                CreateState(),
+                CreateEvaluation(new uint[256]),
+                localSizeX: 64,
+                localSizeY: 1,
+                localSizeZ: 1,
+                out var shader,
+                out var error,
+                waveLaneCount: 64),
+            error);
+
+        var instructions = ParseInstructions(shader.Spirv);
+        var localInvocationIndex = FindBuiltInVariable(
+            instructions,
+            SpirvBuiltIn.LocalInvocationIndex);
+        var localIndexLoads = ResultIds(
+            instructions,
+            SpirvOp.Load,
+            instruction => instruction.Operands[2] == localInvocationIndex);
+        var lanes = FindBinaryResults(
+            instructions,
+            SpirvOp.BitwiseAnd,
+            localIndexLoads,
+            FindConstantId(instructions, 63));
+        var shiftByTwo = FindBinaryResults(
+            instructions,
+            SpirvOp.BitwiseAnd,
+            new HashSet<uint> { FindConstantId(instructions, 2) },
+            FindConstantId(instructions, 31));
+
+        _ = FindBinaryResult(
+            instructions,
+            SpirvOp.ShiftLeftLogical,
+            lanes,
+            shiftByTwo,
+            commutative: false);
+    }
+
+    [Fact]
+    public void WriteAddtidVertexKeepsPerInvocationLdsWithoutSubgroupInterface()
+    {
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileVertexShader(
+                CreateState(),
+                CreateEvaluation(new uint[256]),
+                out var shader,
+                out var error),
+            error);
+
+        var instructions = ParseInstructions(shader.Spirv);
+        Assert.DoesNotContain(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.Decorate &&
+                instruction.Operands.Length >= 3 &&
+                instruction.Operands[1] == (uint)SpirvDecoration.BuiltIn &&
+                instruction.Operands[2] == (uint)SpirvBuiltIn.SubgroupLocalInvocationId);
+        Assert.DoesNotContain(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.Capability &&
+                instruction.Operands[0] == (uint)SpirvCapability.GroupNonUniform);
+
+        var lds = FindNamedId(instructions, "lds");
+        Assert.Equal(
+            SpirvStorageClass.Private,
+            FindVariableStorageClass(instructions, lds));
+        var ldsPointer = Assert.Single(
+            ResultIds(
+                instructions,
+                SpirvOp.AccessChain,
+                instruction => instruction.Operands[2] == lds));
+        AssertLdsStoreUsesVector(instructions, ldsPointer, 42);
+    }
+
+    private static Gen5ShaderState CreateState() =>
+        new(CreateProgram(), new uint[16], Metadata: null);
+
+    private static Gen5ShaderProgram CreateProgram() =>
+        new(
+            Address: 0x1000,
+            Instructions:
+            [
+                new Gen5ShaderInstruction(
+                    Pc: 0,
+                    Encoding: Gen5ShaderEncoding.Ds,
+                    Opcode: "DsWriteAddtidB32",
+                    Words: [],
+                    Sources: [Gen5Operand.Scalar(124), Gen5Operand.Vector(42)],
+                    Destinations: [],
+                    Control: new Gen5DataShareControl(0x34, 0x12, Gds: false)),
+                new Gen5ShaderInstruction(
+                    Pc: 8,
+                    Encoding: Gen5ShaderEncoding.Sopp,
+                    Opcode: "SEndpgm",
+                    Words: [0xBF810000u],
+                    Sources: [],
+                    Destinations: [],
+                    Control: null),
+            ]);
+
+    private static Gen5ShaderEvaluation CreateEvaluation(uint[] initialScalars) =>
+        new(
+            initialScalars,
+            new uint[256],
+            Array.Empty<Gen5ImageBinding>(),
+            Array.Empty<Gen5GlobalMemoryBinding>());
+
+    private static IReadOnlyList<SpirvInstruction> ParseInstructions(byte[] spirv)
+    {
+        Assert.True(spirv.Length >= 5 * sizeof(uint));
+        Assert.Equal(0, spirv.Length % sizeof(uint));
+        var words = new uint[spirv.Length / sizeof(uint)];
+        for (var index = 0; index < words.Length; index++)
+        {
+            words[index] = BinaryPrimitives.ReadUInt32LittleEndian(
+                spirv.AsSpan(index * sizeof(uint), sizeof(uint)));
+        }
+
+        var instructions = new List<SpirvInstruction>();
+        for (var index = 5; index < words.Length;)
+        {
+            var wordCount = checked((int)(words[index] >> 16));
+            Assert.True(wordCount > 0);
+            Assert.True(index + wordCount <= words.Length);
+            instructions.Add(
+                new SpirvInstruction(
+                    (SpirvOp)(words[index] & 0xFFFF),
+                    words.AsSpan(index + 1, wordCount - 1).ToArray()));
+            index += wordCount;
+        }
+
+        return instructions;
+    }
+
+    private static uint FindNamedId(
+        IReadOnlyList<SpirvInstruction> instructions,
+        string name) =>
+        Assert.Single(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.Name &&
+                DecodeString(instruction.Operands.AsSpan(1)) == name).Operands[0];
+
+    private static uint FindBuiltInVariable(
+        IReadOnlyList<SpirvInstruction> instructions,
+        SpirvBuiltIn builtIn) =>
+        Assert.Single(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.Decorate &&
+                instruction.Operands.Length >= 3 &&
+                instruction.Operands[1] == (uint)SpirvDecoration.BuiltIn &&
+                instruction.Operands[2] == (uint)builtIn).Operands[0];
+
+    private static uint FindConstantId(
+        IReadOnlyList<SpirvInstruction> instructions,
+        uint value) =>
+        Assert.Single(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.Constant &&
+                instruction.Operands.Length == 3 &&
+                instruction.Operands[2] == value).Operands[1];
+
+    private static HashSet<uint> ResultIds(
+        IReadOnlyList<SpirvInstruction> instructions,
+        SpirvOp opcode,
+        Func<SpirvInstruction, bool> predicate) =>
+        instructions
+            .Where(instruction =>
+                instruction.Opcode == opcode &&
+                instruction.Operands.Length >= 2 &&
+                predicate(instruction))
+            .Select(instruction => instruction.Operands[1])
+            .ToHashSet();
+
+    private static uint FindBinaryResult(
+        IReadOnlyList<SpirvInstruction> instructions,
+        SpirvOp opcode,
+        IReadOnlySet<uint> leftCandidates,
+        uint right,
+        bool commutative = true)
+        => FindBinaryResult(
+            instructions,
+            opcode,
+            leftCandidates,
+            new HashSet<uint> { right },
+            commutative);
+
+    private static uint FindBinaryResult(
+        IReadOnlyList<SpirvInstruction> instructions,
+        SpirvOp opcode,
+        IReadOnlySet<uint> leftCandidates,
+        IReadOnlySet<uint> rightCandidates,
+        bool commutative = true)
+    {
+        var results = FindBinaryResults(
+            instructions,
+            opcode,
+            leftCandidates,
+            rightCandidates,
+            commutative);
+        Assert.True(
+            results.Count == 1,
+            $"Expected one {opcode} result, found {results.Count}.");
+        return results.Single();
+    }
+
+    private static HashSet<uint> FindBinaryResults(
+        IReadOnlyList<SpirvInstruction> instructions,
+        SpirvOp opcode,
+        IReadOnlySet<uint> leftCandidates,
+        uint right,
+        bool commutative = true) =>
+        FindBinaryResults(
+            instructions,
+            opcode,
+            leftCandidates,
+            new HashSet<uint> { right },
+            commutative);
+
+    private static HashSet<uint> FindBinaryResults(
+        IReadOnlyList<SpirvInstruction> instructions,
+        SpirvOp opcode,
+        IReadOnlySet<uint> leftCandidates,
+        IReadOnlySet<uint> rightCandidates,
+        bool commutative = true) =>
+        instructions
+            .Where(instruction =>
+                instruction.Opcode == opcode &&
+                instruction.Operands.Length == 4 &&
+                (leftCandidates.Contains(instruction.Operands[2]) &&
+                 rightCandidates.Contains(instruction.Operands[3]) ||
+                 commutative &&
+                 leftCandidates.Contains(instruction.Operands[3]) &&
+                 rightCandidates.Contains(instruction.Operands[2])))
+            .Select(instruction => instruction.Operands[1])
+            .ToHashSet();
+
+    private static SpirvStorageClass FindVariableStorageClass(
+        IReadOnlyList<SpirvInstruction> instructions,
+        uint variable) =>
+        (SpirvStorageClass)Assert.Single(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.Variable &&
+                instruction.Operands.Length >= 3 &&
+                instruction.Operands[1] == variable).Operands[2];
+
+    private static void AssertLdsStoreUsesVector(
+        IReadOnlyList<SpirvInstruction> instructions,
+        uint ldsPointer,
+        uint vectorRegister)
+    {
+        var vectorRegisters = FindNamedId(instructions, "vgpr");
+        var vectorPointers = ResultIds(
+            instructions,
+            SpirvOp.AccessChain,
+            instruction =>
+                instruction.Operands[2] == vectorRegisters &&
+                instruction.Operands[^1] == FindConstantId(instructions, vectorRegister));
+        var vectorLoads = ResultIds(
+            instructions,
+            SpirvOp.Load,
+            instruction => vectorPointers.Contains(instruction.Operands[2]));
+        var oldLdsLoads = ResultIds(
+            instructions,
+            SpirvOp.Load,
+            instruction => instruction.Operands[2] == ldsPointer);
+        var selectedValues = ResultIds(
+            instructions,
+            SpirvOp.Select,
+            instruction =>
+                instruction.Operands.Length == 5 &&
+                vectorLoads.Contains(instruction.Operands[3]) &&
+                oldLdsLoads.Contains(instruction.Operands[4]));
+
+        var selectedValue = Assert.Single(selectedValues);
+        Assert.Contains(
+            instructions,
+            instruction =>
+                instruction.Opcode == SpirvOp.Store &&
+                instruction.Operands[0] == ldsPointer &&
+                instruction.Operands[1] == selectedValue);
+    }
+
+    private static string DecodeString(ReadOnlySpan<uint> words)
+    {
+        var bytes = new byte[words.Length * sizeof(uint)];
+        for (var index = 0; index < words.Length; index++)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                bytes.AsSpan(index * sizeof(uint), sizeof(uint)),
+                words[index]);
+        }
+
+        var terminator = Array.IndexOf(bytes, (byte)0);
+        return Encoding.UTF8.GetString(bytes, 0, terminator >= 0 ? terminator : bytes.Length);
+    }
+
+    private sealed record SpirvInstruction(SpirvOp Opcode, uint[] Operands);
+}

--- a/tools/SharpEmu.Tools.ShaderDump/Program.cs
+++ b/tools/SharpEmu.Tools.ShaderDump/Program.cs
@@ -104,6 +104,10 @@ const ulong ProgramAddress = 0x100000;
         0xBFA30000,             // s_waitcnt_depctr 0x0
         0xBF810000,             // s_endpgm
     ]),
+    ("ds-write-addtid", true, [
+        0xDAC01234, 0x00002A11, // ds_write_addtid_b32 v42 offset:0x1234
+        0xBF810000,             // s_endpgm
+    ]),
     // s_round_mode / s_denorm_mode write the FP MODE state and must keep
     // failing decode loudly until their semantics are modeled (see #108);
     // this program pins that behavior.
@@ -233,6 +237,30 @@ foreach (var (name, expectTranslate, words) in testPrograms)
     {
         failures++;
         Console.WriteLine($"[{name}] compute emit: FAILED ({computeError})");
+    }
+
+    if (name == "ds-write-addtid")
+    {
+        if (Gen5SpirvTranslator.TryCompileComputeShader(
+                state,
+                evaluation,
+                64,
+                1,
+                1,
+                out var wave64Shader,
+                out var wave64Error,
+                waveLaneCount: 64))
+        {
+            var path = Path.Combine(outputDirectory, $"{name}-wave64-cs.spv");
+            File.WriteAllBytes(path, wave64Shader.Spirv);
+            Console.WriteLine(
+                $"[{name}] wave64 compute emit: success, {wave64Shader.Spirv.Length} bytes -> {path}");
+        }
+        else
+        {
+            failures++;
+            Console.WriteLine($"[{name}] wave64 compute emit: FAILED ({wave64Error})");
+        }
     }
 
     if (name.StartsWith("mrt", StringComparison.Ordinal))


### PR DESCRIPTION
## Change description

## What changed

Decodes RDNA 2 `DS_WRITE_ADDTID_B32`, computes its LDS byte address from `M0`, the packed immediate, and the current lane, and exposes the opcode in shader diagnostics.

## Why

This instruction has no address VGPR; treating it like other DS writes produces the wrong LDS address.

## Overlap

No matching implementation was found in open shader/GPU PRs #195, #208, or #316. Later large-shader and DS-read work remains separate.

## Testing

- Grand Theft Auto V (PS5) – Exercised on the combined integration branch containing this change.
- Automated, focused, and local validation: Retained in the original description below.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).


## Validation

- 4 focused decode and SPIR-V tests passed.
- The full build and test suite passed.
