### PR TITLE
[CPU] Generalize SSE4a extrq patch to any scratch register

### DIFF
--- a/src/SharpEmu.Core/Cpu/Emulation/Sse4aExtrqRewriter.cs
+++ b/src/SharpEmu.Core/Cpu/Emulation/Sse4aExtrqRewriter.cs
@@ -1,0 +1,96 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Core.Cpu.Emulation;
+
+/// <summary>
+/// Rewrites the AMD SSE4a <c>extrq</c> idiom that Sony's compiler emits into an
+/// equivalent SSE4.1 sequence.
+///
+/// Guest PS5 code runs natively. The PS5's Zen 2 cores implement SSE4a, but Intel
+/// hosts and Rosetta 2 do not, so the raw <c>extrq</c> opcode raises #UD and the
+/// title aborts. The compiler emits a single fixed shape: extract the low 40 bits of
+/// a scratch register, then fold that register's second dword into <c>xmm0</c>.
+///
+/// <code>
+/// 66 0F 78 /0 28 00        extrq    xmmN, 0x28, 0
+/// C4 E3 79 02 /r 02        vpblendd xmm0, xmm0, xmmN, 2
+/// </code>
+///
+/// After <c>extrq xmmN, 0x28, 0</c> only the low 40 bits of <c>xmmN</c> survive, so
+/// the dword the blend takes (lane 1) is just byte 4 of the original register,
+/// zero-extended. <c>pextrb</c>/<c>pinsrd</c> reproduces exactly that, using EAX as a
+/// throwaway scratch:
+///
+/// <code>
+/// 66 0F 3A 14 /r 04        pextrb eax, xmmN, 4
+/// 66 0F 3A 22 C0 01        pinsrd xmm0, eax, 1
+/// </code>
+///
+/// The scratch register N is read out of the ModRM byte rather than compared against
+/// a literal, so every register the compiler picks (xmm0–xmm7) is covered. The
+/// extract field (length 0x28, index 0) and the xmm0 destination stay pinned: the
+/// byte-4 offset in the replacement is only correct for that field, so a different
+/// extract is deliberately left unmatched instead of rewritten wrongly.
+///
+/// The unsafe memory-protection and instruction-cache plumbing lives in the backend;
+/// this class only decides whether a byte window matches and what to write back, so
+/// the equivalence can be unit-tested in isolation.
+/// </summary>
+public static class Sse4aExtrqRewriter
+{
+    /// <summary>Length in bytes of both the matched idiom and its replacement.</summary>
+    public const int SequenceLength = 12;
+
+    /// <summary>
+    /// Matches the <c>extrq</c> + <c>vpblendd</c> idiom at the start of
+    /// <paramref name="source"/> and, when it matches, writes the SSE4.1 replacement
+    /// into <paramref name="replacement"/>.
+    /// </summary>
+    /// <param name="source">Instruction bytes at the faulting address.</param>
+    /// <param name="replacement">Receives the 12-byte replacement when the idiom matches.</param>
+    /// <returns><see langword="true"/> when the idiom matched and a replacement was produced.</returns>
+    public static bool TryGetReplacement(ReadOnlySpan<byte> source, Span<byte> replacement)
+    {
+        if (source.Length < SequenceLength || replacement.Length < SequenceLength)
+        {
+            return false;
+        }
+
+        // extrq xmmN, 0x28, 0 is the /0 form, so the ModRM byte is 0xC0|N (N = 0..7).
+        var modrm = source[3];
+        if (source[0] != 0x66 || source[1] != 0x0F || source[2] != 0x78 ||
+            (modrm & 0xF8) != 0xC0 || source[4] != 0x28 || source[5] != 0x00)
+        {
+            return false;
+        }
+
+        // vpblendd xmm0, xmm0, xmmN, 2: the same register, an xmm0 destination and a
+        // blend mask of 2 all fall out of requiring the ModRM byte to equal the extrq's.
+        if (source[6] != 0xC4 || source[7] != 0xE3 || source[8] != 0x79 || source[9] != 0x02 ||
+            source[10] != modrm || source[11] != 0x02)
+        {
+            return false;
+        }
+
+        var register = modrm & 0x07;
+
+        // pextrb eax, xmmN, 4: xmmN is the reg field, EAX (0) the r/m destination.
+        replacement[0] = 0x66;
+        replacement[1] = 0x0F;
+        replacement[2] = 0x3A;
+        replacement[3] = 0x14;
+        replacement[4] = (byte)(0xC0 | (register << 3));
+        replacement[5] = 0x04;
+
+        // pinsrd xmm0, eax, 1: insert the extracted byte into xmm0's second dword.
+        replacement[6] = 0x66;
+        replacement[7] = 0x0F;
+        replacement[8] = 0x3A;
+        replacement[9] = 0x22;
+        replacement[10] = 0xC0;
+        replacement[11] = 0x01;
+
+        return true;
+    }
+}

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -2495,28 +2495,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private unsafe bool TryPatchSse4aExtrqBlend(nint address, byte* source)
 	{
-		// Rosetta does not implement AMD SSE4a EXTRQ. This exact sequence masks
-		// xmm2 to its low 40 bits, then copies the resulting second dword into
-		// xmm0. PEXTRB/PINSRD provides the same observable result in 12 bytes:
-		// extract source byte 4 and insert the zero-extended value into lane 1.
-		ReadOnlySpan<byte> pattern =
-		[
-			0x66, 0x0F, 0x78, 0xC2, 0x28, 0x00,
-			0xC4, 0xE3, 0x79, 0x02, 0xC2, 0x02,
-		];
-		for (var i = 0; i < pattern.Length; i++)
+		// Sony's toolchain emits AMD SSE4a EXTRQ, which Intel hosts and Rosetta do not
+		// implement; rewrite the fixed extrq+vpblendd idiom to an equivalent SSE4.1
+		// sequence so the guest opcode never reaches the CPU. The scratch register is
+		// read from the ModRM byte, so any of xmm0-xmm7 is handled, not just one.
+		Span<byte> replacement = stackalloc byte[Emulation.Sse4aExtrqRewriter.SequenceLength];
+		var window = new ReadOnlySpan<byte>(source, Emulation.Sse4aExtrqRewriter.SequenceLength);
+		if (!Emulation.Sse4aExtrqRewriter.TryGetReplacement(window, replacement))
 		{
-			if (source[i] != pattern[i])
-			{
-				return false;
-			}
+			return false;
 		}
 
-		ReadOnlySpan<byte> replacement =
-		[
-			0x66, 0x0F, 0x3A, 0x14, 0xD0, 0x04,
-			0x66, 0x0F, 0x3A, 0x22, 0xC0, 0x01,
-		];
 		uint oldProtect = 0;
 		if (!VirtualProtect((void*)address, (nuint)replacement.Length, 64u, &oldProtect))
 		{

--- a/tests/SharpEmu.Libs.Tests/Cpu/Sse4aExtrqRewriterTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/Sse4aExtrqRewriterTests.cs
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Emulation;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+public sealed class Sse4aExtrqRewriterTests
+{
+    // extrq xmmN, 0x28, 0 ; vpblendd xmm0, xmm0, xmmN, 2 — the idiom Sony's toolchain emits.
+    private static byte[] Idiom(byte register)
+    {
+        var modrm = (byte)(0xC0 | register);
+        return
+        [
+            0x66, 0x0F, 0x78, modrm, 0x28, 0x00,
+            0xC4, 0xE3, 0x79, 0x02, modrm, 0x02,
+        ];
+    }
+
+    [Fact]
+    public void Xmm2_ProducesTheBytesTheOriginalPatchShipped()
+    {
+        // Regression guard: the hand-written patch this replaced emitted exactly these
+        // bytes for the xmm2 encoding, so the refactor must stay byte-identical for it.
+        Span<byte> replacement = stackalloc byte[Sse4aExtrqRewriter.SequenceLength];
+
+        Assert.True(Sse4aExtrqRewriter.TryGetReplacement(Idiom(2), replacement));
+        Assert.Equal(
+            new byte[] { 0x66, 0x0F, 0x3A, 0x14, 0xD0, 0x04, 0x66, 0x0F, 0x3A, 0x22, 0xC0, 0x01 },
+            replacement.ToArray());
+    }
+
+    [Fact]
+    public void Xmm1_IsRewritten()
+    {
+        // #328: Dead Cells emits the idiom against xmm1, which the literal xmm2 match missed.
+        Span<byte> replacement = stackalloc byte[Sse4aExtrqRewriter.SequenceLength];
+
+        Assert.True(Sse4aExtrqRewriter.TryGetReplacement(Idiom(1), replacement));
+        Assert.Equal(
+            new byte[] { 0x66, 0x0F, 0x3A, 0x14, 0xC8, 0x04, 0x66, 0x0F, 0x3A, 0x22, 0xC0, 0x01 },
+            replacement.ToArray());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    [InlineData(7)]
+    public void EveryScratchRegister_IsRewritten(int register)
+    {
+        Span<byte> replacement = stackalloc byte[Sse4aExtrqRewriter.SequenceLength];
+
+        Assert.True(Sse4aExtrqRewriter.TryGetReplacement(Idiom((byte)register), replacement));
+
+        // pextrb eax, xmmN, 4 — only the source register byte varies with N.
+        Assert.Equal(
+            new byte[] { 0x66, 0x0F, 0x3A, 0x14, (byte)(0xC0 | (register << 3)), 0x04 },
+            replacement[..6].ToArray());
+        // pinsrd xmm0, eax, 1 — constant across every register.
+        Assert.Equal(
+            new byte[] { 0x66, 0x0F, 0x3A, 0x22, 0xC0, 0x01 },
+            replacement[6..].ToArray());
+    }
+
+    [Fact]
+    public void MismatchedExtractField_IsRejected()
+    {
+        // A different extract length needs different replacement math, so it must not match.
+        var idiom = Idiom(1);
+        idiom[4] = 0x20;
+        Span<byte> replacement = stackalloc byte[Sse4aExtrqRewriter.SequenceLength];
+
+        Assert.False(Sse4aExtrqRewriter.TryGetReplacement(idiom, replacement));
+    }
+
+    [Fact]
+    public void DifferingBlendRegister_IsRejected()
+    {
+        // extrq on xmm1 but a vpblendd folding xmm2 is not the single idiom we rewrite.
+        var idiom = Idiom(1);
+        idiom[10] = 0xC2;
+        Span<byte> replacement = stackalloc byte[Sse4aExtrqRewriter.SequenceLength];
+
+        Assert.False(Sse4aExtrqRewriter.TryGetReplacement(idiom, replacement));
+    }
+
+    [Fact]
+    public void NonZeroExtrqRegField_IsRejected()
+    {
+        // extrq is the /0 form; a set reg field decodes to a different instruction.
+        var idiom = Idiom(1);
+        idiom[3] = 0xCA; // mod=11, reg=001, rm=010
+        Span<byte> replacement = stackalloc byte[Sse4aExtrqRewriter.SequenceLength];
+
+        Assert.False(Sse4aExtrqRewriter.TryGetReplacement(idiom, replacement));
+    }
+
+    [Fact]
+    public void UnrelatedBytes_AreRejected()
+    {
+        Span<byte> replacement = stackalloc byte[Sse4aExtrqRewriter.SequenceLength];
+
+        Assert.False(Sse4aExtrqRewriter.TryGetReplacement(new byte[Sse4aExtrqRewriter.SequenceLength], replacement));
+    }
+
+    [Fact]
+    public void ShortWindow_IsRejected()
+    {
+        Span<byte> replacement = stackalloc byte[Sse4aExtrqRewriter.SequenceLength];
+
+        Assert.False(Sse4aExtrqRewriter.TryGetReplacement(Idiom(1).AsSpan(0, 11), replacement));
+    }
+}


### PR DESCRIPTION
By opening this pull request, I confirm that I have read and agree to follow the contribution guidelines.

## What this fixes

`DirectExecutionBackend.TryPatchSse4aExtrqBlend` rewrites the AMD-only `extrq` + `vpblendd` idiom the PS5 toolchain emits into equivalent SSE4.1, because SSE4a is not implemented on Intel hosts or under Rosetta and the raw opcode raises #UD there. As #328 reports, the matcher pinned the scratch register to `xmm2`:

```
66 0F 78 C2 28 00     extrq    xmm2, 0x28, 0
C4 E3 79 02 C2 02     vpblendd xmm0, xmm0, xmm2, 2
```

Dead Cells (PPSA15552) emits the same idiom against `xmm1` (`...C1...`), so the pattern missed by one byte per instruction, the `extrq` reached the CPU, and the game died with SIGILL right after the first frame. The `Patched ... 0 SSE4a EXTRQ blends` line in the startup log is the giveaway.

## The change

I read the register out of the ModRM byte instead of comparing it to a literal, so every register the toolchain uses (xmm0–xmm7) is handled. For register N it emits:

```
66 0F 3A 14 (C0|N<<3) 04   pextrb eax, xmmN, 4
66 0F 3A 22 C0 01          pinsrd xmm0, eax, 1
```

This is the same equivalence the original patch relied on: `extrq xmmN, 0x28, 0` keeps the low 40 bits of `xmmN` and zeroes the rest, so the dword the `vpblendd` folds into `xmm0` is byte 4 of the original `xmmN`, zero-extended. `pextrb`/`pinsrd` reproduce that using EAX as a throwaway.

I kept the scope narrow on purpose:

- The extract field (`0x28` length, `0` index) is still matched literally, because the byte-4 offset in the replacement is only correct for that field. A different width would need different math, so it is safer not to match it.
- The destination stays `xmm0`, the blend mask stays `2`, and there is no REX prefix, so this does not widen what gets rewritten beyond the single idiom (xmm0–7) — it just stops caring which of those registers the toolchain picked.

I moved the match/encode decision into a small pure `Sse4aExtrqRewriter` so it can be tested directly; the unsafe `VirtualProtect`/write/`FlushInstructionCache` plumbing stays in the backend.

## Testing

- `Sse4aExtrqRewriterTests`: pins the `xmm2` case to the exact bytes the previous patch produced (so the refactor is byte-identical for the case that already shipped), covers `xmm1` and all eight registers, and rejects a mismatched extract field, a differing blend register, a non-`/0` reg field, unrelated bytes, and a short window.
- `dotnet build SharpEmu.slnx -c Release` is clean (0 warnings); `dotnet test SharpEmu.slnx -c Release` passes (249 in the Libs suite, +15 here; 33 in the source-generator suite).
- I disassembled the bytes to double-check: the inputs decode to `extrq xmm1, 0x28, 0` / `vpblendd xmm0, xmm0, xmm1, 2` and the outputs to `pextrb eax, xmm1, 4` / `pinsrd xmm0, eax, 1`.

I have not booted PPSA15552 past the fault myself, so verification here is at the unit-test, build, and instruction-encoding level.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

Fixes #328.
