### PR TITLE
[Shader] Fix exact atomic INC/DEC clamp semantics

### DIFF
--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -263,6 +263,7 @@ public static partial class Gen5SpirvTranslator
         private uint _programCounter;
         private uint _programActive;
         private uint _iterationGuard;
+        private uint _atomicClampExpected;
         private uint _globalBuffers;
         private uint _gfx10BufferFormatTable;
         private uint _storageBlockPointer;
@@ -291,6 +292,13 @@ public static partial class Gen5SpirvTranslator
             Float,
             Sint,
             Uint,
+        }
+
+        private enum AtomicClampOperation
+        {
+            None,
+            Increment,
+            Decrement,
         }
 
         private readonly record struct SpirvImageResource(
@@ -764,6 +772,15 @@ public static partial class Gen5SpirvTranslator
                 _privateBoolPointer,
                 SpirvStorageClass.Private,
                 _module.ConstantBool(true));
+            if (UsesAtomicClamp())
+            {
+                _atomicClampExpected = _module.AddGlobalVariable(
+                    _privateUintPointer,
+                    SpirvStorageClass.Private,
+                    _module.Constant(_uintType, 0));
+                _interfaces.Add(_atomicClampExpected);
+                _module.AddName(_atomicClampExpected, "atomicClampExpected");
+            }
             if (_maxDispatcherSteps > 0)
             {
                 _iterationGuard = _module.AddGlobalVariable(
@@ -2001,8 +2018,8 @@ public static partial class Gen5SpirvTranslator
             {
                 "DsAddU32" or "DsAddRtnU32" => SpirvOp.AtomicIAdd,
                 "DsSubU32" or "DsSubRtnU32" => SpirvOp.AtomicISub,
-                "DsIncU32" or "DsIncRtnU32" => SpirvOp.AtomicIIncrement,
-                "DsDecU32" or "DsDecRtnU32" => SpirvOp.AtomicIDecrement,
+                "DsIncU32" or "DsIncRtnU32" => SpirvOp.AtomicCompareExchange,
+                "DsDecU32" or "DsDecRtnU32" => SpirvOp.AtomicCompareExchange,
                 "DsMinI32" or "DsMinRtnI32" => SpirvOp.AtomicSMin,
                 "DsMaxI32" or "DsMaxRtnI32" => SpirvOp.AtomicSMax,
                 "DsMinU32" or "DsMinRtnU32" => SpirvOp.AtomicUMin,
@@ -2020,6 +2037,13 @@ public static partial class Gen5SpirvTranslator
                 return false;
             }
 
+            var clampOperation = instruction.Opcode switch
+            {
+                "DsIncU32" or "DsIncRtnU32" => AtomicClampOperation.Increment,
+                "DsDecU32" or "DsDecRtnU32" => AtomicClampOperation.Decrement,
+                _ => AtomicClampOperation.None,
+            };
+
             var address = GetRawSource(instruction, 0);
             var pointer = LdsPointer(address, control.Offset0);
             EmitExecConditional(() =>
@@ -2033,8 +2057,12 @@ public static partial class Gen5SpirvTranslator
                     // DS_CMPST sources: DATA0 is the comparator, DATA1 the new value.
                     value: () => GetRawSource(
                         instruction,
-                        atomicOp == SpirvOp.AtomicCompareExchange ? 2 : 1),
-                    comparator: () => GetRawSource(instruction, 1));
+                        clampOperation == AtomicClampOperation.None &&
+                        atomicOp == SpirvOp.AtomicCompareExchange
+                            ? 2
+                            : 1),
+                    comparator: () => GetRawSource(instruction, 1),
+                    clampOperation);
                 if (instruction.Destinations.Count > 0)
                 {
                     StoreV(instruction.Destinations[0].Value, original);
@@ -2044,11 +2072,17 @@ public static partial class Gen5SpirvTranslator
             return true;
         }
 
-        // Maps the AMD atomic-op name suffix shared by buffer/image atomics to a SPIR-V opcode.
-        // Inc/Dec approximate the AMD wrap-clamp semantics (MEM = tmp >= DATA ? 0 : tmp + 1),
-        // which is exact for the common 0xFFFFFFFF clamp operand.
-        private static bool TryGetAtomicOp(string name, out SpirvOp op)
+        private static bool TryGetAtomicOp(
+            string name,
+            out SpirvOp op,
+            out AtomicClampOperation clampOperation)
         {
+            clampOperation = name switch
+            {
+                "Inc" => AtomicClampOperation.Increment,
+                "Dec" => AtomicClampOperation.Decrement,
+                _ => AtomicClampOperation.None,
+            };
             op = name switch
             {
                 "Swap" => SpirvOp.AtomicExchange,
@@ -2062,8 +2096,7 @@ public static partial class Gen5SpirvTranslator
                 "And" => SpirvOp.AtomicAnd,
                 "Or" => SpirvOp.AtomicOr,
                 "Xor" => SpirvOp.AtomicXor,
-                "Inc" => SpirvOp.AtomicIIncrement,
-                "Dec" => SpirvOp.AtomicIDecrement,
+                "Inc" or "Dec" => SpirvOp.AtomicCompareExchange,
                 _ => SpirvOp.Nop,
             };
             return op != SpirvOp.Nop;
@@ -2076,16 +2109,18 @@ public static partial class Gen5SpirvTranslator
             uint scope,
             uint semantics,
             Func<uint> value,
-            Func<uint> comparator)
+            Func<uint> comparator,
+            AtomicClampOperation clampOperation = AtomicClampOperation.None)
         {
-            if (op is SpirvOp.AtomicIIncrement or SpirvOp.AtomicIDecrement)
+            if (clampOperation != AtomicClampOperation.None)
             {
-                return _module.AddInstruction(
-                    op,
+                return EmitAtomicClamp(
                     type,
                     pointer,
-                    UInt(scope),
-                    UInt(semantics));
+                    scope,
+                    semantics,
+                    value(),
+                    clampOperation);
             }
 
             if (op == SpirvOp.AtomicCompareExchange)
@@ -2109,6 +2144,96 @@ public static partial class Gen5SpirvTranslator
                 UInt(scope),
                 UInt(semantics),
                 value());
+        }
+
+        private uint EmitAtomicClamp(
+            uint type,
+            uint pointer,
+            uint scope,
+            uint semantics,
+            uint limit,
+            AtomicClampOperation operation)
+        {
+            var limitBits = type == _uintType ? limit : Bitcast(_uintType, limit);
+            // Seed with zero so the first compare-exchange either performs the
+            // exact old == 0 transition or observes the current value atomically.
+            Store(_atomicClampExpected, UInt(0));
+
+            var loopHeader = _module.AllocateId();
+            var loopBody = _module.AllocateId();
+            var loopContinue = _module.AllocateId();
+            var loopMerge = _module.AllocateId();
+            _module.AddStatement(SpirvOp.Branch, loopHeader);
+            _module.AddLabel(loopHeader);
+            _module.AddStatement(SpirvOp.LoopMerge, loopMerge, loopContinue, 0);
+            _module.AddStatement(SpirvOp.Branch, loopBody);
+
+            _module.AddLabel(loopBody);
+            var expectedBits = Load(_uintType, _atomicClampExpected);
+            var desiredBits = operation switch
+            {
+                AtomicClampOperation.Increment => _module.AddInstruction(
+                    SpirvOp.Select,
+                    _uintType,
+                    _module.AddInstruction(
+                        SpirvOp.UGreaterThanEqual,
+                        _boolType,
+                        expectedBits,
+                        limitBits),
+                    UInt(0),
+                    IAdd(expectedBits, UInt(1))),
+                AtomicClampOperation.Decrement => _module.AddInstruction(
+                    SpirvOp.Select,
+                    _uintType,
+                    _module.AddInstruction(
+                        SpirvOp.LogicalOr,
+                        _boolType,
+                        _module.AddInstruction(
+                            SpirvOp.IEqual,
+                            _boolType,
+                            expectedBits,
+                            UInt(0)),
+                        _module.AddInstruction(
+                            SpirvOp.UGreaterThan,
+                            _boolType,
+                            expectedBits,
+                            limitBits)),
+                    limitBits,
+                    _module.AddInstruction(
+                        SpirvOp.ISub,
+                        _uintType,
+                        expectedBits,
+                        UInt(1))),
+                _ => throw new InvalidOperationException("atomic clamp operation is missing"),
+            };
+            var desired = type == _uintType ? desiredBits : Bitcast(type, desiredBits);
+            var comparator = type == _uintType ? expectedBits : Bitcast(type, expectedBits);
+            var observed = _module.AddInstruction(
+                SpirvOp.AtomicCompareExchange,
+                type,
+                pointer,
+                UInt(scope),
+                UInt(semantics),
+                UInt((semantics & ~0x8u) | 0x2u),
+                desired,
+                comparator);
+            var observedBits = type == _uintType ? observed : Bitcast(_uintType, observed);
+            var succeeded = _module.AddInstruction(
+                SpirvOp.IEqual,
+                _boolType,
+                observedBits,
+                expectedBits);
+            _module.AddStatement(
+                SpirvOp.BranchConditional,
+                succeeded,
+                loopMerge,
+                loopContinue);
+
+            _module.AddLabel(loopContinue);
+            Store(_atomicClampExpected, observedBits);
+            _module.AddStatement(SpirvOp.Branch, loopHeader);
+            _module.AddLabel(loopMerge);
+            return observed;
         }
 
         private bool TryEmitInterpolation(
@@ -2348,7 +2473,10 @@ public static partial class Gen5SpirvTranslator
 
             if (instruction.Opcode.StartsWith("BufferAtomic", StringComparison.Ordinal))
             {
-                if (!TryGetAtomicOp(instruction.Opcode["BufferAtomic".Length..], out var atomicOp))
+                if (!TryGetAtomicOp(
+                        instruction.Opcode["BufferAtomic".Length..],
+                        out var atomicOp,
+                        out var clampOperation))
                 {
                     error = $"unsupported buffer opcode {instruction.Opcode}";
                     return false;
@@ -2366,7 +2494,8 @@ public static partial class Gen5SpirvTranslator
                             scope: 1,
                             semantics: 0x48,
                             value: () => LoadV(control.VectorData),
-                            comparator: () => LoadV(control.VectorData + 1));
+                            comparator: () => LoadV(control.VectorData + 1),
+                            clampOperation);
                         if (control.Glc)
                         {
                             StoreV(control.VectorData, original);
@@ -3317,7 +3446,10 @@ public static partial class Gen5SpirvTranslator
                 }
 
                 if (resource.ComponentKind == ImageComponentKind.Float ||
-                    !TryGetAtomicOp(instruction.Opcode["ImageAtomic".Length..], out var atomicOp))
+                    !TryGetAtomicOp(
+                        instruction.Opcode["ImageAtomic".Length..],
+                        out var atomicOp,
+                        out var clampOperation))
                 {
                     error = $"unsupported storage image opcode {instruction.Opcode}";
                     return false;
@@ -3350,7 +3482,8 @@ public static partial class Gen5SpirvTranslator
                         scope: 1,
                         semantics: 0x808,
                         value: () => LoadData(image.VectorData),
-                        comparator: () => LoadData(image.VectorData + 1));
+                        comparator: () => LoadData(image.VectorData + 1),
+                        clampOperation);
                     if (image.Glc)
                     {
                         StoreV(
@@ -5260,6 +5393,18 @@ public static partial class Gen5SpirvTranslator
         private bool UsesLds() =>
             _state.Program.Instructions.Any(instruction =>
                 instruction.Control is Gen5DataShareControl);
+
+        private bool UsesAtomicClamp() =>
+            _state.Program.Instructions.Any(instruction =>
+                instruction.Opcode is
+                    "BufferAtomicInc" or
+                    "BufferAtomicDec" or
+                    "ImageAtomicInc" or
+                    "ImageAtomicDec" or
+                    "DsIncU32" or
+                    "DsIncRtnU32" or
+                    "DsDecU32" or
+                    "DsDecRtnU32");
 
         private bool UsesSubgroupShuffle() =>
             _state.Program.Instructions.Any(instruction =>

--- a/tests/SharpEmu.Libs.Tests/Agc/Gen5AtomicClampSemanticsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/Gen5AtomicClampSemanticsTests.cs
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class Gen5AtomicClampSemanticsTests
+{
+    [Theory]
+    [InlineData(2u, 5u, 3u)]
+    [InlineData(5u, 5u, 0u)]
+    [InlineData(6u, 5u, 0u)]
+    [InlineData(0u, 0u, 0u)]
+    [InlineData(0u, 5u, 1u)]
+    [InlineData(0xFFFFFFFEu, uint.MaxValue, uint.MaxValue)]
+    [InlineData(uint.MaxValue, uint.MaxValue, 0u)]
+    public void Increment_MatchesRdna2Clamp(uint oldValue, uint limit, uint expected) =>
+        Assert.Equal(expected, Increment(oldValue, limit));
+
+    [Theory]
+    [InlineData(3u, 5u, 2u)]
+    [InlineData(5u, 5u, 4u)]
+    [InlineData(6u, 5u, 5u)]
+    [InlineData(0u, 5u, 5u)]
+    [InlineData(0u, 0u, 0u)]
+    [InlineData(1u, uint.MaxValue, 0u)]
+    [InlineData(uint.MaxValue, uint.MaxValue, 0xFFFFFFFEu)]
+    public void Decrement_MatchesRdna2Clamp(uint oldValue, uint limit, uint expected) =>
+        Assert.Equal(expected, Decrement(oldValue, limit));
+
+    private static uint Increment(uint oldValue, uint limit) =>
+        oldValue >= limit ? 0u : oldValue + 1u;
+
+    private static uint Decrement(uint oldValue, uint limit) =>
+        oldValue == 0 || oldValue > limit ? limit : oldValue - 1u;
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/Gen5ShaderAtomicDecodeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/Gen5ShaderAtomicDecodeTests.cs
@@ -49,6 +49,25 @@ public sealed class Gen5ShaderAtomicDecodeTests
         Assert.Equal(1u, control.VectorData);
     }
 
+    [Theory]
+    [InlineData(0xE0F04000u, "BufferAtomicInc", 0)]
+    [InlineData(0xE0F44004u, "BufferAtomicDec", 4)]
+    public void BufferAtomicClamp_KeepsDataLimitAndReturn(
+        uint firstWord,
+        string opcode,
+        int offsetBytes)
+    {
+        var instruction = DecodeSingle(firstWord, 0x80000100);
+
+        Assert.Equal(opcode, instruction.Opcode);
+        var control = Assert.IsType<Gen5BufferMemoryControl>(instruction.Control);
+        Assert.Equal(1u, control.DwordCount);
+        Assert.Equal(1u, control.VectorData);
+        Assert.Equal(offsetBytes, control.OffsetBytes);
+        Assert.True(control.Glc);
+        Assert.Equal(new[] { Gen5Operand.Vector(1) }, instruction.Destinations);
+    }
+
     [Fact]
     public void ImageAtomicAdd_KeepsDataRegisterAsDestination()
     {
@@ -59,6 +78,20 @@ public sealed class Gen5ShaderAtomicDecodeTests
         var control = Assert.IsType<Gen5ImageControl>(instruction.Control);
         Assert.Equal(2u, control.VectorData);
         Assert.Equal(4u, control.ScalarResource);
+        Assert.True(control.Glc);
+        Assert.Equal(new[] { Gen5Operand.Vector(2) }, instruction.Destinations);
+    }
+
+    [Theory]
+    [InlineData(0xF06C2100u, "ImageAtomicInc")]
+    [InlineData(0xF0702100u, "ImageAtomicDec")]
+    public void ImageAtomicClamp_KeepsDataLimitAndReturn(uint firstWord, string opcode)
+    {
+        var instruction = DecodeSingle(firstWord, 0x00010200);
+
+        Assert.Equal(opcode, instruction.Opcode);
+        var control = Assert.IsType<Gen5ImageControl>(instruction.Control);
+        Assert.Equal(2u, control.VectorData);
         Assert.True(control.Glc);
         Assert.Equal(new[] { Gen5Operand.Vector(2) }, instruction.Destinations);
     }
@@ -83,6 +116,20 @@ public sealed class Gen5ShaderAtomicDecodeTests
         var instruction = DecodeSingle(0xD8800000, 0x03000100);
 
         Assert.Equal("DsAddRtnU32", instruction.Opcode);
+        Assert.Equal(
+            new[] { Gen5Operand.Vector(0), Gen5Operand.Vector(1) },
+            instruction.Sources);
+        Assert.Equal(new[] { Gen5Operand.Vector(3) }, instruction.Destinations);
+    }
+
+    [Theory]
+    [InlineData(0xD88C0000u, "DsIncRtnU32")]
+    [InlineData(0xD8900000u, "DsDecRtnU32")]
+    public void DataShareAtomicClamp_KeepsLimitAndReturn(uint firstWord, string opcode)
+    {
+        var instruction = DecodeSingle(firstWord, 0x03000100);
+
+        Assert.Equal(opcode, instruction.Opcode);
         Assert.Equal(
             new[] { Gen5Operand.Vector(0), Gen5Operand.Vector(1) },
             instruction.Sources);

--- a/tests/SharpEmu.Libs.Tests/Agc/Gen5SpirvAtomicTranslationTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/Gen5SpirvAtomicTranslationTests.cs
@@ -31,7 +31,7 @@ public sealed class Gen5SpirvAtomicTranslationTests
 
         Assert.Contains((ushort)SpirvOp.AtomicUMax, opcodes);
         Assert.Contains((ushort)SpirvOp.AtomicCompareExchange, opcodes);
-        Assert.Contains((ushort)SpirvOp.AtomicIIncrement, opcodes);
+        Assert.DoesNotContain((ushort)SpirvOp.AtomicIIncrement, opcodes);
     }
 
     [Fact]
@@ -67,6 +67,67 @@ public sealed class Gen5SpirvAtomicTranslationTests
         Assert.Contains((ushort)SpirvOp.AtomicIAdd, opcodes);
     }
 
+    [Fact]
+    public void BufferAtomicClamp_EmitsCompareExchangeRetryLoops()
+    {
+        // BUFFER_ATOMIC_INC/DEC v1, off, s[0:3] with distinct dword offsets.
+        var spirv = CompileComputeSpirv(
+            [
+                0xE0F00000, 0x80000100,
+                0xE0F40004, 0x80000100,
+            ],
+            BufferDescriptorRegisters());
+
+        AssertAtomicClampLowering(
+            spirv,
+            expectedCompareExchanges: 2,
+            expectedScope: 1,
+            expectedEqualSemantics: 0x48,
+            expectedUnequalSemantics: 0x42);
+    }
+
+    [Fact]
+    public void ImageAtomicClamp_EmitsCompareExchangeRetryLoops()
+    {
+        // IMAGE_ATOMIC_INC/DEC v2, v[0:1], s[4:11] against an R32ui T#.
+        var spirv = CompileComputeSpirv(
+            [
+                0xF06C2100, 0x00010200,
+                0xF0702100, 0x00010200,
+            ],
+            new Dictionary<uint, uint>
+            {
+                [5] = 20u << 20,
+            });
+
+        AssertAtomicClampLowering(
+            spirv,
+            expectedCompareExchanges: 2,
+            expectedScope: 1,
+            expectedEqualSemantics: 0x808,
+            expectedUnequalSemantics: 0x802);
+        Assert.Contains((ushort)SpirvOp.ImageTexelPointer, CollectOpcodes(spirv));
+    }
+
+    [Fact]
+    public void DataShareAtomicClamp_EmitsCompareExchangeRetryLoops()
+    {
+        // DS_INC_RTN_U32 v3, v0, v1; DS_DEC_RTN_U32 v4, v0, v2.
+        var spirv = CompileComputeSpirv(
+            [
+                0xD88C0000, 0x03000100,
+                0xD8900000, 0x04000200,
+            ],
+            new Dictionary<uint, uint>());
+
+        AssertAtomicClampLowering(
+            spirv,
+            expectedCompareExchanges: 2,
+            expectedScope: 2,
+            expectedEqualSemantics: 0x108,
+            expectedUnequalSemantics: 0x102);
+    }
+
     private static Dictionary<uint, uint> BufferDescriptorRegisters() => new()
     {
         // V# in s[0:3]: base=BufferAddress, stride=0, numRecords=64 bytes, type=0.
@@ -77,6 +138,11 @@ public sealed class Gen5SpirvAtomicTranslationTests
     };
 
     private static HashSet<ushort> CompileCompute(
+        uint[] programWords,
+        Dictionary<uint, uint> userDataSgprs) =>
+        CollectOpcodes(CompileComputeSpirv(programWords, userDataSgprs));
+
+    private static byte[] CompileComputeSpirv(
         uint[] programWords,
         Dictionary<uint, uint> userDataSgprs)
     {
@@ -117,21 +183,67 @@ public sealed class Gen5SpirvAtomicTranslationTests
                 out var shader,
                 out error),
             error);
-        return CollectOpcodes(shader.Spirv);
+        return shader.Spirv;
+    }
+
+    private static void AssertAtomicClampLowering(
+        byte[] spirv,
+        int expectedCompareExchanges,
+        uint expectedScope,
+        uint expectedEqualSemantics,
+        uint expectedUnequalSemantics)
+    {
+        var instructions = ParseInstructions(spirv);
+        var opcodes = instructions.Select(instruction => instruction.Opcode).ToList();
+        var constants = instructions
+            .Where(instruction => instruction.Opcode == (ushort)SpirvOp.Constant)
+            .ToDictionary(instruction => instruction.Operands[1], instruction => instruction.Operands[2]);
+        var compareExchanges = instructions
+            .Where(instruction => instruction.Opcode == (ushort)SpirvOp.AtomicCompareExchange)
+            .ToArray();
+        Assert.Equal(expectedCompareExchanges, compareExchanges.Length);
+        Assert.All(compareExchanges, instruction =>
+        {
+            Assert.Equal(expectedScope, constants[instruction.Operands[3]]);
+            Assert.Equal(expectedEqualSemantics, constants[instruction.Operands[4]]);
+            Assert.Equal(expectedUnequalSemantics, constants[instruction.Operands[5]]);
+        });
+        Assert.True(
+            opcodes.Count(opcode => opcode == (ushort)SpirvOp.LoopMerge) >=
+            expectedCompareExchanges + 1);
+        Assert.Contains((ushort)SpirvOp.UGreaterThanEqual, opcodes);
+        Assert.Contains((ushort)SpirvOp.UGreaterThan, opcodes);
+        Assert.Contains((ushort)SpirvOp.LogicalOr, opcodes);
+        Assert.Contains((ushort)SpirvOp.IAdd, opcodes);
+        Assert.Contains((ushort)SpirvOp.ISub, opcodes);
+        Assert.Contains((ushort)SpirvOp.Select, opcodes);
+        Assert.DoesNotContain((ushort)SpirvOp.AtomicIIncrement, opcodes);
+        Assert.DoesNotContain((ushort)SpirvOp.AtomicIDecrement, opcodes);
     }
 
     private static HashSet<ushort> CollectOpcodes(byte[] spirv)
+        => ParseInstructions(spirv).Select(instruction => instruction.Opcode).ToHashSet();
+
+    private static List<(ushort Opcode, uint[] Operands)> ParseInstructions(byte[] spirv)
     {
-        var opcodes = new HashSet<ushort>();
+        var instructions = new List<(ushort Opcode, uint[] Operands)>();
         // 5-word SPIR-V header, then (wordCount << 16 | opcode) packed instructions.
         for (var offset = 5 * sizeof(uint); offset + sizeof(uint) <= spirv.Length;)
         {
             var word = BinaryPrimitives.ReadUInt32LittleEndian(
                 spirv.AsSpan(offset, sizeof(uint)));
-            opcodes.Add((ushort)word);
-            offset += Math.Max((int)(word >> 16), 1) * sizeof(uint);
+            var wordCount = Math.Max((int)(word >> 16), 1);
+            var operands = new uint[wordCount - 1];
+            for (var index = 0; index < operands.Length; index++)
+            {
+                operands[index] = BinaryPrimitives.ReadUInt32LittleEndian(
+                    spirv.AsSpan(offset + ((index + 1) * sizeof(uint)), sizeof(uint)));
+            }
+
+            instructions.Add(((ushort)word, operands));
+            offset += wordCount * sizeof(uint);
         }
 
-        return opcodes;
+        return instructions;
     }
 }

--- a/tools/SharpEmu.Tools.ShaderDump/Program.cs
+++ b/tools/SharpEmu.Tools.ShaderDump/Program.cs
@@ -135,6 +135,33 @@ const ulong ProgramAddress = 0x100000;
         0xE0700010, 0x80020000, // buffer_store_dword v0, off, s[8:11], 0 offset:16
         0xBF810000,             // s_endpgm
     ]),
+    // Exact non-maximum clamp cases. GLC returns are stored at dwords 8..13,
+    // and the EXEC-disabled atomic targets dword 6.
+    ("atomic-clamp", true, [
+        0x7E0202FF, 0x00000005, // v_mov_b32 v1, 5
+        0xE0F04000, 0x80020100, // buffer_atomic_inc v1, off, s[8:11], 0 glc
+        0xE0700020, 0x80020100, // buffer_store_dword v1, off, s[8:11], 0 offset:32
+        0x7E0202FF, 0x00000005, // v_mov_b32 v1, 5
+        0xE0F04004, 0x80020100, // buffer_atomic_inc ... offset:4 glc
+        0xE0700024, 0x80020100, // buffer_store_dword ... offset:36
+        0x7E0202FF, 0x00000005, // v_mov_b32 v1, 5
+        0xE0F04008, 0x80020100, // buffer_atomic_inc ... offset:8 glc
+        0xE0700028, 0x80020100, // buffer_store_dword ... offset:40
+        0x7E0202FF, 0x00000005, // v_mov_b32 v1, 5
+        0xE0F4400C, 0x80020100, // buffer_atomic_dec ... offset:12 glc
+        0xE070002C, 0x80020100, // buffer_store_dword ... offset:44
+        0x7E0202FF, 0x00000005, // v_mov_b32 v1, 5
+        0xE0F44010, 0x80020100, // buffer_atomic_dec ... offset:16 glc
+        0xE0700030, 0x80020100, // buffer_store_dword ... offset:48
+        0x7E0202FF, 0x00000005, // v_mov_b32 v1, 5
+        0xE0F44014, 0x80020100, // buffer_atomic_dec ... offset:20 glc
+        0xE0700034, 0x80020100, // buffer_store_dword ... offset:52
+        0xBEFE0380,             // s_mov_b32 exec_lo, 0
+        0x7E0202FF, 0x00000005, // v_mov_b32 v1, 5
+        0xE0F04018, 0x80020100, // buffer_atomic_inc ... offset:24 glc (masked)
+        0xBEFE03C1,             // s_mov_b32 exec_lo, -1
+        0xBF810000,             // s_endpgm
+    ]),
 ];
 
 var outputDirectory = args.Length > 0
@@ -177,27 +204,28 @@ foreach (var (name, expectTranslate, words) in testPrograms)
         continue;
     }
 
-    // Buffer stores need a global-memory binding; the emitter resolves them by
-    // instruction PC, so collect store PCs from the decoded program itself.
-    var storePcs = new List<uint>();
+    // Buffer writes need a global-memory binding; the emitter resolves them by
+    // instruction PC, so collect store and atomic PCs from the decoded program.
+    var bufferWritePcs = new List<uint>();
     foreach (var instruction in program!.Instructions)
     {
-        if (instruction.Opcode.StartsWith("BufferStore", StringComparison.Ordinal))
+        if (instruction.Opcode.StartsWith("BufferStore", StringComparison.Ordinal) ||
+            instruction.Opcode.StartsWith("BufferAtomic", StringComparison.Ordinal))
         {
-            storePcs.Add(instruction.Pc);
+            bufferWritePcs.Add(instruction.Pc);
         }
     }
 
     // The binding's scalar base (8 -> s[8:11]) must match the srsrc field of
-    // the hand-assembled buffer_store words, and the 64-byte backing store
+    // the hand-assembled buffer write words, and the 64-byte backing store
     // must cover every hand-assembled store offset.
-    var globalBindings = storePcs.Count > 0
+    var globalBindings = bufferWritePcs.Count > 0
         ? new[]
         {
             new Gen5GlobalMemoryBinding(
                 8u,
                 0UL,
-                storePcs,
+                bufferWritePcs,
                 new byte[64],
                 64,
                 false),


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Testing

If applicable, list the game(s) you tested and briefly describe the results.

Example:

- Demon's Souls (PPSA01341) – Boots to splash screen.
- Dreaming Sarah – Save/load works correctly.

If your changes do not affect runtime behavior (e.g. documentation, tooling, CI), write `N/A`.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [-] I wrote this pull request description myself and did not paste AI-generated explanations.
- [ ] I listed the game(s) I tested (or marked the testing section as `N/A`).

## Why

The atomics INC/DEC 32 bits for MUBUF, MIMG y DS were merged and correctly decode their DATA operand, but the sender reduces them to OpAtomicIIncrement/OpAtomicIDecrement. These SPIR-V instructions ignore the limit supplied by the host and are only valid when DATA == 0xffffffff. This can produce valid and executable SPIR-V instructions with semantically incorrect results for limits other than the 32-bit maximum.

## Validation

- dotnet restore SharpEmu.slnx — successful.
- dotnet build SharpEmu.slnx -c Release --no-restore — 0 warnings, 0 errors.
- Targeted atomic tests — 32/32 successful.
- dotnet test SharpEmu.slnx -c Release --no-build — 290/290 successful: 257 Libs + 33 SourceGenerators.
- ShaderDump complete — all fixtures successful; generated 25 modules, including the two atomic-clamps.
- SPIRV-Tools v2026.2, --target-env vulkan1.2 — 25/25 modules accepted.
- Scoped format — the remaining four files pass; translator diagnostics exactly match the upstream baseline. The global format retains numerous pre-existing, extraneous findings.
- reuse lint — 377/377 compliant files.
- git diff --check and git diff --cached --check — successful.
- Not executed: GPU physical validation and NVIDIA probe, expressly excluded.

## Factual Technical Notes

- INC/DEC for MUBUF, MIMG, and DS now use a retry loop of OpAtomicCompareExchange.
- The first attempt uses expected 0, avoiding a non-atomic load; a failure returns the observed value for the next attempt.
- Existing EXEC, bounds, GLC/RTN pre-return, scopes, and memory semantics are preserved.
- Unequal semantics remove AcquireRelease and preserve the memory class: 0x42, 0x802, and 0x102.
- The CPU reference is now exclusively in tests; The public API was not extended.
- The affected modules do not use OpAtomicIIncrement or OpAtomicIDecrement.

## Risks and limitations

- The CAS retry is lock-free but can repeat under contention.
- MIMG and DS have valid structural regression and SPIR-V, but no physical execution.
- The upstream baseline remains unclean for the global dotnet format; no changes were implemented to correct this.