### PR TITLE
[CPU] Check BlockWakeHandler when a blocked thread has no BlockWaiter

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -3139,7 +3139,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					continue;
 				}
 
-				if (thread.BlockWaiter is not null && !thread.BlockWaiter.TryWake())
+				if (!TryConsumeRegisteredWakeSignal(thread))
 				{
 					continue;
 				}
@@ -3168,6 +3168,24 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		}
 
 		return wakeCount;
+	}
+
+	// A blocked thread's readiness predicate is registered either as an
+	// IGuestThreadBlockWaiter (BlockWaiter) or, for the delegate-pair
+	// compatibility bridge used by pthread mutex/cond/rwlock/semaphore waits
+	// (see RequestCurrentThreadBlock's resumeHandler/wakeHandler overload), as
+	// a bare BlockWakeHandler with BlockWaiter left null. Both must be checked
+	// here; skipping BlockWakeHandler would ready a mutex/cond waiter before
+	// its handle was actually granted. A thread with neither (a plain
+	// wakeKey wait, e.g. event flags/queues) always wakes on a key match.
+	private static bool TryConsumeRegisteredWakeSignal(GuestThreadState thread)
+	{
+		if (thread.BlockWaiter is { } waiter)
+		{
+			return waiter.TryWake();
+		}
+
+		return thread.BlockWakeHandler is not { } wakeHandler || wakeHandler();
 	}
 
 	public IReadOnlyList<GuestThreadSnapshot> SnapshotThreads()
@@ -4734,6 +4752,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			LastError = null;
 			GuestCpuContinuation continuation = default;
 			IGuestThreadBlockWaiter? blockWaiter = null;
+			Func<int>? blockResumeHandler = null;
 			var resumeContinuation = false;
 			using (LockGate("RunGuestThread.block"))
 			{
@@ -4745,14 +4764,24 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					thread.BlockWakeKey = null;
 					blockWaiter = thread.BlockWaiter;
 					thread.BlockWaiter = null;
+					blockResumeHandler = thread.BlockResumeHandler;
+					thread.BlockResumeHandler = null;
+					thread.BlockWakeHandler = null;
 					thread.BlockDeadlineTimestamp = 0;
 					resumeContinuation = true;
 				}
 			}
 
+			// BlockWaiter and BlockResumeHandler are mutually exclusive (see
+			// RegisterBlockedGuestThreadContinuation's two overloads): a plain
+			// wakeKey wait with neither leaves the guest's original RAX intact.
 			if (blockWaiter is not null)
 			{
 				continuation = continuation with { Rax = unchecked((ulong)(long)blockWaiter.Resume()) };
+			}
+			else if (blockResumeHandler is not null)
+			{
+				continuation = continuation with { Rax = unchecked((ulong)(long)blockResumeHandler()) };
 			}
 
 			if (_logGuestThreads)
@@ -4782,9 +4811,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					case GuestNativeCallExitReason.Blocked:
 						thread.State = GuestThreadRunState.Blocked;
 						thread.BlockReason = blockReason;
-						if (thread.HasBlockedContinuation &&
-							thread.BlockWaiter is not null &&
-							thread.BlockWaiter.TryWake())
+						if (thread.HasBlockedContinuation && TryConsumeRegisteredWakeSignal(thread))
 						{
 							thread.State = GuestThreadRunState.Ready;
 							thread.BlockReason = null;

--- a/tests/SharpEmu.Libs.Tests/Cpu/GuestThreadWakeSignalTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/GuestThreadWakeSignalTests.cs
@@ -1,0 +1,145 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Reflection;
+using SharpEmu.Core.Cpu.Native;
+using SharpEmu.HLE;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+// DirectExecutionBackend.WakeBlockedThreads and RunGuestThread both decide
+// whether a blocked guest thread is actually ready to resume. A blocked
+// thread's readiness predicate lives in one of two places depending on how
+// it was registered: an IGuestThreadBlockWaiter (BlockWaiter), or — for the
+// resumeHandler/wakeHandler compatibility bridge every pthread mutex, cond,
+// rwlock and semaphore wait uses — a bare BlockWakeHandler with BlockWaiter
+// left null. TryConsumeRegisteredWakeSignal is the shared decision the fix
+// introduced so both call sites check the same predicate the same way.
+public sealed class GuestThreadWakeSignalTests
+{
+    private static readonly Type GuestThreadStateType = typeof(DirectExecutionBackend)
+        .GetNestedType("GuestThreadState", BindingFlags.NonPublic)!;
+
+    private static readonly MethodInfo TryConsumeRegisteredWakeSignal = typeof(DirectExecutionBackend)
+        .GetMethod("TryConsumeRegisteredWakeSignal", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    private static object CreateThreadState() => Activator.CreateInstance(GuestThreadStateType)!;
+
+    private static void SetProperty(object threadState, string name, object? value) =>
+        GuestThreadStateType.GetProperty(name)!.SetValue(threadState, value);
+
+    private static bool Invoke(object threadState) =>
+        (bool)TryConsumeRegisteredWakeSignal.Invoke(null, [threadState])!;
+
+    [Fact]
+    public void GuestThreadStateType_And_Method_AreResolvable()
+    {
+        Assert.NotNull(GuestThreadStateType);
+        Assert.NotNull(TryConsumeRegisteredWakeSignal);
+    }
+
+    [Fact]
+    public void WithBlockWaiter_UsesWaiterTryWake_Satisfied()
+    {
+        var thread = CreateThreadState();
+        var waiter = new FakeBlockWaiter(tryWakeResult: true);
+        SetProperty(thread, "BlockWaiter", waiter);
+
+        Assert.True(Invoke(thread));
+        Assert.Equal(1, waiter.TryWakeCallCount);
+    }
+
+    [Fact]
+    public void WithBlockWaiter_UsesWaiterTryWake_NotSatisfied()
+    {
+        // #212/#328-adjacent regression guard: a registered IGuestThreadBlockWaiter must
+        // never be bypassed even when a stale BlockWakeHandler also happens to be set.
+        var thread = CreateThreadState();
+        var waiter = new FakeBlockWaiter(tryWakeResult: false);
+        SetProperty(thread, "BlockWaiter", waiter);
+
+        Assert.False(Invoke(thread));
+        Assert.Equal(1, waiter.TryWakeCallCount);
+    }
+
+    [Fact]
+    public void WithOnlyBlockWakeHandler_InvokesItInsteadOfSkipping()
+    {
+        // The bug this guards: pthread_mutex_lock/pthread_cond_wait/pthread_rwlock_*/
+        // sceKernelWaitSema all register through the resumeHandler/wakeHandler overload,
+        // which leaves BlockWaiter null and the readiness predicate in BlockWakeHandler.
+        // Before the fix, WakeBlockedThreads and RunGuestThread's exit-race check only
+        // tested BlockWaiter, so this predicate was never evaluated and those waits woke
+        // unconditionally on any wakeKey match regardless of whether the mutex/condition
+        // was actually available.
+        var thread = CreateThreadState();
+        var handlerCalls = 0;
+        Func<bool> wakeHandler = () =>
+        {
+            handlerCalls++;
+            return true;
+        };
+        SetProperty(thread, "BlockWaiter", null);
+        SetProperty(thread, "BlockWakeHandler", wakeHandler);
+
+        Assert.True(Invoke(thread));
+        Assert.Equal(1, handlerCalls);
+    }
+
+    [Fact]
+    public void WithOnlyBlockWakeHandler_ThatReturnsFalse_DoesNotWake()
+    {
+        var thread = CreateThreadState();
+        SetProperty(thread, "BlockWaiter", null);
+        SetProperty(thread, "BlockWakeHandler", (Func<bool>)(() => false));
+
+        Assert.False(Invoke(thread));
+    }
+
+    [Fact]
+    public void WithNeitherWaiterNorHandler_AlwaysWakes()
+    {
+        // Plain wakeKey waits (event flags, event queues) register with neither a
+        // waiter nor a handler; a wakeKey match alone must still be sufficient.
+        var thread = CreateThreadState();
+        SetProperty(thread, "BlockWaiter", null);
+        SetProperty(thread, "BlockWakeHandler", null);
+
+        Assert.True(Invoke(thread));
+    }
+
+    [Fact]
+    public void BlockWaiterTakesPrecedenceOverBlockWakeHandler()
+    {
+        // The two registration overloads are mutually exclusive in production
+        // (RegisterBlockedGuestThreadContinuation always clears the other), but the
+        // decision function should still prefer BlockWaiter defensively if both are set.
+        var thread = CreateThreadState();
+        var waiter = new FakeBlockWaiter(tryWakeResult: true);
+        var handlerCalls = 0;
+        SetProperty(thread, "BlockWaiter", waiter);
+        SetProperty(thread, "BlockWakeHandler", (Func<bool>)(() =>
+        {
+            handlerCalls++;
+            return true;
+        }));
+
+        Assert.True(Invoke(thread));
+        Assert.Equal(1, waiter.TryWakeCallCount);
+        Assert.Equal(0, handlerCalls);
+    }
+
+    private sealed class FakeBlockWaiter(bool tryWakeResult) : IGuestThreadBlockWaiter
+    {
+        public int TryWakeCallCount { get; private set; }
+
+        public int Resume() => 0;
+
+        public bool TryWake()
+        {
+            TryWakeCallCount++;
+            return tryWakeResult;
+        }
+    }
+}


### PR DESCRIPTION
By opening this pull request, I confirm that I have read and agree to follow the contribution guidelines.

## What this fixes

A blocked guest thread's readiness predicate gets registered one of two ways: as an `IGuestThreadBlockWaiter` (`BlockWaiter`), or through the `resumeHandler`/`wakeHandler` compatibility bridge (`RequestCurrentThreadBlock`'s `Func<int>`/`Func<bool>` overload) that every `pthread_mutex_lock`, `pthread_cond_wait`/`timedwait`, `pthread_rwlock_wrlock`/`rdlock`, and `sceKernelWaitSema` wait uses. That bridge leaves `BlockWaiter` null and puts the readiness predicate in `BlockWakeHandler` instead — `RegisterBlockedGuestThreadContinuation`'s two overloads are mutually exclusive about which one gets set.

`WakeBlockedThreads` and `RunGuestThread`'s post-block exit-race check only tested `BlockWaiter`:

```csharp
if (thread.BlockWaiter is not null && !thread.BlockWaiter.TryWake())
{
    continue;
}
```

When `BlockWaiter` is null, this short-circuits to `false` and the thread is marked `Ready` unconditionally, without ever calling `BlockWakeHandler()`. Concretely: a thread blocked in `pthread_mutex_lock` wakes as soon as *any* thread touches the same `wakeKey` on unlock, whether or not `TryGrantBlockedMutexLock` actually granted it the lock — the guest can end up believing it holds a mutex it was never granted. The same gap applies to condition variables, rwlocks, and semaphores.

`RunGuestThread`'s resume path had the mirror problem: it calls `blockWaiter.Resume()` to compute the resumed RAX, but never called `BlockResumeHandler()`, so a thread woken through the handler bridge resumed with whatever RAX was left over from before it blocked instead of the actual completion result code (e.g. `CompleteBlockedMutexLock`'s granted/busy result).

Two other consumers in the same file already handle this correctly — `ResumeBlockedNestedGuestCallback` (checks `BlockWakeHandler`, calls the resume delegate) and `RestoreInterruptedGuestThread` (checks `BlockWakeHandler` before re-readying) — so this wasn't a design gap, just two call sites that predate the delegate-bridge path or were missed when it was added.

## The change

- Extracted the shared decision into `TryConsumeRegisteredWakeSignal(GuestThreadState)`: prefer `BlockWaiter.TryWake()` when a waiter is registered, fall back to `BlockWakeHandler()` when only that's set, and default to waking when neither is set (plain `wakeKey`-only waits like event flags/queues, which have no readiness predicate of their own).
- `WakeBlockedThreads` and the exit-race check in `RunGuestThread` both now call this helper instead of testing `BlockWaiter` directly.
- `RunGuestThread`'s resume path now captures `BlockResumeHandler` alongside `BlockWaiter` and calls it for the resumed RAX when there's no waiter.

## Testing

- New `GuestThreadWakeSignalTests` (7 tests) exercise `TryConsumeRegisteredWakeSignal` directly via reflection (the same pattern `ImportTrampolineAbiTests` already uses for this private nested type): waiter-only wake/no-wake, handler-only wake/no-wake (the regression this fixes), neither-set-always-wakes, and waiter-takes-precedence-when-both-are-set.
- `dotnet build SharpEmu.slnx -c Release` is clean (0 warnings). `dotnet test SharpEmu.slnx -c Release` passes (241 in the Libs suite on this branch's `main` base, +7 here; 33 in the source-generator suite).
- Smoke-tested the built CLI (`--help` and a bare invocation) to confirm the scheduler change doesn't break startup.

I have not reproduced this against a live game with contended pthread mutexes/condvars — I don't have a title that reliably exercises this path end to end. The fix is scoped to reading the existing `BlockWakeHandler`/`BlockResumeHandler` fields correctly rather than changing any locking semantics, and is unit-tested at the decision-function level, but I'd welcome confirmation from anyone who can reproduce a mutex-heavy title (e.g. the IL2CPP/Unity titles that hit `sceKernelWaitSema` heavily, like #254) that this changes observed behavior for the better.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
