### PR TITLE
Vulkan: avoid guest writer tracking allocations

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -2380,29 +2380,45 @@ internal static unsafe class VulkanVideoPresenter
 
     private static void RecordGuestImageWritersLocked(object work, long sequence)
     {
-        static IEnumerable<ulong> StorageAddresses(
-            IReadOnlyList<GuestDrawTexture> textures) =>
-            textures
-                .Where(static texture => texture.IsStorage && texture.Address != 0)
-                .Select(static texture => texture.Address);
+        switch (work)
+        {
+            case VulkanOffscreenGuestDraw draw:
+                if (draw.PublishTarget)
+                {
+                    for (var index = 0; index < draw.Targets.Count; index++)
+                    {
+                        var target = draw.Targets[index];
+                        if (target.Address != 0)
+                        {
+                            _guestImageWorkSequences[target.Address] = sequence;
+                        }
+                    }
+                }
 
-        IEnumerable<ulong> addresses = work switch
+                RecordStorageImageWriters(draw.Draw.Textures, sequence);
+                break;
+
+            case VulkanComputeGuestDispatch compute:
+                RecordStorageImageWriters(compute.Textures, sequence);
+                break;
+
+            case VulkanGuestImageWrite imageWrite when imageWrite.Address != 0:
+                _guestImageWorkSequences[imageWrite.Address] = sequence;
+                break;
+        }
+    }
+
+    private static void RecordStorageImageWriters(
+        IReadOnlyList<GuestDrawTexture> textures,
+        long sequence)
+    {
+        for (var index = 0; index < textures.Count; index++)
         {
-            VulkanOffscreenGuestDraw draw =>
-                (draw.PublishTarget
-                    ? draw.Targets
-                        .Where(static target => target.Address != 0)
-                        .Select(static target => target.Address)
-                    : Enumerable.Empty<ulong>())
-                .Concat(StorageAddresses(draw.Draw.Textures)),
-            VulkanComputeGuestDispatch compute => StorageAddresses(compute.Textures),
-            VulkanGuestImageWrite imageWrite when imageWrite.Address != 0 =>
-                new[] { imageWrite.Address },
-            _ => Array.Empty<ulong>(),
-        };
-        foreach (var address in addresses.Distinct())
-        {
-            _guestImageWorkSequences[address] = sequence;
+            var texture = textures[index];
+            if (texture.IsStorage && texture.Address != 0)
+            {
+                _guestImageWorkSequences[texture.Address] = sequence;
+            }
         }
     }
 

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanGuestImageWriterTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanGuestImageWriterTests.cs
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Reflection;
+using SharpEmu.Libs.Gpu;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VulkanGuestImageWriterTests
+{
+    [Fact]
+    public void RecordingSingleRenderTargetDoesNotAllocate()
+    {
+        const ulong address = 0x1000;
+        var draw = new VulkanOffscreenGuestDraw(
+            new VulkanTranslatedGuestDraw(
+                [], [], [], [], [], 0, 0, 0, 0, null, GuestRenderState.Default),
+            [new GuestRenderTarget(address, 1, 1, 0, 0)],
+            null,
+            PublishTarget: true,
+            ShaderAddress: 0);
+        var writers = Assert.IsType<Dictionary<ulong, long>>(
+            typeof(VulkanVideoPresenter)
+                .GetField("_guestImageWorkSequences", BindingFlags.Static | BindingFlags.NonPublic)!
+                .GetValue(null));
+        var record = (Action<object, long>)typeof(VulkanVideoPresenter)
+            .GetMethod("RecordGuestImageWritersLocked", BindingFlags.Static | BindingFlags.NonPublic)!
+            .CreateDelegate(typeof(Action<object, long>));
+
+        writers.Clear();
+        writers[address] = 0;
+        record(draw, 1);
+        writers.Clear();
+        writers[address] = 0;
+
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        record(draw, 2);
+
+        Assert.Equal(0, GC.GetAllocatedBytesForCurrentThread() - allocatedBefore);
+        Assert.Equal(2, writers[address]);
+    }
+}


### PR DESCRIPTION
## Summary

Replace the per-work-item LINQ/`Distinct` pipeline used to record guest image writers with indexed loops. The write set is unchanged: nonzero published render targets and storage texture addresses receive the submitted sequence. Repeated addresses remain harmless identical dictionary assignments.

The included regression test warms the call site, preallocates the dictionary entry, and verifies that recording a normal single-target draw allocates zero managed bytes.

## Testing

- `dotnet build SharpEmu.slnx -c Release`
- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release` — 266 passed
- Real-game testing was not performed.

## Checklist

- [x] I read and followed `CONTRIBUTING.md`.
- [x] I tested the change as described above.
- [x] I wrote the pull request description myself and did not paste AI-generated explanations.
- [x] I listed game(s) I tested (or marked the testing section as `N/A`).