### PR TITLE
docs: note Windows on ARM runs the x64 build via emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 > [!NOTE]  
 > SharpEmu supports Windows x64, Linux x64, and macOS x64. Apple Silicon Macs
-> can run the macOS x64 build through Rosetta 2.
+> can run the macOS x64 build through Rosetta 2, and Windows on ARM devices
+> (e.g. Snapdragon) can run the Windows x64 build through Windows' built-in
+> x64 emulation.
 
 > [!WARNING]  
 > SharpEmu is an experimental PS5 emulator developed from scratch in C#. The current focus is on accuracy and infrastructure setup rather than game-specific compatibility.


### PR DESCRIPTION
The platform-support note says Apple Silicon Macs can run the macOS x64 build
through Rosetta 2, but it doesn't mention the equivalent path on Windows on ARM.
Windows 11 on ARM ships a built-in x64 emulation layer, so Snapdragon-class
devices can run the Windows x64 build the same way Apple Silicon runs the macOS
build under Rosetta.

This adds one matching sentence to that note. Docs only — no code changes.

## Testing

Ran the Windows x64 build on a Snapdragon X Elite (Windows on ARM), launched via
the OS x64 emulation layer:

- Dead Cells (PPSA15552) – launches and runs under x64 emulation.
- Dreaming Sarah (PPSA02929) – launches and runs under x64 emulation.

## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
