### PR TITLE
Reject undefined numeric LogLevel values

### DIFF
--- a/src/SharpEmu.Logging/SharpEmuLog.cs
+++ b/src/SharpEmu.Logging/SharpEmuLog.cs
@@ -110,7 +110,8 @@ public static class SharpEmuLog
         }
 
         var normalized = text.Trim();
-        if (Enum.TryParse<LogLevel>(normalized, ignoreCase: true, out level))
+        if (Enum.TryParse<LogLevel>(normalized, ignoreCase: true, out level) &&
+            Enum.IsDefined(level))
         {
             return true;
         }
@@ -127,6 +128,7 @@ public static class SharpEmuLog
             return true;
         }
 
+        level = default;
         return false;
     }
 

--- a/tests/SharpEmu.Libs.Tests/Logging/SharpEmuLogTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Logging/SharpEmuLogTests.cs
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Logging;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Logging;
+
+public sealed class SharpEmuLogTests
+{
+    [Theory]
+    [InlineData("Trace", LogLevel.Trace)]
+    [InlineData("debug", LogLevel.Debug)]
+    [InlineData(" Info ", LogLevel.Info)]
+    [InlineData("WARNING", LogLevel.Warning)]
+    [InlineData("Error", LogLevel.Error)]
+    [InlineData("critical", LogLevel.Critical)]
+    [InlineData("None", LogLevel.None)]
+    [InlineData("warn", LogLevel.Warning)]
+    [InlineData("fatal", LogLevel.Critical)]
+    public void TryParseLevelAcceptsDefinedNamesAndAliases(string text, LogLevel expected)
+    {
+        Assert.True(SharpEmuLog.TryParseLevel(text, out var actual));
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("unknown")]
+    [InlineData("999")]
+    [InlineData("-1")]
+    public void TryParseLevelRejectsInvalidValues(string? text)
+    {
+        Assert.False(SharpEmuLog.TryParseLevel(text, out var level));
+        Assert.Equal(default, level);
+    }
+}


### PR DESCRIPTION
## Description

Found a small bug in TryParseLevel: Enum.TryParse accepts any numeric literal valid for the underlying type, even if it's not a defined member of the enum. So a value like "999" would parse successfully into (LogLevel)999, which isn't a real LogLevel. This meant SHARPEMU_LOG_LEVEL could end up with an invalid LogLevel, silently disabling log filtering.

I added && Enum.IsDefined(level) to the existing Enum.TryParse check. Since the if condition can now be false even when TryParse itself succeeds, I also reset level back to default in that case, so it doesn't keep the invalid 999 value when the method returns false.

## Testing

I didn't run any games because this doesn't affect gameplay at all; it only changes how the program reads the log level, i tested it by running the automated tests, and all 296 passed, including the new ones I wrote for the bug.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
