### PR TITLE
Fix/mem reserve and mutex exit cleanup

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -4765,6 +4765,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			var exitReason = resumeContinuation
 				? ExecuteBlockedGuestThreadContinuation(thread.Context, continuation, thread.Name, out var blockReason)
 				: ExecuteGuestThreadEntry(thread.Context, thread.EntryPoint, thread.Name, out blockReason);
+			var guestThreadExited = false;
 			using (LockGate("RunGuestThread.exit"))
 			{
 				switch (exitReason)
@@ -4772,6 +4773,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					case GuestNativeCallExitReason.Returned:
 						thread.ExitValue = thread.Context[CpuRegister.Rax];
 						thread.State = GuestThreadRunState.Exited;
+						guestThreadExited = true;
 						if (_logGuestThreads)
 						Console.Error.WriteLine(
 							$"[LOADER][INFO] Guest thread exited: name='{thread.Name}' " +
@@ -4798,6 +4800,15 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 						thread.BlockReason = blockReason;
 						break;
 				}
+			}
+
+			// Release any mutex ownership or queued lock waiters the thread left
+			// behind, now that the gate is released (the cleanup takes per-mutex
+			// locks and may wake blocked threads, mirroring pthread_mutex_unlock).
+			// A stranded owner or waiter would otherwise wedge that mutex forever.
+			if (guestThreadExited)
+			{
+				GuestThreadExecution.NotifyGuestThreadExited(thread.ThreadHandle);
 			}
 			if (_logGuestThreads)
 			{

--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -24,8 +24,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
     private const ulong GuestAllocationArenaAddress = 0x00006000_0000_0000;
     private const ulong GuestAllocationArenaSize = 0x0100_0000;
     private const ulong GuestAllocationArenaStartOffset = PageSize;
-    private const ulong LargeDataReserveThreshold = 0x4000_0000UL; // 1 GiB
-    private const ulong FullCommitRegionLimit = 4UL << 30;
+    private const ulong FullCommitRegionLimit = 4UL << 30; // 4 GiB
     private const ulong DefaultLazyReservePrimeBytes = 0x0400_0000UL; // 64 MiB
     private const ulong LazyReservePrimeChunkBytes = 0x0200_0000UL; // 32 MiB
 
@@ -163,9 +162,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         var protection = executable ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE;
         var hostProtection = executable ? HostPageProtection.ReadWriteExecute : HostPageProtection.ReadWrite;
 
-        var reserveOnly = !executable &&
-            alignedSize >= LargeDataReserveThreshold &&
-            alignedSize > FullCommitRegionLimit;
+        var reserveOnly = !executable && alignedSize > FullCommitRegionLimit;
 
         var result = reserveOnly
             ? _hostMemory.Reserve(desiredAddress, alignedSize, HostPageProtection.ReadWrite)
@@ -235,9 +232,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         var protection = executable ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE;
         var hostProtection = executable ? HostPageProtection.ReadWriteExecute : HostPageProtection.ReadWrite;
         var reservedOnly = false;
-        var preferReserveOnly = !executable &&
-            alignedSize >= LargeDataReserveThreshold &&
-            alignedSize > FullCommitRegionLimit;
+        var preferReserveOnly = !executable && alignedSize > FullCommitRegionLimit;
 
         ulong result = 0;
         if (preferReserveOnly)
@@ -248,10 +243,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
                 result = _hostMemory.Reserve(0, alignedSize, HostPageProtection.ReadWrite);
             }
 
-            if (result != 0)
-            {
-                reservedOnly = true;
-            }
+            reservedOnly = result != 0;
         }
 
         if (result == 0)
@@ -259,37 +251,34 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
             result = _hostMemory.Allocate(desiredAddress, alignedSize, hostProtection);
         }
 
+        if (result == 0 && !allowAlternative)
+        {
+            throw new InvalidOperationException($"Failed to allocate exact mapping at 0x{desiredAddress:X16} ({alignedSize} bytes)");
+        }
+
         if (result == 0)
         {
-            if (!allowAlternative)
-            {
-                throw new InvalidOperationException($"Failed to allocate exact mapping at 0x{desiredAddress:X16} ({alignedSize} bytes)");
-            }
-
             TraceVmem($"Could not allocate at 0x{desiredAddress:X16}, trying any address...");
             result = _hostMemory.Allocate(0, alignedSize, hostProtection);
+        }
 
+        // Last resort for data regions below the reserve-only threshold: the host may have
+        // address space available even when it cannot satisfy the commit. Regions that
+        // already took the reserve-only path above would just repeat those attempts.
+        if (result == 0 && !executable && !preferReserveOnly)
+        {
+            result = _hostMemory.Reserve(desiredAddress, alignedSize, HostPageProtection.ReadWrite);
             if (result == 0)
             {
-                if (!executable)
-                {
-                    result = _hostMemory.Reserve(desiredAddress, alignedSize, HostPageProtection.ReadWrite);
-                    if (result == 0 && allowAlternative)
-                    {
-                        result = _hostMemory.Reserve(0, alignedSize, HostPageProtection.ReadWrite);
-                    }
-
-                    if (result != 0)
-                    {
-                        reservedOnly = true;
-                    }
-                }
-
-                if (result == 0)
-                {
-                    throw new OutOfMemoryException($"Failed to allocate {alignedSize} bytes of virtual memory");
-                }
+                result = _hostMemory.Reserve(0, alignedSize, HostPageProtection.ReadWrite);
             }
+
+            reservedOnly = result != 0;
+        }
+
+        if (result == 0)
+        {
+            throw new OutOfMemoryException($"Failed to allocate {alignedSize} bytes of virtual memory");
         }
 
         var actualAddress = result;

--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -162,7 +162,14 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         var alignedSize = (size + 0xFFF) & ~0xFFFUL;
         var protection = executable ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE;
         var hostProtection = executable ? HostPageProtection.ReadWriteExecute : HostPageProtection.ReadWrite;
-        var result = _hostMemory.Allocate(desiredAddress, alignedSize, hostProtection);
+
+        var reserveOnly = !executable &&
+            alignedSize >= LargeDataReserveThreshold &&
+            alignedSize > FullCommitRegionLimit;
+
+        var result = reserveOnly
+            ? _hostMemory.Reserve(desiredAddress, alignedSize, HostPageProtection.ReadWrite)
+            : _hostMemory.Allocate(desiredAddress, alignedSize, hostProtection);
         if (result == 0)
         {
             return false;
@@ -184,7 +191,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
                 VirtualAddress = actualAddress,
                 Size = alignedSize,
                 IsExecutable = executable,
-                IsReservedOnly = false,
+                IsReservedOnly = reserveOnly,
                 Protection = protection
             });
         }
@@ -193,7 +200,9 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
             _gate.ExitWriteLock();
         }
 
-        var allocationKind = executable ? "executable memory" : "data memory";
+        var allocationKind = reserveOnly
+            ? "reserved data memory (lazy commit)"
+            : (executable ? "executable memory" : "data memory");
         TraceVmem($"Allocated exact {allocationKind}: 0x{actualAddress:X16} - 0x{actualAddress + alignedSize:X16} ({alignedSize} bytes)");
         return true;
     }

--- a/src/SharpEmu.HLE/GuestThreadExecution.cs
+++ b/src/SharpEmu.HLE/GuestThreadExecution.cs
@@ -221,6 +221,29 @@ public static class GuestThreadExecution
 
     public static IGuestThreadScheduler? Scheduler { get; set; }
 
+    /// <summary>
+    /// Raised when a guest thread has terminated (returned from its entry or
+    /// called pthread_exit). Subscribers clean up per-thread kernel state such
+    /// as mutex ownership and queued lock waiters that the dead thread would
+    /// otherwise strand. The argument is the exiting thread's handle.
+    /// </summary>
+    public static event Action<ulong>? GuestThreadExited;
+
+    /// <summary>
+    /// Invoked by the execution backend once a guest thread reaches its
+    /// terminal state, so kernel primitives can release anything the thread
+    /// still held. Safe to call with a zero handle (no-op).
+    /// </summary>
+    public static void NotifyGuestThreadExited(ulong threadHandle)
+    {
+        if (threadHandle == 0)
+        {
+            return;
+        }
+
+        GuestThreadExited?.Invoke(threadHandle);
+    }
+
     public static bool IsGuestThread => _currentGuestThreadHandle != 0;
 
     public static ulong CurrentGuestThreadHandle => _currentGuestThreadHandle;

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -39,109 +39,6 @@ public static class KernelPthreadCompatExports
         Environment.GetEnvironmentVariable("SHARPEMU_LOG_PTHREAD_MUTEX_FILTER"));
     private static long _nextSynchronizationWaiterId;
 
-    // Address-independent mutex diagnostics: when enabled, every mutex op is
-    // appended to a small ring, and the history for a specific mutex is dumped
-    // automatically when an unlock hits an unexpected error (the mutex looks
-    // unlocked or foreign-owned). This survives ASLR — no need to know the
-    // guest mutex address in advance. Enable with SHARPEMU_LOG_PTHREAD_MUTEX_DIAG=1.
-    private static readonly bool _diagPthreadMutex =
-        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_PTHREAD_MUTEX_DIAG"), "1", StringComparison.Ordinal);
-
-    private sealed class MutexOpRecord
-    {
-        public long Seq;
-        public string Op = string.Empty;
-        public ulong Address;
-        public ulong Resolved;
-        public ulong Owner;
-        public int Recursion;
-        public int Waiters;
-        public ulong ThreadId;
-        public int Result;
-    }
-
-    private static readonly MutexOpRecord[] _mutexOpRing = CreateMutexOpRing();
-    private static long _mutexOpSeq;
-
-    private static MutexOpRecord[] CreateMutexOpRing()
-    {
-        var ring = new MutexOpRecord[512];
-        for (var i = 0; i < ring.Length; i++)
-        {
-            ring[i] = new MutexOpRecord();
-        }
-
-        return ring;
-    }
-
-    private static void RecordMutexOp(string op, ulong address, ulong resolved, PthreadMutexState? state, ulong threadId, int result)
-    {
-        var seq = Interlocked.Increment(ref _mutexOpSeq);
-        var slot = _mutexOpRing[(int)((ulong)(seq - 1) % (ulong)_mutexOpRing.Length)];
-        lock (slot)
-        {
-            slot.Seq = seq;
-            slot.Op = op;
-            slot.Address = address;
-            slot.Resolved = resolved;
-            slot.Owner = state?.OwnerThreadId ?? 0;
-            slot.Recursion = state?.RecursionCount ?? 0;
-            slot.Waiters = state?.Waiters.Count ?? 0;
-            slot.ThreadId = threadId;
-            slot.Result = result;
-        }
-    }
-
-    // Dumps the recorded history for one mutex address plus the current
-    // resolution candidates (by raw address and by the handle word the guest
-    // stores in the object). A recursion mismatch between candidates means the
-    // lock and unlock paths disagree on which state object owns the mutex.
-    private static void DumpMutexHistory(CpuContext ctx, ulong mutexAddress, ulong resolvedAddress, ulong currentThreadId, string reason)
-    {
-        _ = KernelMemoryCompatExports.TryReadUInt64Compat(ctx, mutexAddress, out var handleWord);
-        var byAddress = _mutexStates.TryGetValue(mutexAddress, out var addrState) ? addrState : null;
-        var byHandle = handleWord != 0 && _mutexStates.TryGetValue(handleWord, out var handleState) ? handleState : null;
-
-        Console.Error.WriteLine(
-            $"[LOADER][PTHREAD-DIAG] {reason}: mutex=0x{mutexAddress:X16} resolved=0x{resolvedAddress:X16} " +
-            $"current=0x{currentThreadId:X16} handleWord=0x{handleWord:X16} " +
-            $"byAddr(owner=0x{(byAddress?.OwnerThreadId ?? 0):X16} rec={(byAddress?.RecursionCount ?? -1)} waiters={(byAddress?.Waiters.Count ?? -1)}) " +
-            $"byHandle(owner=0x{(byHandle?.OwnerThreadId ?? 0):X16} rec={(byHandle?.RecursionCount ?? -1)} waiters={(byHandle?.Waiters.Count ?? -1)}) " +
-            $"sameObject={(byAddress is not null && ReferenceEquals(byAddress, byHandle))}");
-
-        var history = new List<MutexOpRecord>();
-        foreach (var slot in _mutexOpRing)
-        {
-            lock (slot)
-            {
-                if (slot.Seq != 0 && slot.Address == mutexAddress)
-                {
-                    history.Add(new MutexOpRecord
-                    {
-                        Seq = slot.Seq,
-                        Op = slot.Op,
-                        Address = slot.Address,
-                        Resolved = slot.Resolved,
-                        Owner = slot.Owner,
-                        Recursion = slot.Recursion,
-                        Waiters = slot.Waiters,
-                        ThreadId = slot.ThreadId,
-                        Result = slot.Result,
-                    });
-                }
-            }
-        }
-
-        history.Sort((a, b) => a.Seq.CompareTo(b.Seq));
-        foreach (var record in history)
-        {
-            Console.Error.WriteLine(
-                $"[LOADER][PTHREAD-DIAG]   #{record.Seq} {record.Op} resolved=0x{record.Resolved:X16} " +
-                $"thread=0x{record.ThreadId:X16} owner=0x{record.Owner:X16} rec={record.Recursion} " +
-                $"waiters={record.Waiters} result=0x{unchecked((uint)record.Result):X8}");
-        }
-    }
-
     private sealed class PthreadMutexState
     {
         public ulong OwnerThreadId { get; set; }
@@ -919,10 +816,6 @@ public static class KernelPthreadCompatExports
             if (state.RecursionCount <= 0)
             {
                 TracePthreadMutex(ctx, "unlock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
-                if (_diagPthreadMutex)
-                {
-                    DumpMutexHistory(ctx, mutexAddress, resolvedAddress, currentThreadId, "unlock-not-locked");
-                }
 
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
             }
@@ -930,10 +823,6 @@ public static class KernelPthreadCompatExports
             if (requireOwner && state.OwnerThreadId != currentThreadId)
             {
                 TracePthreadMutex(ctx, "unlock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_PERMISSION_DENIED);
-                if (_diagPthreadMutex)
-                {
-                    DumpMutexHistory(ctx, mutexAddress, resolvedAddress, currentThreadId, "unlock-wrong-owner");
-                }
 
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_PERMISSION_DENIED;
             }
@@ -1953,10 +1842,6 @@ public static class KernelPthreadCompatExports
 
     private static void TracePthreadMutex(CpuContext ctx, string operation, ulong mutexAddress, ulong resolvedAddress, PthreadMutexState? state, ulong currentThreadId, int result)
     {
-        if (_diagPthreadMutex)
-        {
-            RecordMutexOp(operation, mutexAddress, resolvedAddress, state, currentThreadId, result);
-        }
 
         if (!ShouldTracePthreadMutex(mutexAddress, resolvedAddress))
         {

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -39,6 +39,109 @@ public static class KernelPthreadCompatExports
         Environment.GetEnvironmentVariable("SHARPEMU_LOG_PTHREAD_MUTEX_FILTER"));
     private static long _nextSynchronizationWaiterId;
 
+    // Address-independent mutex diagnostics: when enabled, every mutex op is
+    // appended to a small ring, and the history for a specific mutex is dumped
+    // automatically when an unlock hits an unexpected error (the mutex looks
+    // unlocked or foreign-owned). This survives ASLR — no need to know the
+    // guest mutex address in advance. Enable with SHARPEMU_LOG_PTHREAD_MUTEX_DIAG=1.
+    private static readonly bool _diagPthreadMutex =
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_PTHREAD_MUTEX_DIAG"), "1", StringComparison.Ordinal);
+
+    private sealed class MutexOpRecord
+    {
+        public long Seq;
+        public string Op = string.Empty;
+        public ulong Address;
+        public ulong Resolved;
+        public ulong Owner;
+        public int Recursion;
+        public int Waiters;
+        public ulong ThreadId;
+        public int Result;
+    }
+
+    private static readonly MutexOpRecord[] _mutexOpRing = CreateMutexOpRing();
+    private static long _mutexOpSeq;
+
+    private static MutexOpRecord[] CreateMutexOpRing()
+    {
+        var ring = new MutexOpRecord[512];
+        for (var i = 0; i < ring.Length; i++)
+        {
+            ring[i] = new MutexOpRecord();
+        }
+
+        return ring;
+    }
+
+    private static void RecordMutexOp(string op, ulong address, ulong resolved, PthreadMutexState? state, ulong threadId, int result)
+    {
+        var seq = Interlocked.Increment(ref _mutexOpSeq);
+        var slot = _mutexOpRing[(int)((ulong)(seq - 1) % (ulong)_mutexOpRing.Length)];
+        lock (slot)
+        {
+            slot.Seq = seq;
+            slot.Op = op;
+            slot.Address = address;
+            slot.Resolved = resolved;
+            slot.Owner = state?.OwnerThreadId ?? 0;
+            slot.Recursion = state?.RecursionCount ?? 0;
+            slot.Waiters = state?.Waiters.Count ?? 0;
+            slot.ThreadId = threadId;
+            slot.Result = result;
+        }
+    }
+
+    // Dumps the recorded history for one mutex address plus the current
+    // resolution candidates (by raw address and by the handle word the guest
+    // stores in the object). A recursion mismatch between candidates means the
+    // lock and unlock paths disagree on which state object owns the mutex.
+    private static void DumpMutexHistory(CpuContext ctx, ulong mutexAddress, ulong resolvedAddress, ulong currentThreadId, string reason)
+    {
+        _ = KernelMemoryCompatExports.TryReadUInt64Compat(ctx, mutexAddress, out var handleWord);
+        var byAddress = _mutexStates.TryGetValue(mutexAddress, out var addrState) ? addrState : null;
+        var byHandle = handleWord != 0 && _mutexStates.TryGetValue(handleWord, out var handleState) ? handleState : null;
+
+        Console.Error.WriteLine(
+            $"[LOADER][PTHREAD-DIAG] {reason}: mutex=0x{mutexAddress:X16} resolved=0x{resolvedAddress:X16} " +
+            $"current=0x{currentThreadId:X16} handleWord=0x{handleWord:X16} " +
+            $"byAddr(owner=0x{(byAddress?.OwnerThreadId ?? 0):X16} rec={(byAddress?.RecursionCount ?? -1)} waiters={(byAddress?.Waiters.Count ?? -1)}) " +
+            $"byHandle(owner=0x{(byHandle?.OwnerThreadId ?? 0):X16} rec={(byHandle?.RecursionCount ?? -1)} waiters={(byHandle?.Waiters.Count ?? -1)}) " +
+            $"sameObject={(byAddress is not null && ReferenceEquals(byAddress, byHandle))}");
+
+        var history = new List<MutexOpRecord>();
+        foreach (var slot in _mutexOpRing)
+        {
+            lock (slot)
+            {
+                if (slot.Seq != 0 && slot.Address == mutexAddress)
+                {
+                    history.Add(new MutexOpRecord
+                    {
+                        Seq = slot.Seq,
+                        Op = slot.Op,
+                        Address = slot.Address,
+                        Resolved = slot.Resolved,
+                        Owner = slot.Owner,
+                        Recursion = slot.Recursion,
+                        Waiters = slot.Waiters,
+                        ThreadId = slot.ThreadId,
+                        Result = slot.Result,
+                    });
+                }
+            }
+        }
+
+        history.Sort((a, b) => a.Seq.CompareTo(b.Seq));
+        foreach (var record in history)
+        {
+            Console.Error.WriteLine(
+                $"[LOADER][PTHREAD-DIAG]   #{record.Seq} {record.Op} resolved=0x{record.Resolved:X16} " +
+                $"thread=0x{record.ThreadId:X16} owner=0x{record.Owner:X16} rec={record.Recursion} " +
+                $"waiters={record.Waiters} result=0x{unchecked((uint)record.Result):X8}");
+        }
+    }
+
     private sealed class PthreadMutexState
     {
         public ulong OwnerThreadId { get; set; }
@@ -816,12 +919,22 @@ public static class KernelPthreadCompatExports
             if (state.RecursionCount <= 0)
             {
                 TracePthreadMutex(ctx, "unlock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+                if (_diagPthreadMutex)
+                {
+                    DumpMutexHistory(ctx, mutexAddress, resolvedAddress, currentThreadId, "unlock-not-locked");
+                }
+
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
             }
 
             if (requireOwner && state.OwnerThreadId != currentThreadId)
             {
                 TracePthreadMutex(ctx, "unlock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_PERMISSION_DENIED);
+                if (_diagPthreadMutex)
+                {
+                    DumpMutexHistory(ctx, mutexAddress, resolvedAddress, currentThreadId, "unlock-wrong-owner");
+                }
+
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_PERMISSION_DENIED;
             }
 
@@ -1599,6 +1712,8 @@ public static class KernelPthreadCompatExports
                 waiter.ThreadId,
                 waiter.Cooperative,
                 waiter.WakeKey);
+
+            TryGrantMutexWaiterLocked(waiter.MutexState, waiter.MutexWaiter);
         }
 
         Monitor.PulseAll(state.SyncRoot);
@@ -1838,6 +1953,11 @@ public static class KernelPthreadCompatExports
 
     private static void TracePthreadMutex(CpuContext ctx, string operation, ulong mutexAddress, ulong resolvedAddress, PthreadMutexState? state, ulong currentThreadId, int result)
     {
+        if (_diagPthreadMutex)
+        {
+            RecordMutexOp(operation, mutexAddress, resolvedAddress, state, currentThreadId, result);
+        }
+
         if (!ShouldTracePthreadMutex(mutexAddress, resolvedAddress))
         {
             return;

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -84,6 +84,77 @@ public static class KernelPthreadCompatExports
     static KernelPthreadCompatExports()
     {
         RunSynchronizationSelfChecks();
+        GuestThreadExecution.GuestThreadExited += ReleaseThreadSynchronizationState;
+    }
+
+    /// <summary>
+    /// Releases the mutex ownership and dequeues the lock waiters left behind by
+    /// a guest thread that has terminated. Without this, a thread that exits
+    /// while owning a mutex — or while queued waiting for one — strands that
+    /// mutex forever: the fast-acquire path refuses a mutex whose wait queue is
+    /// non-empty (see PthreadMutexLockCore), and ownership is otherwise cleared
+    /// only by an explicit unlock, so every future locker blocks permanently.
+    /// </summary>
+    public static void ReleaseThreadSynchronizationState(ulong threadHandle)
+    {
+        if (threadHandle == 0)
+        {
+            return;
+        }
+
+        // _mutexStates maps both the guest address and the opaque handle to the
+        // same state instance, so dedupe on the object to visit each mutex once.
+        var visited = new HashSet<PthreadMutexState>(ReferenceEqualityComparer.Instance);
+        foreach (var state in _mutexStates.Values)
+        {
+            if (!visited.Add(state))
+            {
+                continue;
+            }
+
+            string? wakeKey = null;
+            lock (state)
+            {
+                // Drop every waiter node this thread left in the queue.
+                var node = state.Waiters.First;
+                while (node is not null)
+                {
+                    var next = node.Next;
+                    if (node.Value.ThreadId == threadHandle)
+                    {
+                        state.Waiters.Remove(node);
+                        node.Value.Node = null;
+                    }
+
+                    node = next;
+                }
+
+                // Release the lock if the dead thread still owned it.
+                if (state.OwnerThreadId == threadHandle)
+                {
+                    state.OwnerThreadId = 0;
+                    state.RecursionCount = 0;
+                }
+
+                // If the mutex is now free but others are still queued, hand it
+                // to the new head so a surviving thread actually proceeds.
+                if (state.OwnerThreadId == 0 && state.Waiters.First is { } headNode)
+                {
+                    if (TryGrantMutexWaiterLocked(state, headNode.Value) &&
+                        headNode.Value.Cooperative)
+                    {
+                        wakeKey = headNode.Value.WakeKey;
+                    }
+
+                    Monitor.PulseAll(state);
+                }
+            }
+
+            if (wakeKey is not null)
+            {
+                _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(wakeKey, 1);
+            }
+        }
     }
 
     [SysAbiExport(

--- a/tests/SharpEmu.Libs.Tests/Memory/GuestMemoryAllocatorTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Memory/GuestMemoryAllocatorTests.cs
@@ -121,6 +121,91 @@ public sealed class GuestMemoryAllocatorTests
         Assert.Equal([alignedAddress + 0x1000], host.FreedAddresses);
     }
 
+    [Fact]
+    public void LargeExactReservationReservesInsteadOfCommitting()
+    {
+        const ulong desiredAddress = 0x0000_8000_0000_0000;
+        const ulong reservationSize = 0x80_0000_0000; // 512 GiB
+        const ulong commitLimit = 0x8_0000_0000;      // 32 GiB
+        var host = new CommitLimitedHostMemory(commitLimit);
+        using var memory = new PhysicalVirtualMemory(host);
+
+        Assert.True(memory.TryAllocateAtExact(desiredAddress, reservationSize, executable: false, out var actualAddress));
+        Assert.Equal(desiredAddress, actualAddress);
+
+        // The range was reserved, never committed: exactly one reserve at the
+        // requested base/size, and no reserve+commit was attempted for it.
+        Assert.Equal([(desiredAddress, reservationSize)], host.ReserveCalls);
+        Assert.DoesNotContain((desiredAddress, reservationSize), host.AllocateCalls);
+    }
+
+    [Fact]
+    public void SmallExactAllocationStillCommits()
+    {
+        // Below the large-reservation threshold, allocations must still be
+        // committed up front (reserve+commit), not switched to lazy reserve.
+        const ulong desiredAddress = 0x0000_9000_0000_0000;
+        const ulong smallSize = 0x1000; // 4 KiB
+        const ulong commitLimit = 0x8_0000_0000;
+        var host = new CommitLimitedHostMemory(commitLimit);
+        using var memory = new PhysicalVirtualMemory(host);
+
+        Assert.True(memory.TryAllocateAtExact(desiredAddress, smallSize, executable: false, out var actualAddress));
+        Assert.Equal(desiredAddress, actualAddress);
+
+        Assert.Equal([(desiredAddress, smallSize)], host.AllocateCalls);
+        Assert.Empty(host.ReserveCalls);
+    }
+
+    private sealed class CommitLimitedHostMemory(ulong commitLimit) : IHostMemory
+    {
+        public List<(ulong Address, ulong Size)> AllocateCalls { get; } = [];
+
+        public List<(ulong Address, ulong Size)> ReserveCalls { get; } = [];
+
+        // Reserve+commit: fails when the request exceeds the host commit limit,
+        // exactly like VirtualAlloc(MEM_COMMIT) rejecting an over-large charge.
+        public ulong Allocate(ulong desiredAddress, ulong size, HostPageProtection protection)
+        {
+            AllocateCalls.Add((desiredAddress, size));
+            return size > commitLimit ? 0 : desiredAddress;
+        }
+
+        // Reserve only: succeeds at the exact address, since claiming address
+        // space (without backing it) is cheap regardless of size.
+        public ulong Reserve(ulong desiredAddress, ulong size, HostPageProtection protection)
+        {
+            ReserveCalls.Add((desiredAddress, size));
+            return desiredAddress;
+        }
+
+        public bool Commit(ulong address, ulong size, HostPageProtection protection) => true;
+
+        public bool Free(ulong address) => true;
+
+        public bool Protect(ulong address, ulong size, HostPageProtection protection, out uint rawOldProtection)
+        {
+            rawOldProtection = 0;
+            return true;
+        }
+
+        public bool ProtectRaw(ulong address, ulong size, uint rawProtection, out uint rawOldProtection)
+        {
+            rawOldProtection = 0;
+            return true;
+        }
+
+        public bool Query(ulong address, out HostRegionInfo info)
+        {
+            info = default;
+            return false;
+        }
+
+        public void FlushInstructionCache(ulong address, ulong size)
+        {
+        }
+    }
+
     private sealed class FakeHostMemory : IHostMemory
     {
         public ulong Allocate(ulong desiredAddress, ulong size, HostPageProtection protection) =>

--- a/tests/SharpEmu.Libs.Tests/Pthread/PthreadCondReacquireTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Pthread/PthreadCondReacquireTests.cs
@@ -1,0 +1,126 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Collections;
+using System.Reflection;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Pthread;
+
+// POSIX permits signalling a condition variable without holding its mutex, so
+// when a cond waiter is woken the mutex may already be free. The signal path
+// (CompleteCondWaiterLocked) moves the waiter onto the mutex's wait queue to
+// re-acquire it; if it fails to grant a free mutex, the waiter is stranded on a
+// free mutex forever and the guest deadlocks (observed hanging Silent Hill deep
+// in Unreal Engine init). These tests exercise that handoff directly.
+public sealed class PthreadCondReacquireTests
+{
+    private const ulong Waiter = 0xC0C0_0000_0000_0001;
+    private const ulong OtherOwner = 0xD0D0_0000_0000_0002;
+
+    [Fact]
+    public void SignalWithFreeMutexGrantsReacquisitionToWaiter()
+    {
+        var mutex = NewMutex();
+        var cond = NewCond();
+        var waiter = EnqueueCondWaiter(cond, mutex, Waiter);
+
+        var completed = CompleteCondWaiterLocked(cond, waiter);
+
+        Assert.True(completed);
+        // The re-acquisition is granted immediately instead of being left to
+        // rot on a free mutex: the waiter now owns it and the queue is empty.
+        Assert.Equal(Waiter, OwnerThreadId(mutex));
+        Assert.Equal(1, RecursionCount(mutex));
+        Assert.Equal(0, MutexWaiterCount(mutex));
+        Assert.Equal(1, MutexWaiterGranted(waiter));
+    }
+
+    [Fact]
+    public void SignalWithHeldMutexLeavesWaiterQueued()
+    {
+        var mutex = NewMutex();
+        SetOwner(mutex, OtherOwner, recursion: 1);
+        var cond = NewCond();
+        var waiter = EnqueueCondWaiter(cond, mutex, Waiter);
+
+        var completed = CompleteCondWaiterLocked(cond, waiter);
+
+        Assert.True(completed);
+        // The mutex is held elsewhere, so the waiter must wait its turn (the
+        // owning thread's unlock hands it over) — ownership is untouched.
+        Assert.Equal(OtherOwner, OwnerThreadId(mutex));
+        Assert.Equal(1, MutexWaiterCount(mutex));
+        Assert.Equal(0, MutexWaiterGranted(waiter));
+    }
+
+    // --- reflection helpers over the private synchronization internals ---
+
+    private static readonly Type ExportsType = typeof(KernelPthreadCompatExports);
+    private static readonly Type MutexStateType = Nested("PthreadMutexState");
+    private static readonly Type CondStateType = Nested("PthreadCondState");
+    private static readonly Type CondWaiterType = Nested("PthreadCondWaiter");
+    private static readonly Type MutexWaiterType = Nested("PthreadMutexWaiter");
+
+    private static Type Nested(string name) =>
+        ExportsType.GetNestedType(name, BindingFlags.NonPublic)!;
+
+    private static object NewMutex() => Activator.CreateInstance(MutexStateType, nonPublic: true)!;
+
+    private static object NewCond() => Activator.CreateInstance(CondStateType, nonPublic: true)!;
+
+    private static object EnqueueCondWaiter(object cond, object mutex, ulong threadId)
+    {
+        var waiter = Activator.CreateInstance(CondWaiterType, nonPublic: true)!;
+        CondWaiterType.GetProperty("ThreadId")!.SetValue(waiter, threadId);
+        CondWaiterType.GetProperty("MutexState")!.SetValue(waiter, mutex);
+        CondWaiterType.GetProperty("WakeKey")!.SetValue(waiter, string.Empty);
+        CondWaiterType.GetProperty("Cooperative")!.SetValue(waiter, false);
+
+        var queue = CondStateType.GetProperty("WaiterQueue")!.GetValue(cond)!;
+        var addLast = queue.GetType().GetMethod("AddLast", [CondWaiterType])!;
+        var node = addLast.Invoke(queue, [waiter]);
+        CondWaiterType.GetProperty("Node")!.SetValue(waiter, node);
+
+        var waiters = (int)CondStateType.GetProperty("Waiters")!.GetValue(cond)!;
+        CondStateType.GetProperty("Waiters")!.SetValue(cond, waiters + 1);
+        return waiter;
+    }
+
+    private static bool CompleteCondWaiterLocked(object cond, object waiter)
+    {
+        var method = ExportsType.GetMethod(
+            "CompleteCondWaiterLocked",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        // Real callers always hold the cond's SyncRoot (the method pulses it).
+        var syncRoot = CondStateType.GetProperty("SyncRoot")!.GetValue(cond)!;
+        lock (syncRoot)
+        {
+            return (bool)method.Invoke(null, [cond, waiter, false])!;
+        }
+    }
+
+    private static void SetOwner(object mutex, ulong threadId, int recursion)
+    {
+        MutexStateType.GetProperty("OwnerThreadId")!.SetValue(mutex, threadId);
+        MutexStateType.GetProperty("RecursionCount")!.SetValue(mutex, recursion);
+    }
+
+    private static ulong OwnerThreadId(object mutex) =>
+        (ulong)MutexStateType.GetProperty("OwnerThreadId")!.GetValue(mutex)!;
+
+    private static int RecursionCount(object mutex) =>
+        (int)MutexStateType.GetProperty("RecursionCount")!.GetValue(mutex)!;
+
+    private static int MutexWaiterCount(object mutex) =>
+        ((ICollection)MutexStateType.GetProperty("Waiters")!.GetValue(mutex)!).Count;
+
+    private static int MutexWaiterGranted(object condWaiter)
+    {
+        var mutexWaiter = CondWaiterType.GetProperty("MutexWaiter")!.GetValue(condWaiter);
+        return mutexWaiter is null
+            ? -1
+            : (int)MutexWaiterType.GetField("Granted")!.GetValue(mutexWaiter)!;
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Pthread/PthreadMutexExitCleanupTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Pthread/PthreadMutexExitCleanupTests.cs
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Collections;
+using System.Reflection;
+using System.Threading;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Pthread;
+
+// A guest thread that exits while owning a mutex — or while queued waiting for
+// one — used to strand that mutex forever: ownership was cleared only by an
+// explicit unlock, and a waiter was removed only when granted the lock. The
+// fast-acquire path refuses a mutex whose wait queue is non-empty, so every
+// future locker blocked permanently. ReleaseThreadSynchronizationState is the
+// on-exit cleanup that fixes this; these tests exercise it directly.
+public sealed class PthreadMutexExitCleanupTests
+{
+    private const ulong DeadThread = 0xAAAA_0000_0000_0001;
+    private const ulong SurvivorThread = 0xBBBB_0000_0000_0002;
+
+    [Fact]
+    public void ExitingWaiterIsDequeuedAndSuccessorIsGranted()
+    {
+        var (address, state) = RegisterMutex();
+        try
+        {
+            // Dead thread is queued at the head; a survivor is queued behind it.
+            EnqueueWaiter(state, DeadThread);
+            EnqueueWaiter(state, SurvivorThread);
+            Assert.Equal(0UL, OwnerThreadId(state));
+            Assert.Equal(2, WaiterCount(state));
+
+            KernelPthreadCompatExports.ReleaseThreadSynchronizationState(DeadThread);
+
+            // The ghost waiter is gone and the survivor now owns the mutex,
+            // instead of being wedged behind a head that never wakes.
+            Assert.Equal(SurvivorThread, OwnerThreadId(state));
+            Assert.Equal(1, RecursionCount(state));
+            Assert.Equal(0, WaiterCount(state));
+        }
+        finally
+        {
+            UnregisterMutex(address);
+        }
+    }
+
+    [Fact]
+    public void ExitingOwnerReleasesLockAndHandsItToWaiter()
+    {
+        var (address, state) = RegisterMutex();
+        try
+        {
+            // Dead thread owns the mutex; a survivor is blocked waiting for it.
+            SetOwner(state, DeadThread, recursion: 1);
+            EnqueueWaiter(state, SurvivorThread);
+
+            KernelPthreadCompatExports.ReleaseThreadSynchronizationState(DeadThread);
+
+            Assert.Equal(SurvivorThread, OwnerThreadId(state));
+            Assert.Equal(1, RecursionCount(state));
+            Assert.Equal(0, WaiterCount(state));
+        }
+        finally
+        {
+            UnregisterMutex(address);
+        }
+    }
+
+    [Fact]
+    public void ExitingUncontendedOwnerLeavesMutexFree()
+    {
+        var (address, state) = RegisterMutex();
+        try
+        {
+            SetOwner(state, DeadThread, recursion: 2);
+
+            KernelPthreadCompatExports.ReleaseThreadSynchronizationState(DeadThread);
+
+            // No waiters: the mutex is simply released, available to the next locker.
+            Assert.Equal(0UL, OwnerThreadId(state));
+            Assert.Equal(0, RecursionCount(state));
+            Assert.Equal(0, WaiterCount(state));
+        }
+        finally
+        {
+            UnregisterMutex(address);
+        }
+    }
+
+    // --- reflection helpers over the private synchronization internals ---
+
+    private static readonly Type ExportsType = typeof(KernelPthreadCompatExports);
+
+    private static readonly Type MutexStateType =
+        ExportsType.GetNestedType("PthreadMutexState", BindingFlags.NonPublic)!;
+
+    private static IDictionary MutexStates =>
+        (IDictionary)ExportsType
+            .GetField("_mutexStates", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+
+    private static ulong _nextAddress = 0xDEAD_0000_0000_0000;
+
+    private static (ulong Address, object State) RegisterMutex()
+    {
+        var state = Activator.CreateInstance(MutexStateType, nonPublic: true)!;
+        var address = Interlocked.Increment(ref _nextAddress);
+        MutexStates[address] = state;
+        return (address, state);
+    }
+
+    private static void UnregisterMutex(ulong address) => MutexStates.Remove(address);
+
+    private static void EnqueueWaiter(object state, ulong threadId)
+    {
+        var method = ExportsType.GetMethod(
+            "EnqueueMutexWaiterLocked",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        lock (state)
+        {
+            method.Invoke(null, [state, threadId, false, null]);
+        }
+    }
+
+    private static void SetOwner(object state, ulong threadId, int recursion)
+    {
+        MutexStateType.GetProperty("OwnerThreadId")!.SetValue(state, threadId);
+        MutexStateType.GetProperty("RecursionCount")!.SetValue(state, recursion);
+    }
+
+    private static ulong OwnerThreadId(object state) =>
+        (ulong)MutexStateType.GetProperty("OwnerThreadId")!.GetValue(state)!;
+
+    private static int RecursionCount(object state) =>
+        (int)MutexStateType.GetProperty("RecursionCount")!.GetValue(state)!;
+
+    private static int WaiterCount(object state) =>
+        ((ICollection)MutexStateType.GetProperty("Waiters")!.GetValue(state)!).Count;
+}


### PR DESCRIPTION
By opening this pull request, I confirm that I have read and agree to follow the contribution guidelines.

## What this fixes

**1. `PhysicalVirtualMemory.TryAllocateAtExact` unconditionally used MEM_RESERVE|MEM_COMMIT.** When a guest calls sceKernelReserveVirtualRange to carve out hundreds of GiB of address space, that tried to commit hundreds of GiB — far beyond what the host can back — so every call failed. That far exceeds the host commit limit, the allocation failed, and the exact-address search loop ground through tens of thousands of doomed attempts until the watchdog fired:

Fix: I essentially copied the fix that 'AllocateAt' already had which was is to use MEM_RESERVE only for very large non-executable requests.

**2. A guest thread that exited or waited in it's queue would strand any mutex it was holding permanently.** Ownership of a mutex would only be cleared by an explicit unlock and waiter was only removed if it was granted the lock. If the thread dies then none of this happens.

Fix: created a guestThreadExited notifcation that's raised on worker thread teardown. KernelPthreadCompatExports now subscribes, dequeues the dead thread waiters, releases any mutexes it owned and hand the free mutex to the next waiter. Explicitly scoped to mutexes.

**3. `pthread_cond_wait` failed to re-acquire a free mutex.** `pthread_cond_wait` releases the mutex, waits, and re-acquires it on wake. The signal path (`CompleteCondWaiterLocked`) moved the woken wait but never granted it when the mutex was already free. POSIX permits signalling a condvar without holding its mutex, and Unreal's async-task queue does exactly that — so no later unlock hands the mutex over, the waiter is stranded on a free mutex, and its next unlock fails.

Fix: Grant the re-acquisition immediately at signal time, if the mutex is free right then.

## The change

**Reserve-only for large exact allocations** (`PhysicalVirtualMemory.TryAllocateAtExact`). For non-executable requests reserve the region `IsReservedOnly` so pages commit on demand through the existing `EnsureRangeCommitted` fault path — the same thing the sibling `AllocateAt` already does. Small and executable allocations still commit up front, unchanged.

**Release synchronization state on thread exit.** Added a `GuestThreadExited` notification, raised from the worker-thread teardown in `DirectExecutionBackend` (which covers both a thread returning from its entry and `pthread_exit`, since both unwind to the same `Returned` point). `KernelPthreadCompatExports.ReleaseThreadSynchronizationState`, for the exiting thread, dequeues its mutex waiters, releases any mutex it still owned, and hands a now-free contended mutex to the next waiter. It fires after the scheduler gate is released, so it keeps the same lock ordering as `pthread_mutex_unlock`.

**Grant the cond-var re-acquire when the mutex is free.**, after enqueuing the re-acquisition waiter, call `TryGrantMutexWaiterLocked`. That call is a no-op unless the mutex is free and this waiter is at the FIFO head, and it is idempotent with the wake-time grant, so held-mutex signalling is unaffected — it only cll time" hole.

I kept the scope narrow on purpose:

- The reserve-only switch is gated on the same thresholdso it does not change small or executable allocations.
- The exit cleanup is scoped to mutexes. Condition-variable and semaphore waiters have the same "only removed on success" shape and are left as follow-ups rather than widened here.
- The cond-var grant does not change queue ordering or the held-mutex path; it only grants when the mutex is already free.

## Testing

Games: SILENT HILL: The Short Message (PPSA10112).

- New unit tests: `GuestMemoryAllocatorTests` (+2: a large exact request reserves instead of committing; a small one still commits), `PthreadMutexExitCleanupTests` (+3: an exiting waiter is dequeued anditing owner releases and hands off; an uncontended exiting
owner leaves the mutex free), `PthreadCondReacquireTests` (+2: a free mutex at signal time is granted to the waiter; a held mutex leaves the waiter queued).
- `dotnet test tests/SharpEmu.Libs.Tests` passes: 241 tests (+7 here).
- `dotnet build src/SharpEmu.CLI -c Release` is clean (0

I also added an address-independent mutex diagnostic behind `SHARPEMU_LOG_PTHREAD_MUTEX_DIAG=1` — it dumps a mutex's recent operation history when an unlock hits an unexpected error, which is what pinneLR.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).