### PR TITLE
[HLE] Expand network, save data, and service compatibility

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
@@ -9,7 +9,9 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using SharpEmu.Core.Cpu.Disasm;
+using SharpEmu.Core.Cpu.Native.Windows;
 using SharpEmu.HLE;
+using SharpEmu.HLE.Host;
 
 namespace SharpEmu.Core.Cpu.Native;
 
@@ -17,6 +19,7 @@ public sealed partial class DirectExecutionBackend
 {
 	private const ulong LazyCommitWindowBytes = 0x0200_0000UL;
 	private static int _lazyCommitTraceCount;
+	private static int _tlsFaultEmulationTraceCount;
 	private static int _guestAllocatorHoleRecoveries;
 	private static int _auxiliaryThreadExecuteFaultRecoveries;
 
@@ -133,6 +136,11 @@ public sealed partial class DirectExecutionBackend
 			{
 				return -1;
 			}
+			if (exceptionCode == WindowsFaultCodes.AccessViolation &&
+				TryHandleTlsAccessFault(exceptionRecord, rip, contextRecord))
+			{
+				return -1;
+			}
 			if (IsBenignHostDebugException(exceptionCode))
 			{
 				return -1;
@@ -181,13 +189,17 @@ public sealed partial class DirectExecutionBackend
 			Console.Error.WriteLine(
 				$"[LOADER][INFO]   Host thread: managed={Environment.CurrentManagedThreadId} " +
 				$"name='{Thread.CurrentThread.Name ?? "<unnamed>"}'");
-			if (_activeGuestThreadState is { } activeGuestThread)
-			{
-				Console.Error.WriteLine(
-					$"[LOADER][INFO]   Guest thread: handle=0x{activeGuestThread.ThreadHandle:X16} " +
-					$"name='{activeGuestThread.Name}' state={activeGuestThread.State} " +
-					$"last_import={activeGuestThread.LastImportNid ?? "<none>"} " +
-					$"last_ret=0x{activeGuestThread.LastReturnRip:X16}");
+				if (_activeGuestThreadState is { } activeGuestThread)
+				{
+					Console.Error.WriteLine(
+						$"[LOADER][INFO]   Guest thread: handle=0x{activeGuestThread.ThreadHandle:X16} " +
+						$"name='{activeGuestThread.Name}' state={activeGuestThread.State} " +
+						$"managed={Environment.CurrentManagedThreadId} " +
+						$"host={Volatile.Read(ref activeGuestThread.HostThreadId)} " +
+						$"imports={Interlocked.Read(ref activeGuestThread.ImportCount)} " +
+						$"last_import={activeGuestThread.LastImportNid ?? "<none>"} " +
+						$"last_ret=0x{activeGuestThread.LastReturnRip:X16} " +
+						$"fs=0x{activeGuestThread.Context.FsBase:X16}");
 				Console.Error.WriteLine(
 					$"[LOADER][INFO]   Last import registers: " +
 					$"rax=0x{Volatile.Read(ref activeGuestThread.LastImportRax):X16} " +
@@ -228,7 +240,6 @@ public sealed partial class DirectExecutionBackend
 			Console.Error.WriteLine($"[LOADER][INFO]   R14: 0x{r14:X16}");
 			Console.Error.WriteLine($"[LOADER][INFO]   R15: 0x{r15:X16}");
 			Console.Error.WriteLine($"[LOADER][INFO]   Flags: 0x{exceptionFlags:X8}");
-
 			ulong accessType = 0;
 			ulong target = 0;
 			if (exceptionCode == 3221225477u && exceptionRecord->NumberParameters >= 2)
@@ -262,7 +273,6 @@ public sealed partial class DirectExecutionBackend
 				}
 				Console.Error.WriteLine($"[LOADER][INFO]     [rsp+0x{i * 8:X2}] @0x{stackAddr:X16} = 0x{value:X16}");
 			}
-
 			if (string.Equals(
 					Environment.GetEnvironmentVariable("SHARPEMU_DUMP_FAULT_STACK_WINDOW"),
 					"1",
@@ -1218,6 +1228,108 @@ public sealed partial class DirectExecutionBackend
 			? $"{symbol.Key} (0x{symbol.Value:X16})"
 			: $"{symbol.Key}+0x{delta:X} (0x{symbol.Value:X16})";
 		return true;
+	}
+
+	// Guest code that reads the FS-relative TLS self pointer (`mov reg, fs:[0]`)
+	// faults on Windows hosts, where the FS segment base is 0 and the access
+	// resolves to linear address 0. The startup scan rewrites matching loads in
+	// the main image, but module initializers can call back into a different,
+	// distant image. Emulate those exact loads in the faulting context. Do not
+	// patch live code from VEH: another guest thread could execute a partially
+	// rewritten instruction. Any other AV falls through to normal fault handling.
+	private unsafe bool TryHandleTlsAccessFault(
+		EXCEPTION_RECORD* exceptionRecord,
+		ulong rip,
+		void* contextRecord)
+	{
+		if (exceptionRecord == null ||
+			exceptionRecord->NumberParameters < 2 ||
+			*exceptionRecord->ExceptionInformation != WindowsFaultCodes.AccessRead ||
+			exceptionRecord->ExceptionInformation[1] != 0 ||
+			_guestTlsBaseTlsIndex == uint.MaxValue ||
+			rip == 0 ||
+			contextRecord == null)
+		{
+			return false;
+		}
+		if (!_hostMemory.Query(rip, out var region) || region.State != HostRegionState.Committed)
+		{
+			return false;
+		}
+		uint protect = region.RawProtection & 0xFF;
+		bool executable = protect == PAGE_EXECUTE || protect == PAGE_EXECUTE_READ
+			|| protect == PAGE_EXECUTE_READWRITE || protect == PAGE_EXECUTE_WRITECOPY;
+		if (!executable)
+		{
+			return false;
+		}
+		ulong regionEnd = region.BaseAddress + region.RegionSize;
+		if (regionEnd <= rip)
+		{
+			return false;
+		}
+		int available = (int)Math.Min(16UL, regionEnd - rip);
+		if (available < MinTlsPatchInstructionBytes)
+		{
+			return false;
+		}
+
+		if (!TryDecodeTlsLoadInstruction(
+				(byte*)rip,
+				available,
+				out var instructionLength,
+				out var destinationRegister))
+		{
+			return false;
+		}
+
+		nint tlsBase = _hostThreading.GetTlsValue(_guestTlsBaseTlsIndex);
+		var cpuContext = ActiveCpuContext;
+		if (tlsBase == 0 && cpuContext is { FsBase: not 0 })
+		{
+			tlsBase = unchecked((nint)cpuContext.FsBase);
+		}
+		if (tlsBase == 0 ||
+			cpuContext is null ||
+			!cpuContext.TryReadUInt64(unchecked((ulong)tlsBase), out var tlsSelfPointer) ||
+			!TryGetContextRegisterOffset(destinationRegister, out var registerOffset))
+		{
+			return false;
+		}
+
+		WriteCtxU64(contextRecord, registerOffset, tlsSelfPointer);
+		WriteCtxU64(contextRecord, CTX_RIP, rip + (ulong)instructionLength);
+		if (Interlocked.Increment(ref _tlsFaultEmulationTraceCount) <= 8)
+		{
+			Console.Error.WriteLine(
+				$"[LOADER][INFO] Emulated TLS load at 0x{rip:X16}: r{destinationRegister}=0x{tlsSelfPointer:X16}");
+		}
+		return true;
+	}
+
+	private static bool TryGetContextRegisterOffset(int register, out int contextOffset)
+	{
+		contextOffset = register switch
+		{
+			0 => CTX_RAX,
+			1 => CTX_RCX,
+			2 => CTX_RDX,
+			3 => CTX_RBX,
+			4 => CTX_RSP,
+			5 => CTX_RBP,
+			6 => CTX_RSI,
+			7 => CTX_RDI,
+			8 => CTX_R8,
+			9 => CTX_R9,
+			10 => CTX_R10,
+			11 => CTX_R11,
+			12 => CTX_R12,
+			13 => CTX_R13,
+			14 => CTX_R14,
+			15 => CTX_R15,
+			_ => -1,
+		};
+		return contextOffset >= 0;
 	}
 
 	private unsafe bool TryHandleLazyCommittedPage(EXCEPTION_RECORD* exceptionRecord, ulong rip, ulong rsp)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -1434,7 +1434,8 @@ public sealed partial class DirectExecutionBackend
 			string.Equals(nid, "fzyMKs9kim0", StringComparison.Ordinal) &&
 			result == OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT;
 		var expectedMutexTrylockBusy =
-			string.Equals(nid, "K-jXhbt2gn4", StringComparison.Ordinal) &&
+			(string.Equals(nid, "K-jXhbt2gn4", StringComparison.Ordinal) ||
+			 string.Equals(nid, "upoVrzMHFeE", StringComparison.Ordinal)) &&
 			result == OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY;
 		var expectedNetAcceptWouldBlock =
 			string.Equals(nid, "PIWqhn9oSxc", StringComparison.Ordinal) &&

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -13,6 +13,7 @@ using SharpEmu.Core.Cpu.Debugging;
 using SharpEmu.Core.Loader;
 using SharpEmu.Core.Memory;
 using SharpEmu.HLE;
+using SharpEmu.HLE.Host;
 
 namespace SharpEmu.Core.Cpu.Native;
 
@@ -746,6 +747,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private nint _selfHandlePtr;
 
+	private readonly IHostThreading _hostThreading;
+
+	private readonly IHostMemory _hostMemory;
+
 	private const int MinTlsPatchInstructionBytes = 9;
 
 	private delegate ulong ImportGatewayDelegate(nint backendHandle, int importIndex, nint argPackPtr);
@@ -1032,6 +1037,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	public unsafe DirectExecutionBackend(IModuleManager moduleManager)
 	{
 		_moduleManager = moduleManager ?? throw new ArgumentNullException("moduleManager");
+		_hostThreading = HostPlatform.Current.Threading;
+		_hostMemory = HostPlatform.Current.Memory;
 		_selfHandle = GCHandle.Alloc(this);
 		_selfHandlePtr = GCHandle.ToIntPtr(_selfHandle);
 		_guestTlsBaseTlsIndex = TlsAlloc();
@@ -1880,7 +1887,6 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			error = $"invalid guest context transfer target rip=0x{target.Rip:X16} rsp=0x{target.Rsp:X16}";
 			return false;
 		}
-
 		Span<byte> ripProbe = stackalloc byte[1];
 		if (!memory.TryRead(target.Rip, ripProbe))
 		{
@@ -2663,7 +2669,27 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private unsafe bool TryPatchTlsLoadInstruction(nint address, byte* source, int availableLength)
 	{
-		if (availableLength < MinTlsPatchInstructionBytes)
+		if (!TryDecodeTlsLoadInstruction(
+				source,
+				availableLength,
+				out var instructionLength,
+				out var destinationRegister))
+		{
+			return false;
+		}
+
+		return PatchTlsLoadInstruction(address, instructionLength, destinationRegister);
+	}
+
+	private unsafe static bool TryDecodeTlsLoadInstruction(
+		byte* source,
+		int availableLength,
+		out int instructionLength,
+		out int destinationRegister)
+	{
+		instructionLength = 0;
+		destinationRegister = 0;
+		if (source == null || availableLength < MinTlsPatchInstructionBytes)
 		{
 			return false;
 		}
@@ -2691,6 +2717,12 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			rex = source[offset];
 			offset++;
 		}
+		// The rewrite and VEH fallback both produce a 64-bit pointer. Refuse the
+		// 16/32-bit encodings rather than silently changing their register semantics.
+		if ((rex & 0x08) == 0)
+		{
+			return false;
+		}
 
 		if (offset + 7 > availableLength || source[offset] != 0x8B)
 		{
@@ -2704,24 +2736,25 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			return false;
 		}
 
-		var displacement = *(int*)(source + offset + 3);
-		if (displacement != 0)
+		if (*(int*)(source + offset + 3) != 0)
 		{
 			return false;
 		}
 
-		var destinationRegister = ((modRm >> 3) & 7) | (((rex & 4) != 0) ? 8 : 0);
-		var instructionLength = offset + 7;
-		if (instructionLength < MinTlsPatchInstructionBytes)
-		{
-			return false;
-		}
-
-		return PatchTlsLoadInstruction(address, instructionLength, destinationRegister);
+		destinationRegister = ((modRm >> 3) & 7) | (((rex & 4) != 0) ? 8 : 0);
+		instructionLength = offset + 7;
+		return instructionLength >= MinTlsPatchInstructionBytes;
 	}
 
 	private unsafe bool PatchTlsLoadInstruction(nint address, int instructionLength, int destinationRegister)
 	{
+		long relativeDisplacement = _tlsHandlerAddress - (address + 5);
+		if (relativeDisplacement < int.MinValue || relativeDisplacement > int.MaxValue)
+		{
+			Console.Error.WriteLine($"[LOADER][WARNING] TLS patch out of rel32 range at 0x{address:X16}");
+			return false;
+		}
+
 		uint flNewProtect = default(uint);
 		if (!VirtualProtect((void*)address, (nuint)instructionLength, 64u, &flNewProtect))
 		{
@@ -2730,16 +2763,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		try
 		{
 			*(sbyte*)address = -24;
-			long num = _tlsHandlerAddress;
-			long num2 = address + 5;
-			long num3 = num - num2;
-			if (num3 < int.MinValue || num3 > int.MaxValue)
-			{
-				Console.Error.WriteLine($"[LOADER][WARNING] TLS patch out of rel32 range at 0x{address:X16}");
-				return false;
-			}
-
-			*(int*)(address + 1) = (int)num3;
+			*(int*)(address + 1) = (int)relativeDisplacement;
 			var offset = 5;
 			if (destinationRegister != 0)
 			{
@@ -3301,6 +3325,40 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		}
 
 		return wakeCount;
+	}
+
+	internal static bool WaitForBlockedGuestCallbackCore(
+		IGuestThreadBlockWaiter waiter,
+		long deadlineTimestamp,
+		Func<bool> stopRequested,
+		Func<IGuestThreadBlockWaiter, bool> tryWake,
+		out int resumeResult,
+		out string? error)
+	{
+		resumeResult = 0;
+		error = null;
+		var spinner = new SpinWait();
+		while (!stopRequested())
+		{
+			if (tryWake(waiter) ||
+				(deadlineTimestamp != 0 && Stopwatch.GetTimestamp() >= deadlineTimestamp))
+			{
+				resumeResult = waiter.Resume();
+				return true;
+			}
+
+			if (spinner.NextSpinWillYield)
+			{
+				Thread.Sleep(1);
+			}
+			else
+			{
+				spinner.SpinOnce();
+			}
+		}
+
+		error = "guest callback wait was interrupted by guest shutdown";
+		return false;
 	}
 
 	private void PumpUntilGuestThreadsIdle(CpuContext callerContext, string reason)

--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -15,8 +15,10 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
 
     private readonly ReaderWriterLockSlim _gate = new(LockRecursionPolicy.SupportsRecursion);
     private readonly object _guestAllocationGate = new();
+    private readonly object _directMemoryBackingGate = new();
     private readonly object _allocationSearchHintGate = new();
     private readonly List<MemoryRegion> _regions = new();
+    private readonly Dictionary<ulong, DirectMapping> _directMappings = new();
     private readonly Dictionary<(ulong DesiredAddress, ulong Alignment, bool Executable), ulong> _allocationSearchHints = new();
     private readonly Dictionary<ulong, ProgramHeaderFlags> _pageProtections = new();
     private bool _disposed;
@@ -41,6 +43,8 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
     private const uint PAGE_READONLY = 0x02;
 
     private readonly IHostMemory _hostMemory;
+    private IHostSharedMemory? _directMemoryBacking;
+    private ulong _directMemoryBackingSize;
     private ulong _guestAllocationArenaBase;
     private readonly SortedDictionary<ulong, ulong> _guestAllocationFreeRanges = new();
     private readonly Dictionary<ulong, (ulong Offset, ulong Size)> _guestAllocations = new();
@@ -48,7 +52,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
 
     public PhysicalVirtualMemory(IHostMemory? hostMemory = null)
     {
-        _hostMemory = hostMemory ?? CrossPlatformHostMemory.Instance;
+        _hostMemory = hostMemory ?? HostPlatform.Current.Memory;
     }
 
     private sealed class CrossPlatformHostMemory : IHostMemory
@@ -286,7 +290,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         var actualAddress = result;
 
         var lazyPrimeState = "n/a";
-        if (reservedOnly)
+        if (reservedOnly && !_hostMemory.UsesPlaceholderReservations)
         {
             var primeBytes = Math.Min(alignedSize, LazyReservePrimeBytes);
             if (primeBytes != 0)
@@ -347,6 +351,54 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         TraceVmem($"Allocated {allocationKind}: 0x{actualAddress:X16} - 0x{actualAddress + alignedSize:X16} ({alignedSize} bytes) lazy_prime={lazyPrimeState}");
 
         return actualAddress;
+    }
+
+    public ulong ReserveAt(ulong desiredAddress, ulong size, bool executable = true, bool allowAlternative = true)
+    {
+        if (size == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), "Size must be greater than zero");
+        }
+
+        var alignedSize = AlignUp(size, PageSize);
+        var result = _hostMemory.Reserve(desiredAddress, alignedSize, HostPageProtection.NoAccess);
+        if (result == 0 && allowAlternative)
+        {
+            result = _hostMemory.Reserve(0, alignedSize, HostPageProtection.NoAccess);
+        }
+
+        if (result == 0 || (desiredAddress != 0 && !allowAlternative && result != desiredAddress))
+        {
+            if (result != 0)
+            {
+                _hostMemory.Free(result);
+            }
+
+            throw new InvalidOperationException(
+                $"Failed to reserve guest range at 0x{desiredAddress:X16} ({alignedSize} bytes)");
+        }
+
+        _gate.EnterWriteLock();
+        try
+        {
+            InsertRegionSorted(new MemoryRegion
+            {
+                VirtualAddress = result,
+                Size = alignedSize,
+                IsExecutable = executable,
+                IsReservedOnly = true,
+                IsGuestReservation = true,
+                Protection = executable ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE
+            });
+        }
+        finally
+        {
+            _gate.ExitWriteLock();
+        }
+
+        TraceVmem(
+            $"Reserved guest range: 0x{result:X16} - 0x{result + alignedSize:X16} ({alignedSize} bytes)");
+        return result;
     }
 
     public bool TryAllocateAtOrAbove(
@@ -419,6 +471,716 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         }
 
         return false;
+    }
+
+    public bool TryReserveAtOrAbove(
+        ulong desiredAddress,
+        ulong size,
+        bool executable,
+        ulong alignment,
+        out ulong actualAddress)
+    {
+        actualAddress = 0;
+        if (size == 0)
+        {
+            return false;
+        }
+
+        var alignedSize = AlignUp(size, PageSize);
+        var effectiveAlignment = Math.Max(PageSize, alignment == 0 ? PageSize : alignment);
+        var requestedCursor = AlignUp(desiredAddress, effectiveAlignment);
+        var cursor = GetAllocationSearchCursor(desiredAddress, requestedCursor, effectiveAlignment, executable);
+
+        for (var attempt = 0; attempt < 0x10000; attempt++)
+        {
+            if (cursor == 0 || ulong.MaxValue - cursor < alignedSize)
+            {
+                return false;
+            }
+
+            if (TryGetOverlappingRegionEnd(cursor, alignedSize, out var overlapEnd))
+            {
+                cursor = AlignUp(overlapEnd, effectiveAlignment);
+                continue;
+            }
+
+            try
+            {
+                actualAddress = ReserveAt(
+                    cursor,
+                    alignedSize,
+                    executable,
+                    allowAlternative: OperatingSystem.IsMacOS());
+                if (actualAddress != 0 &&
+                    (actualAddress & (effectiveAlignment - 1)) == 0)
+                {
+                    UpdateAllocationSearchCursor(
+                        desiredAddress,
+                        effectiveAlignment,
+                        executable,
+                        actualAddress + alignedSize);
+                    return true;
+                }
+
+                if (actualAddress != 0)
+                {
+                    ReleaseUntrackedAllocation(actualAddress);
+                }
+
+                actualAddress = 0;
+            }
+            catch
+            {
+            }
+
+            cursor = AlignUp(cursor + effectiveAlignment, effectiveAlignment);
+        }
+
+        return false;
+    }
+
+    public bool TryMapDirectMemory(
+        ulong desiredAddress,
+        ulong size,
+        ulong directMemoryOffset,
+        ulong directMemorySize,
+        GuestPageProtection protection,
+        ulong alignment,
+        bool allowSearch,
+        out ulong actualAddress)
+    {
+        actualAddress = 0;
+        if (size == 0 ||
+            directMemorySize == 0 ||
+            size > ulong.MaxValue - (PageSize - 1) ||
+            directMemoryOffset > directMemorySize ||
+            size > directMemorySize - directMemoryOffset)
+        {
+            return false;
+        }
+
+        var alignedSize = AlignUp(size, PageSize);
+        if (alignedSize > directMemorySize - directMemoryOffset)
+        {
+            return false;
+        }
+
+        var effectiveAlignment = Math.Max(PageSize, alignment == 0 ? PageSize : alignment);
+        if (effectiveAlignment % PageSize != 0)
+        {
+            return false;
+        }
+
+        IHostSharedMemory backing;
+        lock (_directMemoryBackingGate)
+        {
+            if (_directMemoryBacking is null)
+            {
+                _directMemoryBacking = _hostMemory.CreateSharedMemory(directMemorySize);
+                _directMemoryBackingSize = _directMemoryBacking?.Size ?? 0;
+            }
+
+            if (_directMemoryBacking is null || _directMemoryBackingSize != directMemorySize)
+            {
+                TraceVmem(
+                    $"Failed to create direct-memory backing: requested=0x{directMemorySize:X} actual=0x{_directMemoryBackingSize:X}");
+                return false;
+            }
+
+            backing = _directMemoryBacking;
+        }
+
+        var hostProtection = ResolveProtection(protection);
+        var isExecutable = (protection & GuestPageProtection.Execute) != 0;
+        var rawProtection = isExecutable
+            ? (protection & GuestPageProtection.Write) != 0 ? PAGE_EXECUTE_READWRITE : PAGE_EXECUTE_READ
+            : (protection & GuestPageProtection.Write) != 0 ? PAGE_READWRITE : PAGE_READONLY;
+        ulong cursor;
+        try
+        {
+            cursor = desiredAddress == 0
+                ? 0
+                : allowSearch
+                    ? AlignUpToMultiple(desiredAddress, effectiveAlignment)
+                    : desiredAddress;
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
+
+        if (!allowSearch &&
+            (cursor == 0 || (cursor & (PageSize - 1)) != 0))
+        {
+            return false;
+        }
+
+        var maximumAttempts = allowSearch ? 0x10000 : 1;
+
+        for (var attempt = 0; attempt < maximumAttempts; attempt++)
+        {
+            MemoryRegion? containingReservation = null;
+            if (cursor != 0)
+            {
+                _gate.EnterReadLock();
+                try
+                {
+                    var containingRegion = FindRegion(cursor, alignedSize);
+                    if (containingRegion?.IsReservedOnly == true)
+                    {
+                        containingReservation = containingRegion;
+                    }
+                }
+                finally
+                {
+                    _gate.ExitReadLock();
+                }
+            }
+
+            if (cursor != 0 && containingReservation is null &&
+                (ulong.MaxValue - cursor < alignedSize || TryGetOverlappingRegionEnd(cursor, alignedSize, out _)))
+            {
+                TraceVmem(
+                    $"Direct-memory candidate overlaps committed mapping: va=0x{cursor:X16} size=0x{alignedSize:X}");
+                if (!allowSearch || ulong.MaxValue - cursor < effectiveAlignment)
+                {
+                    return false;
+                }
+
+                cursor = AlignUpToMultiple(
+                    cursor + effectiveAlignment,
+                    effectiveAlignment);
+                continue;
+            }
+
+            var mappedAddress = _hostMemory.MapSharedMemory(
+                backing,
+                cursor,
+                alignedSize,
+                directMemoryOffset,
+                hostProtection);
+            if (mappedAddress != 0 &&
+                (allowSearch
+                    ? mappedAddress % effectiveAlignment == 0
+                    : mappedAddress == cursor))
+            {
+                _gate.EnterWriteLock();
+                try
+                {
+                    if (containingReservation is null)
+                    {
+                        InsertRegionSorted(new MemoryRegion
+                        {
+                            VirtualAddress = mappedAddress,
+                            Size = alignedSize,
+                            IsExecutable = isExecutable,
+                            IsReservedOnly = false,
+                            Protection = rawProtection
+                        });
+                    }
+
+                    _directMappings.Add(
+                        mappedAddress,
+                        new DirectMapping(
+                            mappedAddress,
+                            alignedSize,
+                            directMemoryOffset,
+                            hostProtection));
+                }
+                finally
+                {
+                    _gate.ExitWriteLock();
+                }
+
+                actualAddress = mappedAddress;
+                TraceVmem(
+                    $"Mapped direct memory: phys=0x{directMemoryOffset:X16} va=0x{mappedAddress:X16} size=0x{alignedSize:X}");
+                return true;
+            }
+
+            if (mappedAddress != 0)
+            {
+                _hostMemory.Free(mappedAddress);
+            }
+
+            TraceVmem(
+                $"Host rejected direct-memory view: phys=0x{directMemoryOffset:X16} va=0x{cursor:X16} size=0x{alignedSize:X}");
+
+            if (!allowSearch || cursor == 0 || ulong.MaxValue - cursor < effectiveAlignment)
+            {
+                return false;
+            }
+
+            cursor = AlignUpToMultiple(
+                cursor + effectiveAlignment,
+                effectiveAlignment);
+        }
+
+        return false;
+    }
+
+    public bool TryReplaceDirectMemory(
+        ulong address,
+        ulong size,
+        ulong directMemoryOffset,
+        ulong directMemorySize,
+        GuestPageProtection protection,
+        out ulong actualAddress)
+    {
+        actualAddress = 0;
+        if (address == 0 ||
+            size == 0 ||
+            directMemorySize == 0 ||
+            size > ulong.MaxValue - (PageSize - 1))
+        {
+            return false;
+        }
+
+        var alignedSize = AlignUp(size, PageSize);
+        if ((address & (PageSize - 1)) != 0 ||
+            ulong.MaxValue - address < alignedSize ||
+            directMemoryOffset > directMemorySize ||
+            alignedSize > directMemorySize - directMemoryOffset)
+        {
+            return false;
+        }
+
+        IHostSharedMemory backing;
+        lock (_directMemoryBackingGate)
+        {
+            if (_directMemoryBacking is null)
+            {
+                _directMemoryBacking = _hostMemory.CreateSharedMemory(directMemorySize);
+                _directMemoryBackingSize = _directMemoryBacking?.Size ?? 0;
+            }
+
+            if (_directMemoryBacking is null || _directMemoryBackingSize != directMemorySize)
+            {
+                TraceVmem(
+                    $"Failed to create direct-memory backing: requested=0x{directMemorySize:X} actual=0x{_directMemoryBackingSize:X}");
+                return false;
+            }
+
+            backing = _directMemoryBacking;
+        }
+
+        var end = address + alignedSize;
+        var hostProtection = ResolveProtection(protection);
+        var isExecutable = (protection & GuestPageProtection.Execute) != 0;
+        var rawProtection = isExecutable
+            ? (protection & GuestPageProtection.Write) != 0 ? PAGE_EXECUTE_READWRITE : PAGE_EXECUTE_READ
+            : (protection & GuestPageProtection.Write) != 0 ? PAGE_READWRITE : PAGE_READONLY;
+
+        _gate.EnterWriteLock();
+        try
+        {
+            var overlaps = _directMappings.Values
+                .Where(mapping =>
+                    mapping.VirtualAddress < end &&
+                    address < mapping.VirtualAddress + mapping.Size)
+                .OrderBy(static mapping => mapping.VirtualAddress)
+                .ToArray();
+            if (overlaps.Length == 0)
+            {
+                return false;
+            }
+
+            var standaloneRegions = new Dictionary<ulong, MemoryRegion>();
+            var survivors = new List<DirectMapping>(overlaps.Length * 2);
+            var survivorRegions = new List<MemoryRegion>(overlaps.Length * 2);
+            foreach (var mapping in overlaps)
+            {
+                var standaloneRegion = _regions.FirstOrDefault(region =>
+                    region.VirtualAddress == mapping.VirtualAddress &&
+                    region.Size == mapping.Size &&
+                    !region.IsReservedOnly);
+                if (standaloneRegion is not null)
+                {
+                    standaloneRegions.Add(mapping.VirtualAddress, standaloneRegion);
+                }
+
+                var mappingEnd = mapping.VirtualAddress + mapping.Size;
+                var overlapStart = Math.Max(address, mapping.VirtualAddress);
+                var overlapEnd = Math.Min(end, mappingEnd);
+                if (mapping.VirtualAddress < overlapStart)
+                {
+                    var prefix = mapping with { Size = overlapStart - mapping.VirtualAddress };
+                    survivors.Add(prefix);
+                    if (standaloneRegion is not null)
+                    {
+                        survivorRegions.Add(CloneRegionRange(
+                            standaloneRegion,
+                            prefix.VirtualAddress,
+                            prefix.Size));
+                    }
+                }
+
+                if (overlapEnd < mappingEnd)
+                {
+                    var suffix = new DirectMapping(
+                        overlapEnd,
+                        mappingEnd - overlapEnd,
+                        mapping.PhysicalOffset + (overlapEnd - mapping.VirtualAddress),
+                        mapping.Protection);
+                    survivors.Add(suffix);
+                    if (standaloneRegion is not null)
+                    {
+                        survivorRegions.Add(CloneRegionRange(
+                            standaloneRegion,
+                            suffix.VirtualAddress,
+                            suffix.Size));
+                    }
+                }
+            }
+
+            var replacement = new DirectMapping(
+                address,
+                alignedSize,
+                directMemoryOffset,
+                hostProtection);
+            var containingReservation = FindRegion(address, alignedSize);
+            var replacementRegion = containingReservation?.IsReservedOnly == true
+                ? null
+                : new MemoryRegion
+                {
+                    VirtualAddress = address,
+                    Size = alignedSize,
+                    IsExecutable = isExecutable,
+                    IsReservedOnly = false,
+                    Protection = rawProtection
+                };
+
+            var removedOriginals = new List<DirectMapping>(overlaps.Length);
+            foreach (var mapping in overlaps)
+            {
+                if (!_hostMemory.UnmapSharedMemory(mapping.VirtualAddress, mapping.Size))
+                {
+                    RollbackDirectReplacementLocked(backing, [], removedOriginals);
+                    return false;
+                }
+
+                removedOriginals.Add(mapping);
+            }
+
+            var installedMappings = new List<DirectMapping>(survivors.Count + 1);
+            foreach (var survivor in survivors)
+            {
+                if (!TryMapDirectViewLocked(backing, survivor))
+                {
+                    RollbackDirectReplacementLocked(backing, installedMappings, removedOriginals);
+                    return false;
+                }
+
+                installedMappings.Add(survivor);
+            }
+
+            if (!TryMapDirectViewLocked(backing, replacement))
+            {
+                RollbackDirectReplacementLocked(backing, installedMappings, removedOriginals);
+                return false;
+            }
+
+            installedMappings.Add(replacement);
+
+            foreach (var mapping in overlaps)
+            {
+                _directMappings.Remove(mapping.VirtualAddress);
+                if (standaloneRegions.TryGetValue(mapping.VirtualAddress, out var standaloneRegion))
+                {
+                    _regions.Remove(standaloneRegion);
+                }
+            }
+
+            foreach (var survivor in survivors)
+            {
+                _directMappings.Add(survivor.VirtualAddress, survivor);
+            }
+
+            foreach (var survivorRegion in survivorRegions)
+            {
+                InsertRegionSorted(survivorRegion);
+            }
+
+            _directMappings.Add(replacement.VirtualAddress, replacement);
+            if (replacementRegion is not null)
+            {
+                InsertRegionSorted(replacementRegion);
+            }
+
+            actualAddress = address;
+            TraceVmem(
+                $"Replaced direct memory: phys=0x{directMemoryOffset:X16} va=0x{address:X16} size=0x{alignedSize:X}");
+            return true;
+        }
+        finally
+        {
+            _gate.ExitWriteLock();
+        }
+    }
+
+    private bool TryMapDirectViewLocked(IHostSharedMemory backing, DirectMapping mapping)
+    {
+        var mappedAddress = _hostMemory.MapSharedMemory(
+            backing,
+            mapping.VirtualAddress,
+            mapping.Size,
+            mapping.PhysicalOffset,
+            mapping.Protection);
+        if (mappedAddress == mapping.VirtualAddress)
+        {
+            return true;
+        }
+
+        if (mappedAddress != 0 &&
+            !_hostMemory.UnmapSharedMemory(mappedAddress, mapping.Size))
+        {
+            throw new InvalidOperationException(
+                $"Failed to remove misplaced direct-memory view at 0x{mappedAddress:X16}");
+        }
+
+        return false;
+    }
+
+    private void RollbackDirectReplacementLocked(
+        IHostSharedMemory backing,
+        IReadOnlyList<DirectMapping> installedMappings,
+        IReadOnlyList<DirectMapping> removedOriginals)
+    {
+        var restored = true;
+        for (var index = installedMappings.Count - 1; index >= 0; index--)
+        {
+            var mapping = installedMappings[index];
+            restored &= _hostMemory.UnmapSharedMemory(mapping.VirtualAddress, mapping.Size);
+        }
+
+        foreach (var mapping in removedOriginals)
+        {
+            restored &= TryMapDirectViewLocked(backing, mapping);
+        }
+
+        if (!restored)
+        {
+            throw new InvalidOperationException(
+                "Failed to restore direct-memory mappings after an atomic replacement failure");
+        }
+    }
+
+    public bool TryUnmapDirectMemory(ulong address, ulong size)
+    {
+        if (size == 0)
+        {
+            return false;
+        }
+
+        var alignedSize = AlignUp(size, PageSize);
+        _gate.EnterWriteLock();
+        try
+        {
+            if (!_directMappings.TryGetValue(address, out var mapping) ||
+                mapping.Size != alignedSize ||
+                !_hostMemory.UnmapSharedMemory(address, alignedSize))
+            {
+                return false;
+            }
+
+            _directMappings.Remove(address);
+            for (var index = 0; index < _regions.Count; index++)
+            {
+                var region = _regions[index];
+                if (region.VirtualAddress == address &&
+                    region.Size == alignedSize &&
+                    !region.IsReservedOnly)
+                {
+                    _regions.RemoveAt(index);
+                    break;
+                }
+            }
+
+            return true;
+        }
+        finally
+        {
+            _gate.ExitWriteLock();
+        }
+    }
+
+    public bool TryUnmapDirectMemoryRange(ulong address, ulong size)
+    {
+        if (size == 0 || ulong.MaxValue - address < size)
+        {
+            return false;
+        }
+
+        var alignedSize = AlignUp(size, PageSize);
+        if (ulong.MaxValue - address < alignedSize)
+        {
+            return false;
+        }
+
+        var end = address + alignedSize;
+        _gate.EnterWriteLock();
+        try
+        {
+            var overlaps = _directMappings.Values
+                .Where(mapping =>
+                    mapping.VirtualAddress < end &&
+                    address < mapping.VirtualAddress + mapping.Size)
+                .OrderBy(static mapping => mapping.VirtualAddress)
+                .ToArray();
+            if (overlaps.Length == 0)
+            {
+                return true;
+            }
+
+            IHostSharedMemory? backing;
+            lock (_directMemoryBackingGate)
+            {
+                backing = _directMemoryBacking;
+            }
+
+            if (backing is null)
+            {
+                return false;
+            }
+
+            var standaloneRegions = new Dictionary<ulong, MemoryRegion>();
+            foreach (var mapping in overlaps)
+            {
+                var standaloneRegion = _regions.FirstOrDefault(region =>
+                    region.VirtualAddress == mapping.VirtualAddress &&
+                    region.Size == mapping.Size &&
+                    !region.IsReservedOnly);
+                if (standaloneRegion is not null)
+                {
+                    standaloneRegions.Add(mapping.VirtualAddress, standaloneRegion);
+                }
+
+                if (!_hostMemory.UnmapSharedMemory(mapping.VirtualAddress, mapping.Size))
+                {
+                    return false;
+                }
+
+                _directMappings.Remove(mapping.VirtualAddress);
+                if (standaloneRegion is not null)
+                {
+                    _regions.Remove(standaloneRegion);
+                }
+            }
+
+            foreach (var mapping in overlaps)
+            {
+                var mappingEnd = mapping.VirtualAddress + mapping.Size;
+                var overlapStart = Math.Max(address, mapping.VirtualAddress);
+                var overlapEnd = Math.Min(end, mappingEnd);
+                if (mapping.VirtualAddress < overlapStart &&
+                    !TryRemapDirectFragmentLocked(
+                        backing,
+                        mapping,
+                        mapping.VirtualAddress,
+                        overlapStart - mapping.VirtualAddress,
+                        standaloneRegions.GetValueOrDefault(mapping.VirtualAddress)))
+                {
+                    return false;
+                }
+
+                if (overlapEnd < mappingEnd &&
+                    !TryRemapDirectFragmentLocked(
+                        backing,
+                        mapping,
+                        overlapEnd,
+                        mappingEnd - overlapEnd,
+                        standaloneRegions.GetValueOrDefault(mapping.VirtualAddress)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        finally
+        {
+            _gate.ExitWriteLock();
+        }
+    }
+
+    private bool TryRemapDirectFragmentLocked(
+        IHostSharedMemory backing,
+        DirectMapping source,
+        ulong address,
+        ulong size,
+        MemoryRegion? standaloneRegion)
+    {
+        var physicalOffset = source.PhysicalOffset + (address - source.VirtualAddress);
+        var mappedAddress = _hostMemory.MapSharedMemory(
+            backing,
+            address,
+            size,
+            physicalOffset,
+            source.Protection);
+        if (mappedAddress != address)
+        {
+            if (mappedAddress != 0)
+            {
+                _hostMemory.UnmapSharedMemory(mappedAddress, size);
+            }
+
+            return false;
+        }
+
+        _directMappings.Add(
+            address,
+            new DirectMapping(address, size, physicalOffset, source.Protection));
+        if (standaloneRegion is not null)
+        {
+            InsertRegionSorted(CloneRegionRange(standaloneRegion, address, size));
+        }
+
+        return true;
+    }
+
+    public bool TryUnmapReservedMemory(ulong address, ulong size)
+    {
+        if (size == 0)
+        {
+            return false;
+        }
+
+        var alignedSize = AlignUp(size, PageSize);
+        _gate.EnterWriteLock();
+        try
+        {
+            var region = FindRegion(address, alignedSize);
+            if (region?.IsGuestReservation != true ||
+                _directMappings.Values.Any(mapping =>
+                    mapping.VirtualAddress < address + alignedSize &&
+                    address < mapping.VirtualAddress + mapping.Size) ||
+                !_hostMemory.UnmapReservedMemory(address, alignedSize))
+            {
+                return false;
+            }
+
+            _regions.Remove(region);
+            if (region.VirtualAddress < address)
+            {
+                InsertRegionSorted(CloneRegionRange(
+                    region,
+                    region.VirtualAddress,
+                    address - region.VirtualAddress));
+            }
+
+            var end = address + alignedSize;
+            var regionEnd = region.VirtualAddress + region.Size;
+            if (end < regionEnd)
+            {
+                InsertRegionSorted(CloneRegionRange(region, end, regionEnd - end));
+            }
+
+            return true;
+        }
+        finally
+        {
+            _gate.ExitWriteLock();
+        }
     }
 
     private void ReleaseUntrackedAllocation(ulong address)
@@ -601,11 +1363,17 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
             _gate.EnterWriteLock();
             try
             {
+                foreach (var mapping in _directMappings.Values)
+                {
+                    _hostMemory.UnmapSharedMemory(mapping.VirtualAddress, mapping.Size);
+                }
+
                 foreach (var region in _regions)
                 {
                     _hostMemory.Free(region.VirtualAddress);
                 }
                 _regions.Clear();
+                _directMappings.Clear();
                 _pageProtections.Clear();
                 lock (_allocationSearchHintGate)
                 {
@@ -620,6 +1388,13 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
             _guestAllocationArenaBase = 0;
             _guestAllocationFreeRanges.Clear();
             _guestAllocations.Clear();
+        }
+
+        lock (_directMemoryBackingGate)
+        {
+            _directMemoryBacking?.Dispose();
+            _directMemoryBacking = null;
+            _directMemoryBackingSize = 0;
         }
     }
 
@@ -747,18 +1522,43 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         _gate.EnterReadLock();
         try
         {
-            var snapshot = new VirtualMemoryRegion[_regions.Count];
-            for (var i = 0; i < _regions.Count; i++)
+            var snapshot = new List<VirtualMemoryRegion>(_regions.Count + _directMappings.Count);
+            foreach (var region in _regions)
             {
-                var r = _regions[i];
-                snapshot[i] = new VirtualMemoryRegion(
-                    r.VirtualAddress,
-                    r.Size,
+                if (region.IsGuestReservation)
+                {
+                    continue;
+                }
+
+                snapshot.Add(new VirtualMemoryRegion(
+                    region.VirtualAddress,
+                    region.Size,
                     0,
-                    r.Size,
-                    r.IsExecutable ? ProgramHeaderFlags.Execute | ProgramHeaderFlags.Read : ProgramHeaderFlags.Read);
+                    region.Size,
+                    region.IsExecutable
+                        ? ProgramHeaderFlags.Execute | ProgramHeaderFlags.Read
+                        : ProgramHeaderFlags.Read));
             }
-            return snapshot;
+
+            foreach (var mapping in _directMappings.Values)
+            {
+                var containingRegion = FindRegion(mapping.VirtualAddress, mapping.Size);
+                if (containingRegion?.IsGuestReservation != true)
+                {
+                    continue;
+                }
+
+                snapshot.Add(new VirtualMemoryRegion(
+                    mapping.VirtualAddress,
+                    mapping.Size,
+                    0,
+                    mapping.Size,
+                    ProgramHeaderFlags.Read));
+            }
+
+            return snapshot
+                .OrderBy(static region => region.VirtualAddress)
+                .ToArray();
         }
         finally
         {
@@ -772,29 +1572,25 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         _gate.EnterReadLock();
         try
         {
-            var region = FindRegion(virtualAddress, (ulong)destination.Length);
-            if (region is not null &&
-                TryResolveRegionOffset(
-                    virtualAddress,
-                    (ulong)destination.Length,
-                    region,
-                    out var offset))
+            var length = (ulong)destination.Length;
+            if (TryResolveRegionRun(virtualAddress, length, out var firstIndex, out var regionCount))
             {
-                var srcPtr = (void*)(region.VirtualAddress + offset);
                 if (destination.IsEmpty)
                 {
                     return true;
                 }
 
-                if (region.IsReservedOnly)
+                if (!TryCommitRegionRun(virtualAddress, length, firstIndex, regionCount))
                 {
-                    if (!EnsureRangeCommitted((ulong)srcPtr, (ulong)destination.Length, region))
-                    {
-                        return false;
-                    }
+                    return false;
                 }
 
-                if (!CanReadWithoutProtectionChange((ulong)srcPtr, (ulong)destination.Length, region))
+                if (!CanAccessRegionRunWithoutProtectionChange(
+                        virtualAddress,
+                        length,
+                        firstIndex,
+                        regionCount,
+                        write: false))
                 {
                     requiresExclusiveAccess = true;
                 }
@@ -802,7 +1598,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
                 {
                     fixed (byte* destPtr = destination)
                     {
-                        Buffer.MemoryCopy(srcPtr, destPtr, (nuint)destination.Length, (nuint)destination.Length);
+                        Buffer.MemoryCopy((void*)virtualAddress, destPtr, (nuint)destination.Length, (nuint)destination.Length);
                     }
 
                     return true;
@@ -835,13 +1631,8 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         _gate.EnterReadLock();
         try
         {
-            var region = FindRegion(virtualAddress, (ulong)expected.Length);
-            if (region is null ||
-                !TryResolveRegionOffset(
-                    virtualAddress,
-                    (ulong)expected.Length,
-                    region,
-                    out var offset))
+            var length = (ulong)expected.Length;
+            if (!TryResolveRegionRun(virtualAddress, length, out var firstIndex, out var regionCount))
             {
                 return false;
             }
@@ -851,19 +1642,22 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
                 return true;
             }
 
-            var srcPtr = (void*)(region.VirtualAddress + offset);
-            if (region.IsReservedOnly &&
-                !EnsureRangeCommitted((ulong)srcPtr, (ulong)expected.Length, region))
+            if (!TryCommitRegionRun(virtualAddress, length, firstIndex, regionCount))
             {
                 return false;
             }
 
-            if (!CanReadWithoutProtectionChange((ulong)srcPtr, (ulong)expected.Length, region))
+            if (!CanAccessRegionRunWithoutProtectionChange(
+                    virtualAddress,
+                    length,
+                    firstIndex,
+                    regionCount,
+                    write: false))
             {
                 return false;
             }
 
-            return new ReadOnlySpan<byte>(srcPtr, expected.Length).SequenceEqual(expected);
+            return new ReadOnlySpan<byte>((void*)virtualAddress, expected.Length).SequenceEqual(expected);
         }
         finally
         {
@@ -877,29 +1671,25 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         _gate.EnterReadLock();
         try
         {
-            var region = FindRegion(virtualAddress, (ulong)source.Length);
-            if (region is not null &&
-                TryResolveRegionOffset(
-                    virtualAddress,
-                    (ulong)source.Length,
-                    region,
-                    out var offset))
+            var length = (ulong)source.Length;
+            if (TryResolveRegionRun(virtualAddress, length, out var firstIndex, out var regionCount))
             {
-                var destPtr = (void*)(region.VirtualAddress + offset);
                 if (source.IsEmpty)
                 {
                     return true;
                 }
 
-                if (region.IsReservedOnly)
+                if (!TryCommitRegionRun(virtualAddress, length, firstIndex, regionCount))
                 {
-                    if (!EnsureRangeCommitted((ulong)destPtr, (ulong)source.Length, region))
-                    {
-                        return false;
-                    }
+                    return false;
                 }
 
-                if (!CanWriteWithoutProtectionChange((ulong)destPtr, (ulong)source.Length, region))
+                if (!CanAccessRegionRunWithoutProtectionChange(
+                        virtualAddress,
+                        length,
+                        firstIndex,
+                        regionCount,
+                        write: true))
                 {
                     requiresExclusiveAccess = true;
                 }
@@ -907,7 +1697,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
                 {
                     fixed (byte* srcPtr = source)
                     {
-                        Buffer.MemoryCopy(srcPtr, destPtr, (nuint)source.Length, (nuint)source.Length);
+                        Buffer.MemoryCopy(srcPtr, (void*)virtualAddress, (nuint)source.Length, (nuint)source.Length);
                     }
 
                     return true;
@@ -937,104 +1727,105 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
 
     private bool TryReadExclusive(ulong virtualAddress, Span<byte> destination)
     {
-        var region = FindRegion(virtualAddress, (ulong)destination.Length);
-        if (region is not null &&
-            TryResolveRegionOffset(
-                virtualAddress,
-                (ulong)destination.Length,
-                region,
-                out var offset))
+        var length = (ulong)destination.Length;
+        if (!TryResolveRegionRun(virtualAddress, length, out var firstIndex, out var regionCount))
         {
-            var srcPtr = (void*)(region.VirtualAddress + offset);
-            if (!EnsureRangeCommitted((ulong)srcPtr, (ulong)destination.Length, region))
-            {
-                return false;
-            }
+            return false;
+        }
 
-            if (CanReadWithoutProtectionChange((ulong)srcPtr, (ulong)destination.Length, region))
+        var cursor = virtualAddress;
+        var end = virtualAddress + length;
+        var touchedPages = new List<(ulong Address, uint Protection)>();
+        try
+        {
+            for (var index = firstIndex; index < firstIndex + regionCount; index++)
             {
-                fixed (byte* destPtr = destination)
+                var region = _regions[index];
+                var chunkSize = RegionChunkSize(region, cursor, end);
+                if (!EnsureRangeCommitted(cursor, chunkSize, region))
                 {
-                    Buffer.MemoryCopy(srcPtr, destPtr, (nuint)destination.Length, (nuint)destination.Length);
+                    return false;
                 }
 
-                return true;
-            }
-
-            if (!TryTemporarilyProtectForRead((ulong)srcPtr, (ulong)destination.Length, region, out var touchedPages))
-            {
-                return false;
-            }
-
-            try
-            {
-                fixed (byte* destPtr = destination)
+                if (!CanReadWithoutProtectionChange(cursor, chunkSize, region))
                 {
-                    Buffer.MemoryCopy(srcPtr, destPtr, (nuint)destination.Length, (nuint)destination.Length);
+                    if (!TryTemporarilyProtectForRead(cursor, chunkSize, region, out var chunkPages))
+                    {
+                        return false;
+                    }
+
+                    touchedPages.AddRange(chunkPages);
                 }
+
+                cursor += chunkSize;
             }
-            finally
+
+            fixed (byte* destPtr = destination)
             {
-                RestorePageProtections(touchedPages);
+                Buffer.MemoryCopy((void*)virtualAddress, destPtr, (nuint)destination.Length, (nuint)destination.Length);
             }
 
             return true;
         }
-
-        return false;
+        finally
+        {
+            RestorePageProtections(touchedPages);
+        }
     }
 
     private bool TryWriteExclusive(ulong virtualAddress, ReadOnlySpan<byte> source)
     {
-        var region = FindRegion(virtualAddress, (ulong)source.Length);
-        if (region is not null &&
-            TryResolveRegionOffset(
-                virtualAddress,
-                (ulong)source.Length,
-                region,
-                out var offset))
+        var length = (ulong)source.Length;
+        if (!TryResolveRegionRun(virtualAddress, length, out var firstIndex, out var regionCount))
         {
-            var destPtr = (void*)(region.VirtualAddress + offset);
-            if (!EnsureRangeCommitted((ulong)destPtr, (ulong)source.Length, region))
-            {
-                return false;
-            }
+            return false;
+        }
 
-            if (CanWriteWithoutProtectionChange((ulong)destPtr, (ulong)source.Length, region))
+        var cursor = virtualAddress;
+        var end = virtualAddress + length;
+        var protectedChunks = new List<(ulong Address, ulong Size, uint Protection)>();
+        try
+        {
+            for (var index = firstIndex; index < firstIndex + regionCount; index++)
             {
-                fixed (byte* srcPtr = source)
+                var region = _regions[index];
+                var chunkSize = RegionChunkSize(region, cursor, end);
+                if (!EnsureRangeCommitted(cursor, chunkSize, region))
                 {
-                    Buffer.MemoryCopy(srcPtr, destPtr, (nuint)source.Length, (nuint)source.Length);
+                    return false;
                 }
 
-                return true;
+                if (!CanWriteWithoutProtectionChange(cursor, chunkSize, region))
+                {
+                    if (!_hostMemory.Protect(cursor, chunkSize, HostPageProtection.ReadWriteExecute, out var oldProtect))
+                    {
+                        return false;
+                    }
+
+                    protectedChunks.Add((cursor, chunkSize, oldProtect));
+                }
+
+                cursor += chunkSize;
             }
 
-            if (!_hostMemory.Protect((ulong)destPtr, (ulong)source.Length, HostPageProtection.ReadWriteExecute, out var oldProtect))
+            fixed (byte* srcPtr = source)
             {
-                return false;
-            }
-
-            try
-            {
-                fixed (byte* srcPtr = source)
-                {
-                    Buffer.MemoryCopy(srcPtr, destPtr, (nuint)source.Length, (nuint)source.Length);
-                }
-            }
-            finally
-            {
-                _hostMemory.ProtectRaw((ulong)destPtr, (ulong)source.Length, oldProtect, out _);
-                if (IsExecutableProtection(oldProtect))
-                {
-                    _hostMemory.FlushInstructionCache((ulong)destPtr, (ulong)source.Length);
-                }
+                Buffer.MemoryCopy(srcPtr, (void*)virtualAddress, (nuint)source.Length, (nuint)source.Length);
             }
 
             return true;
         }
-
-        return false;
+        finally
+        {
+            foreach (var (chunkAddress, chunkSize, protection) in protectedChunks)
+            {
+                _hostMemory.ProtectRaw(chunkAddress, chunkSize, protection, out _);
+                if (IsExecutableProtection(protection))
+                {
+                    _hostMemory.FlushInstructionCache(chunkAddress, chunkSize);
+                }
+            }
+        }
     }
 
     public bool TryWriteUInt64(ulong virtualAddress, ulong value)
@@ -1069,7 +1860,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         _gate.EnterReadLock();
         try
         {
-            return FindRegion(virtualAddress, size) is not null;
+            return TryResolveRegionRun(virtualAddress, size, out _, out _);
         }
         finally
         {
@@ -1101,6 +1892,122 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
             TryResolveRegionOffset(address, size, candidate, out _)
                 ? candidate
                 : null;
+    }
+
+    /// <summary>
+    /// Resolves the run of adjacent regions that covers
+    /// <c>[address, address + size)</c> without gaps. Guest-contiguous memory
+    /// is frequently assembled from many separate mappings, so accessors must
+    /// not require a single containing region.
+    /// </summary>
+    private bool TryResolveRegionRun(ulong address, ulong size, out int firstIndex, out int regionCount)
+    {
+        firstIndex = 0;
+        regionCount = 0;
+        if (ulong.MaxValue - address < size)
+        {
+            return false;
+        }
+
+        var low = 0;
+        var high = _regions.Count - 1;
+        var candidate = -1;
+        while (low <= high)
+        {
+            var middle = low + ((high - low) >> 1);
+            if (_regions[middle].VirtualAddress <= address)
+            {
+                candidate = middle;
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle - 1;
+            }
+        }
+
+        if (candidate < 0)
+        {
+            return false;
+        }
+
+        var cursor = address;
+        var end = address + size;
+        for (var index = candidate; index < _regions.Count; index++)
+        {
+            var region = _regions[index];
+            if (region.VirtualAddress > cursor)
+            {
+                return false;
+            }
+
+            var offset = cursor - region.VirtualAddress;
+            if (offset > region.Size)
+            {
+                return false;
+            }
+
+            if (region.Size - offset >= end - cursor)
+            {
+                firstIndex = candidate;
+                regionCount = index - candidate + 1;
+                return true;
+            }
+
+            cursor += region.Size - offset;
+        }
+
+        return false;
+    }
+
+    private static ulong RegionChunkSize(MemoryRegion region, ulong cursor, ulong end)
+    {
+        var available = region.Size - (cursor - region.VirtualAddress);
+        var remaining = end - cursor;
+        return available < remaining ? available : remaining;
+    }
+
+    private bool TryCommitRegionRun(ulong address, ulong size, int firstIndex, int regionCount)
+    {
+        var cursor = address;
+        var end = address + size;
+        for (var index = firstIndex; index < firstIndex + regionCount; index++)
+        {
+            var region = _regions[index];
+            var chunkSize = RegionChunkSize(region, cursor, end);
+            if (region.IsReservedOnly && !EnsureRangeCommitted(cursor, chunkSize, region))
+            {
+                return false;
+            }
+
+            cursor += chunkSize;
+        }
+
+        return true;
+    }
+
+    private bool CanAccessRegionRunWithoutProtectionChange(
+        ulong address,
+        ulong size,
+        int firstIndex,
+        int regionCount,
+        bool write)
+    {
+        var cursor = address;
+        var end = address + size;
+        for (var index = firstIndex; index < firstIndex + regionCount; index++)
+        {
+            var region = _regions[index];
+            var chunkSize = RegionChunkSize(region, cursor, end);
+            if (!CanAccessWithoutProtectionChange(cursor, chunkSize, region, write))
+            {
+                return false;
+            }
+
+            cursor += chunkSize;
+        }
+
+        return true;
     }
 
     private void InsertRegionSorted(MemoryRegion region)
@@ -1265,7 +2172,17 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
 
     private bool EnsureRangeCommitted(ulong address, ulong size, MemoryRegion region)
     {
-        if (size == 0 || !region.IsReservedOnly)
+        if (size == 0)
+        {
+            return true;
+        }
+
+        if (region.IsGuestReservation)
+        {
+            return IsDirectMappedRange(address, size);
+        }
+
+        if (!region.IsReservedOnly)
         {
             return true;
         }
@@ -1314,6 +2231,57 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         return true;
     }
 
+    private bool IsDirectMappedRange(ulong address, ulong size)
+    {
+        if (size == 0 || ulong.MaxValue - address < size)
+        {
+            return false;
+        }
+
+        // Reservations are populated by individually mapped views, so the
+        // range may be covered by several adjacent mappings rather than one.
+        var end = address + size;
+        var cursor = address;
+        while (cursor < end)
+        {
+            var next = cursor;
+            foreach (var mapping in _directMappings.Values)
+            {
+                if (mapping.VirtualAddress > cursor ||
+                    cursor - mapping.VirtualAddress >= mapping.Size)
+                {
+                    continue;
+                }
+
+                var reach = mapping.VirtualAddress + mapping.Size;
+                if (reach > next)
+                {
+                    next = reach < end ? reach : end;
+                }
+            }
+
+            if (next == cursor)
+            {
+                return false;
+            }
+
+            cursor = next;
+        }
+
+        return true;
+    }
+
+    private static MemoryRegion CloneRegionRange(MemoryRegion source, ulong address, ulong size) =>
+        new()
+        {
+            VirtualAddress = address,
+            Size = size,
+            IsExecutable = source.IsExecutable,
+            IsReservedOnly = source.IsReservedOnly,
+            IsGuestReservation = source.IsGuestReservation,
+            Protection = source.Protection,
+        };
+
     private bool TryTemporarilyProtectForRead(
         ulong address,
         ulong size,
@@ -1361,6 +2329,14 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         return checked((value + mask) & ~mask);
     }
 
+    private static ulong AlignUpToMultiple(ulong value, ulong alignment)
+    {
+        var remainder = value % alignment;
+        return remainder == 0
+            ? value
+            : checked(value + alignment - remainder);
+    }
+
     private static ulong ResolveLazyReservePrimeBytes()
     {
         var configured = Environment.GetEnvironmentVariable("SHARPEMU_LAZY_RESERVE_PRIME_MB");
@@ -1399,7 +2375,14 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         public ulong Size { get; set; }
         public bool IsExecutable { get; set; }
         public bool IsReservedOnly { get; set; }
+        public bool IsGuestReservation { get; set; }
         public uint Protection { get; set; }
     }
+
+    private readonly record struct DirectMapping(
+        ulong VirtualAddress,
+        ulong Size,
+        ulong PhysicalOffset,
+        HostPageProtection Protection);
 
 }

--- a/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
+++ b/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
@@ -638,6 +638,10 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
             (Path: Path.Combine(ebootDirectory, "sce_module"), StartAtBoot: true),
             (Path: Path.Combine(ebootDirectory, "sce_modules"), StartAtBoot: true),
             (Path: Path.Combine(ebootDirectory, "Media", "Modules"), StartAtBoot: true),
+            // Titles can ship required application PRXs beside eboot.bin rather
+            // than in sce_module. Search the bundle root after the conventional
+            // module directories so runtime libraries such as libc load first.
+            (Path: ebootDirectory, StartAtBoot: true),
             // Unity native plugins are loaded later through sceKernelLoadStartModule. Map
             // them up front so the HLE loader can return a real module handle and dlsym
             // can resolve their exports, but defer DT_INIT until the guest requests them.

--- a/src/SharpEmu.HLE/Host/IHostMemory.cs
+++ b/src/SharpEmu.HLE/Host/IHostMemory.cs
@@ -12,6 +12,12 @@ namespace SharpEmu.HLE.Host;
 public interface IHostMemory
 {
     /// <summary>
+    /// Whether reserve-only mappings are replaceable placeholders and must be
+    /// materialized explicitly before use.
+    /// </summary>
+    bool UsesPlaceholderReservations => false;
+
+    /// <summary>
     /// Reserves and commits pages in one step. <paramref name="desiredAddress"/> of 0
     /// lets the OS choose the address. Returns the base address, or 0 on failure.
     /// The OS may satisfy the request at a different address than desired; callers
@@ -21,6 +27,27 @@ public interface IHostMemory
 
     /// <summary>Reserves address space without committing pages (lazy regions).</summary>
     ulong Reserve(ulong desiredAddress, ulong size, HostPageProtection protection);
+
+    /// <summary>Creates a sparse shared backing object of the requested size.</summary>
+    IHostSharedMemory? CreateSharedMemory(ulong size) => null;
+
+    /// <summary>
+    /// Maps a view of <paramref name="sharedMemory"/>. A nonzero desired address
+    /// requires exact placement; the returned address denotes the requested
+    /// byte offset, even when the host view has a larger alignment prefix.
+    /// </summary>
+    ulong MapSharedMemory(
+        IHostSharedMemory sharedMemory,
+        ulong desiredAddress,
+        ulong size,
+        ulong offset,
+        HostPageProtection protection) => 0;
+
+    /// <summary>Unmaps one exact shared-memory view previously returned by MapSharedMemory.</summary>
+    bool UnmapSharedMemory(ulong address, ulong size) => false;
+
+    /// <summary>Releases a range from a reserve-only mapping.</summary>
+    bool UnmapReservedMemory(ulong address, ulong size) => false;
 
     /// <summary>Commits pages inside a previously reserved range (fault-path lazy commit).</summary>
     bool Commit(ulong address, ulong size, HostPageProtection protection);

--- a/src/SharpEmu.HLE/Host/IHostSharedMemory.cs
+++ b/src/SharpEmu.HLE/Host/IHostSharedMemory.cs
@@ -1,0 +1,13 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.HLE.Host;
+
+/// <summary>
+/// Sparse host backing whose byte ranges can be mapped at more than one
+/// virtual address. Implementations own the native section/file descriptor.
+/// </summary>
+public interface IHostSharedMemory : IDisposable
+{
+    ulong Size { get; }
+}

--- a/src/SharpEmu.HLE/Host/Posix/PosixHostMemory.cs
+++ b/src/SharpEmu.HLE/Host/Posix/PosixHostMemory.cs
@@ -59,6 +59,22 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
             ToNativeProtection(protection));
     }
 
+    public IHostSharedMemory? CreateSharedMemory(ulong size) => Posix.CreateSharedMemory(size);
+
+    public ulong MapSharedMemory(
+        IHostSharedMemory sharedMemory,
+        ulong desiredAddress,
+        ulong size,
+        ulong offset,
+        HostPageProtection protection) =>
+        Posix.MapSharedMemory(sharedMemory, desiredAddress, size, offset, ToNativeProtection(protection));
+
+    public bool UnmapSharedMemory(ulong address, ulong size) =>
+        Posix.UnmapSharedMemory(address, size);
+
+    public bool UnmapReservedMemory(ulong address, ulong size) =>
+        Posix.UnmapReservedMemory(address, size);
+
     public bool Commit(ulong address, ulong size, HostPageProtection protection)
     {
         return Posix.Alloc(
@@ -163,6 +179,8 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
         private const int PROT_EXEC = 0x4;
 
         private const int MAP_PRIVATE = 0x02;
+        private const int MAP_SHARED = 0x01;
+        private const int MAP_FIXED = 0x10;
         private static readonly int MAP_ANON = OperatingSystem.IsMacOS() ? 0x1000 : 0x20;
         private static readonly int MAP_NORESERVE = OperatingSystem.IsMacOS() ? 0 : 0x4000;
 
@@ -179,12 +197,32 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
 
         private static readonly object Gate = new();
         private static readonly SortedList<ulong, Region> Regions = new();
+        private static readonly Dictionary<ulong, SharedView> SharedViews = new();
+
+        private sealed class PosixSharedMemory(int fileDescriptor, ulong size) : IHostSharedMemory
+        {
+            private int _fileDescriptor = fileDescriptor;
+
+            internal int FileDescriptor => _fileDescriptor;
+
+            public ulong Size { get; } = size;
+
+            public void Dispose()
+            {
+                var current = Interlocked.Exchange(ref _fileDescriptor, -1);
+                if (current >= 0)
+                {
+                    close(current);
+                }
+            }
+        }
 
         private sealed class Region
         {
             public ulong Base;
             public ulong Size;
             public uint DefaultProtect;
+            public bool IsReservation;
             public Dictionary<ulong, uint>? PageProtects;
             public bool UsesMachAllocation;
 
@@ -326,10 +364,257 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
                     Base = (ulong)result,
                     Size = alignedSize,
                     DefaultProtect = protect,
+                    IsReservation = (allocationType & MEM_COMMIT) == 0,
                     UsesMachAllocation = usesMachAllocation,
                 };
 
                 return (void*)result;
+            }
+        }
+
+        private readonly record struct SharedView(
+            PosixSharedMemory Backing,
+            ulong Size,
+            ulong Offset,
+            uint Protection,
+            bool ReplacedReservation);
+
+        public static IHostSharedMemory? CreateSharedMemory(ulong size)
+        {
+            if (size == 0 || size > long.MaxValue)
+            {
+                return null;
+            }
+
+            int fileDescriptor;
+            if (OperatingSystem.IsLinux())
+            {
+                fileDescriptor = memfd_create("sharpemu-direct-memory", 1);
+            }
+            else
+            {
+                var name = $"/sharpemu-{Environment.ProcessId}-{Guid.NewGuid():N}";
+                fileDescriptor = shm_open(name, 0x0202, 0x180);
+                if (fileDescriptor >= 0)
+                {
+                    shm_unlink(name);
+                }
+            }
+
+            if (fileDescriptor < 0)
+            {
+                Trace($"shared backing open failed: size=0x{size:X} errno={Marshal.GetLastPInvokeError()}");
+                return null;
+            }
+
+            if (ftruncate(fileDescriptor, (long)size) != 0)
+            {
+                var error = Marshal.GetLastPInvokeError();
+                close(fileDescriptor);
+                Trace($"shared backing truncate failed: size=0x{size:X} errno={error}");
+                return null;
+            }
+
+            return new PosixSharedMemory(fileDescriptor, size);
+        }
+
+        public static ulong MapSharedMemory(
+            IHostSharedMemory sharedMemory,
+            ulong desiredAddress,
+            ulong size,
+            ulong offset,
+            uint protect)
+        {
+            if (sharedMemory is not PosixSharedMemory posixSharedMemory ||
+                posixSharedMemory.FileDescriptor < 0 ||
+                size == 0 ||
+                offset > posixSharedMemory.Size ||
+                size > posixSharedMemory.Size - offset ||
+                (offset & (PageSize - 1)) != 0 ||
+                offset > long.MaxValue)
+            {
+                Trace(
+                    $"shared mmap rejected arguments: desired=0x{desiredAddress:X16} " +
+                    $"size=0x{size:X} offset=0x{offset:X} backing_size=0x{sharedMemory.Size:X}");
+                return 0;
+            }
+
+            var alignedSize = AlignUp(size, PageSize);
+            lock (Gate)
+            {
+                var replacesReservation = desiredAddress != 0 &&
+                    TryFindRegionLocked(desiredAddress, out var containingRegion) &&
+                    containingRegion.IsReservation &&
+                    desiredAddress <= containingRegion.End &&
+                    alignedSize <= containingRegion.End - desiredAddress;
+                if (desiredAddress != 0 &&
+                    (OverlapsSharedViewLocked(desiredAddress, alignedSize) ||
+                     OverlapsTrackedRegionLocked(desiredAddress, alignedSize) &&
+                     !replacesReservation))
+                {
+                    Trace(
+                        $"shared mmap overlap: desired=0x{desiredAddress:X16} " +
+                        $"size=0x{alignedSize:X} replaces_reservation={replacesReservation}");
+                    return 0;
+                }
+
+                var flags = MAP_SHARED;
+                if (replacesReservation)
+                {
+                    flags |= MAP_FIXED;
+                }
+                else if (desiredAddress != 0 && !OperatingSystem.IsMacOS())
+                {
+                    flags |= MAP_FIXED_NOREPLACE;
+                }
+
+                var result = mmap(
+                    (nint)desiredAddress,
+                    (nuint)alignedSize,
+                    ToPosixProtect(protect),
+                    flags,
+                    posixSharedMemory.FileDescriptor,
+                    (long)offset);
+                if (result == MAP_FAILED || (desiredAddress != 0 && (ulong)result != desiredAddress))
+                {
+                    var error = result == MAP_FAILED ? Marshal.GetLastPInvokeError() : 0;
+                    Trace(
+                        $"shared mmap failed: desired=0x{desiredAddress:X16} " +
+                        $"got=0x{(ulong)result:X16} size=0x{alignedSize:X} " +
+                        $"offset=0x{offset:X} flags=0x{flags:X} errno={error}");
+                    if (result != MAP_FAILED)
+                    {
+                        munmap(result, (nuint)alignedSize);
+                    }
+
+                    return 0;
+                }
+
+                if (!replacesReservation)
+                {
+                    Regions[(ulong)result] = new Region
+                    {
+                        Base = (ulong)result,
+                        Size = alignedSize,
+                        DefaultProtect = protect,
+                        IsReservation = false
+                    };
+                }
+
+                SharedViews[(ulong)result] = new SharedView(
+                    posixSharedMemory,
+                    alignedSize,
+                    offset,
+                    protect,
+                    replacesReservation);
+                return (ulong)result;
+            }
+        }
+
+        public static bool UnmapSharedMemory(ulong address, ulong size)
+        {
+            if (size == 0)
+            {
+                return false;
+            }
+
+            var alignedSize = AlignUp(size, PageSize);
+            lock (Gate)
+            {
+                if (!SharedViews.TryGetValue(address, out var view) ||
+                    view.Size != alignedSize)
+                {
+                    return false;
+                }
+
+                if (!view.ReplacedReservation)
+                {
+                    if (!Regions.TryGetValue(address, out var region) ||
+                        region.Size != alignedSize ||
+                        munmap((nint)address, (nuint)alignedSize) != 0)
+                    {
+                        return false;
+                    }
+
+                    Regions.Remove(region.Base);
+                    SharedViews.Remove(address);
+                    return true;
+                }
+
+                if (!TryFindRegionLocked(address, out var reservation) ||
+                    !reservation.IsReservation ||
+                    alignedSize > reservation.End - address)
+                {
+                    return false;
+                }
+
+                if (munmap((nint)address, (nuint)alignedSize) != 0)
+                {
+                    return false;
+                }
+
+                var replacement = mmap(
+                    (nint)address,
+                    (nuint)alignedSize,
+                    ToPosixProtect(reservation.DefaultProtect),
+                    MAP_PRIVATE | MAP_ANON | MAP_FIXED | MAP_NORESERVE,
+                    -1,
+                    0);
+                if (replacement != MAP_FAILED && (ulong)replacement == address)
+                {
+                    SharedViews.Remove(address);
+                    return true;
+                }
+
+                var restored = mmap(
+                    (nint)address,
+                    (nuint)alignedSize,
+                    ToPosixProtect(view.Protection),
+                    MAP_SHARED | MAP_FIXED,
+                    view.Backing.FileDescriptor,
+                    checked((long)view.Offset));
+                if (restored != MAP_FAILED && (ulong)restored == address)
+                {
+                    return false;
+                }
+
+                throw new InvalidOperationException(
+                    $"Failed to restore shared view at 0x{address:X16} after reservation remap failed");
+            }
+        }
+
+        public static bool UnmapReservedMemory(ulong address, ulong size)
+        {
+            if (size == 0 || ulong.MaxValue - address < size)
+            {
+                return false;
+            }
+
+            var alignedSize = AlignUp(size, PageSize);
+            lock (Gate)
+            {
+                if (!TryFindRegionLocked(address, out var region) ||
+                    !region.IsReservation ||
+                    alignedSize > region.End - address ||
+                    OverlapsSharedViewLocked(address, alignedSize) ||
+                    munmap((nint)address, (nuint)alignedSize) != 0)
+                {
+                    return false;
+                }
+
+                Regions.Remove(region.Base);
+                if (region.Base < address)
+                {
+                    Regions[region.Base] = CloneRegionRange(region, region.Base, address - region.Base);
+                }
+
+                var end = address + alignedSize;
+                if (end < region.End)
+                {
+                    Regions[end] = CloneRegionRange(region, end, region.End - end);
+                }
+
+                return true;
             }
         }
 
@@ -450,6 +735,45 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
             }
 
             return false;
+        }
+
+        private static bool OverlapsSharedViewLocked(ulong start, ulong size)
+        {
+            var end = start + size;
+            foreach (var entry in SharedViews)
+            {
+                if (entry.Key < end && start < entry.Key + entry.Value.Size)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static Region CloneRegionRange(Region source, ulong address, ulong size)
+        {
+            Dictionary<ulong, uint>? pageProtects = null;
+            if (source.PageProtects is not null)
+            {
+                var end = address + size;
+                foreach (var entry in source.PageProtects)
+                {
+                    if (entry.Key >= address && entry.Key < end)
+                    {
+                        (pageProtects ??= [])[entry.Key] = entry.Value;
+                    }
+                }
+            }
+
+            return new Region
+            {
+                Base = address,
+                Size = size,
+                DefaultProtect = source.DefaultProtect,
+                IsReservation = source.IsReservation,
+                PageProtects = pageProtects,
+            };
         }
 
         private static bool TryFindRegionLocked(ulong address, out Region region)
@@ -584,5 +908,20 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
 
         [DllImport("libSystem.B.dylib")]
         private static extern int mach_vm_deallocate(uint target, ulong address, ulong size);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int memfd_create(string name, uint flags);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int shm_open(string name, int oflag, uint mode);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int shm_unlink(string name);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int ftruncate(int fileDescriptor, long length);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int close(int fileDescriptor);
     }
 }

--- a/src/SharpEmu.HLE/Host/Windows/WindowsHostMemory.cs
+++ b/src/SharpEmu.HLE/Host/Windows/WindowsHostMemory.cs
@@ -13,8 +13,16 @@ internal sealed unsafe partial class WindowsHostMemory : IHostMemory
 {
     private const uint MEM_COMMIT = 0x1000;
     private const uint MEM_RESERVE = 0x2000;
+    private const uint MEM_REPLACE_PLACEHOLDER = 0x4000;
     private const uint MEM_RELEASE = 0x8000;
+    private const uint MEM_COALESCE_PLACEHOLDERS = 0x01;
+    private const uint MEM_PRESERVE_PLACEHOLDER = 0x02;
+    private const uint MEM_RESERVE_PLACEHOLDER = 0x00040000;
     private const uint MEM_FREE = 0x10000;
+    private const uint MEM_MAPPED = 0x40000;
+    private const uint SEC_RESERVE = 0x04000000;
+    private const uint FILE_MAP_ALL_ACCESS = 0x000F001F;
+    private const ulong AllocationGranularity = 0x10000;
 
     private const uint PAGE_NOACCESS = 0x01;
     private const uint PAGE_READONLY = 0x02;
@@ -25,6 +33,12 @@ internal sealed unsafe partial class WindowsHostMemory : IHostMemory
     private const uint PAGE_EXECUTE_READWRITE = 0x40;
     private const uint PAGE_EXECUTE_WRITECOPY = 0x80;
 
+    private readonly object _sharedViewGate = new();
+    private readonly Dictionary<ulong, SharedView> _sharedViews = [];
+    private readonly Dictionary<ulong, ulong> _placeholderRoots = [];
+
+    public bool UsesPlaceholderReservations => true;
+
     public ulong Allocate(ulong desiredAddress, ulong size, HostPageProtection protection)
     {
         return (ulong)VirtualAlloc((void*)desiredAddress, (nuint)size, MEM_COMMIT | MEM_RESERVE, ToNativeProtection(protection));
@@ -32,16 +46,228 @@ internal sealed unsafe partial class WindowsHostMemory : IHostMemory
 
     public ulong Reserve(ulong desiredAddress, ulong size, HostPageProtection protection)
     {
-        return (ulong)VirtualAlloc((void*)desiredAddress, (nuint)size, MEM_RESERVE, ToNativeProtection(protection));
+        _ = protection;
+        var result = (ulong)VirtualAlloc2(
+            GetCurrentProcess(),
+            (void*)desiredAddress,
+            (nuint)size,
+            MEM_RESERVE | MEM_RESERVE_PLACEHOLDER,
+            PAGE_NOACCESS,
+            null,
+            0);
+        if (result != 0)
+        {
+            lock (_sharedViewGate)
+            {
+                _placeholderRoots[result] = size;
+            }
+        }
+
+        return result;
+    }
+
+    public IHostSharedMemory? CreateSharedMemory(ulong size)
+    {
+        if (size == 0)
+        {
+            return null;
+        }
+
+        var handle = CreateFileMappingW(
+            (void*)(nint)(-1),
+            null,
+            PAGE_READWRITE | SEC_RESERVE,
+            (uint)(size >> 32),
+            (uint)size,
+            null);
+        return handle != 0 ? new WindowsSharedMemory(handle, size) : null;
+    }
+
+    public ulong MapSharedMemory(
+        IHostSharedMemory sharedMemory,
+        ulong desiredAddress,
+        ulong size,
+        ulong offset,
+        HostPageProtection protection)
+    {
+        if (sharedMemory is not WindowsSharedMemory windowsSharedMemory ||
+            size == 0 ||
+            offset > windowsSharedMemory.Size ||
+            size > windowsSharedMemory.Size - offset)
+        {
+            return 0;
+        }
+
+        var viewOffset = offset & ~(AllocationGranularity - 1);
+        var delta = offset - viewOffset;
+        if (delta > ulong.MaxValue - size)
+        {
+            return 0;
+        }
+
+        var unalignedViewSize = delta + size;
+        if (unalignedViewSize > ulong.MaxValue - (AllocationGranularity - 1))
+        {
+            return 0;
+        }
+
+        var viewSize = (unalignedViewSize + AllocationGranularity - 1) & ~(AllocationGranularity - 1);
+        var replacingPlaceholder = desiredAddress != 0 &&
+            TryPreparePlaceholder(desiredAddress, size);
+        void* requestedView = null;
+        if (desiredAddress != 0 && !replacingPlaceholder)
+        {
+            if (desiredAddress < delta || ((desiredAddress - delta) & (AllocationGranularity - 1)) != 0)
+            {
+                return 0;
+            }
+
+            requestedView = (void*)(desiredAddress - delta);
+        }
+
+        var view = replacingPlaceholder
+            ? MapViewOfFile3(
+                windowsSharedMemory.Handle,
+                GetCurrentProcess(),
+                (void*)desiredAddress,
+                offset,
+                (nuint)size,
+                MEM_REPLACE_PLACEHOLDER,
+                ToNativeProtection(protection),
+                null,
+                0)
+            : MapViewOfFileEx(
+                windowsSharedMemory.Handle,
+                FILE_MAP_ALL_ACCESS,
+                (uint)(viewOffset >> 32),
+                (uint)viewOffset,
+                (nuint)viewSize,
+                requestedView);
+        if (view == null || (requestedView != null && view != requestedView))
+        {
+            TraceSharedMemoryFailure(
+                replacingPlaceholder ? "MapViewOfFile3" : "MapViewOfFileEx",
+                desiredAddress,
+                size,
+                offset);
+            if (view != null)
+            {
+                CleanupFailedSharedView(view, replacingPlaceholder);
+            }
+
+            return 0;
+        }
+
+        var guestAddress = replacingPlaceholder ? (ulong)view : (ulong)view + delta;
+        if (VirtualAlloc((void*)guestAddress, (nuint)size, MEM_COMMIT, ToNativeProtection(protection)) == null)
+        {
+            TraceSharedMemoryFailure("VirtualAlloc(commit view)", desiredAddress, size, offset);
+            CleanupFailedSharedView(view, replacingPlaceholder);
+            return 0;
+        }
+
+        lock (_sharedViewGate)
+        {
+            if (!_sharedViews.TryAdd(
+                    guestAddress,
+                    new SharedView((ulong)view, size, replacingPlaceholder)))
+            {
+                CleanupFailedSharedView(view, replacingPlaceholder);
+                return 0;
+            }
+        }
+
+        return guestAddress;
+    }
+
+    public bool UnmapSharedMemory(ulong address, ulong size)
+    {
+        lock (_sharedViewGate)
+        {
+            if (!_sharedViews.TryGetValue(address, out var view) || view.Size != size)
+            {
+                return false;
+            }
+
+            var unmapped = UnmapSharedView(
+                (void*)view.Base,
+                view.ReplacedPlaceholder);
+            if (unmapped)
+            {
+                _sharedViews.Remove(address);
+            }
+
+            return unmapped;
+        }
+    }
+
+    public bool UnmapReservedMemory(ulong address, ulong size)
+    {
+        if (size == 0 || ulong.MaxValue - address < size)
+        {
+            return TracePlaceholderFailure("invalid range", address, size);
+        }
+
+        lock (_sharedViewGate)
+        {
+            if (!TryPreparePlaceholderLocked(address, size))
+            {
+                return false;
+            }
+
+            return VirtualFree((void*)address, 0, MEM_RELEASE);
+        }
     }
 
     public bool Commit(ulong address, ulong size, HostPageProtection protection)
     {
-        return VirtualAlloc((void*)address, (nuint)size, MEM_COMMIT, ToNativeProtection(protection)) != null;
+        var nativeProtection = ToNativeProtection(protection);
+        if (VirtualAlloc((void*)address, (nuint)size, MEM_COMMIT, nativeProtection) != null)
+        {
+            return true;
+        }
+
+        lock (_sharedViewGate)
+        {
+            if (!TryPreparePlaceholderLocked(address, size))
+            {
+                return false;
+            }
+
+            return VirtualAlloc2(
+                GetCurrentProcess(),
+                (void*)address,
+                (nuint)size,
+                MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
+                nativeProtection,
+                null,
+                0) != null;
+        }
     }
 
     public bool Free(ulong address)
     {
+        lock (_sharedViewGate)
+        {
+            if (_placeholderRoots.Remove(address, out var placeholderSize))
+            {
+                return ReleasePlaceholderTree(address, placeholderSize);
+            }
+
+            if (_sharedViews.TryGetValue(address, out var view))
+            {
+                var unmapped = UnmapSharedView(
+                    (void*)view.Base,
+                    view.ReplacedPlaceholder);
+                if (unmapped)
+                {
+                    _sharedViews.Remove(address);
+                }
+
+                return unmapped;
+            }
+        }
+
         return VirtualFree((void*)address, 0, MEM_RELEASE);
     }
 
@@ -92,6 +318,25 @@ internal sealed unsafe partial class WindowsHostMemory : IHostMemory
         _ => throw new ArgumentOutOfRangeException(nameof(protection), protection, null),
     };
 
+    private static bool UnmapSharedView(void* view, bool replacedPlaceholder) =>
+        replacedPlaceholder
+            ? UnmapViewOfFile2(
+                GetCurrentProcess(),
+                view,
+                MEM_PRESERVE_PLACEHOLDER)
+            : UnmapViewOfFile(view);
+
+    private static void CleanupFailedSharedView(
+        void* view,
+        bool replacedPlaceholder)
+    {
+        if (!UnmapSharedView(view, replacedPlaceholder))
+        {
+            throw new InvalidOperationException(
+                "Failed to remove an untracked shared-memory view after mapping failed");
+        }
+    }
+
     private static HostRegionState ToRegionState(uint state) => state switch
     {
         MEM_COMMIT => HostRegionState.Committed,
@@ -117,8 +362,253 @@ internal sealed unsafe partial class WindowsHostMemory : IHostMemory
         };
     }
 
+    private bool TryPreparePlaceholder(ulong address, ulong size)
+    {
+        lock (_sharedViewGate)
+        {
+            return TryPreparePlaceholderLocked(address, size);
+        }
+    }
+
+    private static bool TryPreparePlaceholderLocked(ulong address, ulong size)
+    {
+        if (size == 0 || ulong.MaxValue - address < size)
+        {
+            return TracePlaceholderFailure("invalid range", address, size);
+        }
+
+        var end = address + size;
+        if (VirtualQuery((void*)address, out var startInfo, (nuint)sizeof(MemoryBasicInformation64)) == 0 ||
+            startInfo.State != MEM_RESERVE ||
+            address < startInfo.BaseAddress ||
+            address >= startInfo.BaseAddress + startInfo.RegionSize)
+        {
+            // An ordinary free address is expected to fall back to the aligned
+            // MapViewOfFileEx path; it is not a placeholder failure worth tracing.
+            return false;
+        }
+
+        // Preserve the original fast path. Windows accepts sub-allocation-sized
+        // placeholder splits here even when VirtualQuery later exposes the
+        // resulting placeholder as several smaller regions.
+        var startInfoEnd = startInfo.BaseAddress + startInfo.RegionSize;
+        if (end <= startInfoEnd)
+        {
+            if (address > startInfo.BaseAddress &&
+                !VirtualFree(
+                    (void*)startInfo.BaseAddress,
+                    (nuint)(address - startInfo.BaseAddress),
+                    MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER))
+            {
+                return TracePlaceholderFailure("split contained start", address, size);
+            }
+
+            if (end < startInfoEnd &&
+                !VirtualFree(
+                    (void*)address,
+                    (nuint)size,
+                    MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER))
+            {
+                return TracePlaceholderFailure("split contained end", address, size);
+            }
+
+            return true;
+        }
+
+        if (address > startInfo.BaseAddress &&
+            !VirtualFree(
+                (void*)startInfo.BaseAddress,
+                (nuint)(address - startInfo.BaseAddress),
+                MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER))
+        {
+            return TracePlaceholderFailure("split spanning start", address, size);
+        }
+
+        if (VirtualQuery((void*)(end - 1), out var endInfo, (nuint)sizeof(MemoryBasicInformation64)) == 0 ||
+            endInfo.State != MEM_RESERVE ||
+            end - 1 < endInfo.BaseAddress ||
+            end > endInfo.BaseAddress + endInfo.RegionSize)
+        {
+            return TracePlaceholderFailure("query spanning end", address, size);
+        }
+
+        var endInfoEnd = endInfo.BaseAddress + endInfo.RegionSize;
+        if (end < endInfoEnd &&
+            !VirtualFree(
+                (void*)endInfo.BaseAddress,
+                (nuint)(end - endInfo.BaseAddress),
+                MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER))
+        {
+            return TracePlaceholderFailure("split spanning end", address, size);
+        }
+
+        var cursor = address;
+        var segmentCount = 0;
+        while (cursor < end)
+        {
+            if (VirtualQuery((void*)cursor, out var segment, (nuint)sizeof(MemoryBasicInformation64)) == 0 ||
+                segment.State != MEM_RESERVE ||
+                segment.BaseAddress != cursor ||
+                segment.RegionSize == 0 ||
+                segment.RegionSize > end - cursor)
+            {
+                return TracePlaceholderFailure("walk", address, size);
+            }
+
+            cursor += segment.RegionSize;
+            segmentCount++;
+        }
+
+        return segmentCount != 0 &&
+            (VirtualFree(
+                 (void*)address,
+                 (nuint)size,
+                 MEM_RELEASE | MEM_COALESCE_PLACEHOLDERS) ||
+             TracePlaceholderFailure("coalesce", address, size));
+    }
+
+    private static bool TracePlaceholderFailure(string stage, ulong address, ulong size)
+    {
+        if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_VMEM"), "1", StringComparison.Ordinal))
+        {
+            Console.Error.WriteLine(
+                $"[HOSTMEM] Placeholder preparation failed ({stage}): error={Marshal.GetLastPInvokeError()} " +
+                $"va=0x{address:X16} size=0x{size:X}");
+        }
+
+        return false;
+    }
+
+    private bool ReleasePlaceholderTree(ulong address, ulong size)
+    {
+        var end = address + size;
+        var cursor = address;
+        var success = true;
+        while (cursor < end &&
+               VirtualQuery((void*)cursor, out var info, (nuint)sizeof(MemoryBasicInformation64)) != 0)
+        {
+            var next = Math.Min(end, info.BaseAddress + Math.Max(info.RegionSize, 0x1000));
+            if (info.State == MEM_FREE)
+            {
+                cursor = next;
+                continue;
+            }
+
+            if (info.Type == MEM_MAPPED)
+            {
+                success &= UnmapViewOfFile((void*)info.AllocationBase);
+                foreach (var guestAddress in _sharedViews
+                             .Where(entry => entry.Value.Base == info.AllocationBase)
+                             .Select(entry => entry.Key)
+                             .ToArray())
+                {
+                    _sharedViews.Remove(guestAddress);
+                }
+            }
+            else
+            {
+                success &= VirtualFree((void*)info.AllocationBase, 0, MEM_RELEASE);
+            }
+
+            cursor = next;
+        }
+
+        return success;
+    }
+
+    private static void TraceSharedMemoryFailure(string operation, ulong address, ulong size, ulong offset)
+    {
+        if (string.Equals(
+                Environment.GetEnvironmentVariable("SHARPEMU_LOG_VMEM"),
+                "1",
+                StringComparison.Ordinal))
+        {
+            Console.Error.WriteLine(
+                $"[HOSTMEM] {operation} failed: error={Marshal.GetLastPInvokeError()} " +
+                $"va=0x{address:X16} size=0x{size:X} offset=0x{offset:X}");
+        }
+    }
+
+    private sealed class WindowsSharedMemory(nint handle, ulong size) : IHostSharedMemory
+    {
+        private nint _handle = handle;
+
+        internal nint Handle => _handle;
+
+        public ulong Size { get; } = size;
+
+        public void Dispose()
+        {
+            var current = Interlocked.Exchange(ref _handle, 0);
+            if (current != 0)
+            {
+                CloseHandle(current);
+            }
+        }
+    }
+
+    private readonly record struct SharedView(
+        ulong Base,
+        ulong Size,
+        bool ReplacedPlaceholder);
+
     [LibraryImport("kernel32.dll", SetLastError = true)]
     private static partial void* VirtualAlloc(void* lpAddress, nuint dwSize, uint flAllocationType, uint flProtect);
+
+    [LibraryImport("kernelbase.dll", SetLastError = true)]
+    private static partial void* VirtualAlloc2(
+        void* process,
+        void* baseAddress,
+        nuint size,
+        uint allocationType,
+        uint pageProtection,
+        void* extendedParameters,
+        uint parameterCount);
+
+    [LibraryImport("kernel32.dll", EntryPoint = "CreateFileMappingW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    private static partial nint CreateFileMappingW(
+        void* hFile,
+        void* lpFileMappingAttributes,
+        uint flProtect,
+        uint dwMaximumSizeHigh,
+        uint dwMaximumSizeLow,
+        string? lpName);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial void* MapViewOfFileEx(
+        nint hFileMappingObject,
+        uint dwDesiredAccess,
+        uint dwFileOffsetHigh,
+        uint dwFileOffsetLow,
+        nuint dwNumberOfBytesToMap,
+        void* lpBaseAddress);
+
+    [LibraryImport("kernelbase.dll", SetLastError = true)]
+    private static partial void* MapViewOfFile3(
+        nint fileMapping,
+        void* process,
+        void* baseAddress,
+        ulong offset,
+        nuint viewSize,
+        uint allocationType,
+        uint pageProtection,
+        void* extendedParameters,
+        uint parameterCount);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool UnmapViewOfFile(void* lpBaseAddress);
+
+    [LibraryImport("kernelbase.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool UnmapViewOfFile2(
+        void* process,
+        void* baseAddress,
+        uint unmapFlags);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseHandle(nint hObject);
 
     [LibraryImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/SharpEmu.HLE/IGuestAddressSpace.cs
+++ b/src/SharpEmu.HLE/IGuestAddressSpace.cs
@@ -15,7 +15,46 @@ public interface IGuestAddressSpace : IGuestMemoryAllocator
 {
     ulong AllocateAt(ulong desiredAddress, ulong size, bool executable = true, bool allowAlternative = true);
 
+    ulong ReserveAt(ulong desiredAddress, ulong size, bool executable = true, bool allowAlternative = true);
+
     bool TryAllocateAtOrAbove(ulong desiredAddress, ulong size, bool executable, ulong alignment, out ulong actualAddress);
 
+    bool TryReserveAtOrAbove(ulong desiredAddress, ulong size, bool executable, ulong alignment, out ulong actualAddress);
+
     bool TryProtect(ulong address, ulong size, GuestPageProtection protection);
+
+    bool TryMapDirectMemory(
+        ulong desiredAddress,
+        ulong size,
+        ulong directMemoryOffset,
+        ulong directMemorySize,
+        GuestPageProtection protection,
+        ulong alignment,
+        bool allowSearch,
+        out ulong actualAddress);
+
+    /// <summary>
+    /// Transactionally replaces every direct-memory view page in the supplied
+    /// fixed virtual range, preserving unaffected prefixes and suffixes. A
+    /// failed replacement restores the previous mappings before returning.
+    /// </summary>
+    bool TryReplaceDirectMemory(
+        ulong address,
+        ulong size,
+        ulong directMemoryOffset,
+        ulong directMemorySize,
+        GuestPageProtection protection,
+        out ulong actualAddress);
+
+    bool TryUnmapDirectMemory(ulong address, ulong size);
+
+    /// <summary>
+    /// Removes every direct-memory view page in the supplied virtual range,
+    /// preserving and remapping any non-overlapping prefix or suffix.
+    /// </summary>
+    bool TryUnmapDirectMemoryRange(ulong address, ulong size) => false;
+
+    bool TryUnmapReservedMemory(ulong address, ulong size);
+
+    bool IsAccessible(ulong virtualAddress, ulong size);
 }

--- a/src/SharpEmu.HLE/OrbisGen2Result.cs
+++ b/src/SharpEmu.HLE/OrbisGen2Result.cs
@@ -41,6 +41,11 @@ public enum OrbisGen2Result : int
     ORBIS_GEN2_ERROR_DEADLOCK = unchecked((int)0x8002000B),
 
     /// <summary>
+    /// Indicates that a memory mapping or allocation cannot be satisfied.
+    /// </summary>
+    ORBIS_GEN2_ERROR_OUT_OF_MEMORY = unchecked((int)0x8002000C),
+
+    /// <summary>
     /// Indicates that the waited-on object was deleted while the caller was
     /// blocked on it. Matches the SCE kernel EACCES code that waiters of a
     /// deleted semaphore observe.

--- a/src/SharpEmu.Libs/AppContent/AppContentExports.cs
+++ b/src/SharpEmu.Libs/AppContent/AppContentExports.cs
@@ -121,6 +121,54 @@ public static class AppContentExports
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
+    [SysAbiExport(
+        Nid = "SaKib2Ug0yI",
+        ExportName = "sceAppContentTemporaryDataGetAvailableSpaceKb",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAppContent")]
+    public static int AppContentTemporaryDataGetAvailableSpaceKb(CpuContext ctx)
+    {
+        var availableSpaceAddress = ctx[CpuRegister.Rsi];
+        if (ctx[CpuRegister.Rdi] == 0 || availableSpaceAddress == 0)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        Span<byte> availableKb = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(availableKb, 1024UL * 1024); // 1 GiB
+        if (!ctx.Memory.TryWrite(availableSpaceAddress, availableKb))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "Gl6w5i0JokY",
+        ExportName = "sceAppContentDownloadDataGetAvailableSpaceKb",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAppContent")]
+    public static int AppContentDownloadDataGetAvailableSpaceKb(CpuContext ctx)
+    {
+        var availableSpaceAddress = ctx[CpuRegister.Rsi];
+        if (ctx[CpuRegister.Rdi] == 0 || availableSpaceAddress == 0)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        Span<byte> availableKb = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(availableKb, 1024UL * 1024); // 1 GiB
+        if (!ctx.Memory.TryWrite(availableSpaceAddress, availableKb))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
     private static bool TryReadUserDefinedParam(uint paramId, out int value)
     {
         value = 0;

--- a/src/SharpEmu.Libs/CxxAbiExports.cs
+++ b/src/SharpEmu.Libs/CxxAbiExports.cs
@@ -16,7 +16,7 @@ public static class CxaGuardExports
 
     private sealed class GuardState
     {
-        public int OwnerThreadId { get; set; }
+        public ulong OwnerThreadId { get; set; }
         public int RecursionDepth { get; set; }
     }
 
@@ -36,7 +36,7 @@ public static class CxaGuardExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
-        var currentThreadId = Environment.CurrentManagedThreadId;
+        var currentThreadId = GetCurrentThreadIdentity();
         var spinner = new SpinWait();
         while (true)
         {
@@ -107,7 +107,7 @@ public static class CxaGuardExports
         }
 
         if (_inProgress.TryGetValue(guardPtr, out var state) &&
-            state.OwnerThreadId != Environment.CurrentManagedThreadId)
+            state.OwnerThreadId != GetCurrentThreadIdentity())
         {
             ctx[CpuRegister.Rax] = 0;
             LogGuardResult("guard_release", guardPtr, result: 0, initialized: false, inProgress: true, ownerThreadId: state.OwnerThreadId);
@@ -156,7 +156,7 @@ public static class CxaGuardExports
         }
 
         if (_inProgress.TryGetValue(guardPtr, out var state) &&
-            state.OwnerThreadId != Environment.CurrentManagedThreadId)
+            state.OwnerThreadId != GetCurrentThreadIdentity())
         {
             ctx[CpuRegister.Rax] = 0;
             LogGuardResult("guard_abort", guardPtr, result: 0, initialized: false, inProgress: true, ownerThreadId: state.OwnerThreadId);
@@ -186,6 +186,14 @@ public static class CxaGuardExports
         return true;
     }
 
+    private static ulong GetCurrentThreadIdentity()
+    {
+        var guestThreadHandle = GuestThreadExecution.CurrentGuestThreadHandle;
+        return guestThreadHandle != 0
+            ? guestThreadHandle
+            : 0x8000_0000_0000_0000UL | unchecked((uint)Environment.CurrentManagedThreadId);
+    }
+
     private static bool TryWriteGuardState(CpuContext ctx, ulong guardPtr, ulong stateValue)
     {
         if (!ctx.TryReadUInt64(guardPtr, out var word))
@@ -209,7 +217,7 @@ public static class CxaGuardExports
             $"[LOADER][TRACE] {op}: guard=0x{guardPtr:X16} init={initialized} in_progress={inProgress} word={(readable ? $"0x{word:X16}" : "<unreadable>")}");
     }
 
-    private static void LogGuardResult(string op, ulong guardPtr, int result, bool initialized, bool inProgress, int ownerThreadId)
+    private static void LogGuardResult(string op, ulong guardPtr, int result, bool initialized, bool inProgress, ulong ownerThreadId)
     {
         if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_GUARDS"), "1", StringComparison.Ordinal))
         {
@@ -217,6 +225,6 @@ public static class CxaGuardExports
         }
 
         Console.Error.WriteLine(
-            $"[LOADER][TRACE] {op}: guard=0x{guardPtr:X16} result={result} init={initialized} in_progress={inProgress} owner_thread={ownerThreadId}");
+            $"[LOADER][TRACE] {op}: guard=0x{guardPtr:X16} result={result} init={initialized} in_progress={inProgress} owner_thread=0x{ownerThreadId:X16}");
     }
 }

--- a/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
@@ -12,6 +12,7 @@ namespace SharpEmu.Libs.Kernel;
 public static class KernelEventQueueCompatExports
 {
     private const int KernelEventSize = 0x20;
+    public const short KernelEventFilterRead = -1;
     public const short KernelEventFilterGraphics = -14;
     public const short KernelEventFilterUser = -11;
     public const short KernelEventFilterAmpr = -16;
@@ -208,6 +209,43 @@ public static class KernelEventQueueCompatExports
             ctx[CpuRegister.Rsi],
             KernelEventFilterUser);
         TraceEventQueue(ctx, "delete_user", handle);
+        return deleted
+            ? (int)OrbisGen2Result.ORBIS_GEN2_OK
+            : (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+    }
+
+    [SysAbiExport(
+        Nid = "VHCS3rCd0PM",
+        ExportName = "sceKernelAddReadEvent",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelAddReadEvent(CpuContext ctx)
+    {
+        var handle = ctx[CpuRegister.Rdi];
+        var registered = RegisterEvent(
+            handle,
+            ctx[CpuRegister.Rsi],
+            KernelEventFilterRead,
+            ctx[CpuRegister.Rcx]);
+        TraceEventQueue(ctx, "add_read", handle);
+        return registered
+            ? (int)OrbisGen2Result.ORBIS_GEN2_OK
+            : (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+    }
+
+    [SysAbiExport(
+        Nid = "JxJ4tfgKlXA",
+        ExportName = "sceKernelDeleteReadEvent",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelDeleteReadEvent(CpuContext ctx)
+    {
+        var handle = ctx[CpuRegister.Rdi];
+        var deleted = DeleteRegisteredEvent(
+            handle,
+            ctx[CpuRegister.Rsi],
+            KernelEventFilterRead);
+        TraceEventQueue(ctx, "delete_read", handle);
         return deleted
             ? (int)OrbisGen2Result.ORBIS_GEN2_OK
             : (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;

--- a/src/SharpEmu.Libs/Kernel/KernelExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelExports.cs
@@ -125,6 +125,23 @@ public static class KernelExports
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
+    // libc's exported __cxa_thread_atexit (nid BKSCW2bCACA) is a thin wrapper
+    // that forwards straight to this import, so this is the kernel-side
+    // thread-atexit implementation (its plain name doesn't hash to this NID).
+    // Accepted but never run: thread-local dtors are skipped on thread exit.
+    #pragma warning disable SHEM006 // This NID names a private wrapper target, not a catalog export.
+    [SysAbiExport(
+        Nid = "qBS714-Jr3g",
+        ExportName = "__cxa_thread_atexit_impl",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int CxaThreadAtexitImpl(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+    #pragma warning restore SHEM006
+
     [SysAbiExport(
         Nid = "H2e8t5ScQGc",
         ExportName = "__cxa_finalize",

--- a/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
@@ -400,8 +400,6 @@ public static partial class KernelMemoryCompatExports
 
     // ---- fcntl ----
 
-    [SysAbiExport(Nid = "8nY19bKoiZk", ExportName = "fcntl",
-        Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
     public static int PosixFcntl(CpuContext ctx) => KernelFcntlCore(ctx);
 
     [SysAbiExport(Nid = "SoZkxZkCHaw", ExportName = "sceKernelFcntl",

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -195,7 +195,14 @@ public static partial class KernelMemoryCompatExports
 
     private readonly record struct DirectAllocation(ulong Start, ulong Length, int MemoryType);
     private readonly record struct LibcHeapAllocation(nint BaseAddress, nuint Size, nuint Alignment);
-    private readonly record struct MappedRegion(ulong Address, ulong Length, int Protection, bool IsFlexible, bool IsDirect, ulong DirectStart);
+    private readonly record struct MappedRegion(
+        ulong Address,
+        ulong Length,
+        int Protection,
+        bool IsFlexible,
+        bool IsDirect,
+        ulong DirectStart,
+        bool IsReserved = false);
     private readonly record struct BatchMapEntry(ulong Start, ulong Offset, ulong Length, byte Protection, byte Type, int Operation);
 
     public static void RegisterGuestPathMount(string guestMountPoint, string hostRoot)
@@ -222,6 +229,37 @@ public static partial class KernelMemoryCompatExports
                 string.Equals(path, normalizedMountPoint, StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith(normalizedMountPoint + "/", StringComparison.OrdinalIgnoreCase));
         }
+    }
+
+    public static bool TryUnregisterGuestPathMount(string guestMountPoint)
+    {
+        if (string.IsNullOrWhiteSpace(guestMountPoint))
+        {
+            return false;
+        }
+
+        var normalizedMountPoint = NormalizeGuestStatCachePath(guestMountPoint);
+        if (normalizedMountPoint is null || normalizedMountPoint == "/")
+        {
+            return false;
+        }
+
+        lock (_guestMountGate)
+        {
+            if (!_guestMounts.Remove(normalizedMountPoint))
+            {
+                return false;
+            }
+        }
+
+        lock (_statCacheGate)
+        {
+            _negativeStatCache.RemoveWhere(path =>
+                string.Equals(path, normalizedMountPoint, StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith(normalizedMountPoint + "/", StringComparison.OrdinalIgnoreCase));
+        }
+
+        return true;
     }
 
     internal static bool TryAllocateHleData(
@@ -288,7 +326,8 @@ public static partial class KernelMemoryCompatExports
                 Protection: 0,
                 IsFlexible: false,
                 IsDirect: false,
-                DirectStart: 0);
+                DirectStart: 0,
+                IsReserved: true);
         }
     }
 
@@ -2292,23 +2331,35 @@ public static partial class KernelMemoryCompatExports
         LibraryName = "libKernel")]
     public static int ClockGettime(CpuContext ctx)
     {
+        var clockId = unchecked((int)ctx[CpuRegister.Rdi]);
         var timespecAddress = ctx[CpuRegister.Rsi];
         if (timespecAddress == 0)
         {
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+            KernelRuntimeCompatExports.TrySetErrno(ctx, 22);
+            ctx[CpuRegister.Rax] = ulong.MaxValue;
+            return -1;
         }
 
-        var now = DateTimeOffset.UtcNow;
-        var seconds = now.ToUnixTimeSeconds();
-        var nanoseconds = (now.Ticks % TimeSpan.TicksPerSecond) * 100;
+        if (!KernelRuntimeCompatExports.ResolveClockTime(
+                clockId,
+                out var seconds,
+                out var nanoseconds))
+        {
+            KernelRuntimeCompatExports.TrySetErrno(ctx, 22);
+            ctx[CpuRegister.Rax] = ulong.MaxValue;
+            return -1;
+        }
+
         if (!ctx.TryWriteUInt64(timespecAddress, unchecked((ulong)seconds)) ||
             !ctx.TryWriteUInt64(timespecAddress + sizeof(long), unchecked((ulong)nanoseconds)))
         {
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+            KernelRuntimeCompatExports.TrySetErrno(ctx, 14);
+            ctx[CpuRegister.Rax] = ulong.MaxValue;
+            return -1;
         }
 
         ctx[CpuRegister.Rax] = 0;
-        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        return 0;
     }
 
     [SysAbiExport(
@@ -2822,7 +2873,11 @@ public static partial class KernelMemoryCompatExports
             Console.Error.WriteLine(
                 $"[LOADER][TRACE] map_direct: inout=0x{inOutAddressPointer:X16} len=0x{length:X16} prot=0x{protection:X8} flags=0x{flags:X16} direct=0x{directMemoryStart:X16} align=0x{alignment:X16}");
         }
-        if (inOutAddressPointer == 0 || length == 0)
+        if (inOutAddressPointer == 0 ||
+            length == 0 ||
+            (length & (OrbisPageSize - 1)) != 0 ||
+            (directMemoryStart & (OrbisPageSize - 1)) != 0 ||
+            !IsValidMapAlignment(alignment))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
@@ -2832,89 +2887,130 @@ public static partial class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
-        ulong mappedAddress;
+        ulong mappedAddress = 0;
         lock (_memoryGate)
         {
             var effectiveAlignment = alignment == 0 ? OrbisPageSize : alignment;
             var fixedMapping = (flags & 0x10UL) != 0;
-            var desiredAddress = requestedAddress != 0
+            var noOverwrite = fixedMapping && (flags & 0x80UL) != 0;
+            if (fixedMapping &&
+                (requestedAddress == 0 ||
+                 (requestedAddress & (OrbisPageSize - 1)) != 0))
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+            }
+
+            var desiredBase = requestedAddress != 0
                 ? requestedAddress
                 : directMemoryStart != 0
-                    ? AlignUp(directMemoryStart, effectiveAlignment)
-                    : AlignUp(_nextVirtualAddress == 0 ? DefaultMapSearchBase : _nextVirtualAddress, effectiveAlignment);
-
-            var reserved = false;
-            if (fixedMapping && requestedAddress != 0)
+                    ? directMemoryStart
+                    : _nextVirtualAddress == 0
+                        ? DefaultMapSearchBase
+                        : _nextVirtualAddress;
+            if (!TryAlignUpToMultiple(
+                    desiredBase,
+                    fixedMapping ? OrbisPageSize : effectiveAlignment,
+                    out var desiredAddress) ||
+                !TryAddU64(desiredAddress, length, out var desiredEnd) ||
+                directMemoryStart > DirectMemorySizeBytes ||
+                length > DirectMemorySizeBytes - directMemoryStart)
             {
-                mappedAddress = requestedAddress;
-                reserved = IsGuestRangeBacked(ctx, requestedAddress, length);
-                if (!reserved)
-                {
-                    TryReserveExactGuestVirtualRange(ctx, requestedAddress, length, protection);
-                    reserved = IsGuestRangeBacked(ctx, requestedAddress, length);
-                }
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+            }
 
-                if (!reserved)
-                {
-                    // Rosetta places the x86-64 process stack in the low
-                    // address window used by some fixed PS5 mappings. Do not
-                    // clobber that host memory: relocate the mapping and
-                    // return the actual address through the in/out pointer.
-                    if (OperatingSystem.IsMacOS())
-                    {
-                        var fallbackAddress = AlignUp(
-                            _nextVirtualAddress == 0 ? DefaultMapSearchBase : _nextVirtualAddress,
-                            effectiveAlignment);
-                        reserved = TryReserveGuestVirtualRange(
-                            ctx,
-                            fallbackAddress,
-                            length,
-                            protection,
-                            effectiveAlignment,
-                            out mappedAddress);
+            if (!KernelVirtualRangeAllocator.TryResolveAddressSpace(ctx.Memory, out var addressSpace))
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN;
+            }
 
-                        if (reserved && ShouldTraceDirectMemory())
-                        {
-                            Console.Error.WriteLine(
-                                $"[LOADER][WARN] map_direct relocated fixed mapping: requested=0x{requestedAddress:X16} mapped=0x{mappedAddress:X16} len=0x{length:X16}");
-                        }
-                    }
+            if (noOverwrite &&
+                (HasMappedRegionOverlapLocked(desiredAddress, length) ||
+                 addressSpace.IsAccessible(desiredAddress, length)))
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_OUT_OF_MEMORY;
+            }
 
-                    if (!reserved)
-                    {
-                        mappedAddress = 0;
-                    }
-                }
+            var replacedDirectRegions = fixedMapping && !noOverwrite
+                ? GetOverlappingDirectRegionsLocked(desiredAddress, desiredEnd)
+                : [];
+            bool mapped;
+            if (replacedDirectRegions.Length != 0)
+            {
+                mapped = addressSpace.TryReplaceDirectMemory(
+                    desiredAddress,
+                    length,
+                    directMemoryStart,
+                    DirectMemorySizeBytes,
+                    ResolveGuestProtection(protection),
+                    out mappedAddress);
             }
             else
             {
-                reserved = TryReserveGuestVirtualRange(ctx, desiredAddress, length, protection, effectiveAlignment, out mappedAddress);
-            }
-            if (ShouldTraceDirectMemory())
-            {
-                Console.Error.WriteLine(
-                    $"[LOADER][TRACE] map_direct reserve: requested=0x{requestedAddress:X16} desired=0x{desiredAddress:X16} reserved={reserved} mapped=0x{mappedAddress:X16}");
-            }
-            if (!reserved && !fixedMapping)
-            {
-                if (mappedAddress == 0)
+                if (fixedMapping &&
+                    !PreparePartiallyOverlappedReservationsLocked(
+                        addressSpace,
+                        desiredAddress,
+                        length,
+                        desiredEnd))
                 {
-                    mappedAddress = requestedAddress != 0
-                        ? requestedAddress
-                        : AllocateMappedGuestAddress(ctx, length, effectiveAlignment);
-                    if (ShouldTraceDirectMemory())
+                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN;
+                }
+
+                mapped = addressSpace.TryMapDirectMemory(
+                    desiredAddress,
+                    length,
+                    directMemoryStart,
+                    DirectMemorySizeBytes,
+                    ResolveGuestProtection(protection),
+                    effectiveAlignment,
+                    allowSearch: !fixedMapping,
+                    out mappedAddress);
+
+                if ((!mapped || mappedAddress == 0) &&
+                    fixedMapping &&
+                    OperatingSystem.IsMacOS())
+                {
+                    var fallbackAddress = AlignUp(
+                        _nextVirtualAddress == 0 ? DefaultMapSearchBase : _nextVirtualAddress,
+                        effectiveAlignment);
+                    mapped = addressSpace.TryMapDirectMemory(
+                        fallbackAddress,
+                        length,
+                        directMemoryStart,
+                        DirectMemorySizeBytes,
+                        ResolveGuestProtection(protection),
+                        effectiveAlignment,
+                        allowSearch: true,
+                        out mappedAddress);
+                    if (mapped && ShouldTraceDirectMemory())
                     {
-                        Console.Error.WriteLine($"[LOADER][TRACE] map_direct fallback mapped=0x{mappedAddress:X16}");
+                        Console.Error.WriteLine(
+                            $"[LOADER][WARN] map_direct relocated fixed mapping: requested=0x{requestedAddress:X16} mapped=0x{mappedAddress:X16} len=0x{length:X16}");
                     }
                 }
             }
 
-            if (mappedAddress == 0)
+            if (ShouldTraceDirectMemory())
+            {
+                Console.Error.WriteLine(
+                    $"[LOADER][TRACE] map_direct shared: requested=0x{requestedAddress:X16} desired=0x{desiredAddress:X16} mapped={mapped} va=0x{mappedAddress:X16}");
+            }
+
+            if (!mapped || mappedAddress == 0)
             {
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
             }
 
+            if (replacedDirectRegions.Length != 0)
+            {
+                CommitFixedDirectReplacementLocked(
+                    desiredAddress,
+                    desiredEnd,
+                    replacedDirectRegions);
+            }
+
             _nextVirtualAddress = Math.Max(_nextVirtualAddress, mappedAddress + length);
+            CarveReservedMappedRegionLocked(mappedAddress, length);
             _mappedRegions[mappedAddress] = new MappedRegion(
                 mappedAddress,
                 length,
@@ -3097,46 +3193,242 @@ public static partial class KernelMemoryCompatExports
     {
         var address = ctx[CpuRegister.Rdi];
         var length = ctx[CpuRegister.Rsi];
-        if (address == 0 || length == 0 || ulong.MaxValue - address < length)
+        if (address == 0 || length == 0 || !TryAddU64(address, length, out var end))
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
-        var rangeEnd = address + length;
-        var physicallyBacked = IsGuestRangeBacked(ctx, address, length);
-        var removedAny = false;
         lock (_memoryGate)
         {
-            var removedRegions = _mappedRegions.Values
-                .Where(region =>
-                    region.Address >= address &&
-                    region.Address < rangeEnd &&
-                    region.Length <= rangeEnd - region.Address)
-                .ToArray();
+            if (!KernelVirtualRangeAllocator.TryResolveAddressSpace(ctx.Memory, out var addressSpace))
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN;
+            }
 
-            if (removedRegions.Length == 0 && !physicallyBacked)
+            var affectedRegions = _mappedRegions.Values
+                .Where(region =>
+                    TryAddU64(region.Address, region.Length, out var regionEnd) &&
+                    address < regionEnd &&
+                    region.Address < end)
+                .OrderBy(static region => region.Address)
+                .ToArray();
+            if (affectedRegions.Length == 0)
             {
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
             }
 
-            foreach (var mappedRegion in removedRegions)
+            foreach (var mappedRegion in affectedRegions)
             {
-                removedAny |= _mappedRegions.Remove(mappedRegion.Address);
+                var mappedRegionEnd = mappedRegion.Address + mappedRegion.Length;
+                var unmapStart = Math.Max(address, mappedRegion.Address);
+                var unmapEnd = Math.Min(end, mappedRegionEnd);
+                var unmapLength = unmapEnd - unmapStart;
+                var isWholeRegion = unmapStart == mappedRegion.Address &&
+                    unmapLength == mappedRegion.Length;
+                if (mappedRegion.IsDirect)
+                {
+                    if (!addressSpace.TryUnmapDirectMemoryRange(unmapStart, unmapLength))
+                    {
+                        return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN;
+                    }
+
+                    // A direct view may have replaced a host reservation. Once
+                    // the view is gone, release the restored placeholder too.
+                    _ = addressSpace.TryUnmapReservedMemory(unmapStart, unmapLength);
+                }
+                else if (mappedRegion.IsReserved)
+                {
+                    if (!addressSpace.TryUnmapReservedMemory(unmapStart, unmapLength))
+                    {
+                        return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN;
+                    }
+                }
+                else if (!isWholeRegion)
+                {
+                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN;
+                }
+
+                _mappedRegions.Remove(mappedRegion.Address);
+                _mappedRegionNames.Remove(mappedRegion.Address, out var mappedName);
+                if (mappedRegion.Address < unmapStart)
+                {
+                    AddMunmapRemainderLocked(
+                        mappedRegion,
+                        mappedRegion.Address,
+                        unmapStart - mappedRegion.Address,
+                        mappedName);
+                }
+
+                if (unmapEnd < mappedRegionEnd)
+                {
+                    AddMunmapRemainderLocked(
+                        mappedRegion,
+                        unmapEnd,
+                        mappedRegionEnd - unmapEnd,
+                        mappedName);
+                }
+
                 if (mappedRegion.IsFlexible)
                 {
-                    _allocatedFlexibleBytes = mappedRegion.Length >= _allocatedFlexibleBytes
+                    _allocatedFlexibleBytes = unmapLength >= _allocatedFlexibleBytes
                         ? 0
-                        : _allocatedFlexibleBytes - mappedRegion.Length;
+                        : _allocatedFlexibleBytes - unmapLength;
                 }
             }
         }
 
-        if (physicallyBacked || removedAny)
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    private static void AddMunmapRemainderLocked(
+        MappedRegion source,
+        ulong address,
+        ulong length,
+        string? name)
+    {
+        var directStart = source.IsDirect
+            ? source.DirectStart + (address - source.Address)
+            : source.DirectStart;
+        _mappedRegions[address] = source with
         {
-            KernelRuntimeCompatExports.RegisterReleasedVirtualRange(address, length);
+            Address = address,
+            Length = length,
+            DirectStart = directStart,
+        };
+        if (name is not null)
+        {
+            _mappedRegionNames[address] = name;
+        }
+    }
+
+    private static void CarveReservedMappedRegionLocked(ulong address, ulong length)
+    {
+        if (!TryAddU64(address, length, out var end))
+        {
+            return;
         }
 
-        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        var reservations = _mappedRegions.Values
+            .Where(region =>
+                region.IsReserved &&
+                TryAddU64(region.Address, region.Length, out var regionEnd) &&
+                address < regionEnd &&
+                region.Address < end)
+            .ToArray();
+        foreach (var reservation in reservations)
+        {
+            var reservationEnd = reservation.Address + reservation.Length;
+            var overlapStart = Math.Max(address, reservation.Address);
+            var overlapEnd = Math.Min(end, reservationEnd);
+            _mappedRegions.Remove(reservation.Address);
+            _mappedRegionNames.Remove(reservation.Address, out var name);
+            if (reservation.Address < overlapStart)
+            {
+                AddMunmapRemainderLocked(
+                    reservation,
+                    reservation.Address,
+                    overlapStart - reservation.Address,
+                    name);
+            }
+
+            if (overlapEnd < reservationEnd)
+            {
+                AddMunmapRemainderLocked(
+                    reservation,
+                    overlapEnd,
+                    reservationEnd - overlapEnd,
+                    name);
+            }
+        }
+    }
+
+    private static MappedRegion[] GetOverlappingDirectRegionsLocked(
+        ulong address,
+        ulong end)
+    {
+        return _mappedRegions.Values
+            .Where(region =>
+                region.IsDirect &&
+                TryAddU64(region.Address, region.Length, out var regionEnd) &&
+                address < regionEnd &&
+                region.Address < end)
+            .ToArray();
+    }
+
+    private static void CommitFixedDirectReplacementLocked(
+        ulong address,
+        ulong end,
+        IReadOnlyList<MappedRegion> directRegions)
+    {
+        foreach (var region in directRegions)
+        {
+            var regionEnd = region.Address + region.Length;
+            var overlapStart = Math.Max(address, region.Address);
+            var overlapEnd = Math.Min(end, regionEnd);
+            _mappedRegions.Remove(region.Address);
+            _mappedRegionNames.Remove(region.Address, out var name);
+            if (region.Address < overlapStart)
+            {
+                AddMunmapRemainderLocked(
+                    region,
+                    region.Address,
+                    overlapStart - region.Address,
+                    name);
+            }
+
+            if (overlapEnd < regionEnd)
+            {
+                AddMunmapRemainderLocked(region, overlapEnd, regionEnd - overlapEnd, name);
+            }
+        }
+    }
+
+    private static bool HasMappedRegionOverlapLocked(ulong address, ulong length)
+    {
+        if (!TryAddU64(address, length, out var end))
+        {
+            return true;
+        }
+
+        return _mappedRegions.Values.Any(region =>
+            TryAddU64(region.Address, region.Length, out var regionEnd) &&
+            address < regionEnd &&
+            region.Address < end);
+    }
+
+    private static bool PreparePartiallyOverlappedReservationsLocked(
+        IGuestAddressSpace addressSpace,
+        ulong address,
+        ulong length,
+        ulong end)
+    {
+        var reservations = _mappedRegions.Values
+            .Where(region =>
+                region.IsReserved &&
+                TryAddU64(region.Address, region.Length, out var regionEnd) &&
+                address < regionEnd &&
+                region.Address < end)
+            .ToArray();
+        if (reservations.Length == 0 || reservations.Any(region =>
+                address >= region.Address &&
+                end <= region.Address + region.Length))
+        {
+            return true;
+        }
+
+        foreach (var reservation in reservations)
+        {
+            var reservationEnd = reservation.Address + reservation.Length;
+            var overlapStart = Math.Max(address, reservation.Address);
+            var overlapEnd = Math.Min(end, reservationEnd);
+            if (!addressSpace.TryUnmapReservedMemory(overlapStart, overlapEnd - overlapStart))
+            {
+                return false;
+            }
+        }
+
+        CarveReservedMappedRegionLocked(address, length);
+        return true;
     }
 
     [SysAbiExport(
@@ -3225,7 +3517,10 @@ public static partial class KernelMemoryCompatExports
             stateFlags |= 0x02u;
         }
 
-        stateFlags |= 0x10u;
+        if (!region.IsReserved)
+        {
+            stateFlags |= 0x10u;
+        }
 
         BinaryPrimitives.WriteUInt64LittleEndian(payload[0..8], region.Address);
         BinaryPrimitives.WriteUInt64LittleEndian(payload[8..16], regionEnd);
@@ -4449,6 +4744,7 @@ public static partial class KernelMemoryCompatExports
             desiredAddress,
             length,
             executable,
+            reserveOnly: false,
             alignment,
             allowSearch: true,
             allowAllocateAtAlternative: false,
@@ -4468,6 +4764,7 @@ public static partial class KernelMemoryCompatExports
             desiredAddress,
             length,
             executable,
+            reserveOnly: false,
             alignment: 0,
             allowSearch: false,
             allowAllocateAtAlternative: false,
@@ -5677,6 +5974,27 @@ public static partial class KernelMemoryCompatExports
                 : HostPageNoAccess;
     }
 
+    private static GuestPageProtection ResolveGuestProtection(int orbisProtection)
+    {
+        var protection = GuestPageProtection.None;
+        if ((orbisProtection & (OrbisProtCpuRead | OrbisProtGpuRead)) != 0)
+        {
+            protection |= GuestPageProtection.Read;
+        }
+
+        if ((orbisProtection & (OrbisProtCpuWrite | OrbisProtGpuWrite)) != 0)
+        {
+            protection |= GuestPageProtection.Write;
+        }
+
+        if ((orbisProtection & OrbisProtCpuExec) != 0)
+        {
+            protection |= GuestPageProtection.Execute;
+        }
+
+        return protection;
+    }
+
     private static bool TryFindVirtualQueryRegionLocked(ulong queryAddress, bool findNext, out MappedRegion region)
     {
         region = default;
@@ -5994,6 +6312,117 @@ public static partial class KernelMemoryCompatExports
         return highWaterMark;
     }
 
+    private static bool TryUnmapReleasedDirectMappingsLocked(
+        CpuContext ctx,
+        ulong releaseStart,
+        ulong releaseEnd)
+    {
+        if (releaseStart >= releaseEnd ||
+            !KernelVirtualRangeAllocator.TryResolveAddressSpace(ctx.Memory, out var addressSpace))
+        {
+            return releaseStart < releaseEnd;
+        }
+
+        var affectedMappings = _mappedRegions.Values
+            .Where(static region => region.IsDirect)
+            .Where(region =>
+                TryAddU64(region.DirectStart, region.Length, out var directEnd) &&
+                releaseEnd > region.DirectStart &&
+                releaseStart < directEnd)
+            .OrderBy(static region => region.Address)
+            .ToArray();
+        foreach (var mapping in affectedMappings)
+        {
+            if (!TryAddU64(mapping.DirectStart, mapping.Length, out var directEnd) ||
+                !addressSpace.TryUnmapDirectMemory(mapping.Address, mapping.Length))
+            {
+                return false;
+            }
+
+            _mappedRegions.Remove(mapping.Address);
+            _mappedRegionNames.Remove(mapping.Address, out var mappingName);
+
+            var overlapStart = Math.Max(releaseStart, mapping.DirectStart);
+            var overlapEnd = Math.Min(releaseEnd, directEnd);
+            if (mapping.DirectStart < overlapStart &&
+                !TryRemapDirectFragmentLocked(
+                    addressSpace,
+                    mapping,
+                    mapping.Address,
+                    mapping.DirectStart,
+                    overlapStart - mapping.DirectStart,
+                    mappingName))
+            {
+                return false;
+            }
+
+            if (overlapEnd < directEnd)
+            {
+                var fragmentAddress = mapping.Address + (overlapEnd - mapping.DirectStart);
+                if (!TryRemapDirectFragmentLocked(
+                        addressSpace,
+                        mapping,
+                        fragmentAddress,
+                        overlapEnd,
+                        directEnd - overlapEnd,
+                        mappingName))
+                {
+                    return false;
+                }
+            }
+
+            if (ShouldTraceDirectMemory())
+            {
+                Console.Error.WriteLine(
+                    $"[LOADER][TRACE] release_direct unmap: phys=0x{overlapStart:X16}-0x{overlapEnd:X16} " +
+                    $"va=0x{mapping.Address:X16} size=0x{mapping.Length:X}");
+            }
+
+            var releasedVirtualAddress = mapping.Address + (overlapStart - mapping.DirectStart);
+            _ = addressSpace.TryUnmapReservedMemory(
+                releasedVirtualAddress,
+                overlapEnd - overlapStart);
+        }
+
+        return true;
+    }
+
+    private static bool TryRemapDirectFragmentLocked(
+        IGuestAddressSpace addressSpace,
+        MappedRegion source,
+        ulong address,
+        ulong directStart,
+        ulong length,
+        string? name)
+    {
+        if (!addressSpace.TryMapDirectMemory(
+                address,
+                length,
+                directStart,
+                DirectMemorySizeBytes,
+                ResolveGuestProtection(source.Protection),
+                OrbisPageSize,
+                allowSearch: false,
+                out var mappedAddress) ||
+            mappedAddress != address)
+        {
+            return false;
+        }
+
+        _mappedRegions[address] = source with
+        {
+            Address = address,
+            Length = length,
+            DirectStart = directStart,
+        };
+        if (name is not null)
+        {
+            _mappedRegionNames[address] = name;
+        }
+
+        return true;
+    }
+
     private static bool TryReadHostMemory(ulong address, Span<byte> destination)
     {
         if (destination.IsEmpty || !IsHostRangeAccessible(address, (ulong)destination.Length, writeAccess: false))
@@ -6039,6 +6468,37 @@ public static partial class KernelMemoryCompatExports
                 }
 
                 return TryReadHostMemory(address, destination);
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool TryWriteTrackedLibcHeap(
+        ulong address,
+        ReadOnlySpan<byte> source)
+    {
+        if (source.IsEmpty)
+        {
+            return true;
+        }
+
+        var length = (ulong)source.Length;
+        lock (_libcAllocGate)
+        {
+            foreach (var (allocationAddress, allocation) in _libcAllocations)
+            {
+                var allocationSize = (ulong)allocation.Size;
+                var offset = address >= allocationAddress
+                    ? address - allocationAddress
+                    : ulong.MaxValue;
+                if (offset > allocationSize ||
+                    length > allocationSize - offset)
+                {
+                    continue;
+                }
+
+                return TryWriteHostMemory(address, source);
             }
         }
 
@@ -6876,6 +7336,26 @@ public static partial class KernelMemoryCompatExports
 
         var mask = alignment - 1;
         return value & ~mask;
+    }
+
+    private static bool IsValidMapAlignment(ulong alignment) =>
+        alignment == 0 ||
+        (alignment & (alignment - 1)) == 0 ||
+        alignment % OrbisPageSize == 0;
+
+    private static bool TryAlignUpToMultiple(
+        ulong value,
+        ulong alignment,
+        out ulong aligned)
+    {
+        var remainder = value % alignment;
+        if (remainder == 0)
+        {
+            aligned = value;
+            return true;
+        }
+
+        return TryAddU64(value, alignment - remainder, out aligned);
     }
 
     private static bool TryAddU64(ulong left, ulong right, out ulong sum)

--- a/src/SharpEmu.Libs/Kernel/KernelPosixSemaphoreCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPosixSemaphoreCompatExports.cs
@@ -1,0 +1,469 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using SharpEmu.HLE;
+
+namespace SharpEmu.Libs.Kernel;
+
+public static class KernelPosixSemaphoreCompatExports
+{
+    private const int ErrnoBusy = 16;
+    private const int ErrnoFault = 14;
+    private const int ErrnoInvalidArgument = 22;
+    private const int ErrnoTryAgain = 35;
+    private const int ErrnoTimedOut = 60;
+    private const int ErrnoOverflow = 84;
+    private const uint SemaphoreValueMax = int.MaxValue;
+
+    private static readonly ConcurrentDictionary<ulong, PosixSemaphoreState> _semaphores = new();
+
+    private sealed class PosixSemaphoreState
+    {
+        public required ulong Address { get; init; }
+        public required string WakeKey { get; init; }
+        public int Count { get; set; }
+        public int WaitingThreads { get; set; }
+        public bool Destroyed { get; set; }
+        public object Gate { get; } = new();
+    }
+
+    private sealed class PosixSemaphoreWaiter : IGuestThreadBlockWaiter
+    {
+        public required CpuContext Context { get; init; }
+        public required PosixSemaphoreState Semaphore { get; init; }
+        public bool Timed { get; init; }
+        public int? Result { get; set; }
+        public int ErrorNumber { get; set; }
+
+        public int Resume() => CompleteBlockedWait(this);
+
+        public bool TryWake() => TryReserveBlockedWait(this);
+    }
+
+    [SysAbiExport(
+        Nid = "pDuPEf3m4fI",
+        ExportName = "sem_init",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixSemaphoreInit(CpuContext ctx)
+    {
+        var semaphoreAddress = ctx[CpuRegister.Rdi];
+        var initialValue = unchecked((uint)ctx[CpuRegister.Rdx]);
+
+        if (semaphoreAddress == 0 || initialValue > SemaphoreValueMax)
+        {
+            return PosixFailure(ctx, ErrnoInvalidArgument);
+        }
+
+        if (!ctx.TryReadUInt32(semaphoreAddress, out _))
+        {
+            return PosixFailure(ctx, ErrnoFault);
+        }
+
+        if (_semaphores.TryGetValue(semaphoreAddress, out var previous))
+        {
+            lock (previous.Gate)
+            {
+                if (!previous.Destroyed && previous.WaitingThreads != 0)
+                {
+                    return PosixFailure(ctx, ErrnoBusy);
+                }
+            }
+        }
+
+        if (!ctx.TryWriteUInt32(semaphoreAddress, initialValue))
+        {
+            return PosixFailure(ctx, ErrnoFault);
+        }
+
+        var state = new PosixSemaphoreState
+        {
+            Address = semaphoreAddress,
+            WakeKey = GetWakeKey(semaphoreAddress),
+            Count = checked((int)initialValue),
+        };
+
+        if (previous is not null)
+        {
+            lock (previous.Gate)
+            {
+                previous.Destroyed = true;
+            }
+        }
+
+        _semaphores[semaphoreAddress] = state;
+        return PosixSuccess(ctx);
+    }
+
+    [SysAbiExport(
+        Nid = "cDW233RAwWo",
+        ExportName = "sem_destroy",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixSemaphoreDestroy(CpuContext ctx)
+    {
+        var semaphoreAddress = ctx[CpuRegister.Rdi];
+        if (!TryGetSemaphore(semaphoreAddress, out var semaphore))
+        {
+            return PosixFailure(ctx, ErrnoInvalidArgument);
+        }
+
+        lock (semaphore.Gate)
+        {
+            if (semaphore.Destroyed)
+            {
+                return PosixFailure(ctx, ErrnoInvalidArgument);
+            }
+
+            if (semaphore.WaitingThreads != 0)
+            {
+                return PosixFailure(ctx, ErrnoBusy);
+            }
+
+            semaphore.Destroyed = true;
+        }
+
+        _semaphores.TryRemove(new KeyValuePair<ulong, PosixSemaphoreState>(semaphoreAddress, semaphore));
+        _ = ctx.TryWriteUInt32(semaphoreAddress, 0);
+        return PosixSuccess(ctx);
+    }
+
+    [SysAbiExport(
+        Nid = "YCV5dGGBcCo",
+        ExportName = "sem_wait",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixSemaphoreWait(CpuContext ctx) =>
+        WaitCore(ctx, timed: false, deadlineTimestamp: 0);
+
+    [SysAbiExport(
+        Nid = "WBWzsRifCEA",
+        ExportName = "sem_trywait",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixSemaphoreTryWait(CpuContext ctx)
+    {
+        var semaphoreAddress = ctx[CpuRegister.Rdi];
+        if (!TryGetSemaphore(semaphoreAddress, out var semaphore))
+        {
+            return PosixFailure(ctx, ErrnoInvalidArgument);
+        }
+
+        lock (semaphore.Gate)
+        {
+            if (semaphore.Destroyed)
+            {
+                return PosixFailure(ctx, ErrnoInvalidArgument);
+            }
+
+            if (semaphore.Count == 0)
+            {
+                return PosixFailure(ctx, ErrnoTryAgain);
+            }
+
+            semaphore.Count--;
+            SyncGuestCount(ctx, semaphore);
+        }
+
+        return PosixSuccess(ctx);
+    }
+
+    [SysAbiExport(
+        Nid = "w5IHyvahg-o",
+        ExportName = "sem_timedwait",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixSemaphoreTimedWait(CpuContext ctx)
+    {
+        var timeoutAddress = ctx[CpuRegister.Rsi];
+        Span<byte> timeout = stackalloc byte[sizeof(long) * 2];
+        if (timeoutAddress == 0 || !ctx.Memory.TryRead(timeoutAddress, timeout))
+        {
+            return PosixFailure(ctx, ErrnoFault);
+        }
+
+        var seconds = BinaryPrimitives.ReadInt64LittleEndian(timeout);
+        var nanoseconds = BinaryPrimitives.ReadInt64LittleEndian(timeout[sizeof(long)..]);
+        if (nanoseconds < 0 || nanoseconds >= 1_000_000_000L)
+        {
+            return PosixFailure(ctx, ErrnoInvalidArgument);
+        }
+
+        var deadlineTimestamp = ComputeRealtimeDeadline(seconds, nanoseconds, out var expired);
+        if (expired)
+        {
+            var semaphoreAddress = ctx[CpuRegister.Rdi];
+            if (!TryGetSemaphore(semaphoreAddress, out var semaphore))
+            {
+                return PosixFailure(ctx, ErrnoInvalidArgument);
+            }
+
+            lock (semaphore.Gate)
+            {
+                if (semaphore.Destroyed)
+                {
+                    return PosixFailure(ctx, ErrnoInvalidArgument);
+                }
+
+                if (semaphore.Count == 0)
+                {
+                    return PosixFailure(ctx, ErrnoTimedOut);
+                }
+
+                semaphore.Count--;
+                SyncGuestCount(ctx, semaphore);
+                return PosixSuccess(ctx);
+            }
+        }
+
+        return WaitCore(ctx, timed: true, deadlineTimestamp);
+    }
+
+    [SysAbiExport(
+        Nid = "IKP8typ0QUk",
+        ExportName = "sem_post",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixSemaphorePost(CpuContext ctx)
+    {
+        var semaphoreAddress = ctx[CpuRegister.Rdi];
+        if (!TryGetSemaphore(semaphoreAddress, out var semaphore))
+        {
+            return PosixFailure(ctx, ErrnoInvalidArgument);
+        }
+
+        lock (semaphore.Gate)
+        {
+            if (semaphore.Destroyed)
+            {
+                return PosixFailure(ctx, ErrnoInvalidArgument);
+            }
+
+            if (semaphore.Count == SemaphoreValueMax)
+            {
+                return PosixFailure(ctx, ErrnoOverflow);
+            }
+
+            semaphore.Count++;
+            SyncGuestCount(ctx, semaphore);
+        }
+
+        _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(semaphore.WakeKey, maxCount: 1);
+        return PosixSuccess(ctx);
+    }
+
+    [SysAbiExport(
+        Nid = "Bq+LRV-N6Hk",
+        ExportName = "sem_getvalue",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixSemaphoreGetValue(CpuContext ctx)
+    {
+        var semaphoreAddress = ctx[CpuRegister.Rdi];
+        var valueAddress = ctx[CpuRegister.Rsi];
+        if (valueAddress == 0)
+        {
+            return PosixFailure(ctx, ErrnoFault);
+        }
+
+        if (!TryGetSemaphore(semaphoreAddress, out var semaphore))
+        {
+            return PosixFailure(ctx, ErrnoInvalidArgument);
+        }
+
+        int value;
+        lock (semaphore.Gate)
+        {
+            if (semaphore.Destroyed)
+            {
+                return PosixFailure(ctx, ErrnoInvalidArgument);
+            }
+
+            value = semaphore.Count;
+        }
+
+        if (!ctx.TryWriteInt32(valueAddress, value))
+        {
+            return PosixFailure(ctx, ErrnoFault);
+        }
+
+        return PosixSuccess(ctx);
+    }
+
+    internal static void ResetForTests()
+    {
+        foreach (var semaphore in _semaphores.Values)
+        {
+            lock (semaphore.Gate)
+            {
+                semaphore.Destroyed = true;
+            }
+        }
+
+        _semaphores.Clear();
+    }
+
+    private static int WaitCore(CpuContext ctx, bool timed, long deadlineTimestamp)
+    {
+        var semaphoreAddress = ctx[CpuRegister.Rdi];
+        if (!TryGetSemaphore(semaphoreAddress, out var semaphore))
+        {
+            return PosixFailure(ctx, ErrnoInvalidArgument);
+        }
+
+        lock (semaphore.Gate)
+        {
+            if (semaphore.Destroyed)
+            {
+                return PosixFailure(ctx, ErrnoInvalidArgument);
+            }
+
+            if (semaphore.Count != 0)
+            {
+                semaphore.Count--;
+                SyncGuestCount(ctx, semaphore);
+                return PosixSuccess(ctx);
+            }
+
+            var waiter = new PosixSemaphoreWaiter
+            {
+                Context = ctx,
+                Semaphore = semaphore,
+                Timed = timed,
+            };
+            if (GuestThreadExecution.RequestCurrentThreadBlock(
+                    ctx,
+                    timed ? "sem_timedwait" : "sem_wait",
+                    semaphore.WakeKey,
+                    waiter,
+                    blockDeadlineTimestamp: deadlineTimestamp))
+            {
+                semaphore.WaitingThreads++;
+                return PosixSuccess(ctx);
+            }
+        }
+
+        return PosixFailure(ctx, timed ? ErrnoTimedOut : ErrnoTryAgain);
+    }
+
+    private static bool TryReserveBlockedWait(PosixSemaphoreWaiter waiter)
+    {
+        var semaphore = waiter.Semaphore;
+        lock (semaphore.Gate)
+        {
+            if (waiter.Result.HasValue)
+            {
+                return true;
+            }
+
+            if (semaphore.Destroyed)
+            {
+                waiter.Result = -1;
+                waiter.ErrorNumber = ErrnoInvalidArgument;
+            }
+            else if (semaphore.Count != 0)
+            {
+                semaphore.Count--;
+                waiter.Result = 0;
+                SyncGuestCount(waiter.Context, semaphore);
+            }
+            else
+            {
+                return false;
+            }
+
+            semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
+            return true;
+        }
+    }
+
+    private static int CompleteBlockedWait(PosixSemaphoreWaiter waiter)
+    {
+        var semaphore = waiter.Semaphore;
+        lock (semaphore.Gate)
+        {
+            if (!waiter.Result.HasValue)
+            {
+                if (!semaphore.Destroyed && semaphore.Count != 0)
+                {
+                    semaphore.Count--;
+                    waiter.Result = 0;
+                    SyncGuestCount(waiter.Context, semaphore);
+                }
+                else
+                {
+                    waiter.Result = -1;
+                    waiter.ErrorNumber = semaphore.Destroyed
+                        ? ErrnoInvalidArgument
+                        : waiter.Timed
+                            ? ErrnoTimedOut
+                            : ErrnoTryAgain;
+                }
+
+                semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
+            }
+        }
+
+        if (waiter.Result.Value == -1)
+        {
+            _ = KernelRuntimeCompatExports.TrySetErrno(waiter.Context, waiter.ErrorNumber);
+        }
+
+        return waiter.Result.Value;
+    }
+
+    private static long ComputeRealtimeDeadline(long seconds, long nanoseconds, out bool expired)
+    {
+        KernelRuntimeCompatExports.ResolveClockTime(
+            KernelRuntimeCompatExports.ClockRealtime,
+            out var nowSeconds,
+            out var nowNanoseconds);
+
+        var totalSeconds = (double)seconds - nowSeconds +
+            ((double)nanoseconds - nowNanoseconds) / 1_000_000_000d;
+        if (totalSeconds <= 0)
+        {
+            expired = true;
+            return Stopwatch.GetTimestamp();
+        }
+
+        expired = false;
+        var timeout = totalSeconds >= TimeSpan.MaxValue.TotalSeconds
+            ? TimeSpan.MaxValue
+            : TimeSpan.FromSeconds(totalSeconds);
+        return GuestThreadExecution.ComputeDeadlineTimestamp(timeout);
+    }
+
+    private static bool TryGetSemaphore(ulong address, out PosixSemaphoreState semaphore)
+    {
+        if (address != 0 && _semaphores.TryGetValue(address, out var found))
+        {
+            semaphore = found;
+            return true;
+        }
+
+        semaphore = null!;
+        return false;
+    }
+
+    private static void SyncGuestCount(CpuContext ctx, PosixSemaphoreState semaphore) =>
+        _ = ctx.TryWriteUInt32(semaphore.Address, unchecked((uint)semaphore.Count));
+
+    private static string GetWakeKey(ulong address) => $"posix_sem:0x{address:X16}";
+
+    private static int PosixSuccess(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    private static int PosixFailure(CpuContext ctx, int errorNumber)
+    {
+        _ = KernelRuntimeCompatExports.TrySetErrno(ctx, errorNumber);
+        ctx[CpuRegister.Rax] = ulong.MaxValue;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+}

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -309,6 +309,49 @@ public static class KernelPthreadCompatExports
         LibraryName = "libKernel")]
     public static int PosixPthreadMutexattrSetprotocol(CpuContext ctx) => PthreadMutexattrSetprotocolCore(ctx, ctx[CpuRegister.Rdi], unchecked((int)ctx[CpuRegister.Rsi]));
 
+    // Cond attrs are accepted but ignored: PthreadCondInitCore never reads the
+    // attr argument, so init just writes a nonzero opaque handle.
+    [SysAbiExport(
+        Nid = "mKoTx03HRWA",
+        ExportName = "pthread_condattr_init",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixPthreadCondattrInit(CpuContext ctx)
+    {
+        var attrAddress = ctx[CpuRegister.Rdi];
+        if (attrAddress == 0)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (!KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, attrAddress, 1))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "dJcuQVn6-Iw",
+        ExportName = "pthread_condattr_destroy",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixPthreadCondattrDestroy(CpuContext ctx) =>
+        ctx[CpuRegister.Rdi] == 0
+            ? (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT
+            : (int)OrbisGen2Result.ORBIS_GEN2_OK;
+
+    [SysAbiExport(
+        Nid = "EjllaAqAPZo",
+        ExportName = "pthread_condattr_setclock",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixPthreadCondattrSetclock(CpuContext ctx) =>
+        ctx[CpuRegister.Rdi] == 0
+            ? (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT
+            : (int)OrbisGen2Result.ORBIS_GEN2_OK;
+
     [SysAbiExport(
         Nid = "2Tb92quprl0",
         ExportName = "scePthreadCondInit",
@@ -571,6 +614,13 @@ public static class KernelPthreadCompatExports
         return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
+    [SysAbiExport(
+        Nid = "Z4QosVuAsA0",
+        ExportName = "pthread_once",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixPthreadOnce(CpuContext ctx) => PthreadOnce(ctx);
+
     private static int PthreadMutexInitCore(CpuContext ctx, ulong mutexAddress, ulong attrAddress)
     {
         if (mutexAddress == 0)
@@ -591,6 +641,7 @@ public static class KernelPthreadCompatExports
         }
         if (!InitializeMutexObject(ctx, handle, state))
         {
+            TryFreeOpaqueObject(ctx, handle);
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
@@ -602,6 +653,7 @@ public static class KernelPthreadCompatExports
             _mutexStates.TryRemove(mutexAddress, out _);
             _mutexStates.TryRemove(handle, out _);
 
+            TryFreeOpaqueObject(ctx, handle);
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
@@ -636,6 +688,7 @@ public static class KernelPthreadCompatExports
         }
 
         _ = KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, mutexAddress, 0);
+        TryFreeOpaqueObject(ctx, resolvedAddress);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -794,6 +847,7 @@ public static class KernelPthreadCompatExports
         var initialState = new PthreadMutexAttrState(MutexTypeErrorCheck, 0);
         if (!WriteMutexAttrObject(ctx, handle, initialState))
         {
+            TryFreeOpaqueObject(ctx, handle);
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
@@ -811,6 +865,7 @@ public static class KernelPthreadCompatExports
                 _mutexAttrStates.Remove(handle);
             }
 
+            TryFreeOpaqueObject(ctx, handle);
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
@@ -834,6 +889,8 @@ public static class KernelPthreadCompatExports
             }
         }
 
+        _ = KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, attrAddress, 0);
+        TryFreeOpaqueObject(ctx, resolvedAddress);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -902,17 +959,21 @@ public static class KernelPthreadCompatExports
             return 0;
         }
 
-        if (_mutexStates.ContainsKey(mutexAddress))
-        {
-            return mutexAddress;
-        }
-
+        // Init indexes the same state by both the public pthread object address
+        // and its allocated opaque handle. Destruction must prefer the pointer
+        // stored in the public object so it removes and frees the allocation;
+        // returning the public key first leaks one opaque object per lifecycle.
         if (KernelMemoryCompatExports.TryReadUInt64Compat(ctx, mutexAddress, out var pointedHandle) && pointedHandle != 0)
         {
             if (_mutexStates.ContainsKey(pointedHandle))
             {
                 return pointedHandle;
             }
+        }
+
+        if (_mutexStates.ContainsKey(mutexAddress))
+        {
+            return mutexAddress;
         }
 
         return mutexAddress;
@@ -1017,14 +1078,9 @@ public static class KernelPthreadCompatExports
             return 0;
         }
 
-        lock (_stateGate)
-        {
-            if (_condStates.ContainsKey(condAddress))
-            {
-                return condAddress;
-            }
-        }
-
+        // As with mutexes, prefer the stored opaque handle so destroy returns
+        // the allocator-owned address rather than attempting to free the public
+        // pthread_cond_t slot.
         if (KernelMemoryCompatExports.TryReadUInt64Compat(ctx, condAddress, out var pointedHandle) && pointedHandle != 0)
         {
             lock (_stateGate)
@@ -1033,6 +1089,14 @@ public static class KernelPthreadCompatExports
                 {
                     return pointedHandle;
                 }
+            }
+        }
+
+        lock (_stateGate)
+        {
+            if (_condStates.ContainsKey(condAddress))
+            {
+                return condAddress;
             }
         }
 
@@ -1104,6 +1168,7 @@ public static class KernelPthreadCompatExports
                 _condStates.Remove(handle);
             }
 
+            TryFreeOpaqueObject(ctx, handle);
             return false;
         }
 
@@ -1123,7 +1188,22 @@ public static class KernelPthreadCompatExports
 
         Span<byte> initialData = stackalloc byte[size];
         initialData.Clear();
-        return ctx.Memory.TryWrite(address, initialData);
+        if (ctx.Memory.TryWrite(address, initialData))
+        {
+            return true;
+        }
+
+        allocator.TryFreeGuestMemory(address);
+        address = 0;
+        return false;
+    }
+
+    private static void TryFreeOpaqueObject(CpuContext ctx, ulong address)
+    {
+        if (ctx.Memory is IGuestMemoryAllocator allocator)
+        {
+            allocator.TryFreeGuestMemory(address);
+        }
     }
 
     private static bool InitializeMutexObject(CpuContext ctx, ulong address, PthreadMutexState state) =>
@@ -1168,6 +1248,7 @@ public static class KernelPthreadCompatExports
                 _condStates.Remove(handle);
             }
 
+            TryFreeOpaqueObject(ctx, handle);
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
@@ -1205,6 +1286,7 @@ public static class KernelPthreadCompatExports
         }
 
         _ = KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, condAddress, 0);
+        TryFreeOpaqueObject(ctx, resolvedAddress);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -1708,6 +1790,7 @@ public static class KernelPthreadCompatExports
         }
         if (!InitializeMutexObject(ctx, handle, createdState))
         {
+            TryFreeOpaqueObject(ctx, handle);
             resolvedAddress = 0;
             state = null;
             return false;
@@ -1736,6 +1819,7 @@ public static class KernelPthreadCompatExports
             _mutexStates.TryRemove(mutexAddress, out _);
             _mutexStates.TryRemove(handle, out _);
 
+            TryFreeOpaqueObject(ctx, handle);
             resolvedAddress = 0;
             state = null;
             return false;

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
@@ -554,10 +554,10 @@ public static class KernelPthreadExtendedCompatExports
 				TryInferNativeGuestStack(ctx[CpuRegister.Rsp], out var stackAddress))
 			{
 				threadState.Attributes = threadState.Attributes with
-				{
-					StackAddress = stackAddress,
-					StackSize = NativeGuestStackSize,
-				};
+					{
+						StackAddress = stackAddress,
+						StackSize = NativeGuestStackSize,
+					};
 			}
             _attrStates[outAttrAddress] = threadState.Attributes;
         }
@@ -1134,6 +1134,65 @@ public static class KernelPthreadExtendedCompatExports
     public static int PosixPthreadRwlockWrlock(CpuContext ctx) => PthreadRwlockWrlock(ctx);
 
     [SysAbiExport(
+        Nid = "bIHoZCTomsI",
+        ExportName = "scePthreadRwlockTrywrlock",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PthreadRwlockTrywrlock(CpuContext ctx)
+        => PthreadRwlockTryWrlockCore(ctx, ctx[CpuRegister.Rdi]);
+
+    // Non-blocking write acquire. The blocking wrlock path (PthreadRwlockLockCore)
+    // parks the caller on contention; a try-lock must never block, so this
+    // acquires only when the lock is free and returns EBUSY otherwise. Some
+    // guests spin while trywrlock returns busy, so an unimplemented export
+    // returning the error sentinel would leave that loop permanently stuck.
+    private static int PthreadRwlockTryWrlockCore(CpuContext ctx, ulong rwlockAddress)
+    {
+        if (rwlockAddress == 0)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (!TryResolveRwlockState(ctx, rwlockAddress, createIfZero: true, out _, out var rwlock))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+        }
+
+        var currentThreadId = KernelPthreadState.GetCurrentThreadHandle();
+        lock (rwlock.SyncRoot)
+        {
+            if (rwlock.WriterThreadId == currentThreadId || rwlock.GetReaderCount(currentThreadId) > 0)
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_DEADLOCK;
+            }
+
+            if (rwlock.CompatWriterCounts.GetValueOrDefault(currentThreadId) > 0)
+            {
+                rwlock.AddCompatWriter(currentThreadId);
+                return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+            }
+
+            if (rwlock.WriterThreadId == 0 &&
+                rwlock.ReaderTotalCount == 0 &&
+                rwlock.CompatWriterTotalCount == 0)
+            {
+                if (GuestThreadExecution.IsGuestThread && !_strictRwlockWriterPreference)
+                {
+                    rwlock.AddCompatWriter(currentThreadId);
+                }
+                else
+                {
+                    rwlock.WriterThreadId = currentThreadId;
+                }
+
+                return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+            }
+
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY;
+        }
+    }
+
+    [SysAbiExport(
         Nid = "+L98PIbGttk",
         ExportName = "scePthreadRwlockUnlock",
         Target = Generation.Gen4 | Generation.Gen5,
@@ -1634,14 +1693,9 @@ public static class KernelPthreadExtendedCompatExports
             return 0;
         }
 
-        lock (_stateGate)
-        {
-            if (_rwlockStates.ContainsKey(rwlockAddress))
-            {
-                return rwlockAddress;
-            }
-        }
-
+        // Init indexes the same state by both the public pthread object and its
+        // synthetic handle. Prefer the value stored in the public object so a
+        // destroy/re-init removes the handle entry as well as the public alias.
         if (KernelMemoryCompatExports.TryReadUInt64Compat(ctx, rwlockAddress, out var pointedHandle) && pointedHandle != 0)
         {
             lock (_stateGate)
@@ -1650,6 +1704,14 @@ public static class KernelPthreadExtendedCompatExports
                 {
                     return pointedHandle;
                 }
+            }
+        }
+
+        lock (_stateGate)
+        {
+            if (_rwlockStates.ContainsKey(rwlockAddress))
+            {
+                return rwlockAddress;
             }
         }
 
@@ -1701,17 +1763,30 @@ public static class KernelPthreadExtendedCompatExports
             return false;
         }
 
-        var createdRwlock = new PthreadRwlockState();
-        var syntheticHandle = AllocateSyntheticHandle(SyntheticRwlockHandleBase, ref _nextSyntheticRwlockHandleId);
+        // Publish a lazy rwlock and its guest-visible handle as one operation.
+        // Previously two callers could both observe a zero slot, create distinct
+        // host states, and then acquire both "locks" concurrently.
         lock (_stateGate)
         {
+            if (_rwlockStates.TryGetValue(rwlockAddress, out rwlock))
+            {
+                resolvedAddress = rwlockAddress;
+                return true;
+            }
+
+            var createdRwlock = new PthreadRwlockState();
+            var syntheticHandle = AllocateSyntheticHandle(SyntheticRwlockHandleBase, ref _nextSyntheticRwlockHandleId);
+            if (!KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, rwlockAddress, syntheticHandle))
+            {
+                return false;
+            }
+
             _rwlockStates[rwlockAddress] = createdRwlock;
             _rwlockStates[syntheticHandle] = createdRwlock;
+            resolvedAddress = syntheticHandle;
+            rwlock = createdRwlock;
         }
 
-        _ = KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, rwlockAddress, syntheticHandle);
-        resolvedAddress = syntheticHandle;
-        rwlock = createdRwlock;
         return true;
     }
 

--- a/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
@@ -17,6 +17,20 @@ namespace SharpEmu.Libs.Kernel;
 
 public static class KernelRuntimeCompatExports
 {
+    internal const int ClockRealtime = 0;
+    internal const int ClockVirtual = 1;
+    internal const int ClockProf = 2;
+    internal const int ClockMonotonic = 4;
+    internal const int ClockUptime = 5;
+    internal const int ClockUptimePrecise = 7;
+    internal const int ClockUptimeFast = 8;
+    internal const int ClockRealtimePrecise = 9;
+    internal const int ClockRealtimeFast = 10;
+    internal const int ClockMonotonicPrecise = 11;
+    internal const int ClockMonotonicFast = 12;
+    internal const int ClockSecond = 13;
+    internal const int ClockThreadCputimeId = 14;
+    internal const int ClockProcTime = 15;
     private const ulong TlsErrnoOffset = 0x40;
     private const ulong TlsStackChkGuardBaseOffset = 0x800;
     private const ulong StackChkGuardFieldOffset = 0x10;
@@ -38,6 +52,11 @@ public static class KernelRuntimeCompatExports
     private const ulong ModuleInfoExSegmentsOffset = 0x160;
     private const ulong ModuleInfoExSegmentCountOffset = 0x1A0;
     private const int ModuleInfoSegmentSize = 16;
+    private const int UnwindInfoSize = 0x130;
+    private const int UnwindInfoNameOffset = 0x8;
+    private const int UnwindInfoNameMaxBytes = 256;
+    private const uint ElfPtLoad = 1;
+    private const uint ElfPtGnuEhFrame = 0x6474E550;
     private const ulong DefaultKernelTscFrequency = 10_000_000UL;
     private const ulong PrtAreaStartAddress = 0x0000001000000000UL;
     private const ulong PrtAreaSize = 0x000000EC00000000UL;
@@ -62,6 +81,8 @@ public static class KernelRuntimeCompatExports
     private static readonly List<ReleasedVirtualRange> _releasedVirtualRanges = new();
     private static uint _gpoStateBits;
     private static readonly HashSet<int> _loadedSysmodules = new();
+    private static readonly object _moduleUnwindGate = new();
+    private static readonly Dictionary<int, ModuleUnwindInfo?> _moduleUnwindCache = new();
     private static readonly object _prtApertureGate = new();
     private static readonly (ulong Base, ulong Size)[] _prtApertures = new (ulong Base, ulong Size)[3];
     private static int _stackChkFailCount;
@@ -204,29 +225,9 @@ public static class KernelRuntimeCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
-        long seconds;
-        long nanoseconds;
-        if (clockId == 0)
+        if (!ResolveClockTime(clockId, out var seconds, out var nanoseconds))
         {
-            var now = DateTimeOffset.UtcNow;
-            seconds = now.ToUnixTimeSeconds();
-            nanoseconds = (now.Ticks % TimeSpan.TicksPerSecond) * 100;
-        }
-        else
-        {
-            var elapsedTicks = Stopwatch.GetTimestamp() - _processStartCounter;
-            if (_stopwatchTicksAreNanoseconds)
-            {
-                // Constant divisors let the JIT strength-reduce the division;
-                // games call this thousands of times per second.
-                seconds = elapsedTicks / 1_000_000_000L;
-                nanoseconds = elapsedTicks - seconds * 1_000_000_000L;
-            }
-            else
-            {
-                seconds = elapsedTicks / Stopwatch.Frequency;
-                nanoseconds = (elapsedTicks % Stopwatch.Frequency) * 1_000_000_000L / Stopwatch.Frequency;
-            }
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
         if (!ctx.TryWriteUInt64(timeAddress, unchecked((ulong)seconds)) ||
@@ -647,6 +648,66 @@ public static class KernelRuntimeCompatExports
         return address != 0 && TryWriteInt32(ctx, address, value);
     }
 
+    internal static bool ResolveClockTime(
+        int clockId,
+        out long seconds,
+        out long nanoseconds)
+    {
+        switch (clockId)
+        {
+            case ClockRealtime:
+            case ClockRealtimePrecise:
+            case ClockRealtimeFast:
+            case ClockVirtual:
+            case ClockProf:
+            {
+                var now = DateTimeOffset.UtcNow;
+                seconds = now.ToUnixTimeSeconds();
+                nanoseconds = (now.Ticks % TimeSpan.TicksPerSecond) * 100;
+                return true;
+            }
+
+            case ClockSecond:
+                seconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                nanoseconds = 0;
+                return true;
+
+            case ClockMonotonic:
+            case ClockMonotonicPrecise:
+            case ClockMonotonicFast:
+            case ClockUptime:
+            case ClockUptimePrecise:
+            case ClockUptimeFast:
+            case ClockThreadCputimeId:
+            case ClockProcTime:
+                GetProcessMonotonicTime(out seconds, out nanoseconds);
+                return true;
+
+            default:
+                seconds = 0;
+                nanoseconds = 0;
+                return false;
+        }
+    }
+
+    internal static void GetProcessMonotonicTime(
+        out long seconds,
+        out long nanoseconds)
+    {
+        var elapsedTicks = Stopwatch.GetTimestamp() - _processStartCounter;
+        if (_stopwatchTicksAreNanoseconds)
+        {
+            seconds = elapsedTicks / 1_000_000_000L;
+            nanoseconds = elapsedTicks - seconds * 1_000_000_000L;
+            return;
+        }
+
+        seconds = elapsedTicks / Stopwatch.Frequency;
+        nanoseconds =
+            (elapsedTicks % Stopwatch.Frequency) * 1_000_000_000L /
+            Stopwatch.Frequency;
+    }
+
     [SysAbiExport(
         Nid = "bnZxYgAFeA0",
         ExportName = "sceKernelGetSanitizerNewReplaceExternal",
@@ -760,19 +821,23 @@ public static class KernelRuntimeCompatExports
                 : AlignUp(_nextReservedVirtualBase, effectiveAlignment);
         }
 
+        // MAP_FIXED replaces an existing mapping. Remove direct-memory views
+        // first; their containing reservation remains in place and can be
+        // reused as the new reserved range.
+        if (fixedMapping &&
+            requestedAddress != 0 &&
+            KernelVirtualRangeAllocator.TryResolveAddressSpace(ctx.Memory, out var addressSpace))
+        {
+            _ = addressSpace.TryUnmapDirectMemoryRange(requestedAddress, length);
+        }
+
         ulong releasedAddress = 0;
         var reusedReleasedRange = !fixedMapping && requestedAddress == 0 &&
             TryTakeReleasedVirtualRange(length, effectiveAlignment, out releasedAddress);
-        var alreadyBacked = fixedMapping && requestedAddress != 0 &&
-            KernelMemoryCompatExports.IsGuestRangeBacked(ctx, requestedAddress, length);
         ulong mappedAddress;
         if (reusedReleasedRange)
         {
             mappedAddress = releasedAddress;
-        }
-        else if (alreadyBacked)
-        {
-            mappedAddress = requestedAddress;
         }
         else if (!TryReserveVirtualRange(
                      ctx,
@@ -788,7 +853,7 @@ public static class KernelRuntimeCompatExports
         if (ShouldTraceVirtualMemory())
         {
             Console.Error.WriteLine(
-                $"[LOADER][TRACE] reserve_virtual_range: req=0x{requestedAddress:X16} desired=0x{desiredAddress:X16} mapped=0x{mappedAddress:X16} len=0x{length:X16} flags=0x{flags:X8} align=0x{effectiveAlignment:X16} already_backed={alreadyBacked} reused={reusedReleasedRange}");
+                $"[LOADER][TRACE] reserve_virtual_range: req=0x{requestedAddress:X16} desired=0x{desiredAddress:X16} mapped=0x{mappedAddress:X16} len=0x{length:X16} flags=0x{flags:X8} align=0x{effectiveAlignment:X16} reused={reusedReleasedRange}");
         }
 
         if (!ctx.TryWriteUInt64(inOutAddressPointer, mappedAddress))
@@ -978,10 +1043,20 @@ public static class KernelRuntimeCompatExports
         LibraryName = "libKernel")]
     public static int KernelGetModuleInfoForUnwind(CpuContext ctx)
     {
+        // Sony's libunwind calls this on every C++ throw and trusts the eh_frame fields;
+        // returning success without filling them makes _Unwind_RaiseException dereference
+        // stack garbage and abort the process.
         var queriedAddress = ctx[CpuRegister.Rdi];
         var flags = unchecked((int)ctx[CpuRegister.Rsi]);
         var outInfoAddress = ctx[CpuRegister.Rdx];
         if (outInfoAddress == 0)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        if (flags >= 3 ||
+            !ctx.TryReadUInt64(outInfoAddress, out var callerStructSize) ||
+            callerStructSize < UnwindInfoSize)
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
@@ -993,7 +1068,9 @@ public static class KernelRuntimeCompatExports
 
         if (!ctx.TryReadUInt64(outInfoAddress, out var callerSize))
         {
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+            // Fail cleanly so the unwinder gives up on this frame; success with zeroed
+            // eh_frame fields would send it dereferencing address zero instead.
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
         }
 
         if (callerSize < 0x130)
@@ -1523,6 +1600,68 @@ public static class KernelRuntimeCompatExports
     }
 
     [SysAbiExport(
+        Nid = "tU5e3f9gSiU",
+        ExportName = "sceKernelIsTrinityMode",
+        Target = Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelIsTrinityMode(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "YFC3dBBipj8",
+        ExportName = "sceKernelWriteThrottlingStatus",
+        Target = Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelWriteThrottlingStatus(CpuContext ctx)
+    {
+        var outStatusAddress = ctx[CpuRegister.Rdi];
+        if (outStatusAddress == 0)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        // Callers scale the first qword by <<16 and classify it against write-bandwidth
+        // tiers topping out at 0x4AF00001; 0x4B00 << 16 lands in the unthrottled tier.
+        if (!ctx.TryWriteUInt64(outStatusAddress, 0x4B00))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "PI7jIZj4pcE",
+        ExportName = "sceRandomGetRandomNumber",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceRandom")]
+    public static int RandomGetRandomNumber(CpuContext ctx)
+    {
+        const int maxSize = 64;
+        var bufferAddress = ctx[CpuRegister.Rdi];
+        var size = ctx[CpuRegister.Rsi];
+        if (bufferAddress == 0 || size > maxSize)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        Span<byte> random = stackalloc byte[maxSize];
+        var payload = random[..(int)size];
+        RandomNumberGenerator.Fill(payload);
+        if (!ctx.Memory.TryWrite(bufferAddress, payload))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
         Nid = "Xjoosiw+XPI",
         ExportName = "sceKernelUuidCreate",
         Target = Generation.Gen4 | Generation.Gen5,
@@ -1732,6 +1871,179 @@ public static class KernelRuntimeCompatExports
         // Loaded modules are represented as a single aggregate readable and
         // executable range until per-program-header registry data is exposed.
         BinaryPrimitives.WriteInt32LittleEndian(payload.Slice(offset + 12), 5);
+    }
+
+    private sealed record ModuleUnwindInfo(
+        ulong EhFrameHdrOffset,
+        ulong EhFrameOffset,
+        ulong EhFrameSize,
+        ulong Segment0Offset,
+        ulong Segment0Size);
+
+    private static ModuleUnwindInfo? GetOrLoadModuleUnwindInfo(
+        CpuContext ctx,
+        KernelModuleRegistry.ModuleEntry module)
+    {
+        lock (_moduleUnwindGate)
+        {
+            if (_moduleUnwindCache.TryGetValue(module.Handle, out var cached))
+            {
+                return cached;
+            }
+        }
+
+        var info = LoadModuleUnwindInfo(ctx, module);
+        lock (_moduleUnwindGate)
+        {
+            _moduleUnwindCache[module.Handle] = info;
+        }
+
+        return info;
+    }
+
+    private static ModuleUnwindInfo? LoadModuleUnwindInfo(
+        CpuContext ctx,
+        KernelModuleRegistry.ModuleEntry module)
+    {
+        // ELF headers are not mapped into guest memory, so segment layout comes from the
+        // module's file on disk; the eh_frame_hdr contents themselves live inside a
+        // PT_LOAD and are read back from guest memory.
+        if (!TryReadProgramHeaders(module.Path, out var programHeaders))
+        {
+            return null;
+        }
+
+        var hasLoad = false;
+        var hasEhFrameHdr = false;
+        ulong segment0Offset = 0;
+        ulong segment0Size = 0;
+        ulong ehFrameHdrOffset = 0;
+        foreach (var (type, virtualAddress, memorySize) in programHeaders)
+        {
+            if (type == ElfPtLoad && !hasLoad)
+            {
+                segment0Offset = virtualAddress;
+                segment0Size = memorySize;
+                hasLoad = true;
+            }
+            else if (type == ElfPtGnuEhFrame)
+            {
+                ehFrameHdrOffset = virtualAddress;
+                hasEhFrameHdr = true;
+            }
+        }
+
+        if (!hasLoad ||
+            !hasEhFrameHdr ||
+            !TryDecodeEhFrameHdrPointer(ctx, module.BaseAddress + ehFrameHdrOffset, out var ehFrameAddress) ||
+            ehFrameAddress < module.BaseAddress ||
+            ehFrameAddress >= module.EndAddress)
+        {
+            return null;
+        }
+
+        // .eh_frame either directly precedes .eh_frame_hdr or fills the rest of the
+        // mapped image behind it; an over-estimated size is fine for FDE lookups.
+        var ehFrameOffset = ehFrameAddress - module.BaseAddress;
+        var moduleSize = module.EndAddress - module.BaseAddress;
+        var ehFrameSize = ehFrameHdrOffset > ehFrameOffset
+            ? ehFrameHdrOffset - ehFrameOffset
+            : moduleSize - ehFrameHdrOffset;
+        return new ModuleUnwindInfo(ehFrameHdrOffset, ehFrameOffset, ehFrameSize, segment0Offset, segment0Size);
+    }
+
+    private static bool TryReadProgramHeaders(
+        string modulePath,
+        out List<(uint Type, ulong VirtualAddress, ulong MemorySize)> programHeaders)
+    {
+        programHeaders = new();
+        try
+        {
+            if (string.IsNullOrEmpty(modulePath) || !File.Exists(modulePath))
+            {
+                return false;
+            }
+
+            using var stream = File.OpenRead(modulePath);
+            // The ELF header and program header table are stored in plaintext even inside
+            // SELF containers, directly after the SELF entry table.
+            var probe = new byte[0x10000];
+            var probeLength = stream.Read(probe, 0, probe.Length);
+            var elfOffset = probe.AsSpan(0, probeLength).IndexOf("\u007FELF"u8);
+            if (elfOffset < 0 ||
+                probeLength < elfOffset + 0x40 ||
+                probe[elfOffset + 4] != 2) // ELFCLASS64
+            {
+                return false;
+            }
+
+            var header = probe.AsSpan(elfOffset, 0x40);
+            var phdrTableOffset = BinaryPrimitives.ReadUInt64LittleEndian(header[0x20..]);
+            var phdrEntrySize = BinaryPrimitives.ReadUInt16LittleEndian(header[0x36..]);
+            var phdrCount = BinaryPrimitives.ReadUInt16LittleEndian(header[0x38..]);
+            if (phdrEntrySize < 0x38 || phdrCount == 0 || phdrCount > 128)
+            {
+                return false;
+            }
+
+            var table = new byte[phdrCount * phdrEntrySize];
+            stream.Position = elfOffset + (long)phdrTableOffset;
+            stream.ReadExactly(table);
+            for (var i = 0; i < phdrCount; i++)
+            {
+                var entry = table.AsSpan(i * phdrEntrySize, phdrEntrySize);
+                programHeaders.Add((
+                    BinaryPrimitives.ReadUInt32LittleEndian(entry),
+                    BinaryPrimitives.ReadUInt64LittleEndian(entry[0x10..]),
+                    BinaryPrimitives.ReadUInt64LittleEndian(entry[0x28..])));
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryDecodeEhFrameHdrPointer(CpuContext ctx, ulong hdrAddress, out ulong ehFrameAddress)
+    {
+        ehFrameAddress = 0;
+        Span<byte> hdr = stackalloc byte[12];
+        if (!ctx.Memory.TryRead(hdrAddress, hdr) || hdr[0] != 1)
+        {
+            return false;
+        }
+
+        // DWARF-encoded eh_frame_ptr at offset 4. Toolchains emit pcrel|sdata4 (0x1B),
+        // but decode the format/application nibbles properly to be safe.
+        var encoding = hdr[1];
+        ulong value;
+        switch (encoding & 0x0F)
+        {
+            case 0x03: // udata4
+                value = BinaryPrimitives.ReadUInt32LittleEndian(hdr[4..]);
+                break;
+            case 0x0B: // sdata4
+                value = unchecked((ulong)BinaryPrimitives.ReadInt32LittleEndian(hdr[4..]));
+                break;
+            case 0x00: // absptr
+            case 0x04: // udata8
+            case 0x0C: // sdata8
+                value = BinaryPrimitives.ReadUInt64LittleEndian(hdr[4..]);
+                break;
+            default:
+                return false;
+        }
+
+        ehFrameAddress = (encoding & 0x70) switch
+        {
+            0x00 => value, // absolute
+            0x10 => unchecked(hdrAddress + 4 + value), // pcrel
+            0x30 => unchecked(hdrAddress + value), // datarel
+            _ => 0,
+        };
+        return ehFrameAddress != 0;
     }
 
     private static bool TryReadUtf8Z(CpuContext ctx, ulong address, int maxLength, out string value)
@@ -2029,6 +2341,7 @@ public static class KernelRuntimeCompatExports
             desiredAddress,
             length,
             executable: false,
+            reserveOnly: true,
             alignment,
             allowSearch,
             allowAllocateAtAlternative: allowSearch,

--- a/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
@@ -386,11 +386,6 @@ public static class KernelSemaphoreCompatExports
         return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
-    [SysAbiExport(
-        Nid = "pDuPEf3m4fI",
-        ExportName = "sem_init",
-        Target = Generation.Gen4 | Generation.Gen5,
-        LibraryName = "libKernel")]
     public static int PosixSemInit(CpuContext ctx)
     {
         var semaphoreAddress = ctx[CpuRegister.Rdi];
@@ -428,11 +423,6 @@ public static class KernelSemaphoreCompatExports
         return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
-    [SysAbiExport(
-        Nid = "YCV5dGGBcCo",
-        ExportName = "sem_wait",
-        Target = Generation.Gen4 | Generation.Gen5,
-        LibraryName = "libKernel")]
     public static int PosixSemWait(CpuContext ctx)
     {
         if (!TryGetPosixSemaphoreHandle(ctx, ctx[CpuRegister.Rdi], out var handle))
@@ -446,11 +436,6 @@ public static class KernelSemaphoreCompatExports
         return KernelWaitSema(ctx);
     }
 
-    [SysAbiExport(
-        Nid = "WBWzsRifCEA",
-        ExportName = "sem_trywait",
-        Target = Generation.Gen4 | Generation.Gen5,
-        LibraryName = "libKernel")]
     public static int PosixSemTryWait(CpuContext ctx)
     {
         if (!TryGetPosixSemaphoreHandle(ctx, ctx[CpuRegister.Rdi], out var handle))
@@ -463,11 +448,6 @@ public static class KernelSemaphoreCompatExports
         return KernelPollSema(ctx, handle, 1);
     }
 
-    [SysAbiExport(
-        Nid = "w5IHyvahg-o",
-        ExportName = "sem_timedwait",
-        Target = Generation.Gen4 | Generation.Gen5,
-        LibraryName = "libKernel")]
     public static int PosixSemTimedWait(CpuContext ctx)
     {
         var timeoutAddress = ctx[CpuRegister.Rsi];
@@ -482,11 +462,6 @@ public static class KernelSemaphoreCompatExports
         return KernelWaitSema(ctx);
     }
 
-    [SysAbiExport(
-        Nid = "IKP8typ0QUk",
-        ExportName = "sem_post",
-        Target = Generation.Gen4 | Generation.Gen5,
-        LibraryName = "libKernel")]
     public static int PosixSemPost(CpuContext ctx)
     {
         if (!TryGetPosixSemaphoreHandle(ctx, ctx[CpuRegister.Rdi], out var handle))
@@ -499,11 +474,6 @@ public static class KernelSemaphoreCompatExports
         return KernelSignalSema(ctx, handle, 1);
     }
 
-    [SysAbiExport(
-        Nid = "Bq+LRV-N6Hk",
-        ExportName = "sem_getvalue",
-        Target = Generation.Gen4 | Generation.Gen5,
-        LibraryName = "libKernel")]
     public static int PosixSemGetValue(CpuContext ctx)
     {
         var semaphoreAddress = ctx[CpuRegister.Rdi];
@@ -526,11 +496,6 @@ public static class KernelSemaphoreCompatExports
             : SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
     }
 
-    [SysAbiExport(
-        Nid = "cDW233RAwWo",
-        ExportName = "sem_destroy",
-        Target = Generation.Gen4 | Generation.Gen5,
-        LibraryName = "libKernel")]
     public static int PosixSemDestroy(CpuContext ctx)
     {
         var semaphoreAddress = ctx[CpuRegister.Rdi];

--- a/src/SharpEmu.Libs/Kernel/KernelSocketCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelSocketCompatExports.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
@@ -11,14 +12,54 @@ namespace SharpEmu.Libs.Kernel;
 
 internal static class KernelSocketCompatExports
 {
+    private const int AddressFamilyInet = 2;
+    private const int SocketTypeMask = 0xF;
+    private const int SocketTypeStream = 1;
+    private const int SocketTypeDatagram = 2;
+    private const int SocketTypeNonBlocking = 0x20000000;
+    private const int MaxUdpPayloadBytes = 65_507;
+    private const int MaxUdpPacketBytes = 65_535;
+    private const int FcntlGetFlags = 3;
+    private const int FcntlSetFlags = 4;
+    private const int OpenFlagReadWrite = 2;
+    private const int OpenFlagNonBlocking = 4;
+    private const int MessageFlagPeek = 0x02;
+    private const int MessageFlagDontWait = 0x80;
+    private const int ErrnoIo = 5;
+    private const int ErrnoBadFileDescriptor = 9;
+    private const int ErrnoAccess = 13;
+    private const int ErrnoFault = 14;
+    private const int ErrnoInvalidArgument = 22;
+    private const int ErrnoWouldBlock = 35;
+    private const int ErrnoNotSocket = 38;
+    private const int ErrnoDestinationAddressRequired = 39;
+    private const int ErrnoMessageSize = 40;
+    private const int ErrnoProtocolNotSupported = 43;
+    private const int ErrnoAddressFamilyNotSupported = 47;
+    private const int ErrnoAddressInUse = 48;
+    private const int ErrnoAddressNotAvailable = 49;
+    private const int ErrnoNetworkDown = 50;
+    private const int ErrnoNetworkUnreachable = 51;
+    private const int ErrnoConnectionAborted = 53;
+    private const int ErrnoConnectionReset = 54;
+    private const int ErrnoNoBufferSpace = 55;
+    private const int ErrnoNotConnected = 57;
+    private const int ErrnoTimedOut = 60;
+    private const int ErrnoConnectionRefused = 61;
+    private const int ErrnoHostDown = 64;
+    private const int ErrnoHostUnreachable = 65;
+
     private sealed class EmulatedSocketState
     {
         public TcpClient? Client;
         public NetworkStream? Stream;
+        public System.Net.Sockets.Socket? DatagramSocket;
+        public int GuestSocketType = SocketTypeStream;
         public IPAddress BoundAddress = IPAddress.Any;
         public int BoundPort;
         public bool Bound;
         public bool Connected;
+        public int StatusFlags = OpenFlagReadWrite;
     }
 
     private static readonly object Gate = new();
@@ -130,12 +171,47 @@ internal static class KernelSocketCompatExports
         LibraryName = "libKernel")]
     public static int Socket(CpuContext ctx)
     {
+        var addressFamily = unchecked((int)ctx[CpuRegister.Rdi]);
+        var rawSocketType = unchecked((int)ctx[CpuRegister.Rsi]);
+        var socketType = rawSocketType & SocketTypeMask;
+        var protocol = unchecked((int)ctx[CpuRegister.Rdx]);
+
+        System.Net.Sockets.Socket? datagramSocket = null;
+        if (addressFamily == AddressFamilyInet && socketType == SocketTypeDatagram)
+        {
+            try
+            {
+                datagramSocket = new System.Net.Sockets.Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+                {
+                    EnableBroadcast = true,
+                    ExclusiveAddressUse = false,
+                };
+                datagramSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                if ((rawSocketType & SocketTypeNonBlocking) != 0)
+                {
+                    datagramSocket.Blocking = false;
+                }
+            }
+            catch (SocketException ex)
+            {
+                datagramSocket?.Dispose();
+                return SetPosixSocketFailure(ctx, MapSocketErrorToGuestErrno(ex.SocketErrorCode));
+            }
+        }
+
         var fd = KernelMemoryCompatExports.AllocateGuestFileDescriptor();
         lock (Gate)
         {
-            Sockets[fd] = new EmulatedSocketState();
+            Sockets[fd] = new EmulatedSocketState
+            {
+                DatagramSocket = datagramSocket,
+                GuestSocketType = socketType,
+                StatusFlags = OpenFlagReadWrite |
+                    (((rawSocketType & SocketTypeNonBlocking) != 0) ? OpenFlagNonBlocking : 0),
+            };
         }
 
+        LogNet($"socket fd={fd} family={addressFamily} type=0x{rawSocketType:X} protocol={protocol} datagram={datagramSocket is not null}");
         ctx[CpuRegister.Rax] = unchecked((ulong)fd);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
@@ -232,9 +308,31 @@ internal static class KernelSocketCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_OK;
         }
 
-        state.BoundAddress = ipAddress;
-        state.BoundPort = port;
-        state.Bound = true;
+        if (state.DatagramSocket is { } datagramSocket)
+        {
+            try
+            {
+                datagramSocket.Bind(new IPEndPoint(ipAddress, port));
+                UpdateBoundEndpoint(state, datagramSocket);
+                LogNet($"bind udp ok: fd={fd} ip={state.BoundAddress} port={state.BoundPort}");
+            }
+            catch (SocketException ex)
+            {
+                LogNet($"bind udp failed: fd={fd} ip={ipAddress} port={port} error={ex.SocketErrorCode}");
+                return SetPosixSocketFailure(ctx, MapSocketErrorToGuestErrno(ex.SocketErrorCode));
+            }
+            catch (ObjectDisposedException)
+            {
+                return SetPosixSocketFailure(ctx, ErrnoBadFileDescriptor);
+            }
+        }
+        else
+        {
+            state.BoundAddress = ipAddress;
+            state.BoundPort = port;
+            state.Bound = true;
+        }
+
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
@@ -270,8 +368,9 @@ internal static class KernelSocketCompatExports
         }
 
         Span<byte> sockaddr = stackalloc byte[16];
+        sockaddr.Clear();
         sockaddr[0] = 16;
-        sockaddr[1] = 2;
+        sockaddr[1] = AddressFamilyInet;
         BinaryPrimitives.WriteUInt16BigEndian(sockaddr.Slice(2, 2), (ushort)state.BoundPort);
         var addressBytes = state.BoundAddress.GetAddressBytes();
         if (addressBytes.Length == 4)
@@ -293,6 +392,289 @@ internal static class KernelSocketCompatExports
 
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "8nY19bKoiZk",
+        ExportName = "fcntl",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int Fcntl(CpuContext ctx)
+    {
+        var fd = unchecked((int)ctx[CpuRegister.Rdi]);
+        var command = unchecked((int)ctx[CpuRegister.Rsi]);
+        var argument = unchecked((int)ctx[CpuRegister.Rdx]);
+        System.Net.Sockets.Socket? datagramSocket = null;
+        bool? blocking = null;
+        var isSocket = false;
+
+        lock (Gate)
+        {
+            if (Sockets.TryGetValue(fd, out var state) && state is not null)
+            {
+                isSocket = true;
+                switch (command)
+                {
+                    case FcntlGetFlags:
+                        ctx[CpuRegister.Rax] = unchecked((uint)state.StatusFlags);
+                        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                    case FcntlSetFlags:
+                        state.StatusFlags = argument;
+                        datagramSocket = state.DatagramSocket;
+                        blocking = (argument & OpenFlagNonBlocking) == 0;
+                        break;
+                }
+            }
+        }
+
+        if (!isSocket)
+        {
+            return KernelMemoryCompatExports.PosixFcntl(ctx);
+        }
+
+        if (datagramSocket is not null && blocking.HasValue)
+        {
+            try
+            {
+                datagramSocket.Blocking = blocking.Value;
+            }
+            catch (SocketException ex)
+            {
+                return SetPosixSocketFailure(ctx, MapSocketErrorToGuestErrno(ex.SocketErrorCode));
+            }
+            catch (ObjectDisposedException)
+            {
+                return SetPosixSocketFailure(ctx, ErrnoBadFileDescriptor);
+            }
+        }
+
+        // Unknown commands and non-socket fds succeed benignly: guest code feeds
+        // any returned value straight back into F_SETFL, so an error-shaped result
+        // would circulate as bogus flags.
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "fFxGkxF2bVo",
+        ExportName = "setsockopt",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int Setsockopt(CpuContext ctx)
+    {
+        // Emulated sockets have no per-option behavior to configure; accept and ignore.
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "oBr313PppNE",
+        ExportName = "sendto",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int Sendto(CpuContext ctx)
+    {
+        var fd = unchecked((int)ctx[CpuRegister.Rdi]);
+        var bufferAddress = ctx[CpuRegister.Rsi];
+        var requestedRaw = ctx[CpuRegister.Rdx];
+        var destinationAddress = ctx[CpuRegister.R8];
+        var destinationLengthRaw = ctx[CpuRegister.R9];
+
+        if (requestedRaw > MaxUdpPayloadBytes)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoMessageSize);
+        }
+
+        var requested = unchecked((int)requestedRaw);
+        if (requested > 0 && bufferAddress == 0)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoFault);
+        }
+        if (destinationAddress == 0)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoDestinationAddressRequired);
+        }
+        if (destinationLengthRaw > int.MaxValue ||
+            !TryParseGuestSockaddrIn(
+                destinationAddress,
+                unchecked((int)destinationLengthRaw),
+                ctx,
+                out var ipAddress,
+                out var port))
+        {
+            return SetPosixSocketFailure(ctx, ErrnoInvalidArgument);
+        }
+
+        if (!TryGetEmulatedSocketState(fd, out var state) || state is null)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoBadFileDescriptor);
+        }
+        if (state.DatagramSocket is not { } datagramSocket)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoNotSocket);
+        }
+
+        var payload = requested == 0
+            ? Array.Empty<byte>()
+            : GC.AllocateUninitializedArray<byte>(requested);
+        if (requested > 0 && !ctx.Memory.TryRead(bufferAddress, payload))
+        {
+            return SetPosixSocketFailure(ctx, ErrnoFault);
+        }
+
+        var redirectApplied = TryApplyNetRedirect(ref ipAddress);
+        if (!IsGuestUdpOutboundAllowed(ipAddress, redirectApplied))
+        {
+            // LAN discovery and telemetry traffic must not escape the host by
+            // default. Report a complete datagram so titles can continue their
+            // offline paths; an explicit redirect still permits real testing.
+            LogNet($"sendto suppressed by outbound policy: fd={fd} ip={ipAddress} port={port} bytes={requested}");
+            ctx[CpuRegister.Rax] = unchecked((ulong)requested);
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        int sent;
+        try
+        {
+            sent = datagramSocket.SendTo(
+                payload,
+                0,
+                payload.Length,
+                SocketFlags.None,
+                new IPEndPoint(ipAddress, port));
+            UpdateBoundEndpoint(state, datagramSocket);
+        }
+        catch (SocketException ex)
+        {
+            return SetPosixSocketFailure(ctx, MapSocketErrorToGuestErrno(ex.SocketErrorCode));
+        }
+        catch (ObjectDisposedException)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoBadFileDescriptor);
+        }
+        catch (ArgumentException)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoInvalidArgument);
+        }
+
+        LogNet($"sendto ok: fd={fd} ip={ipAddress} port={port} bytes={sent}");
+        ctx[CpuRegister.Rax] = unchecked((ulong)sent);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "lUk6wrGXyMw",
+        ExportName = "recvfrom",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int Recvfrom(CpuContext ctx)
+    {
+        var fd = unchecked((int)ctx[CpuRegister.Rdi]);
+        var bufferAddress = ctx[CpuRegister.Rsi];
+        var requestedRaw = ctx[CpuRegister.Rdx];
+        var guestFlags = unchecked((int)ctx[CpuRegister.Rcx]);
+        var sourceAddress = ctx[CpuRegister.R8];
+        var sourceLengthAddress = ctx[CpuRegister.R9];
+
+        if (requestedRaw > int.MaxValue)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoMessageSize);
+        }
+
+        var requested = unchecked((int)requestedRaw);
+        if (requested > 0 && bufferAddress == 0)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoFault);
+        }
+
+        var sourceCapacity = 0u;
+        if (sourceLengthAddress != 0)
+        {
+            if (!ctx.TryReadUInt32(sourceLengthAddress, out sourceCapacity))
+            {
+                return SetPosixSocketFailure(ctx, ErrnoFault);
+            }
+        }
+
+        if (!TryGetEmulatedSocketState(fd, out var state) || state is null)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoBadFileDescriptor);
+        }
+        if (state.DatagramSocket is not { } datagramSocket)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoNotSocket);
+        }
+
+        var nonBlocking = (state.StatusFlags & OpenFlagNonBlocking) != 0 ||
+            (guestFlags & MessageFlagDontWait) != 0;
+        try
+        {
+            if (nonBlocking && !datagramSocket.Poll(0, SelectMode.SelectRead))
+            {
+                return SetPosixSocketFailure(ctx, ErrnoWouldBlock);
+            }
+        }
+        catch (SocketException ex)
+        {
+            return SetPosixSocketFailure(ctx, MapSocketErrorToGuestErrno(ex.SocketErrorCode));
+        }
+        catch (ObjectDisposedException)
+        {
+            return SetPosixSocketFailure(ctx, ErrnoBadFileDescriptor);
+        }
+
+        var receiveBuffer = ArrayPool<byte>.Shared.Rent(MaxUdpPacketBytes);
+        try
+        {
+            EndPoint remoteEndpoint = new IPEndPoint(IPAddress.Any, 0);
+            int received;
+            try
+            {
+                var socketFlags = (guestFlags & MessageFlagPeek) != 0
+                    ? SocketFlags.Peek
+                    : SocketFlags.None;
+                received = datagramSocket.ReceiveFrom(
+                    receiveBuffer,
+                    0,
+                    MaxUdpPacketBytes,
+                    socketFlags,
+                    ref remoteEndpoint);
+                UpdateBoundEndpoint(state, datagramSocket);
+            }
+            catch (SocketException ex)
+            {
+                return SetPosixSocketFailure(ctx, MapSocketErrorToGuestErrno(ex.SocketErrorCode));
+            }
+            catch (ObjectDisposedException)
+            {
+                return SetPosixSocketFailure(ctx, ErrnoBadFileDescriptor);
+            }
+            catch (ArgumentException)
+            {
+                return SetPosixSocketFailure(ctx, ErrnoInvalidArgument);
+            }
+
+            var copied = Math.Min(received, requested);
+            if (copied > 0 && !ctx.Memory.TryWrite(bufferAddress, receiveBuffer.AsSpan(0, copied)))
+            {
+                return SetPosixSocketFailure(ctx, ErrnoFault);
+            }
+            if (sourceAddress != 0 &&
+                sourceLengthAddress != 0 &&
+                remoteEndpoint is IPEndPoint remoteIpEndpoint &&
+                !TryWriteGuestSockaddrIn(ctx, sourceAddress, sourceLengthAddress, sourceCapacity, remoteIpEndpoint))
+            {
+                return SetPosixSocketFailure(ctx, ErrnoFault);
+            }
+
+            LogNet($"recvfrom ok: fd={fd} source={remoteEndpoint} bytes={copied} datagram={received}");
+            ctx[CpuRegister.Rax] = unchecked((ulong)copied);
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(receiveBuffer);
+        }
     }
 
     [SysAbiExport(
@@ -355,6 +737,58 @@ internal static class KernelSocketCompatExports
     }
 
     [SysAbiExport(
+        Nid = "8Kcp5d-q1Uo",
+        ExportName = "sceNetInetPton",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceNet")]
+    public static int SceNetInetPton(CpuContext ctx)
+    {
+        return InetPton(ctx);
+    }
+
+    [SysAbiExport(
+        Nid = "5jRCs2axtr4",
+        ExportName = "inet_ntop",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int InetNtop(CpuContext ctx)
+    {
+        // const char* inet_ntop(int af, const void* src, char* dst, socklen_t size):
+        // returns dst on success, NULL on failure.
+        var af = unchecked((int)ctx[CpuRegister.Rdi]);
+        var srcAddress = ctx[CpuRegister.Rsi];
+        var dstAddress = ctx[CpuRegister.Rdx];
+        var size = unchecked((int)ctx[CpuRegister.Rcx]);
+        ctx[CpuRegister.Rax] = 0;
+        if (af != 2 || srcAddress == 0 || dstAddress == 0)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        Span<byte> packed = stackalloc byte[4];
+        if (!ctx.Memory.TryRead(srcAddress, packed))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        var text = $"{packed[0]}.{packed[1]}.{packed[2]}.{packed[3]}";
+        if (size < text.Length + 1)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        var encoded = new byte[text.Length + 1];
+        Encoding.ASCII.GetBytes(text, encoded);
+        if (!ctx.Memory.TryWrite(dstAddress, encoded))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        ctx[CpuRegister.Rax] = dstAddress;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
         Nid = "jogUIsOV3-U",
         ExportName = "htons",
         Target = Generation.Gen4 | Generation.Gen5,
@@ -374,6 +808,87 @@ internal static class KernelSocketCompatExports
             return Sockets.TryGetValue(fd, out state);
         }
     }
+
+    private static bool TryWriteGuestSockaddrIn(
+        CpuContext ctx,
+        ulong address,
+        ulong addrlenAddress,
+        uint capacity,
+        IPEndPoint endpoint)
+    {
+        Span<byte> sockaddr = stackalloc byte[16];
+        sockaddr.Clear();
+        sockaddr[0] = 16;
+        sockaddr[1] = AddressFamilyInet;
+        BinaryPrimitives.WriteUInt16BigEndian(sockaddr.Slice(2, 2), unchecked((ushort)endpoint.Port));
+        var addressBytes = endpoint.Address.GetAddressBytes();
+        if (addressBytes.Length != 4)
+        {
+            return false;
+        }
+        addressBytes.CopyTo(sockaddr.Slice(4, 4));
+
+        var writeLength = unchecked((int)Math.Min(capacity, (uint)sockaddr.Length));
+        if (writeLength > 0 && !ctx.Memory.TryWrite(address, sockaddr.Slice(0, writeLength)))
+        {
+            return false;
+        }
+
+        return ctx.TryWriteUInt32(addrlenAddress, unchecked((uint)writeLength));
+    }
+
+    private static void UpdateBoundEndpoint(EmulatedSocketState state, System.Net.Sockets.Socket socket)
+    {
+        try
+        {
+            if (socket.LocalEndPoint is not IPEndPoint localEndpoint)
+            {
+                return;
+            }
+
+            state.BoundAddress = localEndpoint.Address;
+            state.BoundPort = localEndpoint.Port;
+            state.Bound = true;
+        }
+        catch (ObjectDisposedException)
+        {
+            // A concurrent guest close owns disposal; the caller reports its
+            // operation result and must not resurrect the descriptor state.
+        }
+    }
+
+    private static int SetPosixSocketFailure(CpuContext ctx, int errno)
+    {
+        _ = KernelRuntimeCompatExports.TrySetErrno(ctx, errno);
+        ctx[CpuRegister.Rax] = ulong.MaxValue;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    private static int MapSocketErrorToGuestErrno(SocketError error) => error switch
+    {
+        SocketError.Interrupted => 4,
+        SocketError.AccessDenied => ErrnoAccess,
+        SocketError.Fault => ErrnoFault,
+        SocketError.InvalidArgument => ErrnoInvalidArgument,
+        SocketError.WouldBlock or SocketError.IOPending or SocketError.InProgress => ErrnoWouldBlock,
+        SocketError.NotSocket => ErrnoNotSocket,
+        SocketError.MessageSize => ErrnoMessageSize,
+        SocketError.ProtocolNotSupported => ErrnoProtocolNotSupported,
+        SocketError.AddressFamilyNotSupported => ErrnoAddressFamilyNotSupported,
+        SocketError.AddressAlreadyInUse => ErrnoAddressInUse,
+        SocketError.AddressNotAvailable => ErrnoAddressNotAvailable,
+        SocketError.NetworkDown => ErrnoNetworkDown,
+        SocketError.NetworkUnreachable => ErrnoNetworkUnreachable,
+        SocketError.ConnectionAborted => ErrnoConnectionAborted,
+        SocketError.ConnectionReset => ErrnoConnectionReset,
+        SocketError.NoBufferSpaceAvailable => ErrnoNoBufferSpace,
+        SocketError.NotConnected => ErrnoNotConnected,
+        SocketError.TimedOut => ErrnoTimedOut,
+        SocketError.ConnectionRefused => ErrnoConnectionRefused,
+        SocketError.HostDown => ErrnoHostDown,
+        SocketError.HostUnreachable => ErrnoHostUnreachable,
+        _ => ErrnoIo,
+    };
 
     private static bool TryParseGuestSockaddrIn(
         ulong address,
@@ -410,8 +925,10 @@ internal static class KernelSocketCompatExports
     {
         try { state.Stream?.Dispose(); } catch (IOException) { }
         try { state.Client?.Dispose(); } catch (IOException) { }
+        try { state.DatagramSocket?.Dispose(); } catch (SocketException) { }
         state.Stream = null;
         state.Client = null;
+        state.DatagramSocket = null;
         state.Connected = false;
     }
 
@@ -449,6 +966,11 @@ internal static class KernelSocketCompatExports
     private static bool IsGuestTcpOutboundAllowed(IPAddress ipAddress, bool redirectApplied)
     {
         return redirectApplied || IsNetRedirectConfigured() || IPAddress.IsLoopback(ipAddress);
+    }
+
+    private static bool IsGuestUdpOutboundAllowed(IPAddress ipAddress, bool redirectApplied)
+    {
+        return redirectApplied || IPAddress.IsLoopback(ipAddress);
     }
 
     private static bool TryEstablishHostTcpConnection(

--- a/src/SharpEmu.Libs/Kernel/KernelVirtualRangeAllocator.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelVirtualRangeAllocator.cs
@@ -14,6 +14,7 @@ internal static class KernelVirtualRangeAllocator
         ulong desiredAddress,
         ulong length,
         bool executable,
+        bool reserveOnly,
         ulong alignment,
         bool allowSearch,
         bool allowAllocateAtAlternative,
@@ -35,14 +36,27 @@ internal static class KernelVirtualRangeAllocator
             }
 
             if (allowSearch &&
-                addressSpace.TryAllocateAtOrAbove(desiredAddress, length, executable, alignment, out var searchedAddress) &&
+                (reserveOnly
+                    ? addressSpace.TryReserveAtOrAbove(desiredAddress, length, executable, alignment, out var searchedAddress)
+                    : addressSpace.TryAllocateAtOrAbove(desiredAddress, length, executable, alignment, out searchedAddress)) &&
                 searchedAddress != 0)
             {
                 mappedAddress = searchedAddress;
                 return true;
             }
 
-            var allocated = addressSpace.AllocateAt(desiredAddress, length, executable, allowAllocateAtAlternative);
+            if (!allowSearch && desiredAddress != 0 &&
+                addressSpace.IsAccessible(desiredAddress, length))
+            {
+                // MAP_FIXED over an already-reserved range succeeds (POSIX
+                // replace semantics); the host mapping is already in place.
+                mappedAddress = desiredAddress;
+                return true;
+            }
+
+            var allocated = reserveOnly
+                ? addressSpace.ReserveAt(desiredAddress, length, executable, allowAllocateAtAlternative)
+                : addressSpace.AllocateAt(desiredAddress, length, executable, allowAllocateAtAlternative);
             if (allocated == 0)
             {
                 Console.Error.WriteLine($"[LOADER][TRACE] {traceName}: AllocateAt returned {typeof(ulong).FullName} value=0");

--- a/src/SharpEmu.Libs/Network/Http2Exports.cs
+++ b/src/SharpEmu.Libs/Network/Http2Exports.cs
@@ -1,7 +1,9 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Buffers;
 using System.Collections.Concurrent;
+using System.Text;
 using SharpEmu.HLE;
 
 namespace SharpEmu.Libs.Network;
@@ -10,11 +12,26 @@ public static class Http2Exports
 {
     private const int Http2ErrorInvalidId = unchecked((int)0x80436004);
     private const int Http2ErrorInvalidArgument = unchecked((int)0x80436016);
+    private const int MethodCStringCapacity = 64;
+    private const int UrlCStringCapacity = 4096;
 
+    private static readonly object _stateGate = new();
     private static readonly ConcurrentDictionary<int, Http2Context> _contexts = new();
+    private static readonly ConcurrentDictionary<int, Http2Template> _templates = new();
+    private static readonly ConcurrentDictionary<int, Http2RequestState> _requests = new();
     private static int _nextContextId;
+    private static int _nextTemplateId = 0x100;
+    private static int _nextRequestId = 0x200;
 
     private sealed record Http2Context(int NetId, int SslId, ulong PoolSize, int MaxRequests);
+
+    private sealed record Http2Template(int ContextId, ulong UserAgentAddress, int HttpVersion, int AutoProxy);
+
+    internal readonly record struct Http2RequestState(
+        int TemplateId,
+        string Method,
+        string Url,
+        ulong ContentLength);
 
     [SysAbiExport(
         Nid = "3JCe3lCbQ8A",
@@ -33,8 +50,12 @@ public static class Http2Exports
             return ctx.SetReturn(Http2ErrorInvalidArgument);
         }
 
-        var id = Interlocked.Increment(ref _nextContextId);
-        _contexts[id] = new Http2Context(netId, sslId, poolSize, maxRequests);
+        int id;
+        lock (_stateGate)
+        {
+            id = Interlocked.Increment(ref _nextContextId);
+            _contexts[id] = new Http2Context(netId, sslId, poolSize, maxRequests);
+        }
 
         TraceHttp2("init", id, unchecked((ulong)netId), unchecked((ulong)sslId), poolSize, unchecked((ulong)maxRequests));
         ctx[CpuRegister.Rax] = unchecked((ulong)id);
@@ -49,13 +70,220 @@ public static class Http2Exports
     public static int Http2Term(CpuContext ctx)
     {
         var id = unchecked((int)ctx[CpuRegister.Rdi]);
-        if (!_contexts.TryRemove(id, out _))
+        var removedTemplateIds = new HashSet<int>();
+        var removedRequestCount = 0;
+        lock (_stateGate)
         {
-            return ctx.SetReturn(Http2ErrorInvalidId);
+            if (!_contexts.TryRemove(id, out _))
+            {
+                return ctx.SetReturn(Http2ErrorInvalidId);
+            }
+
+            foreach (var pair in _templates)
+            {
+                if (pair.Value.ContextId == id && _templates.TryRemove(pair.Key, out _))
+                {
+                    removedTemplateIds.Add(pair.Key);
+                }
+            }
+
+            if (removedTemplateIds.Count != 0)
+            {
+                foreach (var pair in _requests)
+                {
+                    if (removedTemplateIds.Contains(pair.Value.TemplateId) &&
+                        _requests.TryRemove(pair.Key, out _))
+                    {
+                        removedRequestCount++;
+                    }
+                }
+            }
         }
 
-        TraceHttp2("term", id, 0, 0, 0, 0);
+        TraceHttp2(
+            "term",
+            id,
+            unchecked((ulong)removedTemplateIds.Count),
+            unchecked((ulong)removedRequestCount),
+            0,
+            0);
         return ctx.SetReturn(0);
+    }
+
+    [SysAbiExport(
+        Nid = "+wCt7fCijgk",
+        ExportName = "sceHttp2CreateTemplate",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2CreateTemplate(CpuContext ctx)
+    {
+        var contextId = unchecked((int)ctx[CpuRegister.Rdi]);
+        var userAgentAddress = ctx[CpuRegister.Rsi];
+        var httpVersion = unchecked((int)ctx[CpuRegister.Rdx]);
+        var autoProxy = unchecked((int)ctx[CpuRegister.Rcx]);
+
+        int id;
+        lock (_stateGate)
+        {
+            if (!_contexts.ContainsKey(contextId))
+            {
+                return ctx.SetReturn(Http2ErrorInvalidId);
+            }
+
+            id = Interlocked.Increment(ref _nextTemplateId);
+            _templates[id] = new Http2Template(contextId, userAgentAddress, httpVersion, autoProxy);
+        }
+
+        TraceHttp2("template.create", id, unchecked((ulong)contextId), userAgentAddress, unchecked((ulong)httpVersion), unchecked((ulong)autoProxy));
+        ctx[CpuRegister.Rax] = unchecked((ulong)id);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "mmyOCxQMVYQ",
+        ExportName = "sceHttp2CreateRequestWithURL",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2CreateRequestWithUrl(CpuContext ctx)
+    {
+        var templateId = unchecked((int)ctx[CpuRegister.Rdi]);
+        var methodAddress = ctx[CpuRegister.Rsi];
+        var urlAddress = ctx[CpuRegister.Rdx];
+        var contentLength = ctx[CpuRegister.Rcx];
+
+        lock (_stateGate)
+        {
+            if (!_templates.ContainsKey(templateId))
+            {
+                return ctx.SetReturn(Http2ErrorInvalidId);
+            }
+        }
+
+        if (!TryReadRequiredCString(ctx, methodAddress, MethodCStringCapacity, out var method) ||
+            !TryReadRequiredCString(ctx, urlAddress, UrlCStringCapacity, out var url))
+        {
+            return ctx.SetReturn(Http2ErrorInvalidArgument);
+        }
+
+        int id;
+        lock (_stateGate)
+        {
+            if (!_templates.ContainsKey(templateId))
+            {
+                return ctx.SetReturn(Http2ErrorInvalidId);
+            }
+
+            id = Interlocked.Increment(ref _nextRequestId);
+            _requests[id] = new Http2RequestState(templateId, method, url, contentLength);
+        }
+
+        TraceHttp2(
+            "request.create",
+            id,
+            unchecked((ulong)templateId),
+            methodAddress,
+            urlAddress,
+            contentLength);
+        ctx[CpuRegister.Rax] = unchecked((ulong)id);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    internal static bool TryGetRequestState(int requestId, out Http2RequestState state) =>
+        _requests.TryGetValue(requestId, out state);
+
+    internal static void ResetForTests()
+    {
+        lock (_stateGate)
+        {
+            _contexts.Clear();
+            _templates.Clear();
+            _requests.Clear();
+            _nextContextId = 0;
+            _nextTemplateId = 0x100;
+            _nextRequestId = 0x200;
+        }
+    }
+
+    private static bool TryReadRequiredCString(
+        CpuContext ctx,
+        ulong address,
+        int capacity,
+        out string value)
+    {
+        value = string.Empty;
+        if (address == 0 || capacity <= 0)
+        {
+            return false;
+        }
+
+        const int ReadChunkLength = 128;
+        var rented = ArrayPool<byte>.Shared.Rent(capacity);
+        try
+        {
+            var length = 0;
+            Span<byte> singleByte = stackalloc byte[1];
+            while (length < capacity)
+            {
+                var currentAddress = address + unchecked((ulong)length);
+                if (currentAddress < address)
+                {
+                    return false;
+                }
+
+                var chunkLength = Math.Min(ReadChunkLength, capacity - length);
+                var chunk = rented.AsSpan(length, chunkLength);
+                if (ctx.Memory.TryRead(currentAddress, chunk))
+                {
+                    var terminator = chunk.IndexOf((byte)0);
+                    if (terminator >= 0)
+                    {
+                        var stringLength = length + terminator;
+                        if (stringLength == 0)
+                        {
+                            return false;
+                        }
+
+                        value = Encoding.UTF8.GetString(rented, 0, stringLength);
+                        return true;
+                    }
+
+                    length += chunkLength;
+                    continue;
+                }
+
+                for (var i = 0; i < chunkLength; i++)
+                {
+                    var byteAddress = currentAddress + unchecked((ulong)i);
+                    if (byteAddress < currentAddress ||
+                        !ctx.Memory.TryRead(byteAddress, singleByte))
+                    {
+                        return false;
+                    }
+
+                    if (singleByte[0] == 0)
+                    {
+                        var stringLength = length + i;
+                        if (stringLength == 0)
+                        {
+                            return false;
+                        }
+
+                        value = Encoding.UTF8.GetString(rented, 0, stringLength);
+                        return true;
+                    }
+
+                    rented[length + i] = singleByte[0];
+                }
+
+                length += chunkLength;
+            }
+
+            return false;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
     }
 
     private static void TraceHttp2(string operation, int id, ulong arg0, ulong arg1, ulong arg2, ulong arg3)

--- a/src/SharpEmu.Libs/Np/NpEntitlementAccessExports.cs
+++ b/src/SharpEmu.Libs/Np/NpEntitlementAccessExports.cs
@@ -9,6 +9,7 @@ public static class NpEntitlementAccessExports
 {
     private const int BootParamClearSize = 0x20;
     private const int EmptyAddcontInfoListSize = 0x10;
+    private const uint SkuFlagFull = 3;
 
     [SysAbiExport(
         Nid = "jO8DM8oyego",
@@ -55,6 +56,27 @@ public static class NpEntitlementAccessExports
         TraceNpEntitlementAccess(
             $"get_addcont_info_list service=0x{ctx[CpuRegister.Rdi]:X16} list=0x{listAddress:X16} " +
             $"max={ctx[CpuRegister.Rdx]} flags=0x{ctx[CpuRegister.Rcx]:X16} -> empty");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "lPDO62PpJIA",
+        ExportName = "sceNpEntitlementAccessGetSkuFlag",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceNpEntitlementAccess")]
+    public static int NpEntitlementAccessGetSkuFlag(CpuContext ctx)
+    {
+        var skuFlagAddress = ctx[CpuRegister.Rdi];
+        if (skuFlagAddress == 0)
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+        if (!ctx.TryWriteUInt32(skuFlagAddress, SkuFlagFull))
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceNpEntitlementAccess($"get_sku_flag out=0x{skuFlagAddress:X16} value={SkuFlagFull}");
         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 

--- a/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
@@ -12,9 +12,11 @@ namespace SharpEmu.Libs.SaveData;
 public static class SaveDataExports
 {
     private const int OrbisSaveDataErrorParameter = unchecked((int)0x809F0000);
+    private const int OrbisSaveDataErrorBusy = unchecked((int)0x809F0003);
     private const int OrbisSaveDataErrorExists = unchecked((int)0x809F0007);
     private const int OrbisSaveDataErrorNotFound = unchecked((int)0x809F0008);
     private const int OrbisSaveDataErrorInternal = unchecked((int)0x809F000B);
+    private const int OrbisSaveDataErrorMountFull = unchecked((int)0x809F000C);
     private const int OrbisSaveDataErrorMemoryNotReady = unchecked((int)0x809F0012);
     private const int SaveDataTitleIdSize = 10;
     private const int SaveDataDirNameSize = 32;
@@ -33,15 +35,20 @@ public static class SaveDataExports
     private const int MountResultSize = 0x40;
     // Emulator guard against corrupt or misread sizes, not a platform limit.
     private const ulong SaveDataMemoryMaxSize = 64UL * 1024 * 1024;
+    private const int MountInfoSize = 0x30;
+    private const ulong MountInfoBlocks = 0x8000;
+    private const int MountSlotCount = 16;
     private static readonly object _stateGate = new();
     private static readonly object _memoryGate = new();
     private static readonly HashSet<int> _preparedTransactionResources = [];
+    private static readonly MountSlot?[] _mountSlots = new MountSlot?[MountSlotCount];
     private static string? _titleId;
 
     public static void ConfigureApplicationInfo(string? titleId)
     {
         lock (_stateGate)
         {
+            ResetMountSlotsLocked();
             _titleId = string.IsNullOrWhiteSpace(titleId) ? null : SanitizePathSegment(titleId.Trim());
             _preparedTransactionResources.Clear();
         }
@@ -162,6 +169,62 @@ public static class SaveDataExports
         }
     }
 
+    // PS5 variant that keeps the PS4 cond/result layout.
+    [SysAbiExport(
+        Nid = "X4MYzukPc3g",
+        ExportName = "sceSaveDataDirNameSearchPs4",
+        Target = Generation.Gen5,
+        LibraryName = "libSceSaveData")]
+    public static int SaveDataDirNameSearchPs4(CpuContext ctx) => SaveDataDirNameSearch(ctx);
+
+    [SysAbiExport(
+        Nid = "65VH0Qaaz6s",
+        ExportName = "sceSaveDataGetMountInfo",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceSaveData")]
+    public static int SaveDataGetMountInfo(CpuContext ctx)
+    {
+        var mountPointAddress = ctx[CpuRegister.Rdi];
+        var infoAddress = ctx[CpuRegister.Rsi];
+        if (mountPointAddress == 0 || infoAddress == 0)
+        {
+            return ctx.SetReturn(OrbisSaveDataErrorParameter);
+        }
+
+        // SceSaveDataMountInfo: u64 blocks, u64 freeBlocks, u8 reserved[32].
+        Span<byte> info = stackalloc byte[MountInfoSize];
+        info.Clear();
+        BinaryPrimitives.WriteUInt64LittleEndian(info[0x00..], MountInfoBlocks);
+        BinaryPrimitives.WriteUInt64LittleEndian(info[0x08..], MountInfoBlocks - 96);
+        if (!ctx.Memory.TryWrite(infoAddress, info))
+        {
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        return ctx.SetReturn(0);
+    }
+
+    [SysAbiExport(
+        Nid = "85zul--eGXs",
+        ExportName = "sceSaveDataSetParam",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceSaveData")]
+    public static int SaveDataSetParam(CpuContext ctx)
+    {
+        var mountPointAddress = ctx[CpuRegister.Rdi];
+        var paramType = (uint)ctx[CpuRegister.Rsi];
+        var paramBufAddress = ctx[CpuRegister.Rdx];
+        var paramBufSize = ctx[CpuRegister.Rcx];
+        if (mountPointAddress == 0 || paramBufAddress == 0)
+        {
+            return ctx.SetReturn(OrbisSaveDataErrorParameter);
+        }
+
+        // Accepted but not persisted; search results fabricate params from directory metadata.
+        TraceSaveData($"set_param type={paramType} buf=0x{paramBufAddress:X16} size=0x{paramBufSize:X}");
+        return ctx.SetReturn(0);
+    }
+
     [SysAbiExport(
         Nid = "ZP4e7rlzOUk",
         ExportName = "sceSaveDataMount3",
@@ -176,13 +239,13 @@ public static class SaveDataExports
             return SetReturn(ctx, OrbisSaveDataErrorParameter);
         }
 
-        if (!TryReadInt32(ctx, mountAddress, out var userId) ||
+        if (!ctx.TryReadInt32(mountAddress, out var userId) ||
             !ctx.TryReadUInt64(mountAddress + 0x08, out var dirNameAddress) ||
             !ctx.TryReadUInt64(mountAddress + 0x10, out var blocks) ||
             !ctx.TryReadUInt64(mountAddress + 0x18, out var systemBlocks) ||
-            !TryReadUInt32(ctx, mountAddress + 0x20, out var mountMode) ||
-            !TryReadUInt32(ctx, mountAddress + 0x24, out var resource) ||
-            !TryReadUInt32(ctx, mountAddress + 0x28, out var mode) ||
+            !ctx.TryReadUInt32(mountAddress + 0x20, out var mountMode) ||
+            !ctx.TryReadUInt32(mountAddress + 0x24, out var resource) ||
+            !ctx.TryReadUInt32(mountAddress + 0x28, out var mode) ||
             dirNameAddress == 0 ||
             !TryReadFixedAscii(ctx, dirNameAddress, SaveDataDirNameSize, out var dirName))
         {
@@ -200,41 +263,82 @@ public static class SaveDataExports
             var savePath = Path.Combine(
                 ResolveTitleSaveRoot(userId, titleId),
                 SanitizePathSegment(dirName));
-            var existed = Directory.Exists(savePath);
             var create = (mountMode & MountModeCreate) != 0;
             var createIfMissing = (mountMode & MountModeCreate2) != 0;
+            bool existed;
+            string mountPoint;
+            int slotIndex;
 
-            if (!existed && !create && !createIfMissing)
+            lock (_stateGate)
             {
-                return SetReturn(ctx, OrbisSaveDataErrorNotFound);
-            }
+                for (var i = 0; i < _mountSlots.Length; i++)
+                {
+                    var activeMount = _mountSlots[i];
+                    if (activeMount is not null &&
+                        string.Equals(activeMount.SavePath, savePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return SetReturn(ctx, OrbisSaveDataErrorBusy);
+                    }
+                }
 
-            if (existed && create)
-            {
-                return SetReturn(ctx, OrbisSaveDataErrorExists);
-            }
+                slotIndex = Array.FindIndex(_mountSlots, static slot => slot is null);
+                if (slotIndex < 0)
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorMountFull);
+                }
 
-            if (!existed)
-            {
-                Directory.CreateDirectory(savePath);
-            }
+                existed = Directory.Exists(savePath);
+                if (!existed && !create && !createIfMissing)
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorNotFound);
+                }
 
-            const string mountPoint = "/savedata0";
-            KernelMemoryCompatExports.RegisterGuestPathMount(mountPoint, savePath);
+                if (existed && create)
+                {
+                    return SetReturn(ctx, OrbisSaveDataErrorExists);
+                }
 
-            Span<byte> result = stackalloc byte[MountResultSize];
-            result.Clear();
-            WriteAscii(result[..16], mountPoint);
-            BinaryPrimitives.WriteUInt32LittleEndian(result[0x1C..], createIfMissing && !existed ? 1u : 0u);
-            if (!ctx.Memory.TryWrite(resultAddress, result))
-            {
-                return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+                if (!existed)
+                {
+                    Directory.CreateDirectory(savePath);
+                }
+
+                mountPoint = $"/savedata{slotIndex}";
+                var registered = false;
+                try
+                {
+                    KernelMemoryCompatExports.RegisterGuestPathMount(mountPoint, savePath);
+                    registered = true;
+
+                    Span<byte> result = stackalloc byte[MountResultSize];
+                    result.Clear();
+                    WriteAscii(result[..16], mountPoint);
+                    BinaryPrimitives.WriteUInt32LittleEndian(
+                        result[0x1C..],
+                        createIfMissing && !existed ? 1u : 0u);
+                    if (!ctx.Memory.TryWrite(resultAddress, result))
+                    {
+                        KernelMemoryCompatExports.TryUnregisterGuestPathMount(mountPoint);
+                        return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+                    }
+
+                    _mountSlots[slotIndex] = new MountSlot(mountPoint, savePath);
+                }
+                catch
+                {
+                    if (registered)
+                    {
+                        KernelMemoryCompatExports.TryUnregisterGuestPathMount(mountPoint);
+                    }
+
+                    throw;
+                }
             }
 
             TraceSaveData(
                 $"mount3 user={userId} title={titleId} dir={dirName} blocks={blocks} " +
                 $"system_blocks={systemBlocks} mount_mode=0x{mountMode:X} resource={resource} mode={mode} " +
-                $"mount_point={mountPoint} created={!existed} root='{savePath}'");
+                $"mount_point={mountPoint} slot={slotIndex} created={!existed} root='{savePath}'");
             return SetReturn(ctx, 0);
         }
         catch (IOException)
@@ -318,11 +422,69 @@ public static class SaveDataExports
         LibraryName = "libSceSaveData")]
     public static int SaveDataUmount2(CpuContext ctx)
     {
-        // Unmounting a save directory always succeeds in the stub filesystem;
-        // returning an error here makes the game's save flow stall before it
-        // hands control to the title/gameplay state.
-        TraceSaveData($"umount2 user={unchecked((int)ctx[CpuRegister.Rdi])}");
+        var mountPointAddress = ctx[CpuRegister.Rdi];
+        if (mountPointAddress == 0)
+        {
+            mountPointAddress = ctx[CpuRegister.Rsi];
+        }
+
+        if (mountPointAddress == 0)
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+
+        if (!TryReadFixedAscii(ctx, mountPointAddress, 16, out var mountPoint))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        if (string.IsNullOrWhiteSpace(mountPoint))
+        {
+            return SetReturn(ctx, OrbisSaveDataErrorParameter);
+        }
+
+        var slotIndex = -1;
+        var unmounted = false;
+        lock (_stateGate)
+        {
+            for (var i = 0; i < _mountSlots.Length; i++)
+            {
+                var activeMount = _mountSlots[i];
+                if (activeMount is null ||
+                    !string.Equals(
+                        activeMount.MountPoint,
+                        mountPoint,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                slotIndex = i;
+                unmounted = KernelMemoryCompatExports.TryUnregisterGuestPathMount(
+                    activeMount.MountPoint);
+                _mountSlots[i] = null;
+                break;
+            }
+        }
+
+        TraceSaveData(
+            $"umount2 mount_point={mountPoint} slot={slotIndex} unregistered={unmounted}");
         return SetReturn(ctx, 0);
+    }
+
+    private static void ResetMountSlotsLocked()
+    {
+        for (var i = 0; i < _mountSlots.Length; i++)
+        {
+            var activeMount = _mountSlots[i];
+            if (activeMount is null)
+            {
+                continue;
+            }
+
+            KernelMemoryCompatExports.TryUnregisterGuestPathMount(activeMount.MountPoint);
+            _mountSlots[i] = null;
+        }
     }
 
     private static bool TryReadSearchCond(CpuContext ctx, ulong address, out SearchCond cond)
@@ -407,7 +569,7 @@ public static class SaveDataExports
     {
         var param = new byte[SaveDataParamSize];
         WriteAscii(param.AsSpan(0x00, 128), "Saved Data");
-        WriteAscii(param.AsSpan(0x100, 1024), entry.Name);
+        WriteAscii(param.AsSpan(0x80, 128), entry.Name);
         BinaryPrimitives.WriteInt64LittleEndian(
             param.AsSpan(0x508, sizeof(long)),
             new DateTimeOffset(entry.LastWriteUtc).ToUnixTimeSeconds());
@@ -628,6 +790,8 @@ public static class SaveDataExports
         uint DirNamesNum,
         ulong ParamsAddress,
         ulong InfosAddress);
+
+    private sealed record MountSlot(string MountPoint, string SavePath);
 
     private readonly record struct SaveEntry(string Name, string Path, DateTime LastWriteUtc);
 

--- a/src/SharpEmu.Libs/TextToSpeech/TextToSpeech2Exports.cs
+++ b/src/SharpEmu.Libs/TextToSpeech/TextToSpeech2Exports.cs
@@ -1,0 +1,204 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+
+namespace SharpEmu.Libs.TextToSpeech;
+
+public static class TextToSpeech2Exports
+{
+    private const int SpeechStatusIdle = 0;
+
+    private static readonly object _stateGate = new();
+    private static bool _initialized;
+    private static bool _opened;
+
+    [SysAbiExport(
+        Nid = "UOjiprYwVNw",
+        ExportName = "sceTextToSpeech2Initialize",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceTextToSpeech2")]
+    public static int TextToSpeech2Initialize(CpuContext ctx)
+    {
+        lock (_stateGate)
+        {
+            if (!_initialized)
+            {
+                _initialized = true;
+                _opened = false;
+            }
+        }
+
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "SoWHuVW0gpU",
+        ExportName = "sceTextToSpeech2Terminate",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceTextToSpeech2")]
+    public static int TextToSpeech2Terminate(CpuContext ctx)
+    {
+        lock (_stateGate)
+        {
+            _opened = false;
+            _initialized = false;
+        }
+
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "X0HZNbSiqyg",
+        ExportName = "sceTextToSpeech2Open",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceTextToSpeech2")]
+    public static int TextToSpeech2Open(CpuContext ctx)
+    {
+        var configurationAddress = ctx[CpuRegister.Rdi];
+        if (configurationAddress == 0)
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        if (!ctx.TryReadUInt64(configurationAddress, out _))
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        lock (_stateGate)
+        {
+            if (!_initialized)
+            {
+                return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+            }
+
+            if (_opened)
+            {
+                return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY);
+            }
+
+            _opened = true;
+        }
+
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "t4e879M-cSw",
+        ExportName = "sceTextToSpeech2Close",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceTextToSpeech2")]
+    public static int TextToSpeech2Close(CpuContext ctx)
+    {
+        lock (_stateGate)
+        {
+            if (!_initialized || !_opened)
+            {
+                return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+            }
+
+            _opened = false;
+        }
+
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "08JSg9p6bgQ",
+        ExportName = "sceTextToSpeech2GetSpeechStatus",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceTextToSpeech2")]
+    public static int TextToSpeech2GetSpeechStatus(CpuContext ctx)
+    {
+        var statusAddress = ctx[CpuRegister.Rdi];
+        if (statusAddress == 0)
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        lock (_stateGate)
+        {
+            if (!_initialized || !_opened)
+            {
+                return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+            }
+        }
+
+        if (!ctx.TryWriteInt32(statusAddress, SpeechStatusIdle))
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "8ntsRd07EQA",
+        ExportName = "sceTextToSpeech2Speak",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceTextToSpeech2")]
+    public static int TextToSpeech2Speak(CpuContext ctx)
+    {
+        var speechParametersAddress = ctx[CpuRegister.Rdi];
+        if (speechParametersAddress == 0)
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        if (!ctx.TryReadUInt64(speechParametersAddress, out var textAddress))
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        if (textAddress == 0)
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        Span<byte> firstCodeUnit = stackalloc byte[sizeof(ushort)];
+        if (!ctx.Memory.TryRead(textAddress, firstCodeUnit))
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        lock (_stateGate)
+        {
+            if (!_initialized || !_opened)
+            {
+                return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+            }
+        }
+
+        // Until a host speech backend is available, accepted requests complete
+        // synchronously and the observable service status remains idle.
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "2jiIxUmcsGo",
+        ExportName = "sceTextToSpeech2Cancel",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceTextToSpeech2")]
+    public static int TextToSpeech2Cancel(CpuContext ctx)
+    {
+        lock (_stateGate)
+        {
+            if (!_initialized || !_opened)
+            {
+                return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+            }
+        }
+
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    internal static void ResetForTests()
+    {
+        lock (_stateGate)
+        {
+            _initialized = false;
+            _opened = false;
+        }
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Core/DirectExecutionBackendTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Core/DirectExecutionBackendTests.cs
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Native;
+using SharpEmu.HLE;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Core;
+
+public sealed class DirectExecutionBackendTests
+{
+    [Fact]
+    public async Task BlockedGuestCallback_WaitsForWakeBeforeResuming()
+    {
+        var waiter = new ControlledBlockWaiter(0x1234);
+
+        var completion = Task.Run(() =>
+        {
+            var success = DirectExecutionBackend.WaitForBlockedGuestCallbackCore(
+                waiter,
+                deadlineTimestamp: 0,
+                stopRequested: static () => false,
+                tryWake: static candidate => candidate.TryWake(),
+                out var resumeResult,
+                out var error);
+            return (Success: success, ResumeResult: resumeResult, Error: error);
+        });
+
+        await waiter.WakeAttempted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, waiter.ResumeCount);
+        Assert.False(completion.IsCompleted);
+
+        waiter.Ready.Set();
+
+        var result = await completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(result.Success);
+        Assert.Equal(0x1234, result.ResumeResult);
+        Assert.Null(result.Error);
+        Assert.Equal(1, waiter.ResumeCount);
+    }
+
+    private sealed class ControlledBlockWaiter(int resumeResult) : IGuestThreadBlockWaiter
+    {
+        private int _resumeCount;
+
+        public TaskCompletionSource WakeAttempted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ManualResetEventSlim Ready { get; } = new(false);
+
+        public int ResumeCount => Volatile.Read(ref _resumeCount);
+
+        public int Resume()
+        {
+            Interlocked.Increment(ref _resumeCount);
+            return resumeResult;
+        }
+
+        public bool TryWake()
+        {
+            WakeAttempted.TrySetResult();
+            return Ready.IsSet;
+        }
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelPosixSemaphoreCompatExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelPosixSemaphoreCompatExportsTests.cs
@@ -1,0 +1,152 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+[CollectionDefinition("KernelPosixSemaphoreCompatExports", DisableParallelization = true)]
+public sealed class KernelPosixSemaphoreCompatExportsCollectionDefinition;
+
+[Collection("KernelPosixSemaphoreCompatExports")]
+public sealed class KernelPosixSemaphoreCompatExportsTests : IDisposable
+{
+    private const int ErrnoInvalidArgument = 22;
+    private const int ErrnoTryAgain = 35;
+    private const int ErrnoTimedOut = 60;
+    private const ulong MemoryBase = 0x0000_7FFF_7000_0000;
+    private const ulong TlsBase = MemoryBase + 0x1000;
+    private const ulong SemaphoreAddress = MemoryBase + 0x2000;
+    private const ulong ValueAddress = MemoryBase + 0x3000;
+    private const ulong TimeoutAddress = MemoryBase + 0x4000;
+    private readonly FakeCpuMemory _memory = new(MemoryBase, 0x10_000);
+    private readonly CpuContext _context;
+
+    public KernelPosixSemaphoreCompatExportsTests()
+    {
+        KernelPosixSemaphoreCompatExports.ResetForTests();
+        _context = new CpuContext(_memory, Generation.Gen5)
+        {
+            FsBase = TlsBase,
+        };
+    }
+
+    [Fact]
+    public void CountingLifecycle_TracksWaitPostAndValue()
+    {
+        Initialize(2);
+        Assert.Equal(2, GetValue());
+
+        _context[CpuRegister.Rdi] = SemaphoreAddress;
+        Assert.Equal(0, KernelPosixSemaphoreCompatExports.PosixSemaphoreWait(_context));
+        Assert.Equal(0UL, _context[CpuRegister.Rax]);
+        Assert.Equal(0, KernelPosixSemaphoreCompatExports.PosixSemaphoreTryWait(_context));
+        Assert.Equal(0UL, _context[CpuRegister.Rax]);
+        Assert.Equal(0, GetValue());
+
+        Assert.Equal(0, KernelPosixSemaphoreCompatExports.PosixSemaphoreTryWait(_context));
+        Assert.Equal(ulong.MaxValue, _context[CpuRegister.Rax]);
+        Assert.Equal(ErrnoTryAgain, ReadErrno());
+
+        Assert.Equal(0, KernelPosixSemaphoreCompatExports.PosixSemaphorePost(_context));
+        Assert.Equal(0UL, _context[CpuRegister.Rax]);
+        Assert.Equal(1, GetValue());
+
+        _context[CpuRegister.Rdi] = SemaphoreAddress;
+        Assert.Equal(0, KernelPosixSemaphoreCompatExports.PosixSemaphoreDestroy(_context));
+        Assert.Equal(0UL, _context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void Init_RejectsValuesAboveSemaphoreMaximum()
+    {
+        _context[CpuRegister.Rdi] = SemaphoreAddress;
+        _context[CpuRegister.Rsi] = 0;
+        _context[CpuRegister.Rdx] = (ulong)int.MaxValue + 1;
+
+        Assert.Equal(0, KernelPosixSemaphoreCompatExports.PosixSemaphoreInit(_context));
+        Assert.Equal(ulong.MaxValue, _context[CpuRegister.Rax]);
+        Assert.Equal(ErrnoInvalidArgument, ReadErrno());
+    }
+
+    [Fact]
+    public void TimedWait_WithPastDeadlineReturnsTimedOutWithoutChangingCount()
+    {
+        Initialize(0);
+        Assert.True(_context.TryWriteUInt64(TimeoutAddress, 0));
+        Assert.True(_context.TryWriteUInt64(TimeoutAddress + sizeof(long), 0));
+        _context[CpuRegister.Rdi] = SemaphoreAddress;
+        _context[CpuRegister.Rsi] = TimeoutAddress;
+
+        Assert.Equal(0, KernelPosixSemaphoreCompatExports.PosixSemaphoreTimedWait(_context));
+        Assert.Equal(ulong.MaxValue, _context[CpuRegister.Rax]);
+        Assert.Equal(ErrnoTimedOut, ReadErrno());
+        Assert.Equal(0, GetValue());
+    }
+
+    [Fact]
+    public void TimedWait_WithPastDeadlineStillConsumesAnAvailableCount()
+    {
+        Initialize(1);
+        Assert.True(_context.TryWriteUInt64(TimeoutAddress, 0));
+        Assert.True(_context.TryWriteUInt64(TimeoutAddress + sizeof(long), 0));
+        _context[CpuRegister.Rdi] = SemaphoreAddress;
+        _context[CpuRegister.Rsi] = TimeoutAddress;
+
+        Assert.Equal(0, KernelPosixSemaphoreCompatExports.PosixSemaphoreTimedWait(_context));
+        Assert.Equal(0UL, _context[CpuRegister.Rax]);
+        Assert.Equal(0, GetValue());
+    }
+
+    [Fact]
+    public void PublicNids_RegisterAsPosixSemaphoreExports()
+    {
+        var manager = new ModuleManager();
+        manager.RegisterExports(
+            SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen5));
+
+        AssertExport(manager, "pDuPEf3m4fI", "sem_init");
+        AssertExport(manager, "cDW233RAwWo", "sem_destroy");
+        AssertExport(manager, "YCV5dGGBcCo", "sem_wait");
+        AssertExport(manager, "WBWzsRifCEA", "sem_trywait");
+        AssertExport(manager, "w5IHyvahg-o", "sem_timedwait");
+        AssertExport(manager, "IKP8typ0QUk", "sem_post");
+        AssertExport(manager, "Bq+LRV-N6Hk", "sem_getvalue");
+    }
+
+    public void Dispose() => KernelPosixSemaphoreCompatExports.ResetForTests();
+
+    private void Initialize(uint count)
+    {
+        _context[CpuRegister.Rdi] = SemaphoreAddress;
+        _context[CpuRegister.Rsi] = 0;
+        _context[CpuRegister.Rdx] = count;
+        Assert.Equal(0, KernelPosixSemaphoreCompatExports.PosixSemaphoreInit(_context));
+        Assert.Equal(0UL, _context[CpuRegister.Rax]);
+    }
+
+    private int GetValue()
+    {
+        _context[CpuRegister.Rdi] = SemaphoreAddress;
+        _context[CpuRegister.Rsi] = ValueAddress;
+        Assert.Equal(0, KernelPosixSemaphoreCompatExports.PosixSemaphoreGetValue(_context));
+        Assert.Equal(0UL, _context[CpuRegister.Rax]);
+        Assert.True(_context.TryReadInt32(ValueAddress, out var value));
+        return value;
+    }
+
+    private int ReadErrno()
+    {
+        Assert.True(_context.TryReadInt32(TlsBase + 0x40, out var value));
+        return value;
+    }
+
+    private static void AssertExport(ModuleManager manager, string nid, string name)
+    {
+        Assert.True(manager.TryGetExport(nid, out var export));
+        Assert.Equal(name, export.Name);
+        Assert.Equal("libKernel", export.LibraryName);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelPthreadOpaqueAllocationTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelPthreadOpaqueAllocationTests.cs
@@ -1,0 +1,191 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+[CollectionDefinition("KernelPthreadOpaqueAllocation", DisableParallelization = true)]
+public sealed class KernelPthreadOpaqueAllocationCollectionDefinition;
+
+[Collection("KernelPthreadOpaqueAllocation")]
+public sealed class KernelPthreadOpaqueAllocationTests
+{
+    private const ulong MemoryBase = 0x0000_7FFF_4000_0000;
+    private const ulong MutexAddress = MemoryBase + 0x1000;
+    private const ulong CondAddress = MemoryBase + 0x2000;
+    private const ulong AllocationBase = MemoryBase + 0x1_0000;
+
+    [Fact]
+    public void InitDestroy_FreesOpaqueHandlesClearsSlotsAndSupportsHandleReuse()
+    {
+        var memory = new TrackingGuestMemory(MemoryBase, 0x2_0000, AllocationBase);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        var firstHandles = InitializePair(context, memory);
+        DestroyPair(context, memory, firstHandles);
+
+        var secondHandles = InitializePair(context, memory);
+        Assert.Equal(
+            new[] { firstHandles.Mutex, firstHandles.Cond }.Order(),
+            new[] { secondHandles.Mutex, secondHandles.Cond }.Order());
+        DestroyPair(context, memory, secondHandles);
+
+        Assert.Equal(0, memory.ActiveAllocationCount);
+        Assert.Equal(2, memory.GetSuccessfulFreeCount(firstHandles.Mutex));
+        Assert.Equal(2, memory.GetSuccessfulFreeCount(firstHandles.Cond));
+    }
+
+    private static (ulong Mutex, ulong Cond) InitializePair(
+        CpuContext context,
+        TrackingGuestMemory memory)
+    {
+        context[CpuRegister.Rdi] = MutexAddress;
+        context[CpuRegister.Rsi] = 0;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexInit(context));
+        Assert.True(context.TryReadUInt64(MutexAddress, out var mutexHandle));
+        Assert.NotEqual(0UL, mutexHandle);
+        Assert.True(memory.IsAllocationActive(mutexHandle));
+
+        context[CpuRegister.Rdi] = CondAddress;
+        context[CpuRegister.Rsi] = 0;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadCondInit(context));
+        Assert.True(context.TryReadUInt64(CondAddress, out var condHandle));
+        Assert.NotEqual(0UL, condHandle);
+        Assert.NotEqual(mutexHandle, condHandle);
+        Assert.True(memory.IsAllocationActive(condHandle));
+        Assert.Equal(2, memory.ActiveAllocationCount);
+
+        return (mutexHandle, condHandle);
+    }
+
+    private static void DestroyPair(
+        CpuContext context,
+        TrackingGuestMemory memory,
+        (ulong Mutex, ulong Cond) handles)
+    {
+        context[CpuRegister.Rdi] = MutexAddress;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexDestroy(context));
+        Assert.True(context.TryReadUInt64(MutexAddress, out var mutexSlot));
+        Assert.Equal(0UL, mutexSlot);
+        Assert.False(memory.IsAllocationActive(handles.Mutex));
+        Assert.True(memory.IsAllocationActive(handles.Cond));
+
+        context[CpuRegister.Rdi] = CondAddress;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadCondDestroy(context));
+        Assert.True(context.TryReadUInt64(CondAddress, out var condSlot));
+        Assert.Equal(0UL, condSlot);
+        Assert.False(memory.IsAllocationActive(handles.Cond));
+        Assert.Equal(0, memory.ActiveAllocationCount);
+    }
+
+    private sealed class TrackingGuestMemory : ICpuMemory, IGuestMemoryAllocator
+    {
+        private readonly ulong _baseAddress;
+        private readonly byte[] _storage;
+        private readonly List<(ulong Address, ulong Size)> _freeBlocks = new();
+        private readonly Dictionary<ulong, ulong> _activeAllocations = new();
+        private readonly Dictionary<ulong, int> _successfulFreeCounts = new();
+        private ulong _nextAllocationAddress;
+
+        public TrackingGuestMemory(ulong baseAddress, int size, ulong allocationBase)
+        {
+            _baseAddress = baseAddress;
+            _storage = new byte[size];
+            _nextAllocationAddress = allocationBase;
+        }
+
+        public int ActiveAllocationCount => _activeAllocations.Count;
+
+        public bool TryRead(ulong virtualAddress, Span<byte> destination)
+        {
+            if (!TryResolve(virtualAddress, destination.Length, out var offset))
+            {
+                return false;
+            }
+
+            _storage.AsSpan(offset, destination.Length).CopyTo(destination);
+            return true;
+        }
+
+        public bool TryWrite(ulong virtualAddress, ReadOnlySpan<byte> source)
+        {
+            if (!TryResolve(virtualAddress, source.Length, out var offset))
+            {
+                return false;
+            }
+
+            source.CopyTo(_storage.AsSpan(offset, source.Length));
+            return true;
+        }
+
+        public bool TryAllocateGuestMemory(ulong size, ulong alignment, out ulong address)
+        {
+            alignment = Math.Max(alignment, 1);
+            for (var index = 0; index < _freeBlocks.Count; index++)
+            {
+                var block = _freeBlocks[index];
+                if (block.Size != size || block.Address % alignment != 0)
+                {
+                    continue;
+                }
+
+                _freeBlocks.RemoveAt(index);
+                _activeAllocations.Add(block.Address, block.Size);
+                address = block.Address;
+                return true;
+            }
+
+            var remainder = _nextAllocationAddress % alignment;
+            address = remainder == 0
+                ? _nextAllocationAddress
+                : _nextAllocationAddress + alignment - remainder;
+            if (!TryResolve(address, checked((int)size), out _))
+            {
+                address = 0;
+                return false;
+            }
+
+            _activeAllocations.Add(address, size);
+            _nextAllocationAddress = address + size;
+            return true;
+        }
+
+        public bool TryFreeGuestMemory(ulong address)
+        {
+            if (!_activeAllocations.Remove(address, out var size))
+            {
+                return false;
+            }
+
+            _freeBlocks.Add((address, size));
+            _successfulFreeCounts[address] = GetSuccessfulFreeCount(address) + 1;
+            return true;
+        }
+
+        public bool IsAllocationActive(ulong address) => _activeAllocations.ContainsKey(address);
+
+        public int GetSuccessfulFreeCount(ulong address) =>
+            _successfulFreeCounts.GetValueOrDefault(address);
+
+        private bool TryResolve(ulong virtualAddress, int length, out int offset)
+        {
+            offset = 0;
+            if (virtualAddress < _baseAddress || length < 0)
+            {
+                return false;
+            }
+
+            var relative = virtualAddress - _baseAddress;
+            if (relative + (ulong)length > (ulong)_storage.Length)
+            {
+                return false;
+            }
+
+            offset = checked((int)relative);
+            return true;
+        }
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelPthreadRwlockTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelPthreadRwlockTests.cs
@@ -1,0 +1,124 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+[Collection("KernelPthreadOpaqueAllocation")]
+public sealed class KernelPthreadRwlockTests
+{
+    private const ulong MemoryBase = 0x0000_7FFF_5000_0000;
+    private const ulong RwlockAddress = MemoryBase + 0x1000;
+
+    [Fact]
+    public async Task ConcurrentLazyTryWriteLock_UsesOneSharedState()
+    {
+        using var memory = new ConcurrentFirstReadMemory(MemoryBase, 0x2000, RwlockAddress);
+        using var acquired = new Barrier(2);
+
+        var first = Task.Run(() => TryLockThenRelease(memory, acquired));
+        var second = Task.Run(() => TryLockThenRelease(memory, acquired));
+        var results = await Task.WhenAll(first, second);
+
+        Assert.Equal(1, results.Count(result => result == (int)OrbisGen2Result.ORBIS_GEN2_OK));
+        Assert.Equal(1, results.Count(result => result == (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY));
+
+        var destroyContext = new CpuContext(memory, Generation.Gen5);
+        destroyContext[CpuRegister.Rdi] = RwlockAddress;
+        Assert.Equal(0, KernelPthreadExtendedCompatExports.PthreadRwlockDestroy(destroyContext));
+        Assert.True(destroyContext.TryReadUInt64(RwlockAddress, out var slot));
+        Assert.Equal(0UL, slot);
+    }
+
+    private static int TryLockThenRelease(ConcurrentFirstReadMemory memory, Barrier acquired)
+    {
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = RwlockAddress;
+        var result = KernelPthreadExtendedCompatExports.PthreadRwlockTrywrlock(context);
+
+        Assert.True(acquired.SignalAndWait(TimeSpan.FromSeconds(10)));
+        if (result == (int)OrbisGen2Result.ORBIS_GEN2_OK)
+        {
+            Assert.Equal(0, KernelPthreadExtendedCompatExports.PthreadRwlockUnlock(context));
+        }
+
+        return result;
+    }
+
+    private sealed class ConcurrentFirstReadMemory : ICpuMemory, IDisposable
+    {
+        private readonly ulong _baseAddress;
+        private readonly ulong _synchronizedAddress;
+        private readonly byte[] _storage;
+        private readonly object _gate = new();
+        private readonly Barrier _firstReads = new(2);
+        private int _synchronizedReads;
+
+        public ConcurrentFirstReadMemory(ulong baseAddress, int size, ulong synchronizedAddress)
+        {
+            _baseAddress = baseAddress;
+            _synchronizedAddress = synchronizedAddress;
+            _storage = new byte[size];
+        }
+
+        public bool TryRead(ulong virtualAddress, Span<byte> destination)
+        {
+            if (!TryResolve(virtualAddress, destination.Length, out var offset))
+            {
+                return false;
+            }
+
+            lock (_gate)
+            {
+                _storage.AsSpan(offset, destination.Length).CopyTo(destination);
+            }
+
+            if (virtualAddress == _synchronizedAddress &&
+                destination.Length == sizeof(ulong) &&
+                Interlocked.Increment(ref _synchronizedReads) <= 2)
+            {
+                return _firstReads.SignalAndWait(TimeSpan.FromSeconds(10));
+            }
+
+            return true;
+        }
+
+        public bool TryWrite(ulong virtualAddress, ReadOnlySpan<byte> source)
+        {
+            if (!TryResolve(virtualAddress, source.Length, out var offset))
+            {
+                return false;
+            }
+
+            lock (_gate)
+            {
+                source.CopyTo(_storage.AsSpan(offset, source.Length));
+            }
+
+            return true;
+        }
+
+        public void Dispose() => _firstReads.Dispose();
+
+        private bool TryResolve(ulong virtualAddress, int length, out int offset)
+        {
+            offset = 0;
+            if (virtualAddress < _baseAddress || length < 0)
+            {
+                return false;
+            }
+
+            var relative = virtualAddress - _baseAddress;
+            if (relative + (ulong)length > (ulong)_storage.Length)
+            {
+                return false;
+            }
+
+            offset = checked((int)relative);
+            return true;
+        }
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelSocketCompatExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelSocketCompatExportsTests.cs
@@ -1,50 +1,252 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
 using SharpEmu.HLE;
 using SharpEmu.Libs.Kernel;
 using Xunit;
+using HostSocket = System.Net.Sockets.Socket;
 
 namespace SharpEmu.Libs.Tests.Kernel;
 
-public sealed class KernelSocketCompatExportsTests
+[CollectionDefinition("KernelSocketCompat", DisableParallelization = true)]
+public sealed class KernelSocketCompatCollectionDefinition;
+
+[Collection("KernelSocketCompat")]
+public sealed class KernelSocketCompatExportsTests : IDisposable
 {
-    [Fact]
-    public void Connect_InvalidSockaddrLeavesFdOpenForGuestClose()
+    private const ulong MemoryBase = 0x0000_7FFF_3000_0000;
+    private const ulong TlsBase = MemoryBase + 0x1000;
+    private const ulong PayloadAddress = MemoryBase + 0x2000;
+    private const ulong SockaddrAddress = MemoryBase + 0x3000;
+    private const ulong SourceAddress = MemoryBase + 0x3100;
+    private const ulong SourceLengthAddress = MemoryBase + 0x3200;
+    private const ulong ErrnoAddress = TlsBase + 0x40;
+    private const int AddressFamilyInet = 2;
+    private const int SocketTypeStream = 1;
+    private const int SocketTypeDatagram = 2;
+    private const int SocketTypeNonBlocking = 0x20000000;
+    private readonly string? _previousNetRedirect;
+    private readonly FakeCpuMemory _memory = new(MemoryBase, 0x10_000);
+    private readonly CpuContext _context;
+
+    public KernelSocketCompatExportsTests()
     {
-        const ulong memoryBase = 0x0000_7FFF_3000_0000;
-        var context = new CpuContext(new FakeCpuMemory(memoryBase, 0x1000), Generation.Gen5);
-        context[CpuRegister.Rdi] = 2;
-        context[CpuRegister.Rsi] = 1;
-        context[CpuRegister.Rdx] = 6;
+        _previousNetRedirect = Environment.GetEnvironmentVariable("SHARPEMU_NET_REDIRECT");
+        Environment.SetEnvironmentVariable("SHARPEMU_NET_REDIRECT", null);
+        _context = new CpuContext(_memory, Generation.Gen5)
+        {
+            FsBase = TlsBase,
+        };
+    }
 
-        Assert.Equal(0, KernelSocketCompatExports.Socket(context));
-        Assert.NotEqual(ulong.MaxValue, context[CpuRegister.Rax]);
-        var guestFd = checked((int)context[CpuRegister.Rax]);
-
+    [Fact]
+    public void Sendto_SendsGuestDatagramToLoopbackEndpoint()
+    {
+        var guestFd = CreateGuestUdpSocket();
         try
         {
-            context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
-            context[CpuRegister.Rsi] = memoryBase;
-            context[CpuRegister.Rdx] = 0;
+            using var receiver = new HostSocket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+            {
+                ReceiveTimeout = 2_000,
+            };
+            receiver.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            var receiverEndpoint = Assert.IsType<IPEndPoint>(receiver.LocalEndPoint);
+            var payload = new byte[] { 0x53, 0x68, 0x61, 0x72, 0x70, 0x45, 0x6D, 0x75 };
+            Assert.True(_memory.TryWrite(PayloadAddress, payload));
+            WriteGuestSockaddr(SockaddrAddress, receiverEndpoint);
 
-            Assert.Equal(0, KernelSocketCompatExports.Connect(context));
-            Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+            _context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
+            _context[CpuRegister.Rsi] = PayloadAddress;
+            _context[CpuRegister.Rdx] = unchecked((ulong)payload.Length);
+            _context[CpuRegister.Rcx] = 0;
+            _context[CpuRegister.R8] = SockaddrAddress;
+            _context[CpuRegister.R9] = 16;
 
-            context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
-            Assert.Equal(
-                (int)OrbisGen2Result.ORBIS_GEN2_OK,
-                KernelMemoryCompatExports.PosixClose(context));
-            Assert.Equal(0UL, context[CpuRegister.Rax]);
+            Assert.Equal(0, KernelSocketCompatExports.Sendto(_context));
+            Assert.Equal(unchecked((ulong)payload.Length), _context[CpuRegister.Rax]);
 
-            context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
-            Assert.Equal(
-                (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND,
-                KernelMemoryCompatExports.PosixClose(context));
+            var received = new byte[64];
+            var receivedLength = receiver.Receive(received);
+            Assert.Equal(payload, received.AsSpan(0, receivedLength).ToArray());
         }
         finally
         {
-            KernelSocketCompatExports.TryCloseSocketFd(guestFd);
+            CloseGuestSocket(guestFd);
         }
+    }
+
+    [Fact]
+    public void Recvfrom_ConsumesPrequeuedDatagramAndWritesSourceSockaddr()
+    {
+        var guestFd = CreateGuestUdpSocket();
+        try
+        {
+            var guestEndpoint = BindGuestSocketToEphemeralLoopbackPort(guestFd);
+            using var sender = new HostSocket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            sender.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            var senderEndpoint = Assert.IsType<IPEndPoint>(sender.LocalEndPoint);
+            var payload = new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50 };
+            Assert.Equal(payload.Length, sender.SendTo(payload, guestEndpoint));
+            Assert.True(_context.TryWriteUInt32(SourceLengthAddress, 16));
+
+            _context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
+            _context[CpuRegister.Rsi] = PayloadAddress;
+            _context[CpuRegister.Rdx] = 64;
+            _context[CpuRegister.Rcx] = 0;
+            _context[CpuRegister.R8] = SourceAddress;
+            _context[CpuRegister.R9] = SourceLengthAddress;
+
+            Assert.Equal(0, KernelSocketCompatExports.Recvfrom(_context));
+            Assert.Equal(unchecked((ulong)payload.Length), _context[CpuRegister.Rax]);
+
+            var received = new byte[payload.Length];
+            Assert.True(_memory.TryRead(PayloadAddress, received));
+            Assert.Equal(payload, received);
+            Assert.True(_context.TryReadUInt32(SourceLengthAddress, out var sourceLength));
+            Assert.Equal(16u, sourceLength);
+            Assert.Equal(senderEndpoint, ReadGuestSockaddr(SourceAddress));
+        }
+        finally
+        {
+            CloseGuestSocket(guestFd);
+        }
+    }
+
+    [Fact]
+    public void Recvfrom_EmptyNonBlockingSocketReturnsWouldBlockErrno()
+    {
+        var guestFd = CreateGuestUdpSocket(nonBlocking: true);
+        try
+        {
+            _context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
+            _context[CpuRegister.Rsi] = PayloadAddress;
+            _context[CpuRegister.Rdx] = 64;
+            _context[CpuRegister.Rcx] = 0;
+            _context[CpuRegister.R8] = 0;
+            _context[CpuRegister.R9] = 0;
+
+            Assert.Equal(0, KernelSocketCompatExports.Recvfrom(_context));
+            Assert.Equal(ulong.MaxValue, _context[CpuRegister.Rax]);
+            Assert.True(_context.TryReadInt32(ErrnoAddress, out var errno));
+            Assert.Equal(35, errno);
+        }
+        finally
+        {
+            CloseGuestSocket(guestFd);
+        }
+    }
+
+    [Fact]
+    public void Connect_FailureLeavesFdOpenForGuestClose()
+    {
+        var guestFd = CreateGuestTcpSocket();
+
+        // Non-loopback target is denied by the outbound policy (no SHARPEMU_NET_REDIRECT).
+        WriteGuestSockaddr(SockaddrAddress, new IPEndPoint(IPAddress.Parse("203.0.113.1"), 443));
+        _context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
+        _context[CpuRegister.Rsi] = SockaddrAddress;
+        _context[CpuRegister.Rdx] = 16;
+        Assert.Equal(0, KernelSocketCompatExports.Connect(_context));
+        Assert.Equal(ulong.MaxValue, _context[CpuRegister.Rax]);
+
+        // POSIX: a failed connect does not close the fd; the guest's close must find it.
+        _context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, KernelMemoryCompatExports.PosixClose(_context));
+        Assert.Equal(0UL, _context[CpuRegister.Rax]);
+
+        _context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND,
+            KernelMemoryCompatExports.PosixClose(_context));
+    }
+
+    [Theory]
+    [InlineData("oBr313PppNE", "sendto")]
+    [InlineData("lUk6wrGXyMw", "recvfrom")]
+    public void UdpNids_RegisterAsLibKernelExports(string nid, string exportName)
+    {
+        var manager = new ModuleManager();
+        manager.RegisterExports(
+            SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen5));
+
+        Assert.True(manager.TryGetExport(nid, out var export), $"NID {nid} did not register.");
+        Assert.Equal(exportName, export.Name);
+        Assert.Equal("libKernel", export.LibraryName);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("SHARPEMU_NET_REDIRECT", _previousNetRedirect);
+    }
+
+    private int CreateGuestTcpSocket()
+    {
+        _context[CpuRegister.Rdi] = AddressFamilyInet;
+        _context[CpuRegister.Rsi] = SocketTypeStream;
+        _context[CpuRegister.Rdx] = 6;
+
+        Assert.Equal(0, KernelSocketCompatExports.Socket(_context));
+        Assert.NotEqual(ulong.MaxValue, _context[CpuRegister.Rax]);
+        return checked((int)_context[CpuRegister.Rax]);
+    }
+
+    private int CreateGuestUdpSocket(bool nonBlocking = false)
+    {
+        _context[CpuRegister.Rdi] = AddressFamilyInet;
+        _context[CpuRegister.Rsi] = unchecked((ulong)(SocketTypeDatagram |
+            (nonBlocking ? SocketTypeNonBlocking : 0)));
+        _context[CpuRegister.Rdx] = 17;
+
+        Assert.Equal(0, KernelSocketCompatExports.Socket(_context));
+        Assert.NotEqual(ulong.MaxValue, _context[CpuRegister.Rax]);
+        return checked((int)_context[CpuRegister.Rax]);
+    }
+
+    private IPEndPoint BindGuestSocketToEphemeralLoopbackPort(int guestFd)
+    {
+        WriteGuestSockaddr(SockaddrAddress, new IPEndPoint(IPAddress.Loopback, 0));
+        _context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
+        _context[CpuRegister.Rsi] = SockaddrAddress;
+        _context[CpuRegister.Rdx] = 16;
+        Assert.Equal(0, KernelSocketCompatExports.Bind(_context));
+        Assert.Equal(0UL, _context[CpuRegister.Rax]);
+
+        Assert.True(_context.TryWriteUInt32(SourceLengthAddress, 16));
+        _context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
+        _context[CpuRegister.Rsi] = SourceAddress;
+        _context[CpuRegister.Rdx] = SourceLengthAddress;
+        Assert.Equal(0, KernelSocketCompatExports.Getsockname(_context));
+        Assert.Equal(0UL, _context[CpuRegister.Rax]);
+        return ReadGuestSockaddr(SourceAddress);
+    }
+
+    private void CloseGuestSocket(int guestFd)
+    {
+        _context[CpuRegister.Rdi] = unchecked((ulong)guestFd);
+        _ = KernelMemoryCompatExports.PosixClose(_context);
+    }
+
+    private void WriteGuestSockaddr(ulong address, IPEndPoint endpoint)
+    {
+        Span<byte> sockaddr = stackalloc byte[16];
+        sockaddr.Clear();
+        sockaddr[0] = 16;
+        sockaddr[1] = AddressFamilyInet;
+        BinaryPrimitives.WriteUInt16BigEndian(sockaddr[2..4], checked((ushort)endpoint.Port));
+        endpoint.Address.GetAddressBytes().CopyTo(sockaddr[4..8]);
+        Assert.True(_memory.TryWrite(address, sockaddr));
+    }
+
+    private IPEndPoint ReadGuestSockaddr(ulong address)
+    {
+        Span<byte> sockaddr = stackalloc byte[16];
+        Assert.True(_memory.TryRead(address, sockaddr));
+        Assert.Equal(16, sockaddr[0]);
+        Assert.Equal(AddressFamilyInet, sockaddr[1]);
+        var port = BinaryPrimitives.ReadUInt16BigEndian(sockaddr[2..4]);
+        return new IPEndPoint(new IPAddress(sockaddr[4..8]), port);
     }
 }

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelVirtualMemoryCompatExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelVirtualMemoryCompatExportsTests.cs
@@ -1,0 +1,480 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using SharpEmu.Core.Memory;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+[CollectionDefinition("KernelVirtualMemoryCompat", DisableParallelization = true)]
+public sealed class KernelVirtualMemoryCompatCollectionDefinition;
+
+[Collection("KernelVirtualMemoryCompat")]
+public sealed class KernelVirtualMemoryCompatExportsTests
+{
+    private const ulong MemoryBase = 0x0000_7FFF_5000_0000;
+    private const ulong InfoAddress = MemoryBase + 0x1000;
+    private const ulong ReservedAddress = 0x0000_6F00_0000_0000;
+    private const ulong ReservedLength = 0x4000;
+
+    [Fact]
+    public void VirtualQuery_ReservedRangeIsNotReportedAsCommitted()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x4000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        KernelMemoryCompatExports.RegisterReservedVirtualRange(ReservedAddress, ReservedLength);
+
+        context[CpuRegister.Rdi] = ReservedAddress;
+        context[CpuRegister.Rsi] = 0;
+        context[CpuRegister.Rdx] = InfoAddress;
+        context[CpuRegister.Rcx] = 72;
+
+        Assert.Equal(0, KernelMemoryCompatExports.KernelVirtualQuery(context));
+
+        Span<byte> info = stackalloc byte[72];
+        Assert.True(memory.TryRead(InfoAddress, info));
+        Assert.Equal(ReservedAddress, BinaryPrimitives.ReadUInt64LittleEndian(info[0..8]));
+        Assert.Equal(ReservedAddress + ReservedLength, BinaryPrimitives.ReadUInt64LittleEndian(info[8..16]));
+        Assert.Equal(0, BinaryPrimitives.ReadInt32LittleEndian(info[24..28]));
+        Assert.Equal(0, info[32]);
+    }
+
+    [Fact]
+    public void ReserveVirtualRange_FixedReservationReplacesDirectView()
+    {
+        if (!NativeGuestExecutionIsSupported)
+        {
+            return;
+        }
+
+        const ulong scratchAddress = 0x0000_6F10_0000_0000;
+        const ulong mappingAddress = 0x0000_6F10_0010_0000;
+        const ulong mappingLength = 0x4000;
+        const ulong physicalSize = 0x20_000;
+        using var memory = new PhysicalVirtualMemory();
+        Assert.True(memory.TryAllocateAtExact(
+            scratchAddress,
+            0x4000,
+            executable: false,
+            out var scratch));
+        Assert.Equal(
+            mappingAddress,
+            memory.ReserveAt(
+                mappingAddress,
+                mappingLength,
+                executable: false,
+                allowAlternative: false));
+        Assert.True(memory.TryMapDirectMemory(
+            mappingAddress,
+            mappingLength,
+            directMemoryOffset: 0,
+            physicalSize,
+            GuestPageProtection.Read | GuestPageProtection.Write,
+            mappingLength,
+            allowSearch: false,
+            out var mappedAddress));
+        Assert.True(memory.TryWriteUInt64(scratch, mappedAddress));
+
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = scratch;
+        context[CpuRegister.Rsi] = mappingLength;
+        context[CpuRegister.Rdx] = 0x0040_0010;
+        context[CpuRegister.Rcx] = mappingLength;
+
+        Assert.Equal(0, KernelRuntimeCompatExports.KernelReserveVirtualRange(context));
+        Assert.False(memory.TryUnmapDirectMemory(mappedAddress, mappingLength));
+    }
+
+    [Fact]
+    public void Munmap_UnmapsReservedSubrangeAndPreservesRemainderMetadata()
+    {
+        if (!NativeGuestExecutionIsSupported)
+        {
+            return;
+        }
+
+        const ulong scratchAddress = 0x0000_6F20_0000_0000;
+        const ulong reservedAddress = 0x0000_6F20_0010_0000;
+        const ulong reservedLength = 0x40000;
+        const ulong unmapLength = 0x30000;
+        using var memory = new PhysicalVirtualMemory();
+        Assert.True(memory.TryAllocateAtExact(
+            scratchAddress,
+            0x4000,
+            executable: false,
+            out var scratch));
+        Assert.Equal(
+            reservedAddress,
+            memory.ReserveAt(
+                reservedAddress,
+                reservedLength,
+                executable: false,
+                allowAlternative: false));
+        KernelMemoryCompatExports.RegisterReservedVirtualRange(reservedAddress, reservedLength);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = reservedAddress;
+        context[CpuRegister.Rsi] = unmapLength;
+
+        Assert.Equal(0, KernelMemoryCompatExports.KernelMunmap(context));
+
+        context[CpuRegister.Rdi] = reservedAddress + unmapLength;
+        context[CpuRegister.Rsi] = 0;
+        context[CpuRegister.Rdx] = scratch;
+        context[CpuRegister.Rcx] = 72;
+        Assert.Equal(0, KernelMemoryCompatExports.KernelVirtualQuery(context));
+        Span<byte> info = stackalloc byte[72];
+        Assert.True(memory.TryRead(scratch, info));
+        Assert.Equal(
+            reservedAddress + unmapLength,
+            BinaryPrimitives.ReadUInt64LittleEndian(info[0..8]));
+        Assert.Equal(
+            reservedAddress + reservedLength,
+            BinaryPrimitives.ReadUInt64LittleEndian(info[8..16]));
+        Assert.Equal(0, info[32]);
+    }
+
+    [Fact]
+    public void MapDirectMemory_CarvesContainingReservationInVirtualQueryTable()
+    {
+        if (!NativeGuestExecutionIsSupported)
+        {
+            return;
+        }
+
+        const ulong scratchAddress = 0x0000_6F30_0000_0000;
+        const ulong reservedAddress = 0x0000_6F30_0010_0000;
+        const ulong reservedLength = 0x40000;
+        const ulong mappingAddress = reservedAddress + 0x10000;
+        const ulong mappingLength = 0x10000;
+        using var memory = new PhysicalVirtualMemory();
+        Assert.True(memory.TryAllocateAtExact(
+            scratchAddress,
+            0x4000,
+            executable: false,
+            out var scratch));
+        Assert.Equal(
+            reservedAddress,
+            memory.ReserveAt(
+                reservedAddress,
+                reservedLength,
+                executable: false,
+                allowAlternative: false));
+        KernelMemoryCompatExports.RegisterReservedVirtualRange(reservedAddress, reservedLength);
+        Assert.True(memory.TryWriteUInt64(scratch, mappingAddress));
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = scratch;
+        context[CpuRegister.Rsi] = mappingLength;
+        context[CpuRegister.Rdx] = 0x02;
+        context[CpuRegister.Rcx] = 0x0040_0010;
+        context[CpuRegister.R8] = 0;
+        context[CpuRegister.R9] = mappingLength;
+
+        Assert.Equal(0, KernelMemoryCompatExports.KernelMapDirectMemory(context));
+
+        AssertVirtualQueryState(context, memory, scratch, reservedAddress, reservedAddress, mappingAddress, 0x00);
+        AssertVirtualQueryState(context, memory, scratch, mappingAddress, mappingAddress, mappingAddress + mappingLength, 0x12);
+        AssertVirtualQueryState(
+            context,
+            memory,
+            scratch,
+            mappingAddress + mappingLength,
+            mappingAddress + mappingLength,
+            reservedAddress + reservedLength,
+            0x00);
+
+        context[CpuRegister.Rdi] = reservedAddress;
+        context[CpuRegister.Rsi] = mappingLength * 2;
+        Assert.Equal(0, KernelMemoryCompatExports.KernelMunmap(context));
+        AssertVirtualQueryState(
+            context,
+            memory,
+            scratch,
+            mappingAddress + mappingLength,
+            mappingAddress + mappingLength,
+            reservedAddress + reservedLength,
+            0x00);
+    }
+
+    [Fact]
+    public void MapDirectMemory_FixedMappingReplacesOverlappingDirectViews()
+    {
+        if (!NativeGuestExecutionIsSupported)
+        {
+            return;
+        }
+
+        const ulong scratchAddress = 0x0000_6F40_0000_0000;
+        const ulong mappingAddress = 0x0000_6F40_0010_0000;
+        const ulong mappingLength = 0x80000;
+        const ulong replacementAddress = mappingAddress + 0x30000;
+        const ulong replacementLength = 0x80000;
+        using var memory = new PhysicalVirtualMemory();
+        Assert.True(memory.TryAllocateAtExact(scratchAddress, 0x4000, executable: false, out var scratch));
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Assert.True(memory.TryWriteUInt64(scratch, mappingAddress));
+        context[CpuRegister.Rdi] = scratch;
+        context[CpuRegister.Rsi] = mappingLength;
+        context[CpuRegister.Rdx] = 0x02;
+        context[CpuRegister.Rcx] = 0x0040_0010;
+        context[CpuRegister.R8] = 0;
+        context[CpuRegister.R9] = 0x10000;
+        Assert.Equal(0, KernelMemoryCompatExports.KernelMapDirectMemory(context));
+
+        Assert.True(memory.TryWriteUInt64(scratch, replacementAddress));
+        context[CpuRegister.Rsi] = replacementLength;
+        context[CpuRegister.R8] = 0x100000;
+        Assert.Equal(0, KernelMemoryCompatExports.KernelMapDirectMemory(context));
+
+        AssertVirtualQueryState(
+            context,
+            memory,
+            scratch,
+            mappingAddress,
+            mappingAddress,
+            replacementAddress,
+            0x12);
+        AssertVirtualQueryState(
+            context,
+            memory,
+            scratch,
+            replacementAddress,
+            replacementAddress,
+            replacementAddress + replacementLength,
+            0x12);
+    }
+
+    [Fact]
+    public void MapDirectMemory_FixedMappingUsesExactAddressRatherThanSearchAlignment()
+    {
+        if (!NativeGuestExecutionIsSupported)
+        {
+            return;
+        }
+
+        const ulong scratchAddress = 0x0000_6F44_0000_0000;
+        const ulong arenaAddress = 0x0000_6F44_0010_0000;
+        const ulong mappingAddress = 0x0000_6F44_0010_4000;
+        const ulong mappingLength = 0x4000;
+        using var memory = new PhysicalVirtualMemory();
+        Assert.True(memory.TryAllocateAtExact(scratchAddress, 0x4000, executable: false, out var scratch));
+        Assert.Equal(
+            arenaAddress,
+            memory.ReserveAt(
+                arenaAddress,
+                0x20000,
+                executable: false,
+                allowAlternative: false));
+        KernelMemoryCompatExports.RegisterReservedVirtualRange(arenaAddress, 0x20000);
+        Assert.True(memory.TryWriteUInt64(scratch, mappingAddress));
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = scratch;
+        context[CpuRegister.Rsi] = mappingLength;
+        context[CpuRegister.Rdx] = 0x02;
+        context[CpuRegister.Rcx] = 0x0040_0010;
+        context[CpuRegister.R8] = 0x140000;
+        context[CpuRegister.R9] = 0x10000;
+
+        Assert.Equal(0, KernelMemoryCompatExports.KernelMapDirectMemory(context));
+        Assert.True(context.TryReadUInt64(scratch, out var mappedAddress));
+        Assert.Equal(mappingAddress, mappedAddress);
+        Assert.True(memory.IsAccessible(mappingAddress, mappingLength));
+    }
+
+    [Fact]
+    public void MapDirectMemory_FixedNoOverwriteMapsFreeRange()
+    {
+        if (!NativeGuestExecutionIsSupported)
+        {
+            return;
+        }
+
+        const ulong scratchAddress = 0x0000_6F46_0000_0000;
+        const ulong mappingAddress = 0x0000_6F46_0010_0000;
+        using var memory = new PhysicalVirtualMemory();
+        Assert.True(memory.TryAllocateAtExact(scratchAddress, 0x4000, executable: false, out var scratch));
+        Assert.True(memory.TryWriteUInt64(scratch, mappingAddress));
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = scratch;
+        context[CpuRegister.Rsi] = 0x4000;
+        context[CpuRegister.Rdx] = 0x02;
+        context[CpuRegister.Rcx] = 0x0040_0090;
+        context[CpuRegister.R8] = 0x160000;
+        context[CpuRegister.R9] = 0x4000;
+
+        Assert.Equal(0, KernelMemoryCompatExports.KernelMapDirectMemory(context));
+        Assert.True(memory.IsAccessible(mappingAddress, 0x4000));
+    }
+
+    [Fact]
+    public void MapDirectMemory_FixedNoOverwritePreservesExistingDirectView()
+    {
+        if (!NativeGuestExecutionIsSupported)
+        {
+            return;
+        }
+
+        const ulong scratchAddress = 0x0000_6F48_0000_0000;
+        const ulong mappingAddress = 0x0000_6F48_0010_0000;
+        const ulong mappingLength = 0x40000;
+        using var memory = new PhysicalVirtualMemory();
+        Assert.True(memory.TryAllocateAtExact(scratchAddress, 0x4000, executable: false, out var scratch));
+        Assert.True(memory.TryWriteUInt64(scratch, mappingAddress));
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = scratch;
+        context[CpuRegister.Rsi] = mappingLength;
+        context[CpuRegister.Rdx] = 0x02;
+        context[CpuRegister.Rcx] = 0x0040_0010;
+        context[CpuRegister.R8] = 0;
+        context[CpuRegister.R9] = 0x4000;
+        Assert.Equal(0, KernelMemoryCompatExports.KernelMapDirectMemory(context));
+        Assert.True(memory.TryWrite(mappingAddress + 0x120, stackalloc byte[] { 0x53 }));
+
+        Assert.True(memory.TryWriteUInt64(scratch, mappingAddress));
+        context[CpuRegister.Rcx] = 0x0040_0090;
+        context[CpuRegister.R8] = 0x100000;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_OUT_OF_MEMORY,
+            KernelMemoryCompatExports.KernelMapDirectMemory(context));
+
+        Span<byte> value = stackalloc byte[1];
+        Assert.True(memory.TryRead(mappingAddress + 0x120, value));
+        Assert.Equal(0x53, value[0]);
+    }
+
+    [Fact]
+    public void MapDirectMemory_FixedNoOverwriteRejectsReservedOverlap()
+    {
+        if (!NativeGuestExecutionIsSupported)
+        {
+            return;
+        }
+
+        const ulong scratchAddress = 0x0000_6F4C_0000_0000;
+        const ulong reservedAddress = 0x0000_6F4C_0010_0000;
+        const ulong reservedLength = 0x8000;
+        using var memory = new PhysicalVirtualMemory();
+        Assert.True(memory.TryAllocateAtExact(scratchAddress, 0x4000, executable: false, out var scratch));
+        Assert.Equal(
+            reservedAddress,
+            memory.ReserveAt(
+                reservedAddress,
+                reservedLength,
+                executable: false,
+                allowAlternative: false));
+        KernelMemoryCompatExports.RegisterReservedVirtualRange(reservedAddress, reservedLength);
+        Assert.True(memory.TryWriteUInt64(scratch, reservedAddress + 0x4000));
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = scratch;
+        context[CpuRegister.Rsi] = 0x8000;
+        context[CpuRegister.Rdx] = 0x02;
+        context[CpuRegister.Rcx] = 0x0040_0090;
+        context[CpuRegister.R8] = 0x180000;
+        context[CpuRegister.R9] = 0x4000;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_OUT_OF_MEMORY,
+            KernelMemoryCompatExports.KernelMapDirectMemory(context));
+        Assert.True(memory.TryUnmapReservedMemory(reservedAddress, reservedLength));
+    }
+
+    [Theory]
+    [InlineData(0x5000UL, 0UL)]
+    [InlineData(0x4000UL, 0x1000UL)]
+    public void MapDirectMemory_RejectsNonGuestPageAlignedRange(
+        ulong mappingLength,
+        ulong physicalOffset)
+    {
+        if (!NativeGuestExecutionIsSupported)
+        {
+            return;
+        }
+
+        const ulong scratchAddress = 0x0000_6F4E_0000_0000;
+        const ulong mappingAddress = 0x0000_6F4E_0010_0000;
+        using var memory = new PhysicalVirtualMemory();
+        Assert.True(memory.TryAllocateAtExact(scratchAddress, 0x4000, executable: false, out var scratch));
+        Assert.True(memory.TryWriteUInt64(scratch, mappingAddress));
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = scratch;
+        context[CpuRegister.Rsi] = mappingLength;
+        context[CpuRegister.Rdx] = 0x02;
+        context[CpuRegister.Rcx] = 0x0040_0010;
+        context[CpuRegister.R8] = physicalOffset;
+        context[CpuRegister.R9] = 0x4000;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            KernelMemoryCompatExports.KernelMapDirectMemory(context));
+        Assert.False(memory.IsAccessible(mappingAddress, 1));
+    }
+
+    [Fact]
+    public void MapDirectMemory_FixedMappingReplacesPartialReservation()
+    {
+        if (!NativeGuestExecutionIsSupported)
+        {
+            return;
+        }
+
+        const ulong scratchAddress = 0x0000_6F50_0000_0000;
+        const ulong reservedAddress = 0x0000_6F50_0010_0000;
+        const ulong reservedLength = 0xE0000;
+        const ulong mappingLength = 0x180000;
+        using var memory = new PhysicalVirtualMemory();
+        Assert.True(memory.TryAllocateAtExact(scratchAddress, 0x4000, executable: false, out var scratch));
+        Assert.Equal(
+            reservedAddress,
+            memory.ReserveAt(reservedAddress, reservedLength, executable: false, allowAlternative: false));
+        KernelMemoryCompatExports.RegisterReservedVirtualRange(reservedAddress, reservedLength);
+        Assert.True(memory.TryWriteUInt64(scratch, reservedAddress));
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = scratch;
+        context[CpuRegister.Rsi] = mappingLength;
+        context[CpuRegister.Rdx] = 0x02;
+        context[CpuRegister.Rcx] = 0x0040_0010;
+        context[CpuRegister.R8] = 0x200000;
+        context[CpuRegister.R9] = 0x10000;
+
+        Assert.Equal(0, KernelMemoryCompatExports.KernelMapDirectMemory(context));
+
+        AssertVirtualQueryState(
+            context,
+            memory,
+            scratch,
+            reservedAddress,
+            reservedAddress,
+            reservedAddress + mappingLength,
+            0x12);
+        Assert.True(memory.IsAccessible(reservedAddress, mappingLength));
+    }
+
+    private static void AssertVirtualQueryState(
+        CpuContext context,
+        PhysicalVirtualMemory memory,
+        ulong infoAddress,
+        ulong queryAddress,
+        ulong expectedStart,
+        ulong expectedEnd,
+        byte expectedState)
+    {
+        context[CpuRegister.Rdi] = queryAddress;
+        context[CpuRegister.Rsi] = 0;
+        context[CpuRegister.Rdx] = infoAddress;
+        context[CpuRegister.Rcx] = 72;
+        Assert.Equal(0, KernelMemoryCompatExports.KernelVirtualQuery(context));
+        Span<byte> info = stackalloc byte[72];
+        Assert.True(memory.TryRead(infoAddress, info));
+        Assert.Equal(expectedStart, BinaryPrimitives.ReadUInt64LittleEndian(info[0..8]));
+        Assert.Equal(expectedEnd, BinaryPrimitives.ReadUInt64LittleEndian(info[8..16]));
+        Assert.Equal(expectedState, info[32]);
+    }
+
+    private static bool NativeGuestExecutionIsSupported =>
+        RuntimeInformation.ProcessArchitecture == Architecture.X64 &&
+        (OperatingSystem.IsWindows() || OperatingSystem.IsLinux() || OperatingSystem.IsMacOS());
+}

--- a/tests/SharpEmu.Libs.Tests/Libc/CxxAbiExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Libc/CxxAbiExportsTests.cs
@@ -1,0 +1,73 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.CxxAbi;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Libc;
+
+public sealed class CxxAbiExportsTests
+{
+    private const ulong MemoryBase = 0x0000_7FFF_1100_0000;
+    private const ulong GuardAddress = MemoryBase + 0x1000;
+    private const ulong GuestThreadHandle = 0x0000_0200_1234_5000;
+
+    [Fact]
+    public void GuardRelease_AfterHostThreadMigration_UsesGuestThreadIdentity()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x2000);
+
+        var acquire = RunOnNewHostThread(memory, CxaGuardExports.CxaGuardAcquire);
+        var release = RunOnNewHostThread(memory, CxaGuardExports.CxaGuardRelease);
+
+        Assert.NotEqual(acquire.ManagedThreadId, release.ManagedThreadId);
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, acquire.Result);
+        Assert.Equal(1UL, acquire.Rax);
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, release.Result);
+        Assert.Equal(0UL, release.Rax);
+        var verifyContext = new CpuContext(memory, Generation.Gen5);
+        Assert.True(verifyContext.TryReadUInt64(GuardAddress, out var guardWord));
+        Assert.Equal(1UL, guardWord & 0xFFFFUL);
+
+        var completedAcquire = RunOnNewHostThread(memory, CxaGuardExports.CxaGuardAcquire);
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, completedAcquire.Result);
+        Assert.Equal(0UL, completedAcquire.Rax);
+    }
+
+    private static GuardCallResult RunOnNewHostThread(
+        FakeCpuMemory memory,
+        Func<CpuContext, int> operation)
+    {
+        GuardCallResult result = default;
+        Exception? exception = null;
+        var thread = new Thread(() =>
+        {
+            var previousGuestThread = GuestThreadExecution.EnterGuestThread(GuestThreadHandle);
+            try
+            {
+                var context = new CpuContext(memory, Generation.Gen5);
+                context[CpuRegister.Rdi] = GuardAddress;
+                result = new GuardCallResult(
+                    operation(context),
+                    context[CpuRegister.Rax],
+                    Environment.CurrentManagedThreadId);
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+            finally
+            {
+                GuestThreadExecution.RestoreGuestThread(previousGuestThread);
+            }
+        });
+
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(10)));
+        Assert.Null(exception);
+        return result;
+    }
+
+    private readonly record struct GuardCallResult(int Result, ulong Rax, int ManagedThreadId);
+}

--- a/tests/SharpEmu.Libs.Tests/Memory/GuestMemoryAllocatorTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Memory/GuestMemoryAllocatorTests.cs
@@ -3,6 +3,7 @@
 
 using SharpEmu.Core.Memory;
 using SharpEmu.Core.Loader;
+using SharpEmu.HLE;
 using SharpEmu.HLE.Host;
 using Xunit;
 

--- a/tests/SharpEmu.Libs.Tests/Memory/PhysicalVirtualMemoryDirectReplacementTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Memory/PhysicalVirtualMemoryDirectReplacementTests.cs
@@ -1,0 +1,265 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Memory;
+using SharpEmu.HLE;
+using SharpEmu.HLE.Host;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Memory;
+
+public sealed class PhysicalVirtualMemoryDirectReplacementTests
+{
+    [Fact]
+    public void FixedReplacementSpansViewsAndPreservesBothOuterFragments()
+    {
+        const ulong firstAddress = 0x00005000_0400_8000;
+        const ulong viewSize = 0x10000;
+        const ulong secondAddress = firstAddress + viewSize;
+        const ulong replacementAddress = firstAddress + 0x4000;
+        const ulong replacementSize = 0x18000;
+        const ulong replacementEnd = replacementAddress + replacementSize;
+        const ulong directMemorySize = 0x80000;
+        const GuestPageProtection protection =
+            GuestPageProtection.Read | GuestPageProtection.Write;
+        using var host = new FailingSharedHostMemory();
+        using var memory = new PhysicalVirtualMemory(host);
+        Assert.True(memory.TryMapDirectMemory(
+            firstAddress,
+            viewSize,
+            directMemoryOffset: 0,
+            directMemorySize,
+            protection,
+            alignment: 0x4000,
+            allowSearch: false,
+            out _), "first view");
+        Assert.True(memory.TryMapDirectMemory(
+            secondAddress,
+            viewSize,
+            directMemoryOffset: viewSize,
+            directMemorySize,
+            protection,
+            alignment: 0x4000,
+            allowSearch: false,
+            out _), "second view");
+        Assert.True(memory.TryReplaceDirectMemory(
+            replacementAddress,
+            replacementSize,
+            directMemoryOffset: 0x40000,
+            directMemorySize,
+            protection,
+            out var actualAddress), "replacement");
+        Assert.Equal(replacementAddress, actualAddress);
+
+        Assert.Equal(
+            [
+                new SharedView(firstAddress, 0x4000, 0, HostPageProtection.ReadWrite),
+                new SharedView(replacementAddress, replacementSize, 0x40000, HostPageProtection.ReadWrite),
+                new SharedView(replacementEnd, 0x4000, 0x1C000, HostPageProtection.ReadWrite),
+            ],
+            host.ActiveViews.OrderBy(static view => view.Address));
+        Assert.Equal(3, memory.SnapshotRegions().Count);
+        Assert.True(memory.IsAccessible(replacementAddress, replacementSize));
+
+        Assert.True(memory.TryUnmapDirectMemory(firstAddress, 0x4000));
+        Assert.True(memory.TryUnmapDirectMemory(replacementAddress, replacementSize));
+        Assert.True(memory.TryUnmapDirectMemory(replacementEnd, 0x4000));
+        Assert.False(memory.TryUnmapDirectMemory(firstAddress, 0x4000));
+        Assert.False(memory.TryUnmapDirectMemory(replacementAddress, replacementSize));
+        Assert.False(memory.TryUnmapDirectMemory(replacementEnd, 0x4000));
+    }
+
+    [Fact]
+    public void FailedFixedReplacementRestoresOriginalDirectViewAndMetadata()
+    {
+        const ulong originalAddress = 0x00005000_0200_0000;
+        const ulong originalSize = 0xC000;
+        const ulong originalPhysicalOffset = 0x4000;
+        const ulong replacementAddress = originalAddress + 0x4000;
+        const ulong replacementSize = 0x8000;
+        const ulong replacementPhysicalOffset = 0x20000;
+        const ulong directMemorySize = 0x40000;
+        const GuestPageProtection guestProtection =
+            GuestPageProtection.Read | GuestPageProtection.Write;
+        const HostPageProtection hostProtection = HostPageProtection.ReadWrite;
+
+        using var host = new FailingSharedHostMemory();
+        using var memory = new PhysicalVirtualMemory(host);
+        Assert.True(memory.TryMapDirectMemory(
+            originalAddress,
+            originalSize,
+            originalPhysicalOffset,
+            directMemorySize,
+            guestProtection,
+            alignment: 0x4000,
+            allowSearch: false,
+            out var mappedAddress));
+        Assert.Equal(originalAddress, mappedAddress);
+
+        host.FailNextMapAfterViewIsInstalled(
+            replacementAddress,
+            replacementSize,
+            requiredViewAddress: originalAddress,
+            requiredViewSize: replacementAddress - originalAddress);
+
+        Assert.False(memory.TryReplaceDirectMemory(
+            replacementAddress,
+            replacementSize,
+            replacementPhysicalOffset,
+            directMemorySize,
+            guestProtection,
+            out var replacementMapping));
+        Assert.Equal(0UL, replacementMapping);
+        Assert.True(host.FailureWasInjected);
+
+        var restoredView = Assert.Single(host.ActiveViews);
+        Assert.Equal(
+            new SharedView(
+                originalAddress,
+                originalSize,
+                originalPhysicalOffset,
+                hostProtection),
+            restoredView);
+        Assert.True(memory.IsAccessible(originalAddress, originalSize));
+        var restoredRegion = Assert.Single(memory.SnapshotRegions());
+        Assert.Equal(originalAddress, restoredRegion.VirtualAddress);
+        Assert.Equal(originalSize, restoredRegion.MemorySize);
+
+        Assert.True(memory.TryUnmapDirectMemory(originalAddress, originalSize));
+        Assert.Empty(host.ActiveViews);
+        Assert.Empty(memory.SnapshotRegions());
+        Assert.False(memory.IsAccessible(originalAddress, 1));
+        Assert.False(memory.TryUnmapDirectMemory(originalAddress, originalSize));
+    }
+
+    private sealed class FailingSharedHostMemory : IHostMemory, IDisposable
+    {
+        private readonly Dictionary<ulong, SharedView> _activeViews = [];
+        private FakeSharedMemory? _sharedMemory;
+        private ulong _failureAddress;
+        private ulong _failureSize;
+        private ulong _requiredViewAddress;
+        private ulong _requiredViewSize;
+        private bool _failureArmed;
+
+        public IReadOnlyCollection<SharedView> ActiveViews => _activeViews.Values;
+
+        public bool FailureWasInjected { get; private set; }
+
+        public ulong Allocate(ulong desiredAddress, ulong size, HostPageProtection protection) => 0;
+
+        public ulong Reserve(ulong desiredAddress, ulong size, HostPageProtection protection) => 0;
+
+        public IHostSharedMemory? CreateSharedMemory(ulong size)
+        {
+            _sharedMemory = new FakeSharedMemory(size);
+            return _sharedMemory;
+        }
+
+        public ulong MapSharedMemory(
+            IHostSharedMemory sharedMemory,
+            ulong desiredAddress,
+            ulong size,
+            ulong offset,
+            HostPageProtection protection)
+        {
+            Assert.Same(_sharedMemory, sharedMemory);
+            Assert.NotEqual(0UL, desiredAddress);
+
+            if (_failureArmed &&
+                desiredAddress == _failureAddress &&
+                size == _failureSize &&
+                _activeViews.TryGetValue(_requiredViewAddress, out var requiredView) &&
+                requiredView.Size == _requiredViewSize)
+            {
+                _failureArmed = false;
+                FailureWasInjected = true;
+                return 0;
+            }
+
+            var end = checked(desiredAddress + size);
+            if (_activeViews.Values.Any(view =>
+                    view.Address < end &&
+                    desiredAddress < view.Address + view.Size))
+            {
+                return 0;
+            }
+
+            _activeViews.Add(
+                desiredAddress,
+                new SharedView(desiredAddress, size, offset, protection));
+            return desiredAddress;
+        }
+
+        public bool UnmapSharedMemory(ulong address, ulong size) =>
+            _activeViews.TryGetValue(address, out var view) &&
+            view.Size == size &&
+            _activeViews.Remove(address);
+
+        public bool UnmapReservedMemory(ulong address, ulong size) => false;
+
+        public bool Commit(ulong address, ulong size, HostPageProtection protection) => false;
+
+        public bool Free(ulong address) => _activeViews.Remove(address);
+
+        public bool Protect(
+            ulong address,
+            ulong size,
+            HostPageProtection protection,
+            out uint rawOldProtection)
+        {
+            rawOldProtection = 0;
+            return false;
+        }
+
+        public bool ProtectRaw(
+            ulong address,
+            ulong size,
+            uint rawProtection,
+            out uint rawOldProtection)
+        {
+            rawOldProtection = 0;
+            return false;
+        }
+
+        public bool Query(ulong address, out HostRegionInfo info)
+        {
+            info = default;
+            return false;
+        }
+
+        public void FlushInstructionCache(ulong address, ulong size)
+        {
+        }
+
+        public void FailNextMapAfterViewIsInstalled(
+            ulong address,
+            ulong size,
+            ulong requiredViewAddress,
+            ulong requiredViewSize)
+        {
+            _failureAddress = address;
+            _failureSize = size;
+            _requiredViewAddress = requiredViewAddress;
+            _requiredViewSize = requiredViewSize;
+            _failureArmed = true;
+        }
+
+        public void Dispose() => _sharedMemory?.Dispose();
+    }
+
+    private sealed class FakeSharedMemory(ulong size) : IHostSharedMemory
+    {
+        public ulong Size { get; } = size;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private readonly record struct SharedView(
+        ulong Address,
+        ulong Size,
+        ulong Offset,
+        HostPageProtection Protection);
+}

--- a/tests/SharpEmu.Libs.Tests/Network/Http2ExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Network/Http2ExportsTests.cs
@@ -1,0 +1,210 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Network;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Network;
+
+[CollectionDefinition("Http2Exports", DisableParallelization = true)]
+public sealed class Http2ExportsCollectionDefinition;
+
+[Collection("Http2Exports")]
+public sealed class Http2ExportsTests : IDisposable
+{
+    private const int Http2ErrorInvalidId = unchecked((int)0x80436004);
+    private const int Http2ErrorInvalidArgument = unchecked((int)0x80436016);
+    private const ulong MemoryBase = 0x0000_7FFF_5000_0000;
+    private const ulong MethodAddress = MemoryBase + 0x1000;
+    private const ulong UrlAddress = MemoryBase + 0x2000;
+    private const ulong AlternateUrlAddress = MemoryBase + 0x4000;
+    private readonly FakeCpuMemory _memory = new(MemoryBase, 0x10_000);
+    private readonly CpuContext _context;
+
+    public Http2ExportsTests()
+    {
+        Http2Exports.ResetForTests();
+        _context = new CpuContext(_memory, Generation.Gen5);
+    }
+
+    [Fact]
+    public void CreateRequest_StoresBoundedStringsAndContentLengthWithUniquePositiveIds()
+    {
+        var contextId = CreateContext();
+        var templateId = CreateTemplate(contextId);
+        _memory.WriteCString(MethodAddress, "POST");
+        _memory.WriteCString(UrlAddress, "https://example.invalid/first");
+        _memory.WriteCString(AlternateUrlAddress, "https://example.invalid/second");
+
+        var firstRequestId = CreateRequest(
+            templateId,
+            MethodAddress,
+            UrlAddress,
+            0xFEDC_BA98_7654_3210UL);
+        var secondRequestId = CreateRequest(
+            templateId,
+            MethodAddress,
+            AlternateUrlAddress,
+            17);
+
+        Assert.True(firstRequestId > 0);
+        Assert.True(secondRequestId > 0);
+        Assert.NotEqual(firstRequestId, secondRequestId);
+        Assert.True(Http2Exports.TryGetRequestState(firstRequestId, out var first));
+        Assert.Equal(templateId, first.TemplateId);
+        Assert.Equal("POST", first.Method);
+        Assert.Equal("https://example.invalid/first", first.Url);
+        Assert.Equal(0xFEDC_BA98_7654_3210UL, first.ContentLength);
+        Assert.True(Http2Exports.TryGetRequestState(secondRequestId, out var second));
+        Assert.Equal(17UL, second.ContentLength);
+    }
+
+    [Fact]
+    public void CreateRequest_RejectsUnknownTemplate()
+    {
+        _memory.WriteCString(MethodAddress, "GET");
+        _memory.WriteCString(UrlAddress, "https://example.invalid/");
+        SetCreateRequestArguments(int.MaxValue, MethodAddress, UrlAddress, 0);
+
+        var result = Http2Exports.Http2CreateRequestWithUrl(_context);
+
+        Assert.Equal(Http2ErrorInvalidId, result);
+        Assert.Equal(unchecked((ulong)Http2ErrorInvalidId), _context[CpuRegister.Rax]);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void CreateRequest_RejectsNullStringPointers(bool nullMethod, bool nullUrl)
+    {
+        var templateId = CreateTemplate(CreateContext());
+        _memory.WriteCString(MethodAddress, "GET");
+        _memory.WriteCString(UrlAddress, "https://example.invalid/");
+        SetCreateRequestArguments(
+            templateId,
+            nullMethod ? 0 : MethodAddress,
+            nullUrl ? 0 : UrlAddress,
+            0);
+
+        var result = Http2Exports.Http2CreateRequestWithUrl(_context);
+
+        Assert.Equal(Http2ErrorInvalidArgument, result);
+        Assert.Equal(unchecked((ulong)Http2ErrorInvalidArgument), _context[CpuRegister.Rax]);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CreateRequest_RejectsUnreadableStrings(bool unreadableMethod)
+    {
+        var templateId = CreateTemplate(CreateContext());
+        _memory.WriteCString(MethodAddress, "GET");
+        _memory.WriteCString(UrlAddress, "https://example.invalid/");
+        var unreadableAddress = MemoryBase + 0x20_000;
+        SetCreateRequestArguments(
+            templateId,
+            unreadableMethod ? unreadableAddress : MethodAddress,
+            unreadableMethod ? UrlAddress : unreadableAddress,
+            0);
+
+        Assert.Equal(
+            Http2ErrorInvalidArgument,
+            Http2Exports.Http2CreateRequestWithUrl(_context));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CreateRequest_RejectsStringsWithoutTerminatorWithinBound(bool unterminatedMethod)
+    {
+        var templateId = CreateTemplate(CreateContext());
+        _memory.WriteCString(MethodAddress, "GET");
+        _memory.WriteCString(UrlAddress, "https://example.invalid/");
+        var stringAddress = unterminatedMethod ? MethodAddress : UrlAddress;
+        var capacity = unterminatedMethod ? 64 : 4096;
+        Assert.True(_memory.TryWrite(stringAddress, Enumerable.Repeat((byte)'X', capacity).ToArray()));
+        SetCreateRequestArguments(templateId, MethodAddress, UrlAddress, 0);
+
+        Assert.Equal(
+            Http2ErrorInvalidArgument,
+            Http2Exports.Http2CreateRequestWithUrl(_context));
+    }
+
+    [Fact]
+    public void Term_RemovesChildTemplatesAndRequests()
+    {
+        var contextId = CreateContext();
+        var templateId = CreateTemplate(contextId);
+        _memory.WriteCString(MethodAddress, "GET");
+        _memory.WriteCString(UrlAddress, "https://example.invalid/");
+        var requestId = CreateRequest(templateId, MethodAddress, UrlAddress, 0);
+        Assert.True(Http2Exports.TryGetRequestState(requestId, out _));
+
+        _context[CpuRegister.Rdi] = unchecked((ulong)contextId);
+        Assert.Equal(0, Http2Exports.Http2Term(_context));
+        Assert.False(Http2Exports.TryGetRequestState(requestId, out _));
+
+        SetCreateRequestArguments(templateId, MethodAddress, UrlAddress, 0);
+        Assert.Equal(
+            Http2ErrorInvalidId,
+            Http2Exports.Http2CreateRequestWithUrl(_context));
+    }
+
+    [Fact]
+    public void CreateRequestNid_RegistersAsHttp2Export()
+    {
+        var manager = new ModuleManager();
+        manager.RegisterExports(
+            SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen5));
+
+        Assert.True(manager.TryGetExport("mmyOCxQMVYQ", out var export));
+        Assert.Equal("sceHttp2CreateRequestWithURL", export.Name);
+        Assert.Equal("libSceHttp2", export.LibraryName);
+    }
+
+    public void Dispose() => Http2Exports.ResetForTests();
+
+    private int CreateContext()
+    {
+        _context[CpuRegister.Rdi] = 1;
+        _context[CpuRegister.Rsi] = 2;
+        _context[CpuRegister.Rdx] = 0x20_000;
+        _context[CpuRegister.Rcx] = 8;
+        Assert.Equal(0, Http2Exports.Http2Init(_context));
+        return checked((int)_context[CpuRegister.Rax]);
+    }
+
+    private int CreateTemplate(int contextId)
+    {
+        _context[CpuRegister.Rdi] = unchecked((ulong)contextId);
+        _context[CpuRegister.Rsi] = 0;
+        _context[CpuRegister.Rdx] = 2;
+        _context[CpuRegister.Rcx] = 0;
+        Assert.Equal(0, Http2Exports.Http2CreateTemplate(_context));
+        return checked((int)_context[CpuRegister.Rax]);
+    }
+
+    private int CreateRequest(
+        int templateId,
+        ulong methodAddress,
+        ulong urlAddress,
+        ulong contentLength)
+    {
+        SetCreateRequestArguments(templateId, methodAddress, urlAddress, contentLength);
+        Assert.Equal(0, Http2Exports.Http2CreateRequestWithUrl(_context));
+        return checked((int)_context[CpuRegister.Rax]);
+    }
+
+    private void SetCreateRequestArguments(
+        int templateId,
+        ulong methodAddress,
+        ulong urlAddress,
+        ulong contentLength)
+    {
+        _context[CpuRegister.Rdi] = unchecked((ulong)templateId);
+        _context[CpuRegister.Rsi] = methodAddress;
+        _context[CpuRegister.Rdx] = urlAddress;
+        _context[CpuRegister.Rcx] = contentLength;
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/SaveData/SaveDataMountTests.cs
+++ b/tests/SharpEmu.Libs.Tests/SaveData/SaveDataMountTests.cs
@@ -1,0 +1,149 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Text;
+using SharpEmu.HLE;
+using SharpEmu.Libs.SaveData;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.SaveData;
+
+[CollectionDefinition("SaveData", DisableParallelization = true)]
+public sealed class SaveDataCollectionDefinition;
+
+[Collection("SaveData")]
+public sealed class SaveDataMountTests : IDisposable
+{
+    private const ulong MemoryBase = 0x0000_7FFF_2000_0000;
+    private const ulong MountAddress = MemoryBase + 0x1000;
+    private const ulong DirNameAddress = MemoryBase + 0x2000;
+    private const ulong SearchCondAddress = MemoryBase + 0x3000;
+    private const ulong SearchResultAddress = MemoryBase + 0x3100;
+    private const ulong SearchDirNamesAddress = MemoryBase + 0x4000;
+    private const ulong SearchParamsAddress = MemoryBase + 0x5000;
+    private const uint MountModeCreate2 = 1u << 5;
+    private readonly string? _previousSaveDataDirectory;
+    private readonly string _saveDataDirectory;
+    private readonly FakeCpuMemory _memory = new(MemoryBase, 0x20_000);
+    private readonly CpuContext _context;
+
+    public SaveDataMountTests()
+    {
+        _previousSaveDataDirectory = Environment.GetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR");
+        _saveDataDirectory = Path.Combine(Path.GetTempPath(), $"sharpemu-savedata-tests-{Guid.NewGuid():N}");
+        Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", _saveDataDirectory);
+        SaveDataExports.ConfigureApplicationInfo("TEST00001");
+        _context = new CpuContext(_memory, Generation.Gen5);
+    }
+
+    [Fact]
+    public void Mount3_AllocatesDistinctSlotsAndReusesReleasedSlot()
+    {
+        var firstResult = MemoryBase + 0x6000;
+        var secondResult = MemoryBase + 0x6100;
+        var thirdResult = MemoryBase + 0x6200;
+        var afterResetResult = MemoryBase + 0x6300;
+
+        Assert.Equal(0, Mount("Alpha", firstResult));
+        Assert.Equal("/savedata0", ReadCString(firstResult, 16));
+        Assert.Equal(0, Mount("Beta", secondResult));
+        Assert.Equal("/savedata1", ReadCString(secondResult, 16));
+
+        Assert.Equal(0, Umount(firstResult));
+        Assert.Equal(0, Mount("Gamma", thirdResult));
+        Assert.Equal("/savedata0", ReadCString(thirdResult, 16));
+
+        SaveDataExports.ConfigureApplicationInfo("TEST00001");
+        Assert.Equal(0, Mount("Delta", afterResetResult));
+        Assert.Equal("/savedata0", ReadCString(afterResetResult, 16));
+    }
+
+    [Fact]
+    public void Mount3_ReturnsMountFullAfterSixteenLiveMounts()
+    {
+        for (var i = 0; i < 16; i++)
+        {
+            var resultAddress = MemoryBase + 0x6000 + ((ulong)i * 0x100);
+            Assert.Equal(0, Mount($"Slot{i}", resultAddress));
+            Assert.Equal($"/savedata{i}", ReadCString(resultAddress, 16));
+        }
+
+        Assert.Equal(unchecked((int)0x809F000C), Mount("Overflow", MemoryBase + 0x7000));
+    }
+
+    [Fact]
+    public void DirNameSearch_WritesDirectoryNameToParamSubtitle()
+    {
+        var mountResultAddress = MemoryBase + 0x6000;
+        Assert.Equal(0, Mount("WorldOne", mountResultAddress));
+        Assert.Equal(0, Umount(mountResultAddress));
+
+        Span<byte> cond = stackalloc byte[0x40];
+        cond.Clear();
+        BinaryPrimitives.WriteInt32LittleEndian(cond[0x00..], 1000);
+        Assert.True(_memory.TryWrite(SearchCondAddress, cond));
+
+        Span<byte> result = stackalloc byte[0x38];
+        result.Clear();
+        BinaryPrimitives.WriteUInt64LittleEndian(result[0x08..], SearchDirNamesAddress);
+        BinaryPrimitives.WriteUInt32LittleEndian(result[0x10..], 1);
+        BinaryPrimitives.WriteUInt64LittleEndian(result[0x18..], SearchParamsAddress);
+        Assert.True(_memory.TryWrite(SearchResultAddress, result));
+
+        _context[CpuRegister.Rdi] = SearchCondAddress;
+        _context[CpuRegister.Rsi] = SearchResultAddress;
+        Assert.Equal(0, SaveDataExports.SaveDataDirNameSearch(_context));
+
+        Assert.Equal("Saved Data", ReadCString(SearchParamsAddress, 128));
+        Assert.Equal("WorldOne", ReadCString(SearchParamsAddress + 0x80, 128));
+        Assert.Equal(string.Empty, ReadCString(SearchParamsAddress + 0x100, 1024));
+    }
+
+    public void Dispose()
+    {
+        SaveDataExports.ConfigureApplicationInfo(null);
+        Environment.SetEnvironmentVariable("SHARPEMU_SAVEDATA_DIR", _previousSaveDataDirectory);
+        if (Directory.Exists(_saveDataDirectory))
+        {
+            Directory.Delete(_saveDataDirectory, recursive: true);
+        }
+    }
+
+    private int Mount(string dirName, ulong resultAddress)
+    {
+        Span<byte> mount = stackalloc byte[0x50];
+        mount.Clear();
+        BinaryPrimitives.WriteInt32LittleEndian(mount[0x00..], 1000);
+        BinaryPrimitives.WriteUInt64LittleEndian(mount[0x08..], DirNameAddress);
+        BinaryPrimitives.WriteUInt64LittleEndian(mount[0x10..], 96);
+        BinaryPrimitives.WriteUInt64LittleEndian(mount[0x18..], ulong.MaxValue);
+        BinaryPrimitives.WriteUInt32LittleEndian(mount[0x20..], MountModeCreate2);
+        Assert.True(_memory.TryWrite(MountAddress, mount));
+        _memory.WriteCString(DirNameAddress, dirName);
+
+        _context[CpuRegister.Rdi] = MountAddress;
+        _context[CpuRegister.Rsi] = resultAddress;
+        return SaveDataExports.SaveDataMount3(_context);
+    }
+
+    private int Umount(ulong mountPointAddress)
+    {
+        _context[CpuRegister.Rdi] = mountPointAddress;
+        _context[CpuRegister.Rsi] = 0;
+        return SaveDataExports.SaveDataUmount2(_context);
+    }
+
+    private string ReadCString(ulong address, int capacity)
+    {
+        var bytes = new byte[capacity];
+        Assert.True(_memory.TryRead(address, bytes));
+        var length = Array.IndexOf(bytes, (byte)0);
+        if (length < 0)
+        {
+            length = bytes.Length;
+        }
+
+        return Encoding.ASCII.GetString(bytes, 0, length);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/TextToSpeech/TextToSpeech2ExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/TextToSpeech/TextToSpeech2ExportsTests.cs
@@ -1,0 +1,130 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.TextToSpeech;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.TextToSpeech;
+
+[CollectionDefinition("TextToSpeech2Exports", DisableParallelization = true)]
+public sealed class TextToSpeech2ExportsCollectionDefinition;
+
+[Collection("TextToSpeech2Exports")]
+public sealed class TextToSpeech2ExportsTests : IDisposable
+{
+    private const ulong MemoryBase = 0x0000_7FFF_6000_0000;
+    private const ulong ConfigurationAddress = MemoryBase + 0x1000;
+    private const ulong StatusAddress = MemoryBase + 0x2000;
+    private const ulong SpeechParametersAddress = MemoryBase + 0x3000;
+    private const ulong TextAddress = MemoryBase + 0x4000;
+    private readonly FakeCpuMemory _memory = new(MemoryBase, 0x10_000);
+    private readonly CpuContext _context;
+
+    public TextToSpeech2ExportsTests()
+    {
+        TextToSpeech2Exports.ResetForTests();
+        _context = new CpuContext(_memory, Generation.Gen5);
+    }
+
+    [Fact]
+    public void Lifecycle_OpenReportsIdleThenClosesAndTerminates()
+    {
+        InitializeAndOpen();
+
+        _context[CpuRegister.Rdi] = StatusAddress;
+        Assert.Equal(0, TextToSpeech2Exports.TextToSpeech2GetSpeechStatus(_context));
+        Assert.True(_context.TryReadInt32(StatusAddress, out var status));
+        Assert.Equal(0, status);
+
+        Assert.Equal(0, TextToSpeech2Exports.TextToSpeech2Close(_context));
+        Assert.Equal(0, TextToSpeech2Exports.TextToSpeech2Terminate(_context));
+    }
+
+    [Fact]
+    public void Open_RejectsNullAndUnreadableConfigurationPointers()
+    {
+        Assert.Equal(0, TextToSpeech2Exports.TextToSpeech2Initialize(_context));
+
+        _context[CpuRegister.Rdi] = 0;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            TextToSpeech2Exports.TextToSpeech2Open(_context));
+
+        _context[CpuRegister.Rdi] = MemoryBase + 0x20_000;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            TextToSpeech2Exports.TextToSpeech2Open(_context));
+    }
+
+    [Fact]
+    public void GetSpeechStatus_RequiresAnOpenServiceAndWritableOutput()
+    {
+        Assert.Equal(0, TextToSpeech2Exports.TextToSpeech2Initialize(_context));
+        _context[CpuRegister.Rdi] = StatusAddress;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            TextToSpeech2Exports.TextToSpeech2GetSpeechStatus(_context));
+
+        Open();
+        _context[CpuRegister.Rdi] = MemoryBase + 0x20_000;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            TextToSpeech2Exports.TextToSpeech2GetSpeechStatus(_context));
+    }
+
+    [Fact]
+    public void Speak_AcceptsReadableTextAndCompletesSynchronously()
+    {
+        InitializeAndOpen();
+        Assert.True(_context.TryWriteUInt64(SpeechParametersAddress, TextAddress));
+        Assert.True(_memory.TryWrite(TextAddress, stackalloc byte[] { (byte)'H', 0, 0, 0 }));
+
+        _context[CpuRegister.Rdi] = SpeechParametersAddress;
+        Assert.Equal(0, TextToSpeech2Exports.TextToSpeech2Speak(_context));
+        Assert.Equal(0, TextToSpeech2Exports.TextToSpeech2Cancel(_context));
+
+        _context[CpuRegister.Rdi] = StatusAddress;
+        Assert.Equal(0, TextToSpeech2Exports.TextToSpeech2GetSpeechStatus(_context));
+        Assert.True(_context.TryReadInt32(StatusAddress, out var status));
+        Assert.Equal(0, status);
+    }
+
+    [Fact]
+    public void PublicNids_RegisterAsTextToSpeech2Exports()
+    {
+        var manager = new ModuleManager();
+        manager.RegisterExports(
+            SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen5));
+
+        AssertExport(manager, "UOjiprYwVNw", "sceTextToSpeech2Initialize");
+        AssertExport(manager, "SoWHuVW0gpU", "sceTextToSpeech2Terminate");
+        AssertExport(manager, "X0HZNbSiqyg", "sceTextToSpeech2Open");
+        AssertExport(manager, "t4e879M-cSw", "sceTextToSpeech2Close");
+        AssertExport(manager, "08JSg9p6bgQ", "sceTextToSpeech2GetSpeechStatus");
+        AssertExport(manager, "8ntsRd07EQA", "sceTextToSpeech2Speak");
+        AssertExport(manager, "2jiIxUmcsGo", "sceTextToSpeech2Cancel");
+    }
+
+    public void Dispose() => TextToSpeech2Exports.ResetForTests();
+
+    private void InitializeAndOpen()
+    {
+        Assert.Equal(0, TextToSpeech2Exports.TextToSpeech2Initialize(_context));
+        Open();
+    }
+
+    private void Open()
+    {
+        Assert.True(_context.TryWriteUInt64(ConfigurationAddress, 1));
+        _context[CpuRegister.Rdi] = ConfigurationAddress;
+        Assert.Equal(0, TextToSpeech2Exports.TextToSpeech2Open(_context));
+    }
+
+    private static void AssertExport(ModuleManager manager, string nid, string name)
+    {
+        Assert.True(manager.TryGetExport(nid, out var export));
+        Assert.Equal(name, export.Name);
+        Assert.Equal("libSceTextToSpeech2", export.LibraryName);
+    }
+}


### PR DESCRIPTION
## Summary

Review note: this is stacked on #393. The unique HLE change is commit `afcf91f` (10 files, 1,229 source additions and 719 test additions). GitHub will also show #393's files until that PR merges.

This builds on #393 and expands several generally useful HLE services whose public entry points existed only as partial stubs or did not preserve guest-visible state.

The network changes add datagram socket behavior, guest socket flags, endpoint tracking, nonblocking receive errors and consistent host-to-guest errno mapping. HTTP/2 templates and requests now validate their handles and retain the request metadata needed by later calls.

SaveData mount state now has explicit slot ownership, capacity checks, busy handling, mount information and parameter updates. Guest mount paths are registered and removed through the shared runtime path mapping, which is why this branch depends on #393. AppContent and NP entitlement access gain the related compatibility exports.

TextToSpeech2 now has a small state machine for initialize, open, status, speak, cancel, close and terminate. Calls validate guest pointers and service order rather than returning unconditional success.

There are no title checks, fixed game paths or per-game return values in this change. The behavior is expressed through service state, guest ABI validation and documented error results.

Depends on #393. Related to #203.

## Testing

- Release CLI build: 0 warnings, 0 errors.
- Stacked Runtime + HLE branch: `SharpEmu.Libs.Tests` 315/315 passed and `SharpEmu.SourceGenerators.Tests` 33/33 passed.
- Added focused coverage for TCP/UDP socket behavior, nonblocking errors, HTTP/2 handle and request state, SaveData mount lifecycle and TextToSpeech2 service ordering.
- Minecraft (PPSA17221): the prior integration run loaded the executable and seven adjacent PRX modules and reached a 1920x1080 guest presentation. Visual and menu parity with the newest development snapshot will be revalidated before this leaves draft.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
