### PR TITLE
Fix stackalloc in NGS2 render loop

### DIFF
--- a/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
+++ b/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
@@ -496,6 +496,8 @@ public static class Ngs2Exports
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
+        Span<byte> renderBufferInfoBytes = stackalloc byte[RenderBufferInfoSize];
+
         for (uint i = 0; i < bufferInfoCount; i++)
         {
             var entryAddress = bufferInfoAddress + (i * RenderBufferInfoSize);
@@ -527,10 +529,10 @@ public static class Ngs2Exports
 
                 if (ShouldTrace() && Interlocked.Increment(ref _renderInfoDumps) <= 4)
                 {
-                    Span<byte> rbi = stackalloc byte[RenderBufferInfoSize];
-                    ctx.Memory.TryRead(entryAddress, rbi);
+                    renderBufferInfoBytes.Clear();
+                    ctx.Memory.TryRead(entryAddress, renderBufferInfoBytes);
                     Console.Error.WriteLine(
-                        $"[LOADER][TRACE] ngs2.renderbufinfo addr=0x{bufferAddress:X} size={bufferSize} ch={channels} raw={Convert.ToHexString(rbi)}");
+                        $"[LOADER][TRACE] ngs2.renderbufinfo addr=0x{bufferAddress:X} size={bufferSize} ch={channels} raw={Convert.ToHexString(renderBufferInfoBytes)}");
                 }
             }
         }


### PR DESCRIPTION
## Summary

Move the `SceNgs2RenderBufferInfo` diagnostic buffer allocation outside the render-buffer loop.

## Why

The previous `stackalloc` occurred inside the `bufferInfoCount` loop, triggering analyzer warning CA2014 because repeated stack allocations inside a loop can increase stack usage.

## Changes

- Allocate the 24-byte diagnostic buffer once per `sceNgs2SystemRender` call.
- Clear and reuse the buffer before each diagnostic read.
- Preserve the existing trace output and runtime behavior.

## Verification

- Built `SharpEmu.Libs` successfully.
- Ran the complete test suite.
- 406 tests passed, 0 failed, 0 skipped.
- `git diff --check` completed without errors.
- The CA2014 warning in `Ngs2Exports.cs` is no longer emitted.

## AI assistance

AI assistance was used to identify the analyzer warning and review the small refactoring. I reviewed the resulting change, inspected the diff, built the project, and ran the complete test suite.