### PR TITLE
Fix XML documentation warnings

### DIFF
--- a/src/SharpEmu.Core/Cpu/Emulation/BmiInstructionEmulator.cs
+++ b/src/SharpEmu.Core/Cpu/Emulation/BmiInstructionEmulator.cs
@@ -18,7 +18,7 @@ namespace SharpEmu.Core.Cpu.Emulation;
 /// The methods deliberately operate on plain integers rather than on the OS CONTEXT record so the
 /// semantics can be unit-tested in isolation; the unsafe register/memory plumbing lives in the
 /// backend adapter. Each method returns the result already masked to the operand width and, where
-/// the instruction is defined to touch flags, updates <paramref name="eflags"/> in place. Flags
+/// the instruction is defined to touch flags, updates the <c>eflags</c> value in place. Flags
 /// documented as "undefined" by the vendor manuals are left untouched so behaviour stays
 /// deterministic across hosts.
 /// </summary>

--- a/src/SharpEmu.HLE/Host/Posix/PosixHostInput.cs
+++ b/src/SharpEmu.HLE/Host/Posix/PosixHostInput.cs
@@ -7,7 +7,7 @@ namespace SharpEmu.HLE.Host.Posix;
 /// Bridges a window-provided input source into the host input seam. POSIX
 /// hosts have no user32/XInput/raw-HID readers; keyboard and gamepad state
 /// come from the presenter's GLFW window instead, which registers itself via
-/// <see cref="SetSource"/> once the window exists. Until then (and with no
+/// <see cref="PosixHostInput.SetSource(IPosixWindowInputSource)"/> once the window exists. Until then (and with no
 /// window at all, e.g. headless runs) every query reports neutral input.
 /// Rumble and lightbar are unsupported by the GLFW input layer and no-op.
 /// </summary>


### PR DESCRIPTION
## Summary

Fix two invalid XML documentation references.

## Changes

- Replace a class-level `paramref` reference to `eflags` with inline code formatting.
- Fully qualify the `PosixHostInput.SetSource` XML documentation reference.

## Verification

- Full solution build completed successfully.
- 411 tests passed, 0 failed, 0 skipped.
- The CS1734 and CS1574 documentation warnings are no longer emitted.

## AI assistance

AI assistance was used to identify and review the documentation fixes. I reviewed the diff, built the complete solution, and ran the full test suite.