### PR TITLE
Add libc heap trace contract tests

### DIFF
--- a/tests/SharpEmu.Libs.Tests/LibcInternal/LibcInternalExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/LibcInternal/LibcInternalExportsTests.cs
@@ -1,0 +1,137 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.LibcInternal;
+
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.LibcInternal;
+
+public sealed class LibcInternalExportsTests
+{
+    private const ulong Base = 0x3_0000_0000;
+    private const ulong InfoAddress = Base + 0x100;
+    private const ulong ExpectedInfoSize = 32;
+
+    [Fact]
+    public void HeapGetTraceInfo_NullPointer_ReturnsInvalidArgument()
+    {
+        var memory = new FakeCpuMemory(Base, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        context[CpuRegister.Rdi] = 0;
+
+        var result = LibcInternalExports.LibcHeapGetTraceInfo(context);
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            result);
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void HeapGetTraceInfo_WrongSize_ReturnsInvalidArgument()
+    {
+        var memory = new FakeCpuMemory(Base, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Span<byte> sizeBytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            sizeBytes,
+            ExpectedInfoSize - 1);
+
+        Assert.True(memory.TryWrite(InfoAddress, sizeBytes));
+
+        context[CpuRegister.Rdi] = InfoAddress;
+
+        var result = LibcInternalExports.LibcHeapGetTraceInfo(context);
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            result);
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void HeapGetTraceInfo_ValidBuffer_WritesStablePointers()
+    {
+        var memory = new FakeCpuMemory(Base, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Span<byte> sizeBytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            sizeBytes,
+            ExpectedInfoSize);
+
+        Assert.True(memory.TryWrite(InfoAddress, sizeBytes));
+
+        context[CpuRegister.Rdi] = InfoAddress;
+
+        var firstResult =
+            LibcInternalExports.LibcHeapGetTraceInfo(context);
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            firstResult);
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+
+        Assert.True(
+            context.TryReadUInt64(
+                InfoAddress + 16,
+                out var firstMaskAddress));
+
+        Assert.True(
+            context.TryReadUInt64(
+                InfoAddress + 24,
+                out var firstTableAddress));
+
+        Assert.NotEqual(0UL, firstMaskAddress);
+        Assert.Equal(firstMaskAddress + 8UL, firstTableAddress);
+
+        var secondResult =
+            LibcInternalExports.LibcHeapGetTraceInfo(context);
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            secondResult);
+
+        Assert.True(
+            context.TryReadUInt64(
+                InfoAddress + 16,
+                out var secondMaskAddress));
+
+        Assert.True(
+            context.TryReadUInt64(
+                InfoAddress + 24,
+                out var secondTableAddress));
+
+        Assert.Equal(firstMaskAddress, secondMaskAddress);
+        Assert.Equal(firstTableAddress, secondTableAddress);
+    }
+
+    [Fact]
+    public void HeapGetTraceInfo_TruncatedOutput_ReturnsMemoryFault()
+    {
+        var memory = new FakeCpuMemory(Base, 31);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Span<byte> sizeBytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            sizeBytes,
+            ExpectedInfoSize);
+
+        Assert.True(memory.TryWrite(Base, sizeBytes));
+
+        context[CpuRegister.Rdi] = Base;
+
+        var result = LibcInternalExports.LibcHeapGetTraceInfo(context);
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            result);
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+    }
+}


### PR DESCRIPTION
## Summary

Add contract tests for `LibcHeapGetTraceInfo`.

## Tests added

- Null output pointer returns `ORBIS_GEN2_ERROR_INVALID_ARGUMENT`.
- Incorrect structure size returns `ORBIS_GEN2_ERROR_INVALID_ARGUMENT`.
- A valid output buffer receives stable non-zero trace pointers.
- A truncated output buffer returns `ORBIS_GEN2_ERROR_MEMORY_FAULT`.

## Verification

- 4 focused tests passed.
- All 355 `SharpEmu.Libs.Tests` passed.
- Full solution build completed successfully.
- `git diff --check` completed without errors.

Related to #388.

## AI assistance

AI assistance was used to identify the test candidate and draft the initial tests. I reviewed the test code, ran the focused tests, ran the complete library test project, and built the full solution.