### PR TITLE
[CPU] Scan TLS access pattern at final code offset

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/JitStubs.cs
+++ b/src/SharpEmu.Core/Cpu/Native/JitStubs.cs
@@ -252,7 +252,7 @@ public static unsafe class JitStubs
         var pattern = TlsAccessPattern;
         var end = start + length - pattern.Length;
 
-        for (var ptr = start; ptr < end; ptr++)
+        for (var ptr = start; ptr <= end; ptr++)
         {
             if (MatchesPattern(ptr, pattern))
             {

--- a/tests/SharpEmu.Libs.Tests/Cpu/JitStubsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/JitStubsTests.cs
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Native;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+public sealed unsafe class JitStubsTests
+{
+    [Fact]
+    public void FindTlsAccessPatterns_IncludesLastValidOffset()
+    {
+        var pattern = JitStubs.TlsAccessPattern;
+        var code = new byte[pattern.Length + 3];
+        pattern.CopyTo(code.AsSpan(3));
+
+        fixed (byte* codePointer = code)
+        {
+            var matches = JitStubs.FindTlsAccessPatterns(codePointer, code.Length);
+
+            var match = Assert.Single(matches);
+            Assert.Equal((nint)(codePointer + 3), match);
+        }
+    }
+}


### PR DESCRIPTION
## What changed

`FindTlsAccessPatterns` stopped one byte range too early because its loop treated the last valid pattern start as an exclusive bound. A TLS load placed at the end of a guest code block was therefore left unpatched.

This changes that bound to inclusive and adds a regression test with the TLS sequence at the final valid offset.

## Why

`StubManager.PatchTlsAccess` relies on this scan before native guest code runs. Missing the final sequence can leave guest TLS access using the unpatched instruction instead of SharpEmu's TLS stub. The fix is generic and does not change the generated stub or any unrelated CPU path.

## Testing

Game testing: N/A. This is a deterministic scanner boundary case.

- Added a regression test that failed before the fix and passes after it.
- `dotnet test SharpEmu.slnx --no-restore` — 352 passed, 0 failed.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).