### PR TITLE
[CPU] Skip idle guest-exception work on HLE imports

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -532,7 +532,8 @@ public sealed partial class DirectExecutionBackend
 			}
 			DeliverPendingGuestExceptionAtSafePoint(
 				cpuContext,
-				CaptureImportBoundaryContinuation(cpuContext, argPackPtr, num7));
+				argPackPtr,
+				num7);
 			StoreImportVectorReturn(cpuContext, argPackPtr);
 			if (dispatchResolved &&
 				orbisGen2Result == OrbisGen2Result.ORBIS_GEN2_OK &&
@@ -1328,7 +1329,8 @@ public sealed partial class DirectExecutionBackend
 		}
 		DeliverPendingGuestExceptionAtSafePoint(
 			cpuContext,
-			CaptureImportBoundaryContinuation(cpuContext, argPackPtr, returnRip));
+			argPackPtr,
+			returnRip);
 		StoreImportVectorReturn(cpuContext, argPackPtr);
 
 		if (returnValue != (int)OrbisGen2Result.ORBIS_GEN2_OK)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -711,6 +711,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	private static ulong _currentExternalGuestThreadHandle;
 
 	private readonly Dictionary<ulong, PendingGuestException> _pendingGuestExceptions = new Dictionary<ulong, PendingGuestException>();
+	private int _pendingGuestExceptionCount;
 
 	private readonly HashSet<ulong> _activeGuestExceptionDeliveries = new HashSet<ulong>();
 
@@ -3948,10 +3949,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					// unwinding. Unity can begin its next stop-the-world cycle in
 					// that window; treating the new raise as part of the old delivery
 					// strands the collector waiting for an acknowledgement.
-					_pendingGuestExceptions[threadHandle] = new PendingGuestException(
+					SetPendingGuestExceptionLocked(threadHandle, new PendingGuestException(
 						handler,
 						exceptionType,
-						external.ExceptionStackBase);
+						external.ExceptionStackBase));
 					return true;
 				}
 
@@ -3960,10 +3961,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				// managed thread corrupts the worker's control state. Queue the
 				// request and let that exact executor consume it at its next HLE
 				// boundary, where the original guest thread is safely paused.
-				_pendingGuestExceptions[threadHandle] = new PendingGuestException(
+				SetPendingGuestExceptionLocked(threadHandle, new PendingGuestException(
 					handler,
 					exceptionType,
-					external.ExceptionStackBase);
+					external.ExceptionStackBase));
 				if (logGuestExceptions)
 				{
 					Console.Error.WriteLine(
@@ -4008,17 +4009,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				}
 				if (target.ExceptionDeliveryActive)
 				{
-					_pendingGuestExceptions[threadHandle] = new PendingGuestException(
+					SetPendingGuestExceptionLocked(threadHandle, new PendingGuestException(
 						handler,
 						exceptionType,
-						exceptionStackBase);
+						exceptionStackBase));
 					return true;
 				}
 
-				_pendingGuestExceptions[threadHandle] = new PendingGuestException(
+				SetPendingGuestExceptionLocked(threadHandle, new PendingGuestException(
 					handler,
 					exceptionType,
-					exceptionStackBase);
+					exceptionStackBase));
 				if (logGuestExceptions)
 				{
 					Console.Error.WriteLine(
@@ -4179,7 +4180,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					RestoreInterruptedGuestThread();
 					if (target.State == GuestThreadRunState.Blocked &&
 						!target.ExecutorActive &&
-						_pendingGuestExceptions.Remove(threadHandle, out var queued))
+						TryTakePendingGuestExceptionLocked(threadHandle, out var queued))
 					{
 						followUp = queued;
 					}
@@ -4263,8 +4264,14 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private void DeliverPendingGuestExceptionAtSafePoint(
 		CpuContext currentContext,
-		GuestCpuContinuation interruptedContinuation)
+		nint argPackPtr,
+		ulong returnRip)
 	{
+		if (Volatile.Read(ref _pendingGuestExceptionCount) == 0)
+		{
+			return;
+		}
+
 		var threadHandle = GuestThreadExecution.CurrentGuestThreadHandle;
 		if (threadHandle == 0)
 		{
@@ -4278,7 +4285,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				return;
 			}
 
-			if (!_pendingGuestExceptions.Remove(threadHandle, out pending))
+			if (!TryTakePendingGuestExceptionLocked(threadHandle, out pending))
 			{
 				return;
 			}
@@ -4290,6 +4297,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		const ulong callbackStackOffset = 0x1000;
 		const ulong callbackStackSize = 0xF000;
 		var exceptionContextAddress = pending.ExceptionStackBase + 0x100;
+		var interruptedContinuation = CaptureImportBoundaryContinuation(
+			currentContext,
+			argPackPtr,
+			returnRip);
 		try
 		{
 			if (!TryWriteGuestExceptionContext(
@@ -4338,6 +4349,27 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				_activeGuestExceptionDeliveries.Remove(threadHandle);
 			}
 		}
+	}
+
+	private void SetPendingGuestExceptionLocked(
+		ulong threadHandle,
+		PendingGuestException pending)
+	{
+		_pendingGuestExceptions[threadHandle] = pending;
+		Volatile.Write(ref _pendingGuestExceptionCount, _pendingGuestExceptions.Count);
+	}
+
+	private bool TryTakePendingGuestExceptionLocked(
+		ulong threadHandle,
+		out PendingGuestException pending)
+	{
+		if (!_pendingGuestExceptions.Remove(threadHandle, out pending))
+		{
+			return false;
+		}
+
+		Volatile.Write(ref _pendingGuestExceptionCount, _pendingGuestExceptions.Count);
+		return true;
 	}
 
 	private static bool TryWriteGuestExceptionContext(
@@ -4434,6 +4466,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			_guestThreads.Clear();
 			_externalGuestThreads.Clear();
 			_pendingGuestExceptions.Clear();
+			Volatile.Write(ref _pendingGuestExceptionCount, 0);
 			_activeGuestExceptionDeliveries.Clear();
 		}
 


### PR DESCRIPTION
## What changed

This is a follow-up for #410 and targets `gpu-runtime-stalls`, not `main`.

Every HLE import currently builds a full `GuestCpuContinuation` and enters `_guestThreadGate` to discover that no guest exception is pending. The Dead Cells evidence for #410 reaches more than eight million import dispatches during its 60-second run, so that idle check sits on a very hot path.

This commit keeps an atomic count synchronized with the pending-exception dictionary. The normal path now returns after one volatile read. Register capture and the existing lock/delivery path run only while at least one exception is queued.

Queueing, replacement, follow-up delivery, removal and shutdown clear all update the count under the same lock that already protects the dictionary. A concurrent exception raised immediately after a zero read is observed at the next HLE boundary, which is the same boundary-based delivery contract used today.

## Expected impact

- removes one uncontended `Monitor` acquisition from every ordinary HLE import;
- avoids capturing the full guest register continuation when there is no exception;
- leaves exception delivery and HLE return behavior unchanged.

I have not claimed an FPS number yet. The purpose of this dependent PR is to let the existing Dead Cells and Dreaming Sarah runner compare #410 with and without this commit on the same hardware.

## Testing

- `dotnet test SharpEmu.slnx` — 412 passed across the three test projects, 0 failed.
- Manual game testing: N/A; awaiting the automated Linux gameplay runner.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).