### PR TITLE
[AGC/Vulkan] Mirror guest-image DMA copies on the GPU

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -3630,7 +3630,8 @@ public static partial class AgcExports
                         ctx,
                         destinationAddress,
                         byteCount,
-                        immediateFill ? (uint)sourceAddress : null);
+                        immediateFill ? (uint)sourceAddress : null,
+                        immediateFill ? 0 : sourceAddress);
                 }
 
                 if (tracePacket)
@@ -4129,7 +4130,8 @@ public static partial class AgcExports
         CpuContext ctx,
         ulong destinationAddress,
         ulong byteCount,
-        uint? fillValue)
+        uint? fillValue,
+        ulong sourceAddress = 0)
     {
         var hasImage = GuestGpu.Current.TryGetGuestImageExtent(
             destinationAddress,
@@ -4156,6 +4158,17 @@ public static partial class AgcExports
         if (fillValue is { } fill)
         {
             GuestGpu.Current.SubmitGuestImageFill(destinationAddress, fill);
+            return;
+        }
+
+        // When the DMA source is itself a live guest image (e.g. a movie
+        // frame just rendered by the NV12 conversion pass), its freshest
+        // pixels exist only GPU-side; the guest CPU copy this DMA moved is
+        // stale until a writeback lands. Copy image-to-image so the
+        // destination sees what unified memory would hold on hardware.
+        if (sourceAddress != 0 &&
+            VulkanVideoPresenter.SubmitGuestImageCopy(sourceAddress, destinationAddress))
+        {
             return;
         }
 
@@ -4267,7 +4280,12 @@ public static partial class AgcExports
                     byteCount);
                 if (copied)
                 {
-                    MirrorDmaWriteToGuestImage(ctx, destinationAddress, byteCount, fillValue: null);
+                    MirrorDmaWriteToGuestImage(
+                        ctx,
+                        destinationAddress,
+                        byteCount,
+                        fillValue: null,
+                        sourceAddress);
                 }
             }
         }

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1204,6 +1204,10 @@ internal static unsafe class VulkanVideoPresenter
         byte[]? Pixels,
         uint FillValue);
 
+    private sealed record VulkanGuestImageCopy(
+        ulong SourceAddress,
+        ulong DestinationAddress);
+
     /// <summary>
     /// Reports the extent of a live guest image so DMA writes to its backing
     /// memory can be mirrored into the Vulkan image (PS5 render targets alias
@@ -1255,6 +1259,32 @@ internal static unsafe class VulkanVideoPresenter
 
             _guestImageWorkSequences[address] = EnqueueGuestWorkLocked(
                 new VulkanGuestImageWrite(address, pixels, 0));
+        }
+    }
+
+    /// <summary>
+    /// Mirrors a CP DMA copy between two live guest images on the GPU. When
+    /// the source is a render target, its freshest content exists only in the
+    /// Vulkan image (guest CPU memory still holds stale bytes until a
+    /// writeback), so copying image-to-image is the only path that matches
+    /// the unified-memory semantics the guest relies on.
+    /// </summary>
+    internal static bool SubmitGuestImageCopy(ulong sourceAddress, ulong destinationAddress)
+    {
+        lock (_gate)
+        {
+            if (_closed ||
+                !_guestImageExtents.TryGetValue(sourceAddress, out var source) ||
+                !_guestImageExtents.TryGetValue(destinationAddress, out var destination) ||
+                source.Width != destination.Width ||
+                source.Height != destination.Height)
+            {
+                return false;
+            }
+
+            _guestImageWorkSequences[destinationAddress] = EnqueueGuestWorkLocked(
+                new VulkanGuestImageCopy(sourceAddress, destinationAddress));
+            return true;
         }
     }
 
@@ -10865,6 +10895,117 @@ internal static unsafe class VulkanVideoPresenter
             target.Initialized = true;
         }
 
+        private void ExecuteGuestImageCopy(VulkanGuestImageCopy work)
+        {
+            if (_deviceLost ||
+                !_guestImages.TryGetValue(work.SourceAddress, out var source) ||
+                !_guestImages.TryGetValue(work.DestinationAddress, out var target) ||
+                source.Format != target.Format ||
+                source.Width != target.Width ||
+                source.Height != target.Height ||
+                !source.Initialized)
+            {
+                return;
+            }
+
+            var commandBuffer = BeginBatchedGuestCommands();
+            CloseOpenTranslatedRenderPass();
+            var toTransferSrc = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                SrcAccessMask = AccessFlags.ShaderReadBit | AccessFlags.ColorAttachmentWriteBit,
+                DstAccessMask = AccessFlags.TransferReadBit,
+                OldLayout = ImageLayout.ShaderReadOnlyOptimal,
+                NewLayout = ImageLayout.TransferSrcOptimal,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = source.Image,
+                SubresourceRange = ColorSubresourceRange(0, 1),
+            };
+            var toTransferDst = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                SrcAccessMask = target.Initialized ? AccessFlags.ShaderReadBit : 0,
+                DstAccessMask = AccessFlags.TransferWriteBit,
+                OldLayout = target.Initialized
+                    ? ImageLayout.ShaderReadOnlyOptimal
+                    : ImageLayout.Undefined,
+                NewLayout = ImageLayout.TransferDstOptimal,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = target.Image,
+                SubresourceRange = ColorSubresourceRange(0, 1),
+            };
+            var entryBarriers = stackalloc ImageMemoryBarrier[2] { toTransferSrc, toTransferDst };
+            _vk.CmdPipelineBarrier(
+                commandBuffer,
+                PipelineStageFlags.ColorAttachmentOutputBit | PipelineStageFlags.FragmentShaderBit,
+                PipelineStageFlags.TransferBit,
+                0,
+                0,
+                null,
+                0,
+                null,
+                2,
+                entryBarriers);
+
+            var region = new ImageCopy
+            {
+                SrcSubresource = new ImageSubresourceLayers(ImageAspectFlags.ColorBit, 0, 0, 1),
+                DstSubresource = new ImageSubresourceLayers(ImageAspectFlags.ColorBit, 0, 0, 1),
+                Extent = new Extent3D(source.Width, source.Height, 1),
+            };
+            _vk.CmdCopyImage(
+                commandBuffer,
+                source.Image,
+                ImageLayout.TransferSrcOptimal,
+                target.Image,
+                ImageLayout.TransferDstOptimal,
+                1,
+                &region);
+
+            var backToShaderReadSrc = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                SrcAccessMask = AccessFlags.TransferReadBit,
+                DstAccessMask = AccessFlags.ShaderReadBit,
+                OldLayout = ImageLayout.TransferSrcOptimal,
+                NewLayout = ImageLayout.ShaderReadOnlyOptimal,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = source.Image,
+                SubresourceRange = ColorSubresourceRange(0, 1),
+            };
+            var backToShaderReadDst = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                SrcAccessMask = AccessFlags.TransferWriteBit,
+                DstAccessMask = AccessFlags.ShaderReadBit,
+                OldLayout = ImageLayout.TransferDstOptimal,
+                NewLayout = ImageLayout.ShaderReadOnlyOptimal,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = target.Image,
+                SubresourceRange = ColorSubresourceRange(0, 1),
+            };
+            var exitBarriers = stackalloc ImageMemoryBarrier[2] { backToShaderReadSrc, backToShaderReadDst };
+            _vk.CmdPipelineBarrier(
+                commandBuffer,
+                PipelineStageFlags.TransferBit,
+                PipelineStageFlags.FragmentShaderBit,
+                0,
+                0,
+                null,
+                0,
+                null,
+                2,
+                exitBarriers);
+            target.Initialized = true;
+            TraceVulkanShader(
+                $"vk.guest_image_copy src=0x{work.SourceAddress:X16} " +
+                $"dst=0x{work.DestinationAddress:X16} {source.Width}x{source.Height}");
+        }
+
         private void UploadGuestImageInitialData(GuestImageResource target, byte[] pixels)
         {
             var guestDataFormat = (target.GuestFormat & 0x8000_0000u) != 0
@@ -12224,6 +12365,9 @@ internal static unsafe class VulkanVideoPresenter
                             break;
                         case VulkanGuestImageWrite guestImageWrite:
                             ExecuteGuestImageWrite(guestImageWrite);
+                            break;
+                        case VulkanGuestImageCopy guestImageCopy:
+                            ExecuteGuestImageCopy(guestImageCopy);
                             break;
                         case VulkanOrderedGuestAction orderedAction:
                             ExecuteOrderedGuestAction(orderedAction);


### PR DESCRIPTION
## Before submitting

I have read and agree to follow the contribution guidelines.

## What this fixes

A CP DMA copy whose source is a live guest image was mirrored into the destination's Vulkan image by re-reading the destination's guest CPU memory after the CPU-side copy. When the source is a render target (SILENT HILL: The Short Message feeds its title-movie plane by DMA from the NV12 conversion pass's render target), the source's freshest pixels exist only in its Vulkan image until a writeback lands — so the mirror overwrote the destination image with stale black CPU bytes and every later composite sampled black.

## What this does

When both DMA endpoints are registered guest images with matching extents and formats, mirror the copy image-to-image on the GPU (transfer-layout round trip for both images inside the batched guest command stream), preserving the unified-memory semantics the guest relies on. All other cases keep the existing CPU-bytes mirror.

## Testing

- Root-caused from an AGC trace of PPSA10112's title flow (rt_writer NV12 conversion draws into rotating buffers, then `dma_data` into the composited movie plane, presented black).
- Builds clean against main; SharpEmu.Libs test suite passes on the development branch carrying the same change.