### PR TITLE
[Kernel] add NID B5GmVDKwpn0 (pthread_yield)

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -140,6 +140,13 @@ public static class KernelPthreadCompatExports
     }
 
     [SysAbiExport(
+        Nid = "B5GmVDKwpn0",
+        ExportName = "pthread_yield",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixPthreadYield(CpuContext ctx) => PthreadYield(ctx);
+
+    [SysAbiExport(
         Nid = "GBUY7ywdULE",
         ExportName = "scePthreadRename",
         Target = Generation.Gen4 | Generation.Gen5,


### PR DESCRIPTION
Tiny pr, just adds pthread_yield, which calls the same function as scePthreadYield (NID: T72hz6ffq08)

## Testing

- Atari 50: The Anniversary Celebration (PPSA08601)

Result: makes it slightly further, then chokes on not being able to resolve NID db0lWdppb4o (unknown!)

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
