### PR TITLE
[Ngs2] Fall back to single rack when sceNgs2RackGetVoiceHandle is called with rdi=0 (Dead Cells)

### DIFF
--- a/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
+++ b/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
@@ -214,6 +214,21 @@ public static class Ngs2Exports
         var outHandleAddress = ctx[CpuRegister.Rdx];
         lock (StateGate)
         {
+            // Dead Cells (#259) ignores the handle from sceNgs2RackCreate and passes
+            // rdi=0. If exactly one rack exists, fall back to it; otherwise keep the
+            // invalid-rack-handle error to stay deterministic with multiple racks.
+            if (rackHandle == 0)
+            {
+                if (Racks.Count == 1)
+                {
+                    rackHandle = Racks.Keys.Single();
+                }
+                else
+                {
+                    return SetReturn(ctx, OrbisNgs2ErrorInvalidRackHandle);
+                }
+            }
+
             if (!Racks.ContainsKey(rackHandle))
             {
                 return SetReturn(ctx, OrbisNgs2ErrorInvalidRackHandle);
@@ -870,6 +885,32 @@ public static class Ngs2Exports
             Environment.GetEnvironmentVariable("SHARPEMU_LOG_NGS2"),
             "1",
             StringComparison.Ordinal);
+
+    internal static void ClearStateForTests()
+    {
+        lock (StateGate)
+        {
+            Systems.Clear();
+            Racks.Clear();
+            Voices.Clear();
+        }
+    }
+
+    internal static void AddRackForTests(ulong handle, ulong systemHandle, uint rackId)
+    {
+        lock (StateGate)
+        {
+            Racks[handle] = new RackState(systemHandle, rackId);
+        }
+    }
+
+    internal static void AddVoiceForTests(ulong handle, ulong rackHandle, uint voiceIndex)
+    {
+        lock (StateGate)
+        {
+            Voices[handle] = new VoiceState(rackHandle, voiceIndex);
+        }
+    }
 
     private static int SetReturn(CpuContext ctx, int result)
     {

--- a/tests/SharpEmu.Libs.Tests/Ngs2/Ngs2ExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ngs2/Ngs2ExportsTests.cs
@@ -1,0 +1,125 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Ngs2;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Ngs2;
+
+[CollectionDefinition(Ngs2StateCollection.Name, DisableParallelization = true)]
+public sealed class Ngs2StateCollection
+{
+    public const string Name = "Ngs2State";
+}
+
+[Collection(Ngs2StateCollection.Name)]
+public sealed class Ngs2ExportsTests : IDisposable
+{
+    private const int OrbisNgs2ErrorInvalidOutAddress = unchecked((int)0x804A0053);
+    private const int OrbisNgs2ErrorInvalidRackHandle = unchecked((int)0x804A0261);
+
+    private const ulong MemoryBase = 0x1_0000_0000UL;
+    private const ulong OutAddress = MemoryBase + 0x100;
+
+    private const ulong SystemHandle = 0x0001_0000UL;
+    private const ulong FirstRackHandle = 0x0002_0000UL;
+    private const ulong SecondRackHandle = 0x0002_0100UL;
+    private const ulong VoiceHandle = 0x0003_0000UL;
+    private const uint VoiceIndex = 0;
+    private const uint RackId = 1;
+
+    private readonly FakeCpuMemory _memory = new(MemoryBase, 0x1000);
+    private readonly CpuContext _ctx;
+
+    public Ngs2ExportsTests()
+    {
+        Ngs2Exports.ClearStateForTests();
+        _ctx = new CpuContext(_memory, Generation.Gen5);
+    }
+
+    public void Dispose() => Ngs2Exports.ClearStateForTests();
+
+    [Fact]
+    public void RackGetVoiceHandle_NullRackHandleWithSingleRack_FallsBackAndSucceeds()
+    {
+        // Dead Cells (#259): game passes rdi=0 instead of the handle from
+        // sceNgs2RackCreate. With exactly one rack in flight we fall back to it.
+        Ngs2Exports.AddRackForTests(FirstRackHandle, SystemHandle, RackId);
+        Ngs2Exports.AddVoiceForTests(VoiceHandle, FirstRackHandle, VoiceIndex);
+
+        var first = CallRackGetVoiceHandle(rackHandle: 0, voiceIndex: VoiceIndex, outAddress: OutAddress);
+        Assert.True(_ctx.TryReadUInt64(OutAddress, out var firstVoiceHandle));
+
+        var second = CallRackGetVoiceHandle(rackHandle: 0, voiceIndex: VoiceIndex, outAddress: OutAddress);
+        Assert.True(_ctx.TryReadUInt64(OutAddress, out var secondVoiceHandle));
+
+        Assert.Equal(0, first);
+        Assert.NotEqual(0UL, firstVoiceHandle);
+        Assert.Equal(0, second);
+        Assert.Equal(firstVoiceHandle, secondVoiceHandle);
+    }
+
+    [Fact]
+    public void RackGetVoiceHandle_NullRackHandleWithNoRacks_ReturnsInvalidRackHandle()
+    {
+        var result = CallRackGetVoiceHandle(rackHandle: 0, voiceIndex: VoiceIndex, outAddress: OutAddress);
+
+        Assert.Equal(OrbisNgs2ErrorInvalidRackHandle, result);
+    }
+
+    [Fact]
+    public void RackGetVoiceHandle_NullRackHandleWithMultipleRacks_ReturnsInvalidRackHandle()
+    {
+        Ngs2Exports.AddRackForTests(FirstRackHandle, SystemHandle, RackId);
+        Ngs2Exports.AddRackForTests(SecondRackHandle, SystemHandle, RackId);
+
+        var result = CallRackGetVoiceHandle(rackHandle: 0, voiceIndex: VoiceIndex, outAddress: OutAddress);
+
+        Assert.Equal(OrbisNgs2ErrorInvalidRackHandle, result);
+    }
+
+    [Fact]
+    public void RackGetVoiceHandle_InvalidRackHandle_ReturnsInvalidRackHandle()
+    {
+        Ngs2Exports.AddRackForTests(FirstRackHandle, SystemHandle, RackId);
+
+        var result = CallRackGetVoiceHandle(rackHandle: 0xDEADBEEFUL, voiceIndex: VoiceIndex, outAddress: OutAddress);
+
+        Assert.Equal(OrbisNgs2ErrorInvalidRackHandle, result);
+        Assert.Equal(unchecked((ulong)OrbisNgs2ErrorInvalidRackHandle), _ctx[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void RackGetVoiceHandle_ValidRackHandle_ReturnsHandle()
+    {
+        Ngs2Exports.AddRackForTests(FirstRackHandle, SystemHandle, RackId);
+        Ngs2Exports.AddVoiceForTests(VoiceHandle, FirstRackHandle, VoiceIndex);
+
+        var result = CallRackGetVoiceHandle(rackHandle: FirstRackHandle, voiceIndex: VoiceIndex, outAddress: OutAddress);
+
+        Assert.Equal(0, result);
+        Assert.True(_ctx.TryReadUInt64(OutAddress, out var voiceHandle));
+        Assert.Equal(VoiceHandle, voiceHandle);
+    }
+
+    [Fact]
+    public void RackGetVoiceHandle_NullOutAddress_ReturnsInvalidOutAddress()
+    {
+        // No voice is registered for the requested index, so the existing-voice
+        // fast path is skipped and the explicit null out-address check triggers.
+        Ngs2Exports.AddRackForTests(FirstRackHandle, SystemHandle, RackId);
+
+        var result = CallRackGetVoiceHandle(rackHandle: FirstRackHandle, voiceIndex: VoiceIndex, outAddress: 0);
+
+        Assert.Equal(OrbisNgs2ErrorInvalidOutAddress, result);
+    }
+
+    private int CallRackGetVoiceHandle(ulong rackHandle, uint voiceIndex, ulong outAddress)
+    {
+        _ctx[CpuRegister.Rdi] = rackHandle;
+        _ctx[CpuRegister.Rsi] = voiceIndex;
+        _ctx[CpuRegister.Rdx] = outAddress;
+        return Ngs2Exports.Ngs2RackGetVoiceHandle(_ctx);
+    }
+}


### PR DESCRIPTION
Fixes #259.

## What this fixes

Dead Cells (PPSA15552) ignores the rack handle returned by `sceNgs2RackCreate` and calls `sceNgs2RackGetVoiceHandle` with `rdi=0`. The export rejected this as `ORBIS_NGS2_ERROR_INVALID_RACK_HANDLE` and the game's audio path aborted at boot.

When exactly one rack exists, fall back to it. With zero or multiple racks, keep the deterministic invalid-handle error so we never guess.

## The change

`src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs`: at the top of the `StateGate` critical section in `sceNgs2RackGetVoiceHandle`, if `rackHandle == 0` and `Racks.Count == 1`, substitute the single rack key; otherwise return `ORBIS_NGS2_ERROR_INVALID_RACK_HANDLE` as before.

Three `internal static` test helpers (`ClearStateForTests`, `AddRackForTests`, `AddVoiceForTests`) let the unit tests seed `Racks`/`Voices` without going through the full system/rack creation path. They take the same `StateGate` lock and only mutate the dictionaries.

## Testing

- `dotnet build SharpEmu.slnx -c Release`: 0 errors (1 pre-existing CA2014 warning in `Ngs2Exports.cs:545`, unrelated to this change).
- `dotnet test tests/SharpEmu.Libs.Tests --filter "FullyQualifiedName~Ngs2"`: **6/6 passed**.
- `dotnet test tests/SharpEmu.Libs.Tests`: **379/379 passed** (no regressions in the existing suite).

No game run was attempted — the fix is covered by unit tests exercising the single-rack fallback, the multi-rack rejection, and the non-zero invalid-handle path.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).