### PR TITLE
[GUI] PS5-style launcher redesign

### DIFF
--- a/src/SharpEmu.GUI/App.axaml
+++ b/src/SharpEmu.GUI/App.axaml
@@ -223,34 +223,79 @@ SPDX-License-Identifier: GPL-2.0-or-later
       <Setter Property="MinHeight" Value="0" />
     </Style>
 
-    <!-- Cover-art library grid -->
-    <Style Selector="ListBox.tileGrid ListBoxItem">
-      <Setter Property="Padding" Value="10" />
-      <Setter Property="Margin" Value="5" />
-      <Setter Property="CornerRadius" Value="14" />
+    <!-- PS5-style horizontal cover strip. The selected tile scales up and
+         gains a white frame; the Margin change (animated by the
+         ThicknessTransition) pushes its neighbours aside so the scaled tile
+         never overlaps them. -->
+    <Style Selector="ListBox.tileStrip ListBoxItem">
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="Margin" Value="7,0" />
       <Setter Property="Background" Value="Transparent" />
-      <Setter Property="BorderThickness" Value="1" />
-      <Setter Property="BorderBrush" Value="Transparent" />
-      <Setter Property="RenderTransform" Value="translateY(0px)" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+      <Setter Property="RenderTransform" Value="scale(1)" />
       <Setter Property="Transitions">
         <Transitions>
-          <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.12" />
+          <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.15" Easing="CubicEaseOut" />
+          <ThicknessTransition Property="Margin" Duration="0:0:0.15" Easing="CubicEaseOut" />
         </Transitions>
       </Setter>
     </Style>
-    <Style Selector="ListBox.tileGrid ListBoxItem:pointerover">
-      <Setter Property="RenderTransform" Value="translateY(-3px)" />
+    <Style Selector="ListBox.tileStrip ListBoxItem /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="3" />
+      <Setter Property="BorderBrush" Value="Transparent" />
+      <Setter Property="CornerRadius" Value="20" />
+      <Setter Property="Padding" Value="4" />
     </Style>
-    <Style Selector="ListBox.tileGrid ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-      <Setter Property="Background" Value="{StaticResource TileHoverBrush}" />
+    <Style Selector="ListBox.tileStrip ListBoxItem:pointerover">
+      <Setter Property="RenderTransform" Value="scale(1.06)" />
     </Style>
-    <Style Selector="ListBox.tileGrid ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
-      <Setter Property="Background" Value="{StaticResource TileSelectedBrush}" />
-      <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+    <Style Selector="ListBox.tileStrip ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="#66FFFFFF" />
     </Style>
-    <Style Selector="ListBox.tileGrid ListBoxItem:selected:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-      <Setter Property="Background" Value="{StaticResource TileSelectedBrush}" />
-      <Setter Property="BorderBrush" Value="{StaticResource AccentHoverBrush}" />
+    <Style Selector="ListBox.tileStrip ListBoxItem:selected">
+      <Setter Property="RenderTransform" Value="scale(1.24)" />
+      <Setter Property="Margin" Value="22,0" />
+      <Setter Property="ZIndex" Value="1" />
+    </Style>
+    <Style Selector="ListBox.tileStrip ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="#F2FFFFFF" />
+    </Style>
+    <Style Selector="ListBox.tileStrip ListBoxItem:selected:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="#FFFFFFFF" />
+    </Style>
+
+    <!-- PS5-style hero "Play Game" pill: light fill, dark text. -->
+    <Style Selector="Button.play">
+      <Setter Property="Background" Value="#E8ECF4" />
+      <Setter Property="Foreground" Value="#11141B" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="FontSize" Value="16" />
+      <Setter Property="Padding" Value="40,12" />
+      <Setter Property="CornerRadius" Value="999" />
+    </Style>
+    <Style Selector="Button.play:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="#FFFFFF" />
+      <Setter Property="Foreground" Value="#11141B" />
+    </Style>
+
+    <!-- Small round "•••" companion button next to Play. -->
+    <Style Selector="Button.round">
+      <Setter Property="Background" Value="#2EFFFFFF" />
+      <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+      <Setter Property="Width" Value="46" />
+      <Setter Property="Height" Value="46" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="CornerRadius" Value="999" />
+      <Setter Property="HorizontalContentAlignment" Value="Center" />
+      <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Button.round:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="#47FFFFFF" />
+      <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
     </Style>
 
     <Style Selector="Border.coverShadow">

--- a/src/SharpEmu.GUI/App.axaml
+++ b/src/SharpEmu.GUI/App.axaml
@@ -236,6 +236,30 @@ SPDX-License-Identifier: GPL-2.0-or-later
       <Setter Property="Foreground" Value="#11141B" />
     </Style>
 
+    <!-- One stroke style for every toolbar icon; the checked state inverts
+         the stroke to stay visible on the light fill. -->
+    <Style Selector="Button.iconCircle Path">
+      <Setter Property="Stroke" Value="{StaticResource TextBrush}" />
+      <Setter Property="StrokeThickness" Value="1.7" />
+      <Setter Property="StrokeLineCap" Value="Round" />
+      <Setter Property="StrokeJoin" Value="Round" />
+      <Setter Property="Width" Value="20" />
+      <Setter Property="Height" Value="20" />
+      <Setter Property="Stretch" Value="None" />
+    </Style>
+    <Style Selector="ToggleButton.iconCircle Path">
+      <Setter Property="Stroke" Value="{StaticResource TextBrush}" />
+      <Setter Property="StrokeThickness" Value="1.7" />
+      <Setter Property="StrokeLineCap" Value="Round" />
+      <Setter Property="StrokeJoin" Value="Round" />
+      <Setter Property="Width" Value="20" />
+      <Setter Property="Height" Value="20" />
+      <Setter Property="Stretch" Value="None" />
+    </Style>
+    <Style Selector="ToggleButton.iconCircle:checked Path">
+      <Setter Property="Stroke" Value="#11141B" />
+    </Style>
+
     <!-- Options category sidebar entries, console-settings style. -->
     <Style Selector="Button.sideItem">
       <Setter Property="Background" Value="Transparent" />

--- a/src/SharpEmu.GUI/App.axaml
+++ b/src/SharpEmu.GUI/App.axaml
@@ -196,6 +196,67 @@ SPDX-License-Identifier: GPL-2.0-or-later
       <Setter Property="Padding" Value="8,3" />
     </Style>
 
+    <!-- Translucent variant of the card so the key art glows through the
+         options page. -->
+    <Style Selector="Border.glass">
+      <Setter Property="Background" Value="#CC141924" />
+    </Style>
+
+    <!-- Round toolbar icon buttons, PS5 top-bar style. -->
+    <Style Selector="Button.iconCircle">
+      <Setter Property="Background" Value="#26FFFFFF" />
+      <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+      <Setter Property="Width" Value="40" />
+      <Setter Property="Height" Value="40" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="CornerRadius" Value="999" />
+      <Setter Property="HorizontalContentAlignment" Value="Center" />
+      <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Button.iconCircle:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="#40FFFFFF" />
+      <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+    </Style>
+    <Style Selector="ToggleButton.iconCircle">
+      <Setter Property="Background" Value="#26FFFFFF" />
+      <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+      <Setter Property="Width" Value="40" />
+      <Setter Property="Height" Value="40" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="CornerRadius" Value="999" />
+      <Setter Property="HorizontalContentAlignment" Value="Center" />
+      <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+    <Style Selector="ToggleButton.iconCircle:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="#40FFFFFF" />
+      <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+    </Style>
+    <Style Selector="ToggleButton.iconCircle:checked /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="#E8ECF4" />
+      <Setter Property="Foreground" Value="#11141B" />
+    </Style>
+
+    <!-- Options category sidebar entries, console-settings style. -->
+    <Style Selector="Button.sideItem">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Foreground" Value="{StaticResource MutedBrush}" />
+      <Setter Property="FontSize" Value="15" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Padding" Value="14,10" />
+      <Setter Property="CornerRadius" Value="10" />
+      <Setter Property="HorizontalAlignment" Value="Stretch" />
+      <Setter Property="HorizontalContentAlignment" Value="Left" />
+    </Style>
+    <Style Selector="Button.sideItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="#26FFFFFF" />
+      <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+    </Style>
+    <Style Selector="Button.sideItem.active">
+      <Setter Property="Background" Value="#2EFFFFFF" />
+      <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+    </Style>
+
     <Style Selector="ContextMenu">
       <Setter Property="Background" Value="{StaticResource CardBrush}" />
       <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />

--- a/src/SharpEmu.GUI/App.axaml
+++ b/src/SharpEmu.GUI/App.axaml
@@ -142,8 +142,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
       <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
       <Setter Property="BorderThickness" Value="1" />
       <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
-      <Setter Property="Padding" Value="12,7" />
-      <Setter Property="CornerRadius" Value="8" />
+      <Setter Property="Padding" Value="14,7" />
+      <Setter Property="CornerRadius" Value="999" />
     </Style>
     <Style Selector="Button.ghost:pointerover /template/ ContentPresenter#PART_ContentPresenter">
       <Setter Property="Background" Value="{StaticResource ElevatedBrush}" />
@@ -155,8 +155,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
       <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
       <Setter Property="BorderThickness" Value="1" />
       <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
-      <Setter Property="Padding" Value="12,7" />
-      <Setter Property="CornerRadius" Value="8" />
+      <Setter Property="Padding" Value="14,7" />
+      <Setter Property="CornerRadius" Value="999" />
     </Style>
     <Style Selector="ToggleButton.ghost:pointerover /template/ ContentPresenter#PART_ContentPresenter">
       <Setter Property="Background" Value="{StaticResource ElevatedBrush}" />

--- a/src/SharpEmu.GUI/Languages/en.json
+++ b/src/SharpEmu.GUI/Languages/en.json
@@ -102,7 +102,7 @@
   "Launch.NoGameHint": "Pick a game from the library, or open an eboot.bin directly.",
   "Launch.Idle": "Idle",
   "Launch.Console": "≡ Console",
-  "Launch.Launch": "▶  Launch",
+  "Launch.Launch": "Play Game",
   "Launch.Stop": "■  Stop",
   "Launch.Running": "Running — {0}",
   "Launch.Stopping": "Stopping…",

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -22,9 +22,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
   <Grid x:Name="RootLayout" RowDefinitions="Auto,*,Auto">
 
-    <!-- Selected-game backdrop: key art behind the main content, dimmed by
-         a scrim so tiles and text stay readable. Fades on selection. -->
-    <Panel Grid.Row="1" ClipToBounds="True">
+    <!-- Selected-game backdrop: full-bleed key art behind everything (PS5
+         home-screen style), dimmed by a scrim so text stays readable.
+         Fades on selection. -->
+    <Panel Grid.Row="0" Grid.RowSpan="3" ClipToBounds="True">
       <Image x:Name="BackdropImage" Stretch="UniformToFill" Opacity="0"
              HorizontalAlignment="Center" VerticalAlignment="Center">
         <Image.Transitions>
@@ -36,17 +37,18 @@ SPDX-License-Identifier: GPL-2.0-or-later
       <Border>
         <Border.Background>
           <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
-            <GradientStop Offset="0" Color="#730D1017" />
-            <GradientStop Offset="0.55" Color="#BF0D1017" />
-            <GradientStop Offset="1" Color="#EB0D1017" />
+            <GradientStop Offset="0" Color="#590D1017" />
+            <GradientStop Offset="0.55" Color="#A60D1017" />
+            <GradientStop Offset="1" Color="#E60D1017" />
           </LinearGradientBrush>
         </Border.Background>
       </Border>
     </Panel>
 
     <!-- Title bar; hidden in fullscreen (F11) along with the status bar, so
-         the game gets the whole screen. -->
-    <Grid x:Name="TitleBar" Grid.Row="0" Height="44" Background="{StaticResource ChromeBrush}">
+         the game gets the whole screen. Transparent so the key art bleeds
+         through behind it. -->
+    <Grid x:Name="TitleBar" Grid.Row="0" Height="44" Background="Transparent">
       <StackPanel Orientation="Horizontal" Spacing="10" Margin="16,0" VerticalAlignment="Center">
         <Image Source="avares://SharpEmu.GUI/Assets/SharpEmu.ico" Width="20" Height="20"
                RenderOptions.BitmapInterpolationMode="HighQuality" />
@@ -58,11 +60,11 @@ SPDX-License-Identifier: GPL-2.0-or-later
     </Grid>
 
     <!-- Main content -->
-    <Grid x:Name="MainContent" Grid.Row="1" Margin="32,24,32,20" RowDefinitions="Auto,*,Auto,Auto">
+    <Grid x:Name="MainContent" Grid.Row="1" Margin="32,24,32,20" RowDefinitions="Auto,*,Auto">
 
       <!-- The game owns the full client area while running. Session controls
            use a native popup so they can stay above this native child surface. -->
-      <Border x:Name="GameView" Grid.Row="0" Grid.RowSpan="4" IsVisible="False" Background="#000000" ClipToBounds="True">
+      <Border x:Name="GameView" Grid.Row="0" Grid.RowSpan="3" IsVisible="False" Background="#000000" ClipToBounds="True">
         <Grid x:Name="GameSurfaceContainer" />
       </Border>
 
@@ -88,17 +90,21 @@ SPDX-License-Identifier: GPL-2.0-or-later
           <Button x:Name="AddFolderButton" Classes="ghost" Content="＋ Add folder" VerticalAlignment="Center" />
           <Button x:Name="RescanButton" Classes="ghost" Content="⟳ Rescan" VerticalAlignment="Center" />
           <Button x:Name="OpenFileButton" Classes="ghost" Content="Open file…" VerticalAlignment="Center" />
+          <ToggleButton x:Name="ConsoleToggle" Classes="ghost" Content="≡ Console" VerticalAlignment="Center" />
         </StackPanel>
       </Grid>
 
       <Panel Grid.Row="1" x:Name="PagesHost">
 
-        <!-- Library page. The tile row gets extra top margin so it sits
-             closer to eye level (PS5 home-screen style) instead of hugging
-             the Library/Options switcher above it. -->
-        <Panel x:Name="LibraryPage" Margin="0,64,0,0">
-          <ListBox x:Name="GameList" Classes="tileGrid" Background="Transparent"
-                   SelectionMode="Single" Padding="0">
+        <!-- Library page, PS5 home-screen style: a horizontal cover strip at
+             the top, the selected game's key art filling the window behind
+             everything, and a hero block (big title + Play pill) at the
+             bottom left. -->
+        <Grid x:Name="LibraryPage" RowDefinitions="Auto,*,Auto" Margin="0,4,0,0">
+          <ListBox x:Name="GameList" Grid.Row="0" Classes="tileStrip" Background="Transparent"
+                   SelectionMode="Single" Padding="0" Height="156"
+                   ScrollViewer.HorizontalScrollBarVisibility="Hidden"
+                   ScrollViewer.VerticalScrollBarVisibility="Disabled">
             <ListBox.ContextMenu>
               <ContextMenu x:Name="GameContextMenu" Placement="Pointer">
                 <MenuItem x:Name="CtxLaunch" Header="Launch" FontWeight="SemiBold">
@@ -144,34 +150,82 @@ SPDX-License-Identifier: GPL-2.0-or-later
             </ListBox.ContextMenu>
             <ListBox.ItemsPanel>
               <ItemsPanelTemplate>
-                <WrapPanel />
+                <StackPanel Orientation="Horizontal" />
               </ItemsPanelTemplate>
             </ListBox.ItemsPanel>
             <ListBox.ItemTemplate>
               <DataTemplate>
-                <StackPanel Width="128" Height="172" Spacing="7">
-                  <Border Classes="coverShadow" Width="128" Height="128">
-                    <Border Classes="coverClip">
-                      <Panel>
-                        <Border Background="{Binding PlaceholderBrush}" IsVisible="{Binding !HasCover}">
-                          <TextBlock Text="{Binding Initials}" FontSize="36" FontWeight="Bold"
-                                     Foreground="#E8ECF4" Opacity="0.85"
-                                     HorizontalAlignment="Center" VerticalAlignment="Center" />
-                        </Border>
-                        <Image Source="{Binding Cover}" Stretch="UniformToFill" IsVisible="{Binding HasCover}" />
-                      </Panel>
+                <Border Classes="coverClip" Width="104" Height="104" CornerRadius="16"
+                        ToolTip.Tip="{Binding Name}">
+                  <Panel>
+                    <Border Background="{Binding PlaceholderBrush}" IsVisible="{Binding !HasCover}">
+                      <TextBlock Text="{Binding Initials}" FontSize="30" FontWeight="Bold"
+                                 Foreground="#E8ECF4" Opacity="0.85"
+                                 HorizontalAlignment="Center" VerticalAlignment="Center" />
                     </Border>
-                  </Border>
-                  <TextBlock Text="{Binding Name}" FontSize="13" FontWeight="SemiBold"
-                             TextWrapping="Wrap" MaxLines="2" TextTrimming="CharacterEllipsis"
-                             TextAlignment="Center" HorizontalAlignment="Center" />
-                </StackPanel>
+                    <Image Source="{Binding Cover}" Stretch="UniformToFill" IsVisible="{Binding HasCover}" />
+                  </Panel>
+                </Border>
               </DataTemplate>
             </ListBox.ItemTemplate>
           </ListBox>
 
+          <!-- "PS5 | <name>" caption below the strip, console style. -->
+          <StackPanel Grid.Row="1" x:Name="StripCaptionRow" Orientation="Horizontal" Spacing="9"
+                      Margin="12,10,0,0" VerticalAlignment="Top" IsVisible="False">
+            <Border Background="#E8ECF4" CornerRadius="4" Padding="8,2" VerticalAlignment="Center">
+              <TextBlock Text="PS5" FontSize="11" FontWeight="Bold" Foreground="#11141B" />
+            </Border>
+            <TextBlock x:Name="StripCaptionText" FontSize="16" FontWeight="SemiBold"
+                       VerticalAlignment="Center" TextTrimming="CharacterEllipsis" MaxWidth="480" />
+          </StackPanel>
+
+          <!-- Hero: big title, path, Play pill, status; badges bottom right. -->
+          <Grid Grid.Row="2" x:Name="LaunchBar" ColumnDefinitions="*,Auto" Margin="12,0,12,30">
+            <StackPanel Grid.Column="0" Spacing="10" VerticalAlignment="Bottom" MaxWidth="760"
+                        HorizontalAlignment="Left">
+              <TextBlock x:Name="SelectedGameTitle" Text="No game selected" FontSize="44"
+                         FontWeight="Light" TextTrimming="CharacterEllipsis" MaxLines="2"
+                         TextWrapping="Wrap" LineHeight="50" />
+              <TextBlock x:Name="SelectedGamePath"
+                         Text="Pick a game from the library, or open an eboot.bin directly."
+                         FontSize="11" Foreground="{StaticResource MutedBrush}"
+                         TextTrimming="CharacterEllipsis" />
+              <StackPanel Orientation="Horizontal" Spacing="12" Margin="0,8,0,0">
+                <Button x:Name="LaunchButton" Classes="play" Content="Play Game" IsEnabled="False" />
+                <Button x:Name="MoreButton" Classes="round" Content="•••" FontSize="14"
+                        IsEnabled="False" />
+                <Button x:Name="StopButton" Classes="danger" Content="■  Stop" CornerRadius="999"
+                        IsEnabled="False" IsVisible="False" />
+              </StackPanel>
+              <StackPanel Orientation="Horizontal" Spacing="7">
+                <Ellipse x:Name="StatusDot" Width="8" Height="8" Fill="{StaticResource FaintBrush}"
+                         VerticalAlignment="Center" />
+                <TextBlock x:Name="StatusText" Text="Idle" FontSize="11"
+                           Foreground="{StaticResource MutedBrush}" VerticalAlignment="Center" />
+              </StackPanel>
+            </StackPanel>
+
+            <!-- Title id / version / size pills, playtime-pill style. -->
+            <StackPanel Grid.Column="1" x:Name="SelectedBadgesRow" Orientation="Horizontal" Spacing="6"
+                        IsVisible="False" VerticalAlignment="Bottom">
+              <Border Classes="pill" IsVisible="{Binding HasTitleId, FallbackValue=False}">
+                <TextBlock Text="{Binding TitleId}" FontSize="10" FontWeight="SemiBold"
+                           Foreground="{StaticResource MutedBrush}" />
+              </Border>
+              <Border Classes="pill" IsVisible="{Binding HasVersion, FallbackValue=False}">
+                <TextBlock Text="{Binding VersionText}" FontSize="10" FontWeight="SemiBold"
+                           Foreground="{StaticResource MutedBrush}" />
+              </Border>
+              <Border Classes="pill">
+                <TextBlock Text="{Binding SizeText, FallbackValue=''}" FontSize="10" FontWeight="SemiBold"
+                           Foreground="{StaticResource MutedBrush}" />
+              </Border>
+            </StackPanel>
+          </Grid>
+
           <!-- Empty state -->
-          <StackPanel x:Name="EmptyState" Spacing="10" HorizontalAlignment="Center" VerticalAlignment="Center"
+          <StackPanel Grid.Row="1" x:Name="EmptyState" Spacing="10" HorizontalAlignment="Center" VerticalAlignment="Center"
                       IsVisible="False">
             <TextBlock Text="🎮" FontSize="44" HorizontalAlignment="Center" Opacity="0.7" />
             <TextBlock x:Name="EmptyStateTitle" Text="Your library is empty" FontSize="18" FontWeight="SemiBold"
@@ -185,13 +239,13 @@ SPDX-License-Identifier: GPL-2.0-or-later
           <!-- Loading state: covers the grid while a scan (initial load,
                rescan, or a just-added folder) is in flight, so the screen
                never looks blank mid-scan. -->
-          <StackPanel x:Name="LoadingState" Spacing="14" HorizontalAlignment="Center" VerticalAlignment="Center"
+          <StackPanel Grid.Row="1" x:Name="LoadingState" Spacing="14" HorizontalAlignment="Center" VerticalAlignment="Center"
                       IsVisible="False">
             <ProgressBar IsIndeterminate="True" Width="180" Height="3" />
             <TextBlock x:Name="LoadingStateText" Text="Loading library…" FontSize="13"
                        Foreground="{StaticResource MutedBrush}" HorizontalAlignment="Center" />
           </StackPanel>
-        </Panel>
+        </Grid>
 
         <!-- Options page: sub-tabs so future categories (Graphics, …) slot
              in next to General. Card-grouped sections match the visual
@@ -496,70 +550,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
         </Grid>
       </Border>
 
-      <!-- Launch bar; capped so it does not sprawl on a maximized window. -->
-      <Border Grid.Row="3" x:Name="LaunchBar" Classes="card" Margin="0,12,0,0" Padding="14" MaxWidth="1280">
-        <StackPanel Spacing="14">
-          <Grid ColumnDefinitions="Auto,*,Auto">
-
-            <!-- Selected game cover thumbnail -->
-            <Border Grid.Column="0" Classes="coverClip" Width="56" Height="56" CornerRadius="8"
-                    VerticalAlignment="Center">
-              <Panel x:Name="SelectedCoverPanel">
-                <Border Background="{Binding PlaceholderBrush, FallbackValue={x:Null}}"
-                        IsVisible="{Binding !HasCover, FallbackValue=False}">
-                  <TextBlock Text="{Binding Initials}" FontSize="20" FontWeight="Bold"
-                             Foreground="#E8ECF4" Opacity="0.85"
-                             HorizontalAlignment="Center" VerticalAlignment="Center" />
-                </Border>
-                <Image Source="{Binding Cover}" Stretch="UniformToFill"
-                       IsVisible="{Binding HasCover, FallbackValue=False}" />
-              </Panel>
-            </Border>
-
-            <StackPanel Grid.Column="1" Spacing="4" VerticalAlignment="Center" Margin="14,0,14,0">
-              <Grid ColumnDefinitions="Auto,Auto,*">
-                <TextBlock Grid.Column="0" x:Name="SelectedGameTitle" Text="No game selected" FontSize="16"
-                           FontWeight="Bold" TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
-                           MaxWidth="340" Margin="0,0,10,0" />
-
-                <!-- Title id / version / size badges, right next to the
-                     title. The title's own MaxWidth (not a "*" column) is
-                     what keeps them from drifting to the far right. -->
-                <StackPanel Grid.Column="1" x:Name="SelectedBadgesRow" Orientation="Horizontal" Spacing="6"
-                            IsVisible="False" VerticalAlignment="Center">
-                  <Border Classes="pill" IsVisible="{Binding HasTitleId, FallbackValue=False}">
-                    <TextBlock Text="{Binding TitleId}" FontSize="10" FontWeight="SemiBold"
-                               Foreground="{StaticResource MutedBrush}" />
-                  </Border>
-                  <Border Classes="pill" IsVisible="{Binding HasVersion, FallbackValue=False}">
-                    <TextBlock Text="{Binding VersionText}" FontSize="10" FontWeight="SemiBold"
-                               Foreground="{StaticResource MutedBrush}" />
-                  </Border>
-                  <Border Classes="pill">
-                    <TextBlock Text="{Binding SizeText, FallbackValue=''}" FontSize="10" FontWeight="SemiBold"
-                               Foreground="{StaticResource MutedBrush}" />
-                  </Border>
-                </StackPanel>
-              </Grid>
-
-              <TextBlock x:Name="SelectedGamePath" Text="Pick a game from the library, or open an eboot.bin directly."
-                         FontSize="11" Foreground="{StaticResource MutedBrush}" TextTrimming="CharacterEllipsis" />
-              <StackPanel Orientation="Horizontal" Spacing="7">
-                <Ellipse x:Name="StatusDot" Width="8" Height="8" Fill="{StaticResource FaintBrush}"
-                         VerticalAlignment="Center" />
-                <TextBlock x:Name="StatusText" Text="Idle" FontSize="11" Foreground="{StaticResource MutedBrush}"
-                           VerticalAlignment="Center" />
-              </StackPanel>
-            </StackPanel>
-
-            <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-              <ToggleButton x:Name="ConsoleToggle" Classes="ghost" Content="≡ Console" />
-              <Button x:Name="LaunchButton" Classes="accent" Content="▶  Launch" IsEnabled="False" />
-              <Button x:Name="StopButton" Classes="danger" Content="■  Stop" IsEnabled="False" />
-            </StackPanel>
-          </Grid>
-        </StackPanel>
-      </Border>
     </Grid>
 
     <!-- Avalonia's regular overlay layer cannot appear over a native child
@@ -626,7 +616,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     </primitives:Popup>
 
     <!-- Status bar -->
-    <Grid x:Name="StatusBar" Grid.Row="2" Height="32" Background="{StaticResource ChromeBrush}"
+    <Grid x:Name="StatusBar" Grid.Row="2" Height="32" Background="#B3090C12"
           ColumnDefinitions="*,Auto">
       <TextBlock x:Name="EmulatorPathText" Grid.Column="0" Text="Emulator: locating…" FontSize="11"
                  Foreground="{StaticResource FaintBrush}" VerticalAlignment="Center" Margin="16,0"

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -26,11 +26,21 @@ SPDX-License-Identifier: GPL-2.0-or-later
          home-screen style), dimmed by a scrim so text stays readable.
          Fades on selection. -->
     <Panel Grid.Row="0" Grid.RowSpan="3" ClipToBounds="True">
-      <Image x:Name="BackdropImage" Stretch="UniformToFill" Opacity="0"
+      <!-- Two stacked layers so selection changes crossfade between key
+           arts instead of fading to black and popping the new one in. -->
+      <Image x:Name="BackdropImageA" Stretch="UniformToFill" Opacity="0"
              HorizontalAlignment="Center" VerticalAlignment="Center">
         <Image.Transitions>
           <Transitions>
-            <DoubleTransition Property="Opacity" Duration="0:0:0.35" />
+            <DoubleTransition Property="Opacity" Duration="0:0:0.45" />
+          </Transitions>
+        </Image.Transitions>
+      </Image>
+      <Image x:Name="BackdropImageB" Stretch="UniformToFill" Opacity="0"
+             HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Image.Transitions>
+          <Transitions>
+            <DoubleTransition Property="Opacity" Duration="0:0:0.45" />
           </Transitions>
         </Image.Transitions>
       </Image>
@@ -56,6 +66,17 @@ SPDX-License-Identifier: GPL-2.0-or-later
         <Border Classes="pill">
           <TextBlock x:Name="VersionText" Text="v0.0.1" FontSize="11" Foreground="{StaticResource MutedBrush}" />
         </Border>
+      </StackPanel>
+
+      <!-- Console-style clock and controller indicator; the right margin
+           clears the system caption buttons drawn over the client area. -->
+      <StackPanel Orientation="Horizontal" Spacing="12" Margin="0,0,150,0"
+                  HorizontalAlignment="Right" VerticalAlignment="Center">
+        <Border x:Name="PadIndicator" Classes="pill" IsVisible="False"
+                ToolTip.Tip="Controller connected">
+          <TextBlock Text="🎮" FontSize="12" />
+        </Border>
+        <TextBlock x:Name="ClockText" FontSize="15" FontWeight="SemiBold" VerticalAlignment="Center" />
       </StackPanel>
     </Grid>
 
@@ -86,7 +107,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
         <StackPanel Grid.Column="2" x:Name="LibraryToolbar" Orientation="Horizontal" Spacing="8"
                     VerticalAlignment="Center">
-          <TextBox x:Name="SearchBox" Watermark="Search library…" Width="240" VerticalAlignment="Center" />
+          <TextBox x:Name="SearchBox" Watermark="Search library…" Width="240" VerticalAlignment="Center"
+                   CornerRadius="999" Padding="14,6" />
           <Button x:Name="AddFolderButton" Classes="ghost" Content="＋ Add folder" VerticalAlignment="Center" />
           <Button x:Name="RescanButton" Classes="ghost" Content="⟳ Rescan" VerticalAlignment="Center" />
           <Button x:Name="OpenFileButton" Classes="ghost" Content="Open file…" VerticalAlignment="Center" />
@@ -182,8 +204,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
           <!-- Hero: big title, path, Play pill, status; badges bottom right. -->
           <Grid Grid.Row="2" x:Name="LaunchBar" ColumnDefinitions="*,Auto" Margin="12,0,12,30">
-            <StackPanel Grid.Column="0" Spacing="10" VerticalAlignment="Bottom" MaxWidth="760"
-                        HorizontalAlignment="Left">
+            <StackPanel Grid.Column="0" x:Name="HeroPanel" Spacing="10" VerticalAlignment="Bottom"
+                        MaxWidth="760" HorizontalAlignment="Left">
               <TextBlock x:Name="SelectedGameTitle" Text="No game selected" FontSize="44"
                          FontWeight="Light" TextTrimming="CharacterEllipsis" MaxLines="2"
                          TextWrapping="Wrap" LineHeight="50" />
@@ -251,7 +273,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
              in next to General. Card-grouped sections match the visual
              language used by the console panel and launch bar below. -->
         <Grid x:Name="OptionsPage" IsVisible="False">
-          <TabControl>
+          <TabControl x:Name="OptionsTabs">
             <TabItem x:Name="GeneralTabItem" Header="General" FontSize="15">
               <ScrollViewer>
                 <StackPanel Margin="0,14,0,16" Spacing="16" MaxWidth="1280" HorizontalAlignment="Left">

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -112,11 +112,23 @@ SPDX-License-Identifier: GPL-2.0-or-later
                     VerticalAlignment="Center">
           <TextBox x:Name="SearchBox" Watermark="Search library…" Width="230" VerticalAlignment="Center"
                    CornerRadius="999" Padding="14,6" IsVisible="False" />
-          <ToggleButton x:Name="SearchToggle" Classes="iconCircle" Content="🔍" FontSize="15" />
-          <Button x:Name="AddFolderButton" Classes="iconCircle" Content="＋" FontSize="18" />
-          <Button x:Name="OpenFileButton" Classes="iconCircle" Content="📂" FontSize="15" />
-          <Button x:Name="RescanButton" Classes="iconCircle" Content="⟳" FontSize="17" />
-          <ToggleButton x:Name="ConsoleToggle" Classes="iconCircle" Content="≡" FontSize="17" />
+          <!-- Stroke-based vector icons so every button shares one visual
+               weight (mixed emoji/text glyphs render inconsistently). -->
+          <ToggleButton x:Name="SearchToggle" Classes="iconCircle">
+            <Path Data="M4.2,8.8 a4.6,4.6 0 1 0 9.2,0 a4.6,4.6 0 1 0 -9.2,0 M12.2,12.2 L16.4,16.4" />
+          </ToggleButton>
+          <Button x:Name="AddFolderButton" Classes="iconCircle">
+            <Path Data="M10,3.8 L10,16.2 M3.8,10 L16.2,10" />
+          </Button>
+          <Button x:Name="OpenFileButton" Classes="iconCircle">
+            <Path Data="M3,6 A1.5,1.5 0 0 1 4.5,4.5 h3.2 l2,2 h5.8 A1.5,1.5 0 0 1 17,8 v6.5 A1.5,1.5 0 0 1 15.5,16 h-11 A1.5,1.5 0 0 1 3,14.5 Z" />
+          </Button>
+          <Button x:Name="RescanButton" Classes="iconCircle">
+            <Path Data="M10,4.2 A5.8,5.8 0 1 1 4.2,10 M4.2,10 L2.7,11.9 M4.2,10 L5.7,11.9" />
+          </Button>
+          <ToggleButton x:Name="ConsoleToggle" Classes="iconCircle">
+            <Path Data="M4.5,6.2 H15.5 M4.5,10 H15.5 M4.5,13.8 H15.5" />
+          </ToggleButton>
         </StackPanel>
       </Grid>
 

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -105,14 +105,18 @@ SPDX-License-Identifier: GPL-2.0-or-later
           </Border>
         </StackPanel>
 
-        <StackPanel Grid.Column="2" x:Name="LibraryToolbar" Orientation="Horizontal" Spacing="8"
+        <!-- PS5-style icon cluster: every library action is a round icon
+             button (labels live in tooltips); the search field slides out
+             of the magnifier toggle. -->
+        <StackPanel Grid.Column="2" x:Name="LibraryToolbar" Orientation="Horizontal" Spacing="10"
                     VerticalAlignment="Center">
-          <TextBox x:Name="SearchBox" Watermark="Search library…" Width="240" VerticalAlignment="Center"
-                   CornerRadius="999" Padding="14,6" />
-          <Button x:Name="AddFolderButton" Classes="ghost" Content="＋ Add folder" VerticalAlignment="Center" />
-          <Button x:Name="RescanButton" Classes="ghost" Content="⟳ Rescan" VerticalAlignment="Center" />
-          <Button x:Name="OpenFileButton" Classes="ghost" Content="Open file…" VerticalAlignment="Center" />
-          <ToggleButton x:Name="ConsoleToggle" Classes="ghost" Content="≡ Console" VerticalAlignment="Center" />
+          <TextBox x:Name="SearchBox" Watermark="Search library…" Width="230" VerticalAlignment="Center"
+                   CornerRadius="999" Padding="14,6" IsVisible="False" />
+          <ToggleButton x:Name="SearchToggle" Classes="iconCircle" Content="🔍" FontSize="15" />
+          <Button x:Name="AddFolderButton" Classes="iconCircle" Content="＋" FontSize="18" />
+          <Button x:Name="OpenFileButton" Classes="iconCircle" Content="📂" FontSize="15" />
+          <Button x:Name="RescanButton" Classes="iconCircle" Content="⟳" FontSize="17" />
+          <ToggleButton x:Name="ConsoleToggle" Classes="iconCircle" Content="≡" FontSize="17" />
         </StackPanel>
       </Grid>
 
@@ -272,13 +276,22 @@ SPDX-License-Identifier: GPL-2.0-or-later
         <!-- Options page: sub-tabs so future categories (Graphics, …) slot
              in next to General. Card-grouped sections match the visual
              language used by the console panel and launch bar below. -->
-        <Grid x:Name="OptionsPage" IsVisible="False">
-          <TabControl x:Name="OptionsTabs">
-            <TabItem x:Name="GeneralTabItem" Header="General" FontSize="15">
-              <ScrollViewer>
-                <StackPanel Margin="0,14,0,16" Spacing="16" MaxWidth="1280" HorizontalAlignment="Left">
+        <!-- Options page, console-settings style: category sidebar on the
+             left, one scrollable pane per category on the right. The d-pad
+             switches categories (left/right) and scrolls (up/down). -->
+        <Grid x:Name="OptionsPage" IsVisible="False" ColumnDefinitions="240,*">
+          <StackPanel Grid.Column="0" Spacing="4" Margin="0,4,28,0">
+            <TextBlock x:Name="OptionsTitle" Text="Options" FontSize="24" FontWeight="Bold"
+                       Margin="14,0,0,16" />
+            <Button x:Name="GeneralSectionButton" Classes="sideItem active" Content="General" />
+            <Button x:Name="EnvSectionButton" Classes="sideItem" Content="Environment" />
+          </StackPanel>
 
-                  <Border Classes="card">
+          <Panel Grid.Column="1">
+            <ScrollViewer x:Name="GeneralScroll">
+              <StackPanel Margin="0,4,0,16" Spacing="16" MaxWidth="960" HorizontalAlignment="Left">
+
+                  <Border Classes="card glass">
                     <StackPanel Spacing="14">
                       <TextBlock x:Name="EmulationSectionTitle" Classes="sectionTitle" Text="EMULATION" />
 
@@ -298,7 +311,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                     </StackPanel>
                   </Border>
 
-                  <Border Classes="card">
+                  <Border Classes="card glass">
                     <StackPanel Spacing="14">
                       <TextBlock x:Name="LoggingSectionTitle" Classes="sectionTitle" Text="LOGGING" />
 
@@ -342,7 +355,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                     </StackPanel>
                   </Border>
 
-                  <Border Classes="card">
+                  <Border Classes="card glass">
                     <StackPanel Spacing="14">
                       <TextBlock x:Name="LauncherSectionTitle" Classes="sectionTitle" Text="LAUNCHER" />
 
@@ -372,7 +385,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                       </local:SettingRow>
                     </StackPanel>
                   </Border>
-                  <Border Classes="card">
+                  <Border Classes="card glass">
                     <StackPanel Spacing="14">
                       <TextBlock x:Name="AboutSectionTitle"
                                 Classes="sectionTitle"
@@ -474,13 +487,12 @@ SPDX-License-Identifier: GPL-2.0-or-later
                     </StackPanel>
                   </Border>
                 </StackPanel>
-              </ScrollViewer>
-            </TabItem>
-            <TabItem x:Name="EnvTabItem" Header="Environment" FontSize="15">
-              <ScrollViewer>
-                <StackPanel Margin="0,14,0,16" Spacing="16" MaxWidth="1280" HorizontalAlignment="Left">
+            </ScrollViewer>
 
-                  <Border Classes="card">
+            <ScrollViewer x:Name="EnvScroll" IsVisible="False">
+              <StackPanel Margin="0,4,0,16" Spacing="16" MaxWidth="960" HorizontalAlignment="Left">
+
+                  <Border Classes="card glass">
                     <StackPanel Spacing="14">
                       <TextBlock x:Name="EnvSectionTitle" Classes="sectionTitle" Text="ENVIRONMENT VARIABLES" />
                       <TextBlock x:Name="EnvDesc"
@@ -538,9 +550,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
                   </Border>
 
                 </StackPanel>
-              </ScrollViewer>
-            </TabItem>
-          </TabControl>
+            </ScrollViewer>
+          </Panel>
         </Grid>
       </Panel>
 

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -10,6 +12,7 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Platform.Storage;
+using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using SharpEmu.Core.Cpu;
@@ -103,6 +106,19 @@ public partial class MainWindow : Window
     private long _navLeftNextAt;
     private long _navRightNextAt;
 
+    // Eases the tile strip toward keeping the selected tile centered.
+    private readonly DispatcherTimer _stripScrollTimer;
+
+    // Title-bar clock, console style.
+    private readonly DispatcherTimer _clockTimer;
+
+    // Hero fade/slide-in on selection change.
+    private CancellationTokenSource? _heroAnimationCts;
+    private string? _lastHeroPath;
+
+    // Which backdrop layer is currently showing (see ShowBackdrop).
+    private bool _backdropFrontIsA = true;
+
     //Github http client for latest commit
     private static readonly HttpClient GithubHttpClient = CreateGithubHttpClient();
     private string? _latestCommitSha;
@@ -122,8 +138,7 @@ public partial class MainWindow : Window
         {
             _defaultBackdrop = new Bitmap(
                 AssetLoader.Open(new Uri("avares://SharpEmu.GUI/Assets/pic0.png")));
-            BackdropImage.Source = _defaultBackdrop;
-            BackdropImage.Opacity = 1.0;
+            ShowBackdrop(_defaultBackdrop);
         }
         catch (Exception)
         {
@@ -167,7 +182,11 @@ public partial class MainWindow : Window
         };
 
         TitleBar.PointerPressed += OnTitleBarPointerPressed;
-        GameList.SelectionChanged += (_, _) => UpdateSelectedGame();
+        GameList.SelectionChanged += (_, _) =>
+        {
+            UpdateSelectedGame();
+            StartStripCentering();
+        };
         GameList.DoubleTapped += (_, _) => LaunchSelected();
         SearchBox.TextChanged += (_, _) => RefreshVisibleGames();
         ConsoleSearchBox.TextChanged += (_, _) => RefreshVisibleConsoleLines();
@@ -280,6 +299,20 @@ public partial class MainWindow : Window
         };
         _gamepadTimer.Tick += (_, _) => PollGamepad();
         _gamepadTimer.Start();
+
+        _stripScrollTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(16),
+        };
+        _stripScrollTimer.Tick += (_, _) => AdvanceStripCentering();
+
+        ClockText.Text = DateTime.Now.ToString("HH:mm");
+        _clockTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromSeconds(1),
+        };
+        _clockTimer.Tick += (_, _) => ClockText.Text = DateTime.Now.ToString("HH:mm");
+        _clockTimer.Start();
 
 
         GithubButton.Click += (_, _) =>
@@ -447,9 +480,12 @@ public partial class MainWindow : Window
         // DualSense wins when both are connected; XInput covers Xbox pads.
         if (!WindowsDualSenseReader.TryGetState(out var pad) && !WindowsXInputReader.TryGetState(out pad))
         {
+            PadIndicator.IsVisible = false;
             _previousPadButtons = HostGamepadButtons.None;
             return;
         }
+
+        PadIndicator.IsVisible = true;
 
         if (!IsActive)
         {
@@ -481,6 +517,20 @@ public partial class MainWindow : Window
 
         if (_activePageIndex != 0)
         {
+            // The options page has no focus navigation yet, but the d-pad or
+            // left stick can at least scroll it; ~11px per 16ms tick gives a
+            // smooth continuous glide while held.
+            var scrollUp = (pad.Buttons & HostGamepadButtons.Up) != 0 || pad.LeftY < 64;
+            var scrollDown = (pad.Buttons & HostGamepadButtons.Down) != 0 || pad.LeftY > 192;
+            if ((scrollUp || scrollDown) &&
+                (OptionsTabs.SelectedItem as TabItem)?.Content is ScrollViewer optionsScroll)
+            {
+                var maxOffset = Math.Max(0, optionsScroll.Extent.Height - optionsScroll.Viewport.Height);
+                optionsScroll.Offset = new Vector(
+                    optionsScroll.Offset.X,
+                    Math.Clamp(optionsScroll.Offset.Y + (scrollDown ? 11 : -11), 0, maxOffset));
+            }
+
             _previousPadButtons = pad.Buttons;
             return;
         }
@@ -548,7 +598,50 @@ public partial class MainWindow : Window
             ? 0
             : Math.Clamp(GameList.SelectedIndex + delta, 0, _visibleGames.Count - 1);
         GameList.SelectedIndex = index;
-        GameList.ScrollIntoView(index);
+        // The SelectionChanged handler starts the smooth centering scroll.
+    }
+
+    /// <summary>
+    /// Starts easing the strip so the selected tile ends up centered in the
+    /// viewport, console style, instead of the jarring ScrollIntoView jump.
+    /// </summary>
+    private void StartStripCentering()
+    {
+        if (GameList.SelectedIndex >= 0)
+        {
+            _stripScrollTimer.Start();
+        }
+    }
+
+    /// <summary>
+    /// One easing step toward the centered offset. The target is recomputed
+    /// every tick because the selected tile's animated margin is still
+    /// resizing the row while the scroll is in flight.
+    /// </summary>
+    private void AdvanceStripCentering()
+    {
+        if (GameList.Scroll is not ScrollViewer scroll ||
+            GameList.SelectedIndex < 0 ||
+            GameList.ContainerFromIndex(GameList.SelectedIndex) is not Control container ||
+            scroll.Viewport.Width <= 0)
+        {
+            _stripScrollTimer.Stop();
+            return;
+        }
+
+        var target = Math.Clamp(
+            container.Bounds.Center.X - (scroll.Viewport.Width / 2),
+            0,
+            Math.Max(0, scroll.Extent.Width - scroll.Viewport.Width));
+        var current = scroll.Offset.X;
+        var next = current + ((target - current) * 0.22);
+        if (Math.Abs(target - next) < 0.75)
+        {
+            next = target;
+            _stripScrollTimer.Stop();
+        }
+
+        scroll.Offset = new Vector(next, scroll.Offset.Y);
     }
 
     private async Task OnOpenedAsync()
@@ -854,6 +947,8 @@ public partial class MainWindow : Window
         _consoleFlushTimer.Stop();
         _libraryBlurTimer.Stop();
         _gamepadTimer.Stop();
+        _stripScrollTimer.Stop();
+        _clockTimer.Stop();
         _sndPreview.Stop();
         _discord?.Dispose();
         _consoleWindow?.Close();
@@ -1604,17 +1699,76 @@ public partial class MainWindow : Window
             SelectedBadgesRow.IsVisible = true;
             _ = UpdateBackdropAsync(game);
             PlaySelectedGamePreview(game);
+            if (!string.Equals(_lastHeroPath, game.Path, FilePathComparison))
+            {
+                _lastHeroPath = game.Path;
+                AnimateHeroIn();
+            }
         }
         else
         {
             UpdateSelectedGameTexts();
             SelectedBadgesRow.DataContext = null;
             SelectedBadgesRow.IsVisible = false;
+            _lastHeroPath = null;
             _ = UpdateBackdropAsync(null);
             _sndPreview.Stop();
         }
 
         UpdateRunButtons();
+    }
+
+    /// <summary>
+    /// Fades and slides the hero block in when the selection lands on a
+    /// different game. Restarting the animation cancels the previous run, so
+    /// scrubbing quickly through the strip keeps the hero gently pulsing
+    /// rather than stacking animations.
+    /// </summary>
+    private void AnimateHeroIn()
+    {
+        _heroAnimationCts?.Cancel();
+        var cts = new CancellationTokenSource();
+        _heroAnimationCts = cts;
+
+        // Code-run keyframes can only animate properties with registered
+        // animators, which rules out RenderTransform itself — so the fade
+        // targets the panel and the slide targets a TranslateTransform's Y
+        // (both plain doubles).
+        if (HeroPanel.RenderTransform is not TranslateTransform translate)
+        {
+            translate = new TranslateTransform();
+            HeroPanel.RenderTransform = translate;
+        }
+
+        var animation = new Animation
+        {
+            Duration = TimeSpan.FromMilliseconds(240),
+            Easing = new CubicEaseOut(),
+            FillMode = FillMode.Forward,
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0),
+                    Setters =
+                    {
+                        new Setter(OpacityProperty, 0.0),
+                        new Setter(TranslateTransform.YProperty, 14.0),
+                    },
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1),
+                    Setters =
+                    {
+                        new Setter(OpacityProperty, 1.0),
+                        new Setter(TranslateTransform.YProperty, 0.0),
+                    },
+                },
+            },
+        };
+
+        _ = animation.RunAsync(HeroPanel, cts.Token);
     }
 
     /// <summary>
@@ -1702,24 +1856,55 @@ public partial class MainWindow : Window
         }
     }
 
+    private Image BackdropFront => _backdropFrontIsA ? BackdropImageA : BackdropImageB;
+
+    private Image BackdropBack => _backdropFrontIsA ? BackdropImageB : BackdropImageA;
+
     /// <summary>
-    /// Fades the window backdrop to the selected game's key art. The image
-    /// decodes off the UI thread and is cached on the entry; a newer
-    /// selection cancels the fade-in of an older one.
+    /// Crossfades the two backdrop layers to the given bitmap: the hidden
+    /// layer receives the new art and fades in while the old one fades out
+    /// underneath it, so the window never dips to the bare color between
+    /// selections. Null fades both layers out.
+    /// </summary>
+    private void ShowBackdrop(Bitmap? bitmap)
+    {
+        if (bitmap is null)
+        {
+            BackdropImageA.Opacity = 0;
+            BackdropImageB.Opacity = 0;
+            return;
+        }
+
+        if (ReferenceEquals(BackdropFront.Source, bitmap))
+        {
+            BackdropFront.Opacity = 1;
+            BackdropBack.Opacity = 0;
+            return;
+        }
+
+        BackdropBack.Source = bitmap;
+        BackdropBack.Opacity = 1;
+        BackdropFront.Opacity = 0;
+        _backdropFrontIsA = !_backdropFrontIsA;
+    }
+
+    /// <summary>
+    /// Crossfades the window backdrop to the selected game's key art. The
+    /// image decodes off the UI thread and is cached on the entry; the old
+    /// art stays up until the new one is ready, and a newer selection
+    /// invalidates an older decode.
     /// </summary>
     private async Task UpdateBackdropAsync(GameEntry? game)
     {
         var generation = ++_backdropGeneration;
-        BackdropImage.Opacity = 0;
 
         // The bundled key art is the primary backdrop whenever the selection
         // has no art of its own; the window color stays as the last fallback.
         void ShowDefaultBackdrop()
         {
-            if (generation == _backdropGeneration && _defaultBackdrop is not null)
+            if (generation == _backdropGeneration)
             {
-                BackdropImage.Source = _defaultBackdrop;
-                BackdropImage.Opacity = 1.0;
+                ShowBackdrop(_defaultBackdrop);
             }
         }
 
@@ -1749,8 +1934,7 @@ public partial class MainWindow : Window
 
         if (generation == _backdropGeneration)
         {
-            BackdropImage.Source = game.Background;
-            BackdropImage.Opacity = 1.0;
+            ShowBackdrop(game.Background);
         }
     }
 
@@ -2185,7 +2369,7 @@ public partial class MainWindow : Window
         OptionsPage.IsVisible = _activePageIndex == 1;
         // Game art when the source still holds it, otherwise the bundled
         // default; a bare color only when neither is available.
-        BackdropImage.Opacity = BackdropImage.Source is not null ? 1 : 0;
+        BackdropFront.Opacity = BackdropFront.Source is not null ? 1 : 0;
     }
 
     private void AnimateLibraryBlur(double targetRadius, bool clearWhenComplete = false)
@@ -2294,7 +2478,7 @@ public partial class MainWindow : Window
         LibraryPage.IsVisible = _activePageIndex == 0;
         LibraryToolbar.IsVisible = _activePageIndex == 0;
         OptionsPage.IsVisible = _activePageIndex == 1;
-        BackdropImage.Opacity = BackdropImage.Source is not null ? 1 : 0;
+        BackdropFront.Opacity = BackdropFront.Source is not null ? 1 : 0;
         UpdateRunButtons();
         Console.Error.WriteLine("[GUI][INFO] Library restored while embedded session is closing.");
     }

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -78,6 +78,7 @@ public partial class MainWindow : Window
     private bool _awaitingFirstFrame;
     private int _autoScrollTicks;
     private int _activePageIndex;
+    private int _optionsSectionIndex;
     private Updater.UpdateInfo? _availableUpdate;
     private string _updateStatusKey = "Updater.Status.Ready";
     private object?[] _updateStatusArgs = [BuildInfo.CommitSha ?? "dev"];
@@ -203,7 +204,34 @@ public partial class MainWindow : Window
         DetachConsoleButton.Click += (_, _) => ShowConsoleWindow();
         LibraryTabButton.Click += (_, _) => SetActivePage(0);
         OptionsTabButton.Click += (_, _) => SetActivePage(1);
+        GeneralSectionButton.Click += (_, _) => SetOptionsSection(0);
+        EnvSectionButton.Click += (_, _) => SetOptionsSection(1);
         ConsoleToggle.IsCheckedChanged += (_, _) => ConsolePanel.IsVisible = ConsoleToggle.IsChecked == true && _consoleWindow is null;
+
+        // The search field lives behind the magnifier toggle; closing it
+        // also clears the filter so the library never stays silently
+        // filtered by an invisible query.
+        SearchToggle.IsCheckedChanged += (_, _) =>
+        {
+            var open = SearchToggle.IsChecked == true;
+            SearchBox.IsVisible = open;
+            if (open)
+            {
+                SearchBox.Focus();
+            }
+            else if (!string.IsNullOrEmpty(SearchBox.Text))
+            {
+                SearchBox.Text = string.Empty;
+            }
+        };
+        SearchBox.KeyDown += (_, e) =>
+        {
+            if (e.Key == Key.Escape)
+            {
+                SearchToggle.IsChecked = false;
+                e.Handled = true;
+            }
+        };
 
         // The settings page edits _settings live, so a launch started while
         // it is open already uses the new values.
@@ -373,6 +401,19 @@ public partial class MainWindow : Window
         OptionsPage.IsVisible = index == 1;
     }
 
+    /// <summary>
+    /// Switches the visible options category. Also reachable with the d-pad
+    /// (left/right) while the Options page is active.
+    /// </summary>
+    private void SetOptionsSection(int index)
+    {
+        _optionsSectionIndex = index;
+        SetActiveClass(GeneralSectionButton, index == 0);
+        SetActiveClass(EnvSectionButton, index == 1);
+        GeneralScroll.IsVisible = index == 0;
+        EnvScroll.IsVisible = index == 1;
+    }
+
     private static void SetActiveClass(Button button, bool active)
     {
         if (active)
@@ -517,14 +558,35 @@ public partial class MainWindow : Window
 
         if (_activePageIndex != 0)
         {
-            // The options page has no focus navigation yet, but the d-pad or
-            // left stick can at least scroll it; ~11px per 16ms tick gives a
-            // smooth continuous glide while held.
-            var scrollUp = (pad.Buttons & HostGamepadButtons.Up) != 0 || pad.LeftY < 64;
-            var scrollDown = (pad.Buttons & HostGamepadButtons.Down) != 0 || pad.LeftY > 192;
-            if ((scrollUp || scrollDown) &&
-                (OptionsTabs.SelectedItem as TabItem)?.Content is ScrollViewer optionsScroll)
+            // Options page: d-pad left/right switches the category, and the
+            // d-pad or left stick scrolls the active pane; ~11px per 16ms
+            // tick gives a smooth continuous glide while held.
+            var sectionPressed = pad.Buttons & ~_previousPadButtons;
+            if ((sectionPressed & HostGamepadButtons.Left) != 0)
             {
+                SetOptionsSection(Math.Max(0, _optionsSectionIndex - 1));
+            }
+
+            if ((sectionPressed & HostGamepadButtons.Right) != 0)
+            {
+                SetOptionsSection(Math.Min(1, _optionsSectionIndex + 1));
+            }
+
+            var scrollUp = pad.LeftY < 64;
+            var scrollDown = pad.LeftY > 192;
+            if ((pad.Buttons & HostGamepadButtons.Up) != 0)
+            {
+                scrollUp = true;
+            }
+
+            if ((pad.Buttons & HostGamepadButtons.Down) != 0)
+            {
+                scrollDown = true;
+            }
+
+            if (scrollUp || scrollDown)
+            {
+                var optionsScroll = _optionsSectionIndex == 0 ? GeneralScroll : EnvScroll;
                 var maxOffset = Math.Max(0, optionsScroll.Extent.Height - optionsScroll.Viewport.Height);
                 optionsScroll.Offset = new Vector(
                     optionsScroll.Offset.X,
@@ -710,10 +772,14 @@ public partial class MainWindow : Window
         LibraryTabButton.Content = loc.Get("Page.Library");
         OptionsTabButton.Content = loc.Get("Page.Options");
 
+        // The toolbar buttons are round icons; the localized labels go into
+        // tooltips instead of the button faces.
         SearchBox.Watermark = loc.Get("Library.SearchWatermark");
-        AddFolderButton.Content = loc.Get("Library.AddFolder");
-        RescanButton.Content = loc.Get("Library.Rescan");
-        OpenFileButton.Content = loc.Get("Library.OpenFile");
+        ToolTip.SetTip(SearchToggle, loc.Get("Library.SearchWatermark"));
+        ToolTip.SetTip(AddFolderButton, loc.Get("Library.AddFolder"));
+        ToolTip.SetTip(RescanButton, loc.Get("Library.Rescan"));
+        ToolTip.SetTip(OpenFileButton, loc.Get("Library.OpenFile"));
+        ToolTip.SetTip(ConsoleToggle, loc.Get("Launch.Console"));
 
         CtxLaunch.Header = loc.Get("Library.Context.Launch");
         CtxOpenFolder.Header = loc.Get("Library.Context.OpenFolder");
@@ -725,8 +791,9 @@ public partial class MainWindow : Window
         EmptyAddFolderButton.Content = loc.Get("Library.Empty.AddFolder");
         LoadingStateText.Text = loc.Get("Library.Loading");
 
-        GeneralTabItem.Header = loc.Get("Options.General");
-        EnvTabItem.Header = loc.Get("Options.Env.Tab");
+        OptionsTitle.Text = loc.Get("Page.Options");
+        GeneralSectionButton.Content = loc.Get("Options.General");
+        EnvSectionButton.Content = loc.Get("Options.Env.Tab");
         EnvSectionTitle.Text = loc.Get("Options.Section.Environment");
         EnvDesc.Text = loc.Get("Options.Env.Desc");
         EnvBthidRow.Description = loc.Get("Options.Env.Bthid.Desc");
@@ -794,7 +861,6 @@ public partial class MainWindow : Window
         CopyLogButton.Content = loc.Get("Console.Copy");
         ClearLogButton.Content = loc.Get("Console.Clear");
 
-        ConsoleToggle.Content = loc.Get("Launch.Console");
         LaunchButton.Content = loc.Get("Launch.Launch");
         StopButton.Content = loc.Get("Launch.Stop");
 

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -102,8 +102,6 @@ public partial class MainWindow : Window
     private HostGamepadButtons _previousPadButtons;
     private long _navLeftNextAt;
     private long _navRightNextAt;
-    private long _navUpNextAt;
-    private long _navDownNextAt;
 
     //Github http client for latest commit
     private static readonly HttpClient GithubHttpClient = CreateGithubHttpClient();
@@ -239,6 +237,37 @@ public partial class MainWindow : Window
         CtxGameSettings.Click += (_, _) => OpenSelectedGameSettings();
         CtxRemove.Click += (_, _) => RemoveSelectedFromLibrary();
 
+        // The hero "•••" button opens the same context menu the tiles use.
+        // The menu must be attached to the button as well: ContextMenu.Open
+        // throws for a control the menu is not attached to.
+        MoreButton.ContextMenu = GameContextMenu;
+        MoreButton.Click += (_, _) =>
+        {
+            if (GameList.SelectedItem is not GameEntry game || GameContextMenu.IsOpen)
+            {
+                return;
+            }
+
+            PrepareGameContextMenu(game);
+            GameContextMenu.Placement = PlacementMode.Bottom;
+            GameContextMenu.Open(MoreButton);
+        };
+
+        // Right-clicking the button opens the attached menu automatically;
+        // prep the item states (and placement) before that happens.
+        MoreButton.AddHandler(ContextRequestedEvent, (_, e) =>
+        {
+            if (GameList.SelectedItem is GameEntry game)
+            {
+                PrepareGameContextMenu(game);
+                GameContextMenu.Placement = PlacementMode.Bottom;
+            }
+            else
+            {
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+
         Opened += async (_, _) => await OnOpenedAsync();
         Closing += (_, _) => OnWindowClosing();
 
@@ -246,7 +275,8 @@ public partial class MainWindow : Window
         WindowsXInputReader.EnsureStarted();
         _gamepadTimer = new DispatcherTimer
         {
-            Interval = TimeSpan.FromMilliseconds(50),
+            // ~60Hz so stick/d-pad presses register with no perceptible lag.
+            Interval = TimeSpan.FromMilliseconds(16),
         };
         _gamepadTimer.Tick += (_, _) => PollGamepad();
         _gamepadTimer.Start();
@@ -455,11 +485,11 @@ public partial class MainWindow : Window
             return;
         }
 
+        // The library is a single horizontal strip, so navigation is purely
+        // left/right (d-pad or left stick).
         var now = Environment.TickCount64;
         var left = (pad.Buttons & HostGamepadButtons.Left) != 0 || pad.LeftX < 64;
         var right = (pad.Buttons & HostGamepadButtons.Right) != 0 || pad.LeftX > 192;
-        var up = (pad.Buttons & HostGamepadButtons.Up) != 0 || pad.LeftY < 64;
-        var down = (pad.Buttons & HostGamepadButtons.Down) != 0 || pad.LeftY > 192;
 
         if (ShouldNavigate(left, ref _navLeftNextAt, now))
         {
@@ -469,16 +499,6 @@ public partial class MainWindow : Window
         if (ShouldNavigate(right, ref _navRightNextAt, now))
         {
             MoveSelection(1);
-        }
-
-        if (ShouldNavigate(up, ref _navUpNextAt, now))
-        {
-            MoveSelection(-TilesPerRow());
-        }
-
-        if (ShouldNavigate(down, ref _navDownNextAt, now))
-        {
-            MoveSelection(TilesPerRow());
         }
 
         var pressed = pad.Buttons & ~_previousPadButtons;
@@ -492,7 +512,7 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// Edge-triggered with hold-to-repeat: fires on press, then repeats
-    /// after 400ms at 130ms intervals while held.
+    /// after 350ms at 120ms intervals while held.
     /// </summary>
     private static bool ShouldNavigate(bool held, ref long nextAt, long now)
     {
@@ -504,13 +524,13 @@ public partial class MainWindow : Window
 
         if (nextAt == 0)
         {
-            nextAt = now + 400;
+            nextAt = now + 350;
             return true;
         }
 
         if (now >= nextAt)
         {
-            nextAt = now + 130;
+            nextAt = now + 120;
             return true;
         }
 
@@ -529,14 +549,6 @@ public partial class MainWindow : Window
             : Math.Clamp(GameList.SelectedIndex + delta, 0, _visibleGames.Count - 1);
         GameList.SelectedIndex = index;
         GameList.ScrollIntoView(index);
-    }
-
-    private int TilesPerRow()
-    {
-        // Tile footprint: 128 content + 20 item padding + 10 item margin.
-        const double TileOuterWidth = 158;
-        var width = GameList.Bounds.Width;
-        return width > TileOuterWidth ? (int)(width / TileOuterWidth) : 1;
     }
 
     private async Task OnOpenedAsync()
@@ -566,6 +578,10 @@ public partial class MainWindow : Window
             _ = CheckForUpdatesAsync();
         }
         await RescanLibraryAsync();
+
+        // Keyboard arrows should page through the strip immediately, without
+        // requiring a click first.
+        GameList.Focus();
     }
 
     private void PopulateLanguageBox()
@@ -1420,6 +1436,17 @@ public partial class MainWindow : Window
         }
 
         GameList.SelectedItem = game;
+        PrepareGameContextMenu(game);
+        // The hero "•••" button may have left the menu anchored to itself.
+        GameContextMenu.Placement = PlacementMode.Pointer;
+    }
+
+    /// <summary>
+    /// Syncs the shared game context menu's item states to the given game.
+    /// Used by both the tile right-click path and the hero "•••" button.
+    /// </summary>
+    private void PrepareGameContextMenu(GameEntry game)
+    {
         CtxLaunch.IsEnabled = !_isRunning;
         CtxCopyTitleId.IsEnabled = game.TitleId is not null;
         CtxGameSettings.IsEnabled = !string.IsNullOrWhiteSpace(game.TitleId);
@@ -1532,6 +1559,14 @@ public partial class MainWindow : Window
             GameList.SelectedItem = reselected;
         }
 
+        // Console home screens always have a focused tile; keeping a live
+        // selection also means the controller always has somewhere to move
+        // from and Cross always has something to launch.
+        if (GameList.SelectedItem is null && _visibleGames.Count > 0)
+        {
+            GameList.SelectedIndex = 0;
+        }
+
         EmptyState.IsVisible = _visibleGames.Count == 0;
         UpdateEmptyStateTexts();
 
@@ -1565,7 +1600,6 @@ public partial class MainWindow : Window
         if (GameList.SelectedItem is GameEntry game)
         {
             UpdateSelectedGameTexts();
-            SelectedCoverPanel.DataContext = game;
             SelectedBadgesRow.DataContext = game;
             SelectedBadgesRow.IsVisible = true;
             _ = UpdateBackdropAsync(game);
@@ -1574,7 +1608,6 @@ public partial class MainWindow : Window
         else
         {
             UpdateSelectedGameTexts();
-            SelectedCoverPanel.DataContext = null;
             SelectedBadgesRow.DataContext = null;
             SelectedBadgesRow.IsVisible = false;
             _ = UpdateBackdropAsync(null);
@@ -1595,11 +1628,14 @@ public partial class MainWindow : Window
         {
             SelectedGameTitle.Text = game.Name;
             SelectedGamePath.Text = game.Path;
+            StripCaptionText.Text = game.Name;
+            StripCaptionRow.IsVisible = true;
         }
         else
         {
             SelectedGameTitle.Text = Localization.Instance.Get("Launch.NoGameSelected");
             SelectedGamePath.Text = Localization.Instance.Get("Launch.NoGameHint");
+            StripCaptionRow.IsVisible = false;
         }
     }
 
@@ -2318,7 +2354,9 @@ public partial class MainWindow : Window
     private void UpdateRunButtons()
     {
         LaunchButton.IsEnabled = !_isRunning && GameList.SelectedItem is GameEntry;
+        MoreButton.IsEnabled = GameList.SelectedItem is GameEntry;
         StopButton.IsEnabled = _isRunning && !_isStopping;
+        StopButton.IsVisible = _isRunning;
         SessionStopButton.IsEnabled = _isRunning && !_isStopping;
         OpenFileButton.IsEnabled = !_isRunning;
     }

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -113,8 +113,12 @@ public partial class MainWindow : Window
     // Title-bar clock, console style.
     private readonly DispatcherTimer _clockTimer;
 
-    // Hero fade/slide-in on selection change.
+    // Fade/slide-in animation state (hero block, page switch, options
+    // section switch); each target keeps its own cancellation source so
+    // restarting one animation never cancels another.
     private CancellationTokenSource? _heroAnimationCts;
+    private CancellationTokenSource? _pageAnimationCts;
+    private CancellationTokenSource? _sectionAnimationCts;
     private string? _lastHeroPath;
 
     // Which backdrop layer is currently showing (see ShowBackdrop).
@@ -399,6 +403,7 @@ public partial class MainWindow : Window
         LibraryPage.IsVisible = index == 0;
         LibraryToolbar.IsVisible = index == 0;
         OptionsPage.IsVisible = index == 1;
+        AnimateSlideFadeIn(index == 0 ? LibraryPage : OptionsPage, ref _pageAnimationCts, 18);
     }
 
     /// <summary>
@@ -407,11 +412,17 @@ public partial class MainWindow : Window
     /// </summary>
     private void SetOptionsSection(int index)
     {
+        if (index == _optionsSectionIndex)
+        {
+            return;
+        }
+
         _optionsSectionIndex = index;
         SetActiveClass(GeneralSectionButton, index == 0);
         SetActiveClass(EnvSectionButton, index == 1);
         GeneralScroll.IsVisible = index == 0;
         EnvScroll.IsVisible = index == 1;
+        AnimateSlideFadeIn(index == 0 ? GeneralScroll : EnvScroll, ref _sectionAnimationCts, 12);
     }
 
     private static void SetActiveClass(Button button, bool active)
@@ -1790,20 +1801,25 @@ public partial class MainWindow : Window
     /// scrubbing quickly through the strip keeps the hero gently pulsing
     /// rather than stacking animations.
     /// </summary>
-    private void AnimateHeroIn()
-    {
-        _heroAnimationCts?.Cancel();
-        var cts = new CancellationTokenSource();
-        _heroAnimationCts = cts;
+    private void AnimateHeroIn() => AnimateSlideFadeIn(HeroPanel, ref _heroAnimationCts, 14);
 
-        // Code-run keyframes can only animate properties with registered
-        // animators, which rules out RenderTransform itself — so the fade
-        // targets the panel and the slide targets a TranslateTransform's Y
-        // (both plain doubles).
-        if (HeroPanel.RenderTransform is not TranslateTransform translate)
+    /// <summary>
+    /// Fades a panel in while sliding it up from <paramref name="fromY"/>
+    /// pixels below. Restarting cancels the previous run on the same target.
+    /// Code-run keyframes can only animate properties with registered
+    /// animators, which rules out RenderTransform itself — so the fade
+    /// targets the panel and the slide targets a TranslateTransform's Y
+    /// (both plain doubles).
+    /// </summary>
+    private static void AnimateSlideFadeIn(Control target, ref CancellationTokenSource? animationCts, double fromY)
+    {
+        animationCts?.Cancel();
+        var cts = new CancellationTokenSource();
+        animationCts = cts;
+
+        if (target.RenderTransform is not TranslateTransform)
         {
-            translate = new TranslateTransform();
-            HeroPanel.RenderTransform = translate;
+            target.RenderTransform = new TranslateTransform();
         }
 
         var animation = new Animation
@@ -1819,7 +1835,7 @@ public partial class MainWindow : Window
                     Setters =
                     {
                         new Setter(OpacityProperty, 0.0),
-                        new Setter(TranslateTransform.YProperty, 14.0),
+                        new Setter(TranslateTransform.YProperty, fromY),
                     },
                 },
                 new KeyFrame
@@ -1834,7 +1850,7 @@ public partial class MainWindow : Window
             },
         };
 
-        _ = animation.RunAsync(HeroPanel, cts.Token);
+        _ = animation.RunAsync(target, cts.Token);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Redesigns the launcher as a PS5-style home screen: full-bleed key art backdrop (crossfading between selections), a horizontal cover strip whose selected tile scales up inside a white frame, and a hero block with the game title, a Play Game pill, and a context-menu button.
- Controller-first navigation: ~60Hz pad polling with hold-to-repeat, smooth eased centering of the strip, LB/RB page switching, d-pad category switching and scrolling on the options page, and a controller-connected indicator plus clock in the title bar.
- Reworks the toolbar into round vector-icon buttons with a slide-out search field, and the options page into a console-settings layout (category sidebar, translucent cards).
- Adds fade/slide transitions for page switches, options sections, and selection changes.

## Testing

- Exercised manually on Windows with a DualSense connected: strip navigation, launch, LB/RB switching, tile and hero context menus, search filtering, library scan, options editing.
- Existing behaviors (fullscreen, session popups, console panel, localization, title music) are wired to the same control names and were left functionally unchanged.
<img width="1280" height="824" alt="image" src="https://github.com/user-attachments/assets/44129c22-5111-4692-9182-c5a10360b8c7" />
