### PR TITLE
Gui Settings Null list Entries

### DIFF
--- a/src/SharpEmu.GUI/GuiSettings.cs
+++ b/src/SharpEmu.GUI/GuiSettings.cs
@@ -71,7 +71,7 @@ public sealed class GuiSettings
             if (File.Exists(SettingsPath))
             {
                 var json = File.ReadAllText(SettingsPath);
-                return JsonSerializer.Deserialize<GuiSettings>(json, SerializerOptions) ?? new GuiSettings();
+                return NormalizeFromJson(json);
             }
         }
         catch (Exception)
@@ -80,6 +80,35 @@ public sealed class GuiSettings
         }
 
         return new GuiSettings();
+    }
+
+    /// <summary>
+    /// Deserializes settings and normalizes null references and null or empty list
+    /// entries introduced by JSON. Empty scalar strings remain unchanged.
+    /// </summary>
+    internal static GuiSettings NormalizeFromJson(string json)
+    {
+        var settings = JsonSerializer.Deserialize<GuiSettings>(json, SerializerOptions) ?? new GuiSettings();
+
+        settings.GameFolders = FilterNullOrEmpty(settings.GameFolders);
+        settings.ExcludedGames = FilterNullOrEmpty(settings.ExcludedGames);
+        settings.EnvironmentToggles = FilterNullOrEmpty(settings.EnvironmentToggles);
+        settings.LogLevel ??= "Info";
+        settings.Language ??= "en";
+        settings.DiscordClientId ??= "1525606762248540221";
+
+        return settings;
+    }
+
+    // JSON can populate non-nullable lists with null references and entries.
+    private static List<string> FilterNullOrEmpty(List<string>? source)
+    {
+        if (source is null)
+        {
+            return [];
+        }
+
+        return source.Where(entry => !string.IsNullOrEmpty(entry)).ToList();
     }
 
     public void Save()

--- a/src/SharpEmu.GUI/SharpEmu.GUI.csproj
+++ b/src/SharpEmu.GUI/SharpEmu.GUI.csproj
@@ -25,6 +25,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="SharpEmu.Libs.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Fonts.Inter" />

--- a/tests/SharpEmu.Libs.Tests/GUI/GuiSettingsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/GUI/GuiSettingsTests.cs
@@ -1,0 +1,100 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.GUI;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.GUI;
+
+public sealed class GuiSettingsTests
+{
+    [Fact]
+    public void NormalizeFromJson_AllPropertiesNull_FallsBackToDefaults()
+    {
+        const string json = """
+            {
+              "LogLevel": null,
+              "GameFolders": null,
+              "ExcludedGames": null,
+              "EnvironmentToggles": null,
+              "Language": null,
+              "DiscordClientId": null
+            }
+            """;
+
+        var settings = GuiSettings.NormalizeFromJson(json);
+
+        Assert.Equal("Info", settings.LogLevel);
+        Assert.Equal("en", settings.Language);
+        Assert.Equal("1525606762248540221", settings.DiscordClientId);
+        Assert.Empty(settings.GameFolders);
+        Assert.Empty(settings.ExcludedGames);
+        Assert.Empty(settings.EnvironmentToggles);
+    }
+
+    [Fact]
+    public void NormalizeFromJson_ValidValues_ArePreserved()
+    {
+        const string json = """
+            {
+              "LogLevel": "Debug",
+              "GameFolders": ["C:\\Games"],
+              "ExcludedGames": ["C:\\Games\\skip.bin"],
+              "EnvironmentToggles": ["SHARPEMU_TRACE"],
+              "Language": "pt-BR",
+              "DiscordClientId": "999"
+            }
+            """;
+
+        var settings = GuiSettings.NormalizeFromJson(json);
+
+        Assert.Equal("Debug", settings.LogLevel);
+        Assert.Equal("pt-BR", settings.Language);
+        Assert.Equal("999", settings.DiscordClientId);
+        Assert.Equal(["C:\\Games"], settings.GameFolders);
+        Assert.Equal(["C:\\Games\\skip.bin"], settings.ExcludedGames);
+        Assert.Equal(["SHARPEMU_TRACE"], settings.EnvironmentToggles);
+    }
+
+    // An empty Discord client ID intentionally disables Rich Presence.
+    [Fact]
+    public void NormalizeFromJson_EmptyDiscordClientId_IsPreservedNotNormalized()
+    {
+        const string json = """{ "DiscordClientId": "" }""";
+
+        var settings = GuiSettings.NormalizeFromJson(json);
+
+        Assert.Equal(string.Empty, settings.DiscordClientId);
+    }
+
+    [Fact]
+    public void NormalizeFromJson_NullOrEmptyListEntries_AreFilteredOut()
+    {
+        const string json = """
+            {
+              "GameFolders": ["C:\\Games", null, ""],
+              "ExcludedGames": [null],
+              "EnvironmentToggles": [null, "SHARPEMU_TRACE", ""]
+            }
+            """;
+
+        var settings = GuiSettings.NormalizeFromJson(json);
+
+        Assert.Equal(["C:\\Games"], settings.GameFolders);
+        Assert.Empty(settings.ExcludedGames);
+        Assert.Equal(["SHARPEMU_TRACE"], settings.EnvironmentToggles);
+    }
+
+    [Fact]
+    public void NormalizeFromJson_EmptyObject_UsesConstructorDefaults()
+    {
+        var settings = GuiSettings.NormalizeFromJson("{}");
+
+        Assert.Equal("Info", settings.LogLevel);
+        Assert.Equal("en", settings.Language);
+        Assert.Equal("1525606762248540221", settings.DiscordClientId);
+        Assert.Empty(settings.GameFolders);
+        Assert.Empty(settings.ExcludedGames);
+        Assert.Empty(settings.EnvironmentToggles);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj
+++ b/tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj
@@ -14,6 +14,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <ProjectReference Include="..\..\src\SharpEmu.Core\SharpEmu.Core.csproj" />
     <ProjectReference Include="..\..\src\SharpEmu.Libs\SharpEmu.Libs.csproj" />
     <ProjectReference Include="..\..\src\SharpEmu.HLE\SharpEmu.HLE.csproj" />
+    <ProjectReference Include="..\..\src\SharpEmu.GUI\SharpEmu.GUI.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

GuiSettings properties are declared non-nullable, but that doesn't stop the deserializer from assigning null from the JSON. The fallback in Load() doesn't catch this because it only returns new GuiSettings() when the entire deserialization result is null - not when individual properties inside it are null. Since no exception is thrown during deserialization, the catch block in Load() never runs either.

While fixing this, I found the same issue inside lists: "EnvironmentToggles": [null] deserializes fine and the null value flows straight into Environment.SetEnvironmentVariable later, throwing an exception. I fixed both cases.

## Testing

N/A. No game-specific testing was applicable. Dotnet test - all 438 passed 

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
