### PR TITLE
[GUI/CLI] Fix space-in-path game launching on Windows

### DIFF
--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -607,7 +607,7 @@ internal static partial class Program
             nint jobHandle = 0;
             Environment.SetEnvironmentVariable(MitigatedChildEnvironment, "1");
             var created = CreateProcessW(
-                processPath,
+                null,
                 cmdLineBuilder,
                 0,
                 0,
@@ -1433,7 +1433,7 @@ internal static partial class Program
     [DllImport("kernel32.dll", EntryPoint = "CreateProcessW", SetLastError = true, CharSet = CharSet.Unicode)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool CreateProcessW(
-        string applicationName,
+        string? applicationName,
         StringBuilder commandLine,
         nint processAttributes,
         nint threadAttributes,

--- a/src/SharpEmu.GUI/EmulatorProcess.cs
+++ b/src/SharpEmu.GUI/EmulatorProcess.cs
@@ -248,7 +248,7 @@ internal sealed class EmulatorProcess : IDisposable
                 {
                     Environment.SetEnvironmentVariable(MitigatedChildEnvironment, "1");
                     if (!CreateProcessW(
-                            exePath,
+                            null,
                             commandLine,
                             0,
                             0,
@@ -629,7 +629,7 @@ internal sealed class EmulatorProcess : IDisposable
 
     [DllImport("kernel32.dll", EntryPoint = "CreateProcessW", SetLastError = true, CharSet = CharSet.Unicode)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool CreateProcessW(string applicationName, StringBuilder commandLine, nint processAttributes, nint threadAttributes, [MarshalAs(UnmanagedType.Bool)] bool inheritHandles, uint flags, nint environment, string currentDirectory, ref StartupInfoEx startupInfo, out ProcessInformation processInformation);
+    private static extern bool CreateProcessW(string? applicationName, StringBuilder commandLine, nint processAttributes, nint threadAttributes, [MarshalAs(UnmanagedType.Bool)] bool inheritHandles, uint flags, nint environment, string currentDirectory, ref StartupInfoEx startupInfo, out ProcessInformation processInformation);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern uint WaitForSingleObject(nint handle, uint milliseconds);


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Description

This PR resolves an issue on Windows where double-clicking a game in the GUI fails to launch if the game's path contains spaces. 

### Cause
In both the GUI (`EmulatorProcess.cs`) and CLI mitigation relauncher (`Program.cs`), `CreateProcessW` was called with the executable path passed as `lpApplicationName`. 

While the command line string passed to `lpCommandLine` is quoted, passing a non-null `lpApplicationName` can trigger differences in quoting/escaping interpretations across the process boundary. If the executable path token in the command line is unquoted (or there is a mismatch), subsequent quoted arguments (such as game paths containing spaces) are parsed incorrectly by the child process's argument parser, causing it to fail validation and display the CLI usage screen.

### Fix
- Updated the P/Invoke declarations for `CreateProcessW` in both projects to accept a nullable `string? applicationName`.
- Passed `null` for `lpApplicationName` and allowed the system to resolve the executable path via the first quoted argument in `lpCommandLine`. This is the standard Windows process launching pattern (matching `Process.Start`) and ensures consistent argument parsing.

## Testing

Tested using the compiled emulator and a mock game:
- Mock game (minimal ELF header under `C:\Users\Aadi.B\Downloads\My Game Test Folder\eboot.bin`) – Successfully bypassed the argument verification and proceeded to initialize the HLE runtime loader.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
