### PR TITLE
[Kernel] Implement sceKernelMapDirectMemory2

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -2827,12 +2827,51 @@ public static partial class KernelMemoryCompatExports
         LibraryName = "libKernel")]
     public static int KernelMapDirectMemory(CpuContext ctx)
     {
-        var inOutAddressPointer = ctx[CpuRegister.Rdi];
-        var length = ctx[CpuRegister.Rsi];
-        var protection = unchecked((int)ctx[CpuRegister.Rdx]);
-        var flags = ctx[CpuRegister.Rcx];
-        var directMemoryStart = ctx[CpuRegister.R8];
-        var alignment = ctx[CpuRegister.R9];
+        return MapDirectMemoryCore(
+            ctx,
+            inOutAddressPointer: ctx[CpuRegister.Rdi],
+            length: ctx[CpuRegister.Rsi],
+            protection: unchecked((int)ctx[CpuRegister.Rdx]),
+            flags: ctx[CpuRegister.Rcx],
+            directMemoryStart: ctx[CpuRegister.R8],
+            alignment: ctx[CpuRegister.R9]);
+    }
+
+    [SysAbiExport(
+        Nid = "BQQniolj9tQ",
+        ExportName = "sceKernelMapDirectMemory2",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelMapDirectMemory2(CpuContext ctx)
+    {
+        // The "2" variant inserts a memoryType argument (rdx) ahead of v1's
+        // protection, shifting protection/flags/directMemoryStart down one
+        // register each and pushing alignment onto the stack (the 7th argument,
+        // at [rsp + 8], above the return address). The memoryType only selects
+        // cache/GPU access attributes, which this HLE does not model per
+        // mapping, so it is accepted but does not affect placement.
+        ulong alignment = 0;
+        _ = ctx.TryReadUInt64(ctx[CpuRegister.Rsp] + sizeof(ulong), out alignment);
+
+        return MapDirectMemoryCore(
+            ctx,
+            inOutAddressPointer: ctx[CpuRegister.Rdi],
+            length: ctx[CpuRegister.Rsi],
+            protection: unchecked((int)ctx[CpuRegister.Rcx]),
+            flags: ctx[CpuRegister.R8],
+            directMemoryStart: ctx[CpuRegister.R9],
+            alignment: alignment);
+    }
+
+    private static int MapDirectMemoryCore(
+        CpuContext ctx,
+        ulong inOutAddressPointer,
+        ulong length,
+        int protection,
+        ulong flags,
+        ulong directMemoryStart,
+        ulong alignment)
+    {
         if (ShouldTraceDirectMemory())
         {
             Console.Error.WriteLine(


### PR DESCRIPTION
## What this adds

`sceKernelMapDirectMemory2` (NID `BQQniolj9tQ`) was unimplemented while its v1
counterpart `sceKernelMapDirectMemory` (NID `L-Q3LEjIbgA`) already exists. A
title that calls the v2 variant therefore hit an unresolved import that
returned an error value the guest then treated as the mapped address.

## How it works

The "2" variant inserts a `memoryType` argument (rdx) ahead of v1's protection,
shifting protection, flags and directMemoryStart down one register each and
pushing alignment onto the stack (the 7th argument, at `[rsp + 8]`, above the
return address). v1's body is extracted into a shared `MapDirectMemoryCore`
and both exports route through it. v2 reads its shifted arguments plus the
stack alignment and accepts the memoryType, which only selects cache/GPU
access attributes this HLE does not model per mapping, so it does not affect
placement. The ABI shift was confirmed against real call arguments (the value
in rcx is a valid protection mask, which only makes sense in v2's layout).

## Testing

macOS (Apple Silicon, Rosetta 2), native CPU backend:

- Gex Trilogy (PPSA28542) - calls `sceKernelMapDirectMemory2` during init.
  Before: unresolved import returning an error. After: it maps like v1 and
  returns a valid address. (The title progresses to a later spin on separate
  still-unimplemented AGC/GPU driver functions, so this alone does not make it
  playable, but the mapping call is now handled with no crash.)
- Dreaming Sarah (PPSA02929) - no regression from the shared-core refactor
  (it exercises v1); around 1,800 draw submissions.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
