### PR TITLE
[CPU] Skip idle exception work at HLE import boundaries

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -532,7 +532,8 @@ public sealed partial class DirectExecutionBackend
 			}
 			DeliverPendingGuestExceptionAtSafePoint(
 				cpuContext,
-				CaptureImportBoundaryContinuation(cpuContext, argPackPtr, num7));
+				argPackPtr,
+				num7);
 			StoreImportVectorReturn(cpuContext, argPackPtr);
 			if (dispatchResolved &&
 				orbisGen2Result == OrbisGen2Result.ORBIS_GEN2_OK &&
@@ -1328,7 +1329,8 @@ public sealed partial class DirectExecutionBackend
 		}
 		DeliverPendingGuestExceptionAtSafePoint(
 			cpuContext,
-			CaptureImportBoundaryContinuation(cpuContext, argPackPtr, returnRip));
+			argPackPtr,
+			returnRip);
 		StoreImportVectorReturn(cpuContext, argPackPtr);
 
 		if (returnValue != (int)OrbisGen2Result.ORBIS_GEN2_OK)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -711,6 +711,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	private static ulong _currentExternalGuestThreadHandle;
 
 	private readonly Dictionary<ulong, PendingGuestException> _pendingGuestExceptions = new Dictionary<ulong, PendingGuestException>();
+	private int _pendingGuestExceptionCount;
 
 	private readonly HashSet<ulong> _activeGuestExceptionDeliveries = new HashSet<ulong>();
 
@@ -3948,10 +3949,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					// unwinding. Unity can begin its next stop-the-world cycle in
 					// that window; treating the new raise as part of the old delivery
 					// strands the collector waiting for an acknowledgement.
-					_pendingGuestExceptions[threadHandle] = new PendingGuestException(
+					SetPendingGuestExceptionLocked(threadHandle, new PendingGuestException(
 						handler,
 						exceptionType,
-						external.ExceptionStackBase);
+						external.ExceptionStackBase));
 					return true;
 				}
 
@@ -3960,10 +3961,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				// managed thread corrupts the worker's control state. Queue the
 				// request and let that exact executor consume it at its next HLE
 				// boundary, where the original guest thread is safely paused.
-				_pendingGuestExceptions[threadHandle] = new PendingGuestException(
+				SetPendingGuestExceptionLocked(threadHandle, new PendingGuestException(
 					handler,
 					exceptionType,
-					external.ExceptionStackBase);
+					external.ExceptionStackBase));
 				if (logGuestExceptions)
 				{
 					Console.Error.WriteLine(
@@ -4008,17 +4009,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				}
 				if (target.ExceptionDeliveryActive)
 				{
-					_pendingGuestExceptions[threadHandle] = new PendingGuestException(
+					SetPendingGuestExceptionLocked(threadHandle, new PendingGuestException(
 						handler,
 						exceptionType,
-						exceptionStackBase);
+						exceptionStackBase));
 					return true;
 				}
 
-				_pendingGuestExceptions[threadHandle] = new PendingGuestException(
+				SetPendingGuestExceptionLocked(threadHandle, new PendingGuestException(
 					handler,
 					exceptionType,
-					exceptionStackBase);
+					exceptionStackBase));
 				if (logGuestExceptions)
 				{
 					Console.Error.WriteLine(
@@ -4179,7 +4180,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					RestoreInterruptedGuestThread();
 					if (target.State == GuestThreadRunState.Blocked &&
 						!target.ExecutorActive &&
-						_pendingGuestExceptions.Remove(threadHandle, out var queued))
+						TryTakePendingGuestExceptionLocked(threadHandle, out var queued))
 					{
 						followUp = queued;
 					}
@@ -4263,8 +4264,16 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private void DeliverPendingGuestExceptionAtSafePoint(
 		CpuContext currentContext,
-		GuestCpuContinuation interruptedContinuation)
+		nint argPackPtr,
+		ulong returnRip)
 	{
+		// Exceptions are delivered at import boundaries. If one is queued just
+		// after this read, the following boundary will observe it.
+		if (Volatile.Read(ref _pendingGuestExceptionCount) == 0)
+		{
+			return;
+		}
+
 		var threadHandle = GuestThreadExecution.CurrentGuestThreadHandle;
 		if (threadHandle == 0)
 		{
@@ -4278,7 +4287,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				return;
 			}
 
-			if (!_pendingGuestExceptions.Remove(threadHandle, out pending))
+			if (!TryTakePendingGuestExceptionLocked(threadHandle, out pending))
 			{
 				return;
 			}
@@ -4290,6 +4299,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		const ulong callbackStackOffset = 0x1000;
 		const ulong callbackStackSize = 0xF000;
 		var exceptionContextAddress = pending.ExceptionStackBase + 0x100;
+		var interruptedContinuation = CaptureImportBoundaryContinuation(
+			currentContext,
+			argPackPtr,
+			returnRip);
 		try
 		{
 			if (!TryWriteGuestExceptionContext(
@@ -4338,6 +4351,27 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				_activeGuestExceptionDeliveries.Remove(threadHandle);
 			}
 		}
+	}
+
+	private void SetPendingGuestExceptionLocked(
+		ulong threadHandle,
+		PendingGuestException pending)
+	{
+		_pendingGuestExceptions[threadHandle] = pending;
+		Volatile.Write(ref _pendingGuestExceptionCount, _pendingGuestExceptions.Count);
+	}
+
+	private bool TryTakePendingGuestExceptionLocked(
+		ulong threadHandle,
+		out PendingGuestException pending)
+	{
+		if (!_pendingGuestExceptions.Remove(threadHandle, out pending))
+		{
+			return false;
+		}
+
+		Volatile.Write(ref _pendingGuestExceptionCount, _pendingGuestExceptions.Count);
+		return true;
 	}
 
 	private static bool TryWriteGuestExceptionContext(
@@ -4434,6 +4468,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			_guestThreads.Clear();
 			_externalGuestThreads.Clear();
 			_pendingGuestExceptions.Clear();
+			Volatile.Write(ref _pendingGuestExceptionCount, 0);
 			_activeGuestExceptionDeliveries.Clear();
 		}
 


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What changed

Every HLE import currently captures the guest continuation and enters `_guestThreadGate` to check for a pending guest exception. Most imports have no exception waiting, so that work is repeated on the normal path for no result.

This adds a small atomic pending count. When the count is zero, the import returns from the exception check after one volatile read. When an exception is queued, the existing locked path still removes it, captures the continuation, and delivers it as before. Queue replacement, follow-up delivery, removal, and shutdown keep the count synchronized with the dictionary.

An exception queued just after the zero check is observed at the next import boundary, which preserves the existing boundary-based delivery model.

## Why

The Dead Cells trace from #410 recorded more than eight million HLE imports in a 60-second run. Removing a continuation capture and an uncontended monitor acquisition from that common path reduces CPU work without changing GPU memory, command ordering, or emulation state.

This is the same focused change previously submitted as #416 against the #410 branch. That PR was closed after #410 merged, with a request to submit it against `main` for normal game testing. This branch is rebased on the current `main`.

I am not attaching an FPS claim from local testing. The improvement needs to be measured by the gameplay runner on the same real hardware used for other performance PRs.

## Testing

- `dotnet test SharpEmu.slnx -c Release --no-restore -m:1`
  - SharpEmu.Libs.Tests: 391 passed
  - SharpEmu.ShaderCompiler.Metal.Tests: 27 passed
  - SharpEmu.SourceGenerators.Tests: 33 passed
  - Total: 451 passed, 0 failed
- The earlier #416 run passed Dead Cells and Dreaming Sarah without gameplay regressions. This rebased `main` version still requires a fresh runner comparison.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).