### PR TITLE
Doom boot fixes

### DIFF
--- a/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
+++ b/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
@@ -541,8 +541,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
             if (result != OrbisGen2Result.ORBIS_GEN2_OK)
             {
                 Console.Error.WriteLine(
-                    $"[RUNTIME] Module start failed: {moduleName} -> {result}");
-                return result;
+                    $"[RUNTIME] Module start failed (continuing): {moduleName} -> {result}");
             }
         }
 

--- a/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
+++ b/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
@@ -637,6 +637,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
         {
             (Path: Path.Combine(ebootDirectory, "sce_module"), StartAtBoot: true),
             (Path: Path.Combine(ebootDirectory, "sce_modules"), StartAtBoot: true),
+            (Path: Path.Combine(ebootDirectory, "prx"), StartAtBoot: true),
             (Path: Path.Combine(ebootDirectory, "Media", "Modules"), StartAtBoot: true),
             // Unity native plugins are loaded later through sceKernelLoadStartModule. Map
             // them up front so the HLE loader can return a real module handle and dlsym

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -11246,7 +11246,19 @@ public static partial class AgcExports
                             $"addr=0x{commandAddress:X16} dwords={dwordCount}");
                     }
 
-                    ParseSubmittedDcb(ctx, gpuState, gpuState.Graphics, commandAddress, dwordCount, tracePackets);
+                    // Submit through the pending queue rather than parsing inline.
+                    // ParseSubmittedDcb reports "this buffer suspended on a wait"
+                    // through its return value, and only the queue path records
+                    // that and assigns a submission id.
+                    gpuState.Graphics.QueueName = "dcb.graphics";
+                    EnqueueSubmittedDcb(
+                        ctx,
+                        gpuState,
+                        gpuState.Graphics,
+                        commandAddress,
+                        dwordCount,
+                        ++gpuState.SubmissionSequence,
+                        tracePackets);
                 }
 
                 DrainResumableDcbs(ctx, gpuState, tracePackets);

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -640,6 +640,21 @@ public static partial class AgcExports
     public static int GetRegisterDefaults2Internal(CpuContext ctx) =>
         ReturnRegisterDefaults(ctx, internalDefaults: true);
 
+    /// <summary>
+    /// Reports that the GPU is not running in Trinity mode, matching the base
+    /// console this backend emulates.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "BfBDZGbti7A",
+        ExportName = "sceAgcGetIsTrinityMode",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int GetIsTrinityMode(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
     [SysAbiExport(
         Nid = "f3dg2CSgRKY",
         ExportName = "sceAgcCreateShader",

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -5662,6 +5662,74 @@ public static partial class KernelMemoryCompatExports
         return true;
     }
 
+    /// <summary>
+    /// Inserts <paramref name="replacement"/> into the tracked-region table,
+    /// carving it out of any regions it overlaps and preserving the parts of
+    /// those regions that fall outside it.
+    /// </summary>
+    /// <remarks>
+    /// The table is a SortedList keyed by start address, so assigning directly
+    /// destroys any existing entry that happens to share a start address. That
+    /// silently discarded enclosing reservations: a title reserves a large range
+    /// and then commits a small mapping at the same base, and the record of
+    /// everything past the small mapping disappears — leaving sceKernelVirtualQuery
+    /// unable to find memory the guest legitimately owns.
+    ///
+    /// Carving also keeps the table non-overlapping. Previously a new region
+    /// starting inside an existing one produced two overlapping entries, which
+    /// the ordered scan in TryFindVirtualQueryRegionLocked is not written to
+    /// expect.
+    /// </remarks>
+    private static void ReplaceMappedRegionRangeLocked(MappedRegion replacement)
+    {
+        if (replacement.Length == 0 ||
+            !TryAddU64(replacement.Address, replacement.Length, out var replacementEnd))
+        {
+            _mappedRegions[replacement.Address] = replacement;
+            return;
+        }
+
+        var start = replacement.Address;
+        List<MappedRegion>? overlapping = null;
+        foreach (var region in _mappedRegions.Values)
+        {
+            if (region.Length == 0 ||
+                !TryAddU64(region.Address, region.Length, out var regionEnd))
+            {
+                continue;
+            }
+
+            if (region.Address < replacementEnd && regionEnd > start)
+            {
+                (overlapping ??= []).Add(region);
+            }
+        }
+
+        if (overlapping is not null)
+        {
+            foreach (var region in overlapping)
+            {
+                _mappedRegions.Remove(region.Address);
+            }
+
+            foreach (var region in overlapping)
+            {
+                var regionEnd = region.Address + region.Length;
+                if (region.Address < start)
+                {
+                    AddMappedRegionSliceLocked(region, region.Address, start, region.Protection);
+                }
+
+                if (regionEnd > replacementEnd)
+                {
+                    AddMappedRegionSliceLocked(region, replacementEnd, regionEnd, region.Protection);
+                }
+            }
+        }
+
+        _mappedRegions[start] = replacement;
+    }
+
     private static void AddMappedRegionSliceLocked(
         MappedRegion source,
         ulong start,

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -2328,6 +2328,37 @@ public static partial class KernelMemoryCompatExports
     }
 
     [SysAbiExport(
+        Nid = "smIj7eqzZE8",
+        ExportName = "clock_getres",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int ClockGetres(CpuContext ctx)
+    {
+        var timespecAddress = ctx[CpuRegister.Rsi];
+
+        // POSIX allows a null resolution pointer: the call then only validates
+        // the clock id, which every id a title passes here does.
+        if (timespecAddress == 0)
+        {
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        // clock_gettime above is backed by DateTimeOffset.UtcNow, whose tick is
+        // 100 ns, so that is the honest resolution to report rather than the 1 ns
+        // a caller might otherwise assume it can rely on.
+        const ulong ResolutionNanoseconds = 100;
+        if (!ctx.TryWriteUInt64(timespecAddress, 0) ||
+            !ctx.TryWriteUInt64(timespecAddress + sizeof(long), ResolutionNanoseconds))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
         Nid = "vNe1w4diLCs",
         ExportName = "__tls_get_addr",
         Target = Generation.Gen4 | Generation.Gen5,

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -265,13 +265,13 @@ public static partial class KernelMemoryCompatExports
             }
 
             _nextVirtualAddress = Math.Max(_nextVirtualAddress, address + mappedLength);
-            _mappedRegions[address] = new MappedRegion(
+            ReplaceMappedRegionRangeLocked(new MappedRegion(
                 address,
                 mappedLength,
                 OrbisProtCpuReadWrite,
                 IsFlexible: false,
                 IsDirect: false,
-                DirectStart: 0);
+                DirectStart: 0));
         }
 
         for (ulong offset = 0; offset < mappedLength;)
@@ -297,13 +297,13 @@ public static partial class KernelMemoryCompatExports
 
         lock (_memoryGate)
         {
-            _mappedRegions[address] = new MappedRegion(
+            ReplaceMappedRegionRangeLocked(new MappedRegion(
                 address,
                 length,
                 Protection: 0,
                 IsFlexible: false,
                 IsDirect: false,
-                DirectStart: 0);
+                DirectStart: 0));
         }
     }
 
@@ -3001,13 +3001,13 @@ public static partial class KernelMemoryCompatExports
             }
 
             _nextVirtualAddress = Math.Max(_nextVirtualAddress, mappedAddress + length);
-            _mappedRegions[mappedAddress] = new MappedRegion(
+            ReplaceMappedRegionRangeLocked(new MappedRegion(
                 mappedAddress,
                 length,
                 protection,
                 IsFlexible: false,
                 IsDirect: true,
-                DirectStart: directMemoryStart);
+                DirectStart: directMemoryStart));
         }
 
         if (!ctx.TryWriteUInt64(inOutAddressPointer, mappedAddress))
@@ -3092,13 +3092,13 @@ public static partial class KernelMemoryCompatExports
 
             _nextVirtualAddress = Math.Max(_nextVirtualAddress, mappedAddress + length);
             _allocatedFlexibleBytes = Math.Min(FlexibleMemorySizeBytes, _allocatedFlexibleBytes + length);
-            _mappedRegions[mappedAddress] = new MappedRegion(
+            ReplaceMappedRegionRangeLocked(new MappedRegion(
                 mappedAddress,
                 length,
                 protection,
                 IsFlexible: true,
                 IsDirect: false,
-                DirectStart: 0);
+                DirectStart: 0));
         }
 
         if (!ctx.TryWriteUInt64(inOutAddressPointer, mappedAddress))
@@ -3426,6 +3426,47 @@ public static partial class KernelMemoryCompatExports
         }
 
         return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+    }
+
+    /// <summary>
+    /// POSIX alias of <see cref="KernelMprotect"/>; identical (addr, len, prot)
+    /// argument order. Imported by libcohtml, whose embedded V8 changes page
+    /// permissions through this name when moving JIT pages between writable and
+    /// executable.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "YQOfxL4QfeU",
+        ExportName = "mprotect",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixMprotect(CpuContext ctx) => KernelMprotect(ctx);
+
+    /// <summary>
+    /// POSIX alias of <see cref="KernelMunmap"/>; identical (addr, len) argument
+    /// order.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "UqDGjXA5yUM",
+        ExportName = "munmap",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixMunmap(CpuContext ctx) => KernelMunmap(ctx);
+
+    /// <summary>
+    /// Reports the 16 KiB page granularity this backend maps and aligns against
+    /// (<see cref="OrbisPageSize"/>), not the host's 4 KiB. An allocator that
+    /// rounded to the host value would hand back sub-page offsets that every
+    /// mapping call here then rejects for misalignment.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "k+AXqu2-eBc",
+        ExportName = "getpagesize",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixGetPageSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = OrbisPageSize;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     [SysAbiExport(

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -5408,7 +5408,7 @@ public static partial class KernelMemoryCompatExports
         return true;
     }
 
-    private static bool TryWriteUInt32Compat(CpuContext ctx, ulong address, uint value)
+    internal static bool TryWriteUInt32Compat(CpuContext ctx, ulong address, uint value)
     {
         Span<byte> bytes = stackalloc byte[sizeof(uint)];
         BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -578,6 +578,19 @@ public static class KernelPthreadCompatExports
         return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
+    /// <summary>
+    /// The POSIX-named alias of <see cref="PthreadOnce"/>. libKernel exports the
+    /// same routine under two NIDs, and shipped middleware links the plain name:
+    /// DOOM's libcohtml, PlayFab and party modules all import this one rather
+    /// than scePthreadOnce.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "Z4QosVuAsA0",
+        ExportName = "pthread_once",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PthreadOncePOSIX(CpuContext ctx) => PthreadOnce(ctx);
+
     private static int PthreadMutexInitCore(CpuContext ctx, ulong mutexAddress, ulong attrAddress)
     {
         if (mutexAddress == 0)

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
@@ -1134,6 +1134,90 @@ public static class KernelPthreadExtendedCompatExports
     public static int PosixPthreadRwlockWrlock(CpuContext ctx) => PthreadRwlockWrlock(ctx);
 
     [SysAbiExport(
+        Nid = "SFxTMOfuCkE",
+        ExportName = "pthread_rwlock_tryrdlock",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixPthreadRwlockTryrdlock(CpuContext ctx) =>
+        PthreadRwlockTryLockCore(ctx, ctx[CpuRegister.Rdi], write: false);
+
+    [SysAbiExport(
+        Nid = "XhWHn6P5R7U",
+        ExportName = "pthread_rwlock_trywrlock",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixPthreadRwlockTrywrlock(CpuContext ctx) =>
+        PthreadRwlockTryLockCore(ctx, ctx[CpuRegister.Rdi], write: true);
+
+    /// <summary>
+    /// Non-blocking counterpart of <see cref="PthreadRwlockLockCore"/>: acquires
+    /// only if the lock is free right now, otherwise reports BUSY.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not routed through TryAcquireBlockedRwlock. That helper exists
+    /// for the scheduler resume path and decrements WaitingWriters on success,
+    /// which is correct only for a thread that previously incremented it. A fresh
+    /// try never did, so reusing it would silently consume another thread's
+    /// waiter count and let a queued writer be skipped.
+    /// </remarks>
+    private static int PthreadRwlockTryLockCore(CpuContext ctx, ulong rwlockAddress, bool write)
+    {
+        if (rwlockAddress == 0)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (!TryResolveRwlockState(ctx, rwlockAddress, createIfZero: true, out var resolvedAddress, out var rwlock))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+        }
+
+        var currentThreadId = KernelPthreadState.GetCurrentThreadHandle();
+        lock (rwlock.SyncRoot)
+        {
+            if (write)
+            {
+                if (rwlock.WriterThreadId == currentThreadId || rwlock.GetReaderCount(currentThreadId) > 0)
+                {
+                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_DEADLOCK;
+                }
+
+                // Mirrors the blocking path's re-entrant compat-writer grant so the
+                // two agree on what counts as already owning the lock.
+                if (rwlock.CompatWriterCounts.GetValueOrDefault(currentThreadId) > 0)
+                {
+                    rwlock.AddCompatWriter(currentThreadId);
+                    return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                }
+
+                if (rwlock.WriterThreadId != 0 ||
+                    rwlock.ReaderTotalCount != 0 ||
+                    rwlock.CompatWriterTotalCount != 0)
+                {
+                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY;
+                }
+
+                DetectRwlockWriterConflict(resolvedAddress, rwlock, currentThreadId, "trywrlock");
+                rwlock.WriterThreadId = currentThreadId;
+                return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+            }
+
+            if (rwlock.WriterThreadId == currentThreadId)
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_DEADLOCK;
+            }
+
+            if (ReaderMustWaitForRwlock(rwlock, currentThreadId))
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY;
+            }
+
+            rwlock.AddReader(currentThreadId);
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+    }
+
+    [SysAbiExport(
         Nid = "+L98PIbGttk",
         ExportName = "scePthreadRwlockUnlock",
         Target = Generation.Gen4 | Generation.Gen5,

--- a/src/SharpEmu.Libs/Network/NetExports.cs
+++ b/src/SharpEmu.Libs/Network/NetExports.cs
@@ -184,6 +184,212 @@ public static class NetExports
         return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
     }
 
+    /// <summary>
+    /// POSIX alias of <see cref="NetSetsockopt"/>; identical
+    /// (fd, level, option, value, length) argument order.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "fFxGkxF2bVo",
+        ExportName = "setsockopt",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixSetsockopt(CpuContext ctx) => NetSetsockopt(ctx);
+
+    /// <summary>
+    /// Reads back the socket options this backend actually tracks: SO_NBIO,
+    /// SO_REUSEADDR and SO_ERROR.
+    /// </summary>
+    /// <remarks>
+    /// Anything else returns EINVAL rather than a zero-filled buffer. A caller
+    /// that receives success for an option nobody stored would treat whatever
+    /// happens to be in its output buffer as the real setting, which is a harder
+    /// failure to trace than an explicit rejection.
+    /// </remarks>
+    [SysAbiExport(
+        Nid = "6O8EwYOgH9Y",
+        ExportName = "getsockopt",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixGetsockopt(CpuContext ctx)
+    {
+        var id = unchecked((int)ctx[CpuRegister.Rdi]);
+        var level = unchecked((int)ctx[CpuRegister.Rsi]);
+        var option = unchecked((int)ctx[CpuRegister.Rdx]);
+        var valueAddress = ctx[CpuRegister.Rcx];
+        var lengthAddress = ctx[CpuRegister.R8];
+        if (!_sockets.TryGetValue(id, out var socket))
+        {
+            return SetNetError(ctx, NetErrorBadFileDescriptor, NetErrnoBadFileDescriptor);
+        }
+
+        if (valueAddress == 0 || lengthAddress == 0 || level != 0xFFFF)
+        {
+            return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
+        }
+
+        Span<byte> lengthBytes = stackalloc byte[sizeof(int)];
+        if (!ctx.Memory.TryRead(lengthAddress, lengthBytes))
+        {
+            return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
+        }
+
+        if (BinaryPrimitives.ReadInt32LittleEndian(lengthBytes) < sizeof(int))
+        {
+            return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
+        }
+
+        int value;
+        switch (option)
+        {
+            // ORBIS_NET_SO_NBIO: mirrors what sceNetSetsockopt stored.
+            case 0x1200:
+                value = socket.Blocking ? 0 : 1;
+                break;
+            case 0x0004:
+                value = (int)socket.GetSocketOption(
+                    SocketOptionLevel.Socket,
+                    SocketOptionName.ReuseAddress)! != 0 ? 1 : 0;
+                break;
+            // ORBIS_NET_SO_ERROR: nothing here records per-socket async errors,
+            // so report "no pending error" rather than inventing one.
+            case 0x1007:
+                value = 0;
+                break;
+            default:
+                return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
+        }
+
+        Span<byte> valueBytes = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32LittleEndian(valueBytes, value);
+        BinaryPrimitives.WriteInt32LittleEndian(lengthBytes, sizeof(int));
+        if (!ctx.Memory.TryWrite(valueAddress, valueBytes) ||
+            !ctx.Memory.TryWrite(lengthAddress, lengthBytes))
+        {
+            return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
+        }
+
+        TraceNet("socket.getsockopt", id, unchecked((uint)option), unchecked((uint)value), 0);
+        return ctx.SetReturn(0);
+    }
+
+    [SysAbiExport(
+        Nid = "fZOeZIOEmLw",
+        ExportName = "send",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixSend(CpuContext ctx)
+    {
+        var id = unchecked((int)ctx[CpuRegister.Rdi]);
+        var bufferAddress = ctx[CpuRegister.Rsi];
+        var length = unchecked((int)ctx[CpuRegister.Rdx]);
+        if (!_sockets.TryGetValue(id, out var socket))
+        {
+            return SetNetError(ctx, NetErrorBadFileDescriptor, NetErrnoBadFileDescriptor);
+        }
+
+        if (length < 0 || (length != 0 && bufferAddress == 0))
+        {
+            return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
+        }
+
+        if (length == 0)
+        {
+            return ctx.SetReturn(0);
+        }
+
+        var payload = new byte[length];
+        if (!ctx.Memory.TryRead(bufferAddress, payload))
+        {
+            return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
+        }
+
+        try
+        {
+            var sent = socket.Send(payload, SocketFlags.None);
+            TraceNet("socket.send", id, unchecked((uint)length), unchecked((uint)sent), 0);
+            return ctx.SetReturn(sent);
+        }
+        catch (SocketException exception)
+            when (exception.SocketErrorCode == SocketError.WouldBlock)
+        {
+            return SetNetError(ctx, NetErrorWouldBlock, NetErrnoWouldBlock);
+        }
+        catch (SocketException)
+        {
+            return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
+        }
+        catch (ObjectDisposedException)
+        {
+            return SetNetError(ctx, NetErrorBadFileDescriptor, NetErrnoBadFileDescriptor);
+        }
+    }
+
+    /// <summary>
+    /// Formats a binary address as text. Pure conversion with no socket state,
+    /// so it behaves identically to the console version for AF_INET/AF_INET6.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "5jRCs2axtr4",
+        ExportName = "inet_ntop",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PosixInetNtop(CpuContext ctx)
+    {
+        var family = unchecked((int)ctx[CpuRegister.Rdi]);
+        var sourceAddress = ctx[CpuRegister.Rsi];
+        var destinationAddress = ctx[CpuRegister.Rdx];
+        var destinationSize = unchecked((int)ctx[CpuRegister.Rcx]);
+        if (sourceAddress == 0 || destinationAddress == 0 || destinationSize <= 0)
+        {
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        // ORBIS_NET_AF_INET / ORBIS_NET_AF_INET6, matching TryMapAddressFamily.
+        var addressLength = family switch
+        {
+            2 => 4,
+            28 => 16,
+            _ => 0,
+        };
+
+        if (addressLength == 0)
+        {
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        var rawAddress = new byte[addressLength];
+        if (!ctx.Memory.TryRead(sourceAddress, rawAddress))
+        {
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        var text = new IPAddress(rawAddress).ToString();
+        var encoded = Encoding.ASCII.GetBytes(text);
+
+        // POSIX requires the terminator to fit as well; a truncated address string
+        // is worse than a reported failure because the caller cannot detect it.
+        if (encoded.Length + 1 > destinationSize)
+        {
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        var buffer = new byte[encoded.Length + 1];
+        encoded.CopyTo(buffer, 0);
+        if (!ctx.Memory.TryWrite(destinationAddress, buffer))
+        {
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        // inet_ntop returns the destination pointer on success.
+        ctx[CpuRegister.Rax] = destinationAddress;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
     [SysAbiExport(
         Nid = "bErx49PgxyY",
         ExportName = "sceNetBind",

--- a/src/SharpEmu.Libs/Np/NpManagerExports.cs
+++ b/src/SharpEmu.Libs/Np/NpManagerExports.cs
@@ -69,6 +69,23 @@ public static class NpManagerExports
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
+    /// <summary>
+    /// Accepts the reachability callback and never invokes it. Reachability
+    /// transitions only ever fire on a real PSN connection, which an offline
+    /// session does not have, so registering successfully and staying silent is
+    /// the accurate emulation of a signed-out console rather than a stub.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "hw5KNqAAels",
+        ExportName = "sceNpRegisterNpReachabilityStateCallback",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceNpManager")]
+    public static int NpRegisterNpReachabilityStateCallback(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
     [SysAbiExport(
         Nid = "qQJfO8HAiaY",
         ExportName = "sceNpRegisterStateCallbackA",

--- a/src/SharpEmu.Libs/Np/NpTrophy2Exports.cs
+++ b/src/SharpEmu.Libs/Np/NpTrophy2Exports.cs
@@ -80,6 +80,25 @@ public static class NpTrophy2Exports
         LibraryName = "libSceNpTrophy2")]
     public static int NpTrophy2ShowTrophyList(CpuContext ctx) => ReturnOk(ctx);
 
+    /// <summary>
+    /// Gen5 ABI: context, handle, trophy id, then SceNpTrophy2Details and
+    /// SceNpTrophy2Data output pointers.
+    /// </summary>
+    /// <remarks>
+    /// Reports "no such trophy" rather than succeeding. Succeeding would require
+    /// filling both output structures, and their exact layouts are not confirmed
+    /// here — a title that trusted zeroed details would read an empty name and a
+    /// grade of zero as real data. NOT_FOUND is a documented outcome that callers
+    /// must already handle, so it degrades along a path the game tests.
+    /// </remarks>
+    [SysAbiExport(
+        Nid = "EwNylPdWUTM",
+        ExportName = "sceNpTrophy2GetTrophyInfo",
+        Target = Generation.Gen5,
+        LibraryName = "libSceNpTrophy2")]
+    public static int NpTrophy2GetTrophyInfo(CpuContext ctx) =>
+        SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND);
+
     private static int WriteIdAndReturn(CpuContext ctx, ulong outAddress, ref int nextId)
     {
         if (outAddress == 0)

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -197,6 +197,7 @@ public static class VideoOutExports
         public int FlipRate { get; set; }
         public ulong VblankCount { get; set; }
         public ulong FlipCount { get; set; }
+        public long LastFlipArg { get; set; }
         public int CurrentBuffer { get; set; } = -1;
         public uint OutputWidth { get; set; } = 1920;
         public uint OutputHeight { get; set; } = 1080;
@@ -709,18 +710,30 @@ public static class VideoOutExports
         }
 
         ulong count;
+        long flipArg;
         uint currentBuffer;
         lock (_stateGate)
         {
             count = port.FlipCount;
+            flipArg = port.LastFlipArg;
             currentBuffer = unchecked((uint)port.CurrentBuffer);
         }
 
+        // SceVideoOutFlipStatus: count(0x00) processTime(0x08) tsc(0x10) flipArg(0x18)
+        // submitTsc(0x20) reserved(0x28) gcQueueNum(0x30,u32) flipPendingNum(0x34,u32)
+        // currentBuffer(0x38,u32) reserved(0x3C,u32).
+        var tsc = unchecked((ulong)Stopwatch.GetTimestamp());
         KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x00, count);
         KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x08, 0);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x10, 0);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x18, 0);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x20, currentBuffer);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x10, tsc);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x18, unchecked((ulong)flipArg));
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x20, tsc);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x28, 0);
+        // No flips are ever left outstanding: SubmitFlip completes synchronously.
+        KernelMemoryCompatExports.TryWriteUInt32Compat(ctx, statusAddress + 0x30, 0);
+        KernelMemoryCompatExports.TryWriteUInt32Compat(ctx, statusAddress + 0x34, 0);
+        KernelMemoryCompatExports.TryWriteUInt32Compat(ctx, statusAddress + 0x38, currentBuffer);
+        KernelMemoryCompatExports.TryWriteUInt32Compat(ctx, statusAddress + 0x3C, 0);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -1159,6 +1172,7 @@ public static class VideoOutExports
 
             port.CurrentBuffer = bufferIndex;
             port.FlipCount++;
+            port.LastFlipArg = flipArg;
             eventHint = SceVideoOutInternalEventFlip |
                 ((unchecked((ulong)flipArg) & 0x0000_FFFF_FFFF_FFFFUL) << 16);
             flipEventCount = port.FlipEvents.Count;

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -512,6 +512,10 @@ internal static unsafe class VulkanVideoPresenter
     private static uint _windowHeight;
     private static bool _closed;
     private static bool _presenterCloseRequested;
+    // Set once the render thread finishes Vulkan init and begins consuming the
+    // guest-work queue. Guest GPU work enqueued before this point would sit
+    // unexecuted behind CreateSwapchain, so ordered submissions wait on it.
+    private static bool _presenterReady;
     private const string DebugUtilsExtensionName = "VK_EXT_debug_utils";
     private const uint NvidiaVendorId = 0x10DE;
     private const uint AmdVendorId = 0x1002;
@@ -737,6 +741,7 @@ internal static unsafe class VulkanVideoPresenter
             _hostSurface = surface;
             _closed = false;
             _presenterCloseRequested = false;
+            _presenterReady = false;
             return true;
         }
     }
@@ -1428,10 +1433,75 @@ internal static unsafe class VulkanVideoPresenter
         ArgumentNullException.ThrowIfNull(action);
         lock (_gate)
         {
-            return _closed || _thread is null
+            return _closed || _thread is null || !WaitForPresenterReadyLocked()
                 ? 0
                 : EnqueueGuestWorkLocked(new VulkanOrderedGuestAction(action, debugName));
         }
+    }
+
+    /// <summary>
+    /// Marks the guest-work consumer as live. Called by the render thread once
+    /// Vulkan init completes and before it starts draining the queue.
+    /// </summary>
+    private static void SignalPresenterReady()
+    {
+        lock (_gate)
+        {
+            _presenterReady = true;
+            System.Threading.Monitor.PulseAll(_gate);
+        }
+    }
+
+    // How long a guest submission may wait for the presenter to come up before
+    // giving up and letting the caller run its side effect inline. Vulkan init
+    // (device + swapchain against an embedded host window) can take seconds on
+    // a cold start; a guest that submits GPU work in that window would
+    // otherwise queue label writes nobody executes, and titles that poll those
+    // labels declare a GPU hang and abort. Waiting is correct: real hardware
+    // cannot accept submissions before the GPU exists either.
+    private static readonly int _presenterReadyTimeoutMs =
+        int.TryParse(
+            Environment.GetEnvironmentVariable("SHARPEMU_PRESENTER_READY_TIMEOUT_MS"),
+            out var configuredTimeout) && configuredTimeout >= 0
+            ? configuredTimeout
+            : 10_000;
+
+    private static bool _presenterReadyTimeoutLogged;
+
+    /// <summary>
+    /// Blocks the calling guest thread until the presenter is consuming guest
+    /// work. Returns false if the presenter closed or failed to come up in
+    /// time, in which case callers fall back to running the action inline.
+    /// </summary>
+    private static bool WaitForPresenterReadyLocked()
+    {
+        if (_presenterReady)
+        {
+            return true;
+        }
+
+        var deadline = Environment.TickCount64 + _presenterReadyTimeoutMs;
+        while (!_presenterReady && !_closed && _thread is not null)
+        {
+            var remaining = deadline - Environment.TickCount64;
+            if (remaining <= 0)
+            {
+                if (!_presenterReadyTimeoutLogged)
+                {
+                    _presenterReadyTimeoutLogged = true;
+                    Console.Error.WriteLine(
+                        "[LOADER][WARN] Vulkan VideoOut presenter not ready after " +
+                        $"{_presenterReadyTimeoutMs} ms; running guest GPU side effects inline. " +
+                        "Cross-queue ordering is not guaranteed for these submissions.");
+                }
+
+                return false;
+            }
+
+            System.Threading.Monitor.Wait(_gate, (int)Math.Min(remaining, 100));
+        }
+
+        return _presenterReady && !_closed;
     }
 
     /// <summary>
@@ -1621,7 +1691,7 @@ internal static unsafe class VulkanVideoPresenter
                 out var lastVersion)
                     ? lastVersion
                     : 0;
-            return _closed || _thread is null
+            return _closed || _thread is null || !WaitForPresenterReadyLocked()
                 ? 0
                 : EnqueueGuestWorkLocked(
                     new VulkanOrderedGuestFlipWait(
@@ -2157,6 +2227,7 @@ internal static unsafe class VulkanVideoPresenter
             {
                 _closed = true;
                 _thread = null;
+                _presenterReady = false;
                 if (_hostSurfacePendingDetach is not null &&
                     ReferenceEquals(_hostSurface, _hostSurfacePendingDetach))
                 {
@@ -3209,6 +3280,7 @@ internal static unsafe class VulkanVideoPresenter
             CreateCommandResources();
             CreateGuestDrawResources();
             _vulkanReady = true;
+            SignalPresenterReady();
             Console.Error.WriteLine(
                 $"[LOADER][INFO] Vulkan VideoOut ready: {_extent.Width}x{_extent.Height}, format={_swapchainFormat}");
         }


### PR DESCRIPTION
#: 1
Commit: 3da22dd
Problem: 4.4M-iteration import spin — sceVideoOutGetFlipStatus wrote the wrong struct layout, so the guest never saw a flip
land
Fix: Rewrote the writer to the correct field offsets; added LastFlipArg recorded under _stateGate in SubmitFlip
Verified by: Spin eliminated
────────────────────────────────────────
#: 2
Commit: 8e7d5a3
Problem: GPU hanged waiting for m_pContextLabel — guest GPU work queued before the consuming render thread existed
Fix: Presenter-ready gate; SubmitOrderedGuestAction/…FlipWait wait on _presenterReady
Verified by: All 9 per-frame labels moved from post-abort to during-run
────────────────────────────────────────
#: 3
Commit: cb9fc51
Problem: libcohtml.Prospero.prx shipped in prx/ was never loaded; its 7 NIDs hit the unresolved stub whose error code the
guest dereferenced (AV on 0x80020002)
Fix: Added prx/ to the module search path
Verified by: All 7 NIDs resolved
────────────────────────────────────────
#: 4
Commit: 3e39fb4
Problem: #3 caused a boot regression: party.prx now loaded, and its failing DT_INIT aborted boot entirely (0 frames)
Fix: Log-and-continue instead of aborting when a preloaded module fails to start
Verified by: Boot restored; replaced an earlier game-specific skip-list hack
────────────────────────────────────────
#: 5
Commit: 848f035
Problem: Missing clock_getres; pthread_once registered only under its scePthreadOnce name
Fix: Implemented clock_getres (100ns, accepts null); added the POSIX alias
Verified by: NIDs resolve
────────────────────────────────────────
#: 6
Commit: 181286f
Problem: Unresolved sceAgcGetIsTrinityMode, sceNpRegisterNpReachabilityStateCallback, sceNpTrophy2GetTrophyInfo
Fix: Returns 0 / OK-never-fires / NOT_FOUND respectively
Verified by: NIDs resolve
────────────────────────────────────────
#: 7
Commit: 98c6851
Problem: POSIX libKernel + net exports titles link directly
Fix: mprotect, munmap, getpagesize, pthread_rwlock_tryrdlock/trywrlock, setsockopt, getsockopt, send, inet_ntop
Verified by: NIDs resolve
────────────────────────────────────────
#: 8
Commit: 45b1c04
Problem: V8 int3 — _mappedRegions keyed by start address, so a 256 KiB mapping at 0x1200000000 overwrote the enclosing 4 GiB
reservation, destroying the record covering 0x1200040000
Fix: ReplaceMappedRegionRangeLocked carves new regions out of the ones they overlap
Verified by: query_miss 1→0; V8 heap now grows (17 extra mappings observed)
────────────────────────────────────────
#: 9
Commit: 72daa43
Problem: sceAgcDriverSubmitMultiDcbs parsed inline and discarded the "suspended" flag → ActiveSubmissionId stuck at 0 →
completions deduped against a field that also defaults to 0
Fix: Route multi-DCB through EnqueueSubmittedDcb/PumpSubmittedQueue
Verified by: Invariant violations 2–3 → 0

## Testing

N/A

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
