### PR TITLE
[Kernel] Clamp guest path traversal at the mount root

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 SharpEmu Emulator Project
+﻿// Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
@@ -4728,7 +4728,7 @@ public static partial class KernelMemoryCompatExports
                 !guestPath.StartsWith("/", StringComparison.Ordinal) &&
                 !guestPath.StartsWith("\\", StringComparison.Ordinal))
             {
-                var relative = guestPath.Replace('/', Path.DirectorySeparatorChar);
+                var relative = NormalizeMountRelativePath(guestPath);
                 return Path.Combine(app0Root, relative);
             }
         }
@@ -4803,12 +4803,40 @@ public static partial class KernelMemoryCompatExports
         return _cachedApp0Root;
     }
 
+    // Resolves "." and ".." inside a mount-relative guest path and clamps the
+    // result at the mount root, so a guest path can never escape into the host
+    // filesystem. Unreal Engine titles depend on this: their base directory is
+    // <app>/binaries/<platform>, so they address content with "../../../"
+    // prefixes that land back inside /app0 on real hardware. Combining those
+    // raw against the app0 root walked out of the game folder entirely, so the
+    // title enumerated an unrelated host directory and never found its .pak files.
     private static string NormalizeMountRelativePath(string relativePath)
     {
-        return relativePath
-            .TrimStart('/', '\\')
-            .Replace('/', Path.DirectorySeparatorChar)
-            .Replace('\\', Path.DirectorySeparatorChar);
+        var segments = relativePath.Split(
+            new[] { '/', '\\' },
+            StringSplitOptions.RemoveEmptyEntries);
+        var resolved = new List<string>(segments.Length);
+        foreach (var segment in segments)
+        {
+            if (segment == ".")
+            {
+                continue;
+            }
+
+            if (segment == "..")
+            {
+                if (resolved.Count > 0)
+                {
+                    resolved.RemoveAt(resolved.Count - 1);
+                }
+
+                continue;
+            }
+
+            resolved.Add(segment);
+        }
+
+        return string.Join(Path.DirectorySeparatorChar, resolved);
     }
 
     private static string ResolveDevlogAppRoot()


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

A guest path containing `..` escapes its mount and reaches the host filesystem.

`NormalizeMountRelativePath` only strips leading separators and swaps slashes — it never resolves `.` or `..` segments. Worse, the bare-relative fallback in `ResolveGuestPath` doesn't even call it; it combines the guest path against the app0 root verbatim:

```csharp
var relative = guestPath.Replace('/', Path.DirectorySeparatorChar);
return Path.Combine(app0Root, relative);
```

Unreal Engine titles hit this constantly. Their base directory is `<app>/binaries/<platform>`, so they address content with `../../../` prefixes that resolve back inside `/app0` on real hardware. Here those walk straight out of the game folder.

I found it while looking at why The Invincible (PPSA06426) never located its own content. It opens `/app0/..` and enumerates whatever sits above the game directory — in my case my Downloads folder, listing unrelated personal files:

```
getdents path='...\The Invincible 01.000 PPSA06426\..'
  name='Antigravity.exe'
  name='MandatSEPASante.pdf'
  name='Subnautica 2.part1.rar'
```

So this is both a correctness bug (the engine's relative content paths land nowhere useful) and a sandbox escape (a guest can read arbitrary host directories above the game root).

## The change

Walk the path segments, resolve `.` and `..`, and clamp the result at the mount root so a guest path can never climb above it. Then route the bare-relative fallback through the same normalizer instead of concatenating raw.

Clamping rather than erroring is deliberate: `../../../theinvincible/content/paks` has to keep resolving to `theinvincible/content/paks` under app0, which is what the title expects and what it gets on real hardware.

## Testing

- The Invincible (PPSA06426): before, resolved host paths contain `..` and the title enumerates a host directory outside the game. After, no resolved path contains `..` and it enumerates its own tree — `content/paks`, `content/movies`, `content/locale/*`. It still doesn't reach gameplay, that's a separate GPU-side problem, but it now looks at the right files.
- Dead Cells (PPSA15552): no regression, still reaches AGC rendering and presents frames.
- `dotnet test tests/SharpEmu.Libs.Tests -c Release`: 391 passed.
- `dotnet build sharpemu.sln -c Release`: 0 warnings, 0 errors.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [X] I tested my changes or marked the testing section as `N/A`.
- [X] I wrote this pull request description myself and did not paste AI-generated explanations.
- [X] I listed the game(s) I tested (or marked the testing section as `N/A`).
