### PR TITLE
[PlayGo] Derive the installed chunk set from the pak files on disk

### DIFF
--- a/src/SharpEmu.Libs/PlayGo/PlayGoExports.cs
+++ b/src/SharpEmu.Libs/PlayGo/PlayGoExports.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 SharpEmu Emulator Project
+﻿// Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
@@ -698,14 +698,22 @@ public static class PlayGoExports
         var hasMetadata = File.Exists(playGoDat) || File.Exists(scenarioJson) || File.Exists(chunkDefsXml);
         if (!hasMetadata)
         {
-            // No PlayGo sidecar: report a fully-installed single chunk. Available must
-            // stay true or scePlayGoOpen fails with NotSupportPlayGo (fatal PS5-component
-            // init failure for UE titles); chunk 0 reports LocalFast and every other id
-            // returns BAD_CHUNK_ID, terminating title-side chunk enumeration.
-            TracePlayGo("metadata_missing; fully-installed single chunk");
+            // No PlayGo sidecar: derive the installed chunk set from the pak files
+            // actually present on disk. A locally dumped title has all of its data
+            // installed, and a package that splits content across chunks names them
+            // pakchunk<N>-<platform>.pak, so those N are exactly the chunks that
+            // exist. Reporting only chunk 0 told such a title its remaining content
+            // was missing: The Invincible (PPSA06426) ships pakchunk0..8 and spun
+            // forever re-querying scePlayGoGetLocus for a chunk that never became
+            // available. Available must stay true or scePlayGoOpen fails with
+            // NotSupportPlayGo (fatal PS5-component init failure for UE titles).
+            // Ids outside the discovered set still return BAD_CHUNK_ID, so
+            // title-side chunk enumeration still terminates.
+            var installedChunkIds = DiscoverInstalledChunkIds(app0Root);
+            TracePlayGo($"metadata_missing; fully-installed chunks=[{string.Join(',', installedChunkIds)}]");
             return new PlayGoMetadata(
                 true,
-                [(ushort)0],
+                installedChunkIds,
                 PlayGoChunkIdKnowledge.Authoritative);
         }
 
@@ -716,6 +724,41 @@ public static class PlayGoExports
             chunkIds.Length == 0
                 ? PlayGoChunkIdKnowledge.Unknown
                 : PlayGoChunkIdKnowledge.Authoritative);
+    }
+
+    // Chunk ids for a title that ships no PlayGo sidecar, taken from the
+    // pakchunk<N>-<platform>.pak files on disk. Chunk 0 is always included: it
+    // is the base chunk and must resolve even for a title with no pak files at
+    // all (which keeps the single-chunk behaviour for such titles).
+    private static ushort[] DiscoverInstalledChunkIds(string app0Root)
+    {
+        var ids = new SortedSet<ushort> { 0 };
+        try
+        {
+            foreach (var pakFile in Directory.EnumerateFiles(app0Root, "pakchunk*.pak", SearchOption.AllDirectories))
+            {
+                var name = Path.GetFileNameWithoutExtension(pakFile);
+                var digits = name.AsSpan("pakchunk".Length);
+                var length = 0;
+                while (length < digits.Length && char.IsAsciiDigit(digits[length]))
+                {
+                    length++;
+                }
+
+                if (length > 0 && ushort.TryParse(digits[..length], out var chunkId))
+                {
+                    ids.Add(chunkId);
+                }
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+
+        return ids.ToArray();
     }
 
     private static ushort[] LoadChunkIds(string chunkDefsXml)


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

When a title ships no PlayGo sidecar, we report it as a single-chunk package:

```csharp
TracePlayGo("metadata_missing; fully-installed single chunk");
return new PlayGoMetadata(true, [(ushort)0], PlayGoChunkIdKnowledge.Authoritative);
```

That's fine for a title whose content really is one chunk, but wrong for anything split across several. A locally dumped title has all of its data on disk, yet we tell it everything past chunk 0 is missing.

The Invincible (PPSA06426) ships nine chunks:

```
theinvincible/content/paks/pakchunk0-ps5.pak
...
theinvincible/content/paks/pakchunk8-ps5.pak
```

It asks PlayGo whether chunks 1..8 are available, gets `BAD_CHUNK_ID` for all of them, and then re-queries `scePlayGoGetLocus` for the same chunk in a tight loop that never ends. Roughly a thousand consecutive dispatches with byte-identical arguments:

```
Import#39896170 result: -2135818228 (uWIYLFkkwqk) rdi=0x1 rsi=0x7FFFC21FFE9E rdx=0x1 rcx=0x7FFFC21FFEA0
Import#39896171 result: -2135818228 (uWIYLFkkwqk) rdi=0x1 rsi=0x7FFFC21FFE9E rdx=0x1 rcx=0x7FFFC21FFEA0
...
```

## The change

Derive the chunk ids from the `pakchunk<N>-<platform>.pak` files present under the app0 root. Those N are exactly the chunks the package has, so the answer comes from the actual install instead of an assumption.

Chunk 0 is always included, so a title with no pak files at all keeps the current single-chunk behaviour. Ids outside the discovered set still return `BAD_CHUNK_ID`, so a title that discovers its chunk count by scanning until that error still terminates.

I first tried a fixed window of ids and dropped it — it's a guess, and it broke `GetLocus_MetadataFreeApp0_RejectsPastAuthoritativeDefaultChunk`. Reading the filenames is both accurate and leaves that contract intact, since the test's app0 fixture has no pak files.

## Testing

- The Invincible (PPSA06426): discovered set is `[0,1,2,3,4,5,6,7,8]`, matching the nine pak files, and the `scePlayGoGetLocus` retry loop is gone. The title still doesn't reach gameplay — it stalls later on the GPU side — but it stops spinning here.
- Dead Cells (PPSA15552): no regression, still reaches AGC rendering and presents frames.
- `dotnet test tests/SharpEmu.Libs.Tests -c Release`: 391 passed, including the existing metadata-free contract test.
- `dotnet build sharpemu.sln -c Release`: 0 warnings, 0 errors.

## Checklist

By submitting this pull request, you confirm that:

- [X] I have read and followed `CONTRIBUTING.md`.
- [X] I tested my changes or marked the testing section as `N/A`.
- [X] I wrote this pull request description myself and did not paste AI-generated explanations.
- [X] I listed the game(s) I tested (or marked the testing section as `N/A`).
