### PR TITLE
[Kernel] Hand off mutex ownership directly to the head waiter on unlock

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -777,9 +777,21 @@ public static class KernelPthreadCompatExports
             if (state.RecursionCount == 0)
             {
                 state.OwnerThreadId = 0;
-                nextWakeKey = state.Waiters.First?.Value.Cooperative == true
-                    ? state.Waiters.First.Value.WakeKey
-                    : null;
+
+                // Hand the mutex directly to the head waiter instead of only
+                // waking it and relying on it to re-acquire. A woken waiter that
+                // fails to self-grant (its wake races or is lost) would leave the
+                // mutex "free with a queued waiter"; the fast-acquire path refuses
+                // such a mutex (OwnerThreadId == 0 && Waiters.Count == 0), so every
+                // later locker — including the game's main thread — then queues
+                // behind a head that never advances and the process wedges.
+                if (state.Waiters.First is { } headNode &&
+                    TryGrantMutexWaiterLocked(state, headNode.Value) &&
+                    headNode.Value.Cooperative)
+                {
+                    nextWakeKey = headNode.Value.WakeKey;
+                }
+
                 Monitor.PulseAll(state);
             }
         }


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

`pthread_mutex_unlock` clears ownership and only wakes the head waiter, leaving that waiter to re-acquire the mutex itself:

```csharp
state.RecursionCount--;
if (state.RecursionCount == 0)
{
    state.OwnerThreadId = 0;
    nextWakeKey = state.Waiters.First?.Value.Cooperative == true
        ? state.Waiters.First.Value.WakeKey
        : null;
    Monitor.PulseAll(state);
}
```

If that wake races or is lost, the mutex is left free but with a waiter still queued. The fast-acquire path in `PthreadMutexLockCore` refuses exactly that shape:

```csharp
if (state.OwnerThreadId == 0 && state.Waiters.Count == 0)
```

So every later locker queues behind a head that never advances, and the process wedges with the mutex free the whole time. I caught it with a wait-graph dump — the same mutex kept showing `owner=0` with a queued waiter across successive snapshots, while unrelated mutexes churned normally.

## The change

Grant the mutex to the head waiter inside unlock, then wake it. `TryGrantMutexWaiterLocked` already does the FIFO check and the ownership transfer, and it's a no-op unless the mutex is free and the waiter is at the head — so this only closes the window where the mutex was observable as free-with-waiter. Nothing changes for an uncontended unlock.

## Testing

- The Invincible (PPSA06426): forward progress goes from roughly 3.5M to 40M dispatched imports, and the repeated `INVALID_ARGUMENT` failures from unlock disappear. The title still doesn't boot — it stalls later for unrelated reasons — but it stops wedging here.
- Dead Cells (PPSA15552): no regression, still reaches AGC rendering and presents frames with no mutex errors.
- `dotnet test tests/SharpEmu.Libs.Tests -c Release`: 391 passed.
- `dotnet build sharpemu.sln -c Release`: 0 warnings, 0 errors.

## Checklist

By submitting this pull request, you confirm that:

- [X] I have read and followed `CONTRIBUTING.md`.
- [X] I tested my changes or marked the testing section as `N/A`.
- [X] I wrote this pull request description myself and did not paste AI-generated explanations.
- [X] I listed the game(s) I tested (or marked the testing section as `N/A`).
