### PR TITLE
[Font] Implement sceFontGetVerticalLayout

### DIFF
--- a/src/SharpEmu.Libs/Font/FontExports.cs
+++ b/src/SharpEmu.Libs/Font/FontExports.cs
@@ -154,6 +154,37 @@ public static class FontExports
     }
 
     [SysAbiExport(
+        Nid = "3BrWWFU+4ts",
+        ExportName = "sceFontGetVerticalLayout",
+        Target = Generation.Gen5,
+        LibraryName = "libSceFont")]
+    public static int GetVerticalLayout(CpuContext ctx)
+    {
+        var layoutAddress = ctx[CpuRegister.Rsi];
+        if (layoutAddress == 0)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        // Vertical counterpart of GetHorizontalLayout, with the axes exchanged:
+        // the advance runs down the column, so the line advance of the horizontal
+        // layout becomes the character advance here.
+        var values = new[] { 8.0f, 16.0f, 0.0f };
+        for (var index = 0; index < values.Length; index++)
+        {
+            if (!TryWriteUInt32(
+                    ctx,
+                    layoutAddress + (ulong)(index * sizeof(float)),
+                    BitConverter.SingleToUInt32Bits(values[index])))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+        }
+
+        return SetSuccess(ctx);
+    }
+
+    [SysAbiExport(
         Nid = "cKYtVmeSTcw",
         ExportName = "sceFontOpenFontSet",
         Target = Generation.Gen5,


### PR DESCRIPTION
## What this changes

`libSceFont` has a horizontal layout query and a vertical layout query. `FontExports` implements only the horizontal one. This adds `sceFontGetVerticalLayout` (NID `3BrWWFU+4ts`).

## Why

ASTRO BOT (PPSA21564) stops during its first level. The title prints its own assertion and then executes `int 0x41`:

```
ASSERT: .../source/engine/app/Module/Font/FontSystem.cpp:372
sceFontGetVerticalLayout 0x80020002(-2147352574)
```

The title calls this export one time only, so it is easy to miss in a count of unresolved imports. An unresolved import gives the title `0x80020002`, the title treats that as fatal, and the process ends.

This is not specific to one title: any title that lays out vertical text asks for this layout, and the horizontal counterpart is already there.

## How it works

The new export has the same shape as `sceFontGetHorizontalLayout`. It writes three floats to the caller structure in RSI and returns 0. The values are the same invented geometry, with the axes exchanged: the advance runs down the column, so the line advance of the horizontal layout becomes the character advance here.

## Testing

- ASTRO BOT (PPSA21564), Windows 10, Vulkan on an RTX 2060 — the font assertion does not occur any more. The title goes past the font system and continues to its intro video. It then stops for a different reason: `sceAvPlayerAddSource` cannot open the mp4 container. That is a separate problem and this pull request does not touch it.
- `dotnet build SharpEmu.slnx -c Release` — no new warning.
- `dotnet test SharpEmu.slnx -c Release` — 451 tests, all pass.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
