### PR TITLE
fix(loader): fallback to alternative base when PS5 main image base is unavailable

### DIFF
--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -607,7 +607,7 @@ internal static partial class Program
             nint jobHandle = 0;
             Environment.SetEnvironmentVariable(MitigatedChildEnvironment, "1");
             var created = CreateProcessW(
-                processPath,
+                null,
                 cmdLineBuilder,
                 0,
                 0,
@@ -1433,7 +1433,7 @@ internal static partial class Program
     [DllImport("kernel32.dll", EntryPoint = "CreateProcessW", SetLastError = true, CharSet = CharSet.Unicode)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool CreateProcessW(
-        string applicationName,
+        string? applicationName,
         StringBuilder commandLine,
         nint processAttributes,
         nint threadAttributes,

--- a/src/SharpEmu.CLI/SharpEmu.CLI.csproj
+++ b/src/SharpEmu.CLI/SharpEmu.CLI.csproj
@@ -32,6 +32,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
          that collision and keeps the emulator's required mappings available. -->
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <GCRetainVM>false</GCRetainVM>
     <TieredPGO>true</TieredPGO>
   </PropertyGroup>
 

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -13,6 +13,7 @@ using SharpEmu.Core.Cpu.Debugging;
 using SharpEmu.Core.Loader;
 using SharpEmu.Core.Memory;
 using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
 
 namespace SharpEmu.Core.Cpu.Native;
 
@@ -2544,58 +2545,67 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private unsafe void PatchTlsPatterns()
 	{
-        // Large Gen5 executables can keep valid code well past the first 32 MiB.
-        // Astro Bot, for example, has an FS:[0] TLS load near +0x70A0000.
-        const ulong MaxScanBytes = 134217728uL;
-		ulong num = _entryPoint;
-		ulong num2 = num + MaxScanBytes;
 		int num3 = 0;
 		int num4 = 0;
 		int num9 = 0;
 		int sse4aPatchCount = 0;
-		while (num < num2)
+		var handles = KernelModuleRegistry.GetModuleHandles(includeSystemModules: true);
+		foreach (var handle in handles)
 		{
-			if (VirtualQuery((void*)num, out var lpBuffer, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) == 0 || lpBuffer.RegionSize == 0)
+			if (!KernelModuleRegistry.TryGetModuleByHandle(handle, out var entry))
 			{
-				num += 4096uL;
 				continue;
 			}
-			ulong num5 = Math.Max(num, lpBuffer.BaseAddress);
-			ulong num6 = lpBuffer.BaseAddress + lpBuffer.RegionSize;
-			if (num6 > num2)
+			if (entry.BaseAddress == 0 || entry.EndAddress <= entry.BaseAddress)
 			{
-				num6 = num2;
+				continue;
 			}
-			uint num7 = lpBuffer.Protect & 0xFF;
-			bool flag = lpBuffer.State == 4096 && (lpBuffer.Protect & PAGE_GUARD) == 0 && num7 != PAGE_NOACCESS;
-			bool flag2 = num7 == PAGE_EXECUTE || num7 == 32 || num7 == 64 || num7 == PAGE_EXECUTE_WRITECOPY;
-			if (flag && flag2 && num6 > num5 + MinTlsPatchInstructionBytes)
+			ulong num = entry.BaseAddress;
+			ulong num2 = entry.EndAddress;
+			while (num < num2)
 			{
-				byte* ptr = (byte*)num5;
-				int scanBytes = (int)(num6 - num5);
-				for (int i = 0; i <= scanBytes - MinTlsPatchInstructionBytes; i++)
+				if (VirtualQuery((void*)num, out var lpBuffer, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) == 0 || lpBuffer.RegionSize == 0)
 				{
-					nint address = (nint)(ptr + i);
-					int remainingBytes = scanBytes - i;
-					if (TryPatchTlsLoadInstruction(address, ptr + i, remainingBytes))
+					num += 4096uL;
+					continue;
+				}
+				ulong num5 = Math.Max(num, lpBuffer.BaseAddress);
+				ulong num6 = lpBuffer.BaseAddress + lpBuffer.RegionSize;
+				if (num6 > num2)
+				{
+					num6 = num2;
+				}
+				uint num7 = lpBuffer.Protect & 0xFF;
+				bool flag = lpBuffer.State == 4096 && (lpBuffer.Protect & PAGE_GUARD) == 0 && num7 != PAGE_NOACCESS;
+				bool flag2 = num7 == PAGE_EXECUTE || num7 == 32 || num7 == 64 || num7 == PAGE_EXECUTE_WRITECOPY;
+				if (flag && flag2 && num6 > num5 + MinTlsPatchInstructionBytes)
+				{
+					byte* ptr = (byte*)num5;
+					int scanBytes = (int)(num6 - num5);
+					for (int i = 0; i <= scanBytes - MinTlsPatchInstructionBytes; i++)
 					{
-						num3++;
-					}
-					else if (remainingBytes >= 12 && TryPatchTlsImmediateStoreInstruction(address, ptr + i))
-					{
-						num9++;
-					}
-					else if (remainingBytes >= 12 && TryPatchSse4aExtrqBlend(address, ptr + i))
-					{
-						sse4aPatchCount++;
-					}
-					else if (TryPatchStackCanaryInstruction(address, ptr + i))
-					{
-						num4++;
+						nint address = (nint)(ptr + i);
+						int remainingBytes = scanBytes - i;
+						if (TryPatchTlsLoadInstruction(address, ptr + i, remainingBytes))
+						{
+							num3++;
+						}
+						else if (remainingBytes >= 12 && TryPatchTlsImmediateStoreInstruction(address, ptr + i))
+						{
+							num9++;
+						}
+						else if (remainingBytes >= 12 && TryPatchSse4aExtrqBlend(address, ptr + i))
+						{
+							sse4aPatchCount++;
+						}
+						else if (TryPatchStackCanaryInstruction(address, ptr + i))
+						{
+							num4++;
+						}
 					}
 				}
+				num = num6 > num ? num6 : num + 4096uL;
 			}
-			num = num6 > num ? num6 : num + 4096uL;
 		}
 		Console.Error.WriteLine($"[LOADER][INFO] Patched {num3} TLS loads, {num9} TLS stores, {num4} stack-canary accesses, {sse4aPatchCount} SSE4a EXTRQ blends");
 	}

--- a/src/SharpEmu.Core/Loader/SelfImage.cs
+++ b/src/SharpEmu.Core/Loader/SelfImage.cs
@@ -74,6 +74,9 @@ public sealed class SelfImage
 
     public ulong EntryPoint => ElfHeader.EntryPoint + _imageBase;
 
+    /// <summary>Base virtual address where the image was loaded.</summary>
+    public ulong ImageBase => _imageBase;
+
     public ulong ProcParamAddress { get; }
 
     public string? Title { get; }

--- a/src/SharpEmu.Core/Loader/SelfLoader.cs
+++ b/src/SharpEmu.Core/Loader/SelfLoader.cs
@@ -199,9 +199,24 @@ public sealed class SelfLoader : ISelfLoader
             {
                 if (!physicalVm.TryAllocateAtExact(imageBase, totalImageSize, executable: true, out var allocatedBase))
                 {
-                    var reason = physicalVm.DescribeAddressForDiagnostics(imageBase);
-                    throw new InvalidOperationException(
-                        $"Could not allocate main image at required base 0x{imageBase:X16} (size=0x{totalImageSize:X}): {reason}.");
+                    if (isNextGen)
+                    {
+                        allocatedBase = physicalVm.AllocateAt(imageBase, totalImageSize, executable: true, allowAlternative: true);
+                        if (allocatedBase == 0)
+                        {
+                            var reason = physicalVm.DescribeAddressForDiagnostics(imageBase);
+                            throw new InvalidOperationException(
+                                $"Could not allocate main image at required base 0x{imageBase:X16} or any alternative address (size=0x{totalImageSize:X}): {reason}.");
+                        }
+                        Console.WriteLine(
+                            $"[LOADER] Could not allocate main image at exact base 0x{imageBase:X16}; loaded at 0x{allocatedBase:X16} instead.");
+                    }
+                    else
+                    {
+                        var reason = physicalVm.DescribeAddressForDiagnostics(imageBase);
+                        throw new InvalidOperationException(
+                            $"Could not allocate main image at required base 0x{imageBase:X16} (size=0x{totalImageSize:X}): {reason}.");
+                    }
                 }
 
                 imageBase = allocatedBase;

--- a/src/SharpEmu.GUI/EmulatorProcess.cs
+++ b/src/SharpEmu.GUI/EmulatorProcess.cs
@@ -248,7 +248,7 @@ internal sealed class EmulatorProcess : IDisposable
                 {
                     Environment.SetEnvironmentVariable(MitigatedChildEnvironment, "1");
                     if (!CreateProcessW(
-                            exePath,
+                            null,
                             commandLine,
                             0,
                             0,
@@ -629,7 +629,7 @@ internal sealed class EmulatorProcess : IDisposable
 
     [DllImport("kernel32.dll", EntryPoint = "CreateProcessW", SetLastError = true, CharSet = CharSet.Unicode)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool CreateProcessW(string applicationName, StringBuilder commandLine, nint processAttributes, nint threadAttributes, [MarshalAs(UnmanagedType.Bool)] bool inheritHandles, uint flags, nint environment, string currentDirectory, ref StartupInfoEx startupInfo, out ProcessInformation processInformation);
+    private static extern bool CreateProcessW(string? applicationName, StringBuilder commandLine, nint processAttributes, nint threadAttributes, [MarshalAs(UnmanagedType.Bool)] bool inheritHandles, uint flags, nint environment, string currentDirectory, ref StartupInfoEx startupInfo, out ProcessInformation processInformation);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern uint WaitForSingleObject(nint handle, uint milliseconds);

--- a/tests/SharpEmu.Libs.Tests/Loader/SelfLoaderAllocationTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Loader/SelfLoaderAllocationTests.cs
@@ -1,0 +1,246 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Runtime.InteropServices;
+using SharpEmu.Core.Loader;
+using SharpEmu.Core.Memory;
+using SharpEmu.HLE.Host;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Loader;
+
+public sealed class SelfLoaderAllocationTests
+{
+    private const ulong Ps5MainImageBase = 0x0000000800000000UL;
+
+    [Fact]
+    public void Load_ExactBaseUnavailable_FallsBackToAlternativeAddress()
+    {
+        var imageData = BuildMinimalElf();
+        using var host = new BlockingHostMemory(Ps5MainImageBase);
+        using var memory = new PhysicalVirtualMemory(host);
+        var loader = new SelfLoader();
+
+        var image = loader.Load(imageData, memory);
+
+        Assert.NotEqual(0UL, image.ImageBase);
+        Assert.NotEqual(Ps5MainImageBase, image.ImageBase);
+    }
+
+    /// <summary>
+    /// Builds a minimal x86-64 ELF with a single PT_LOAD segment and ABI version 2,
+    /// which causes the loader to request the PS5 main image base.
+    /// </summary>
+    private static byte[] BuildMinimalElf()
+    {
+        const int elfHeaderSize = 64;
+        const int programHeaderSize = 56;
+        const int segmentSize = 16;
+        const int fileSize = elfHeaderSize + programHeaderSize + segmentSize;
+
+        var buffer = new byte[fileSize];
+        var span = buffer.AsSpan();
+
+        // e_ident
+        span[0] = 0x7F;
+        span[1] = (byte)'E';
+        span[2] = (byte)'L';
+        span[3] = (byte)'F';
+        span[4] = 2; // ELFCLASS64
+        span[5] = 1; // ELFDATA2LSB
+        span[6] = 1; // EV_CURRENT
+        span[7] = 0; // ELFOSABI_NONE
+        span[8] = 2; // ABI version 2 -> treated as next-gen/PS5
+        // Remaining ident bytes are zero.
+
+        // e_type = ET_DYN (PIE)
+        WriteUInt16LittleEndian(span, 16, 3);
+        // e_machine = EM_X86_64
+        WriteUInt16LittleEndian(span, 18, 62);
+        // e_version
+        WriteUInt32LittleEndian(span, 20, 1);
+        // e_entry
+        WriteUInt64LittleEndian(span, 24, 0);
+        // e_phoff
+        WriteUInt64LittleEndian(span, 32, elfHeaderSize);
+        // e_shoff
+        WriteUInt64LittleEndian(span, 40, 0);
+        // e_flags
+        WriteUInt32LittleEndian(span, 48, 0);
+        // e_ehsize
+        WriteUInt16LittleEndian(span, 52, elfHeaderSize);
+        // e_phentsize
+        WriteUInt16LittleEndian(span, 54, programHeaderSize);
+        // e_phnum
+        WriteUInt16LittleEndian(span, 56, 1);
+        // e_shentsize
+        WriteUInt16LittleEndian(span, 58, 0);
+        // e_shnum
+        WriteUInt16LittleEndian(span, 60, 0);
+        // e_shstrndx
+        WriteUInt16LittleEndian(span, 62, 0);
+
+        var phOffset = elfHeaderSize;
+        // p_type = PT_LOAD
+        WriteUInt32LittleEndian(span, phOffset + 0, 1);
+        // p_flags = PF_R | PF_X
+        WriteUInt32LittleEndian(span, phOffset + 4, 0x5);
+        // p_offset
+        WriteUInt64LittleEndian(span, phOffset + 8, (ulong)(elfHeaderSize + programHeaderSize));
+        // p_vaddr
+        WriteUInt64LittleEndian(span, phOffset + 16, 0);
+        // p_paddr
+        WriteUInt64LittleEndian(span, phOffset + 24, 0);
+        // p_filesz
+        WriteUInt64LittleEndian(span, phOffset + 32, segmentSize);
+        // p_memsz
+        WriteUInt64LittleEndian(span, phOffset + 40, segmentSize);
+        // p_align
+        WriteUInt64LittleEndian(span, phOffset + 48, 0x1000);
+
+        // Segment data: a few NOPs followed by RET.
+        var segmentData = new byte[] { 0x90, 0x90, 0x90, 0x90, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        segmentData.CopyTo(span.Slice(elfHeaderSize + programHeaderSize, segmentSize));
+
+        return buffer;
+    }
+
+    private static void WriteUInt16LittleEndian(Span<byte> buffer, int offset, ushort value)
+    {
+        buffer[offset] = (byte)(value & 0xFF);
+        buffer[offset + 1] = (byte)((value >> 8) & 0xFF);
+    }
+
+    private static void WriteUInt32LittleEndian(Span<byte> buffer, int offset, uint value)
+    {
+        buffer[offset] = (byte)(value & 0xFF);
+        buffer[offset + 1] = (byte)((value >> 8) & 0xFF);
+        buffer[offset + 2] = (byte)((value >> 16) & 0xFF);
+        buffer[offset + 3] = (byte)((value >> 24) & 0xFF);
+    }
+
+    private static void WriteUInt64LittleEndian(Span<byte> buffer, int offset, ulong value)
+    {
+        for (var i = 0; i < 8; i++)
+        {
+            buffer[offset + i] = (byte)((value >> (i * 8)) & 0xFF);
+        }
+    }
+
+    /// <summary>
+    /// Host memory implementation that blocks a specific exact address and
+    /// returns a real, page-aligned allocation when asked to allocate at any
+    /// address. This allows the loader to actually copy segment data without
+    /// touching unmapped memory.
+    /// </summary>
+    private sealed class BlockingHostMemory : IHostMemory, IDisposable
+    {
+        private const ulong PageSize = 0x1000;
+        private readonly ulong _blockedAddress;
+        private readonly Dictionary<ulong, AllocationInfo> _allocations = new();
+        private ulong? _fallbackAddress;
+
+        public BlockingHostMemory(ulong blockedAddress)
+        {
+            _blockedAddress = blockedAddress;
+        }
+
+        public ulong Allocate(ulong desiredAddress, ulong size, HostPageProtection protection)
+        {
+            if (desiredAddress == _blockedAddress)
+            {
+                return 0;
+            }
+
+            if (desiredAddress == 0)
+            {
+                if (_fallbackAddress is null)
+                {
+                    var allocation = AllocateReal(size);
+                    _fallbackAddress = allocation.Address;
+                    _allocations[_fallbackAddress.Value] = allocation;
+                }
+
+                return _fallbackAddress.Value;
+            }
+
+            if (_allocations.TryGetValue(desiredAddress, out var existing))
+            {
+                return existing.Address;
+            }
+
+            var info = AllocateReal(size);
+            _allocations[info.Address] = info;
+            return info.Address;
+        }
+
+        public ulong Reserve(ulong desiredAddress, ulong size, HostPageProtection protection) =>
+            Allocate(desiredAddress, size, protection);
+
+        public bool Commit(ulong address, ulong size, HostPageProtection protection) => true;
+
+        public bool Free(ulong address)
+        {
+            if (_allocations.Remove(address, out var info))
+            {
+                Marshal.FreeHGlobal(info.OriginalPointer);
+                if (_fallbackAddress == address)
+                {
+                    _fallbackAddress = null;
+                }
+
+                return true;
+            }
+
+            return true;
+        }
+
+        public bool Protect(ulong address, ulong size, HostPageProtection protection, out uint rawOldProtection)
+        {
+            rawOldProtection = 0;
+            return true;
+        }
+
+        public bool ProtectRaw(ulong address, ulong size, uint rawProtection, out uint rawOldProtection)
+        {
+            rawOldProtection = 0;
+            return true;
+        }
+
+        public bool Query(ulong address, out HostRegionInfo info)
+        {
+            info = default;
+            return false;
+        }
+
+        public void FlushInstructionCache(ulong address, ulong size)
+        {
+        }
+
+        public void Dispose()
+        {
+            foreach (var info in _allocations.Values)
+            {
+                Marshal.FreeHGlobal(info.OriginalPointer);
+            }
+
+            _allocations.Clear();
+            _fallbackAddress = null;
+        }
+
+        private static AllocationInfo AllocateReal(ulong size)
+        {
+            var alignedSize = (size + PageSize - 1) & ~(PageSize - 1);
+            var allocation = Marshal.AllocHGlobal(checked((nint)(alignedSize + PageSize)));
+            if (allocation == IntPtr.Zero)
+            {
+                throw new OutOfMemoryException("Test host memory could not allocate real memory.");
+            }
+
+            var address = ((ulong)allocation + PageSize - 1) & ~(PageSize - 1);
+            return new AllocationInfo(address, allocation);
+        }
+
+        private readonly record struct AllocationInfo(ulong Address, IntPtr OriginalPointer);
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Description

Resolves #235 by introducing a fallback allocation mechanism when the exact desired base address for the main executable image is already occupied.

Additionally, `<GCRetainVM>false</GCRetainVM>` is specified in `SharpEmu.CLI.csproj` to prevent the .NET Garbage Collector from retaining released virtual memory, reducing address space reservation conflicts and keeping the required preferred mappings available.

If `TryAllocateAtExact` fails for the preferred main image base (e.g. `0x0000000800000000`), the loader now falls back to allocating virtual memory at alternative locations via `physicalVm.AllocateAt(..., allowAlternative: true)`.

## Testing

- N/A (Verified via unit tests)

We added `SelfLoaderAllocationTests.cs`, which simulates address space contention by blocking the exact PS5 main image base address (`0x0000000800000000`) and verifying that the loader successfully falls back to and maps the image at an alternative address.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
