### PR TITLE
[CLI] Fix main-image allocation failure caused by GC reservation overlap

### DIFF
--- a/docs/gc-region-range.md
+++ b/docs/gc-region-range.md
@@ -1,0 +1,82 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+# GC region range and the PS5 main-image base
+
+Some Windows hosts fail at startup with:
+
+```
+Could not allocate main image at required base 0x0000000800000000
+```
+
+PS5 executables must be mapped at the fixed guest address `0x8_0000_0000`
+(the 32 GiB mark). If anything else in the host process already owns that
+address, the loader has no fallback and no game can boot (issue #235).
+
+## Root cause
+
+Since .NET 7 the regions-based garbage collector reserves one large
+contiguous block of virtual address space during runtime startup, before
+any managed code runs. The block is reservation only (it consumes no RAM),
+but it can span up to 256 GB, and the OS picks its position with
+bottom-up ASLR. When Windows places it low — e.g. at `0x7FFF0000` as
+captured with VMMap in issue #235 — the reservation covers `0x8_0000_0000`
+and the fixed mapping fails. When ASLR happens to place it high, the same
+build works. That placement lottery is why the crash reproduces
+deterministically on some machines and never on others.
+
+`ServerGarbageCollection=false` does not help: workstation GC also uses
+regions. `GCRetainVM` only controls whether memory is returned later, not
+the size of the initial reservation.
+
+## The fix
+
+On Windows the launcher already relaunches a mitigated child process to
+run the emulator (CET/CFG off). Because the GC reads its configuration
+from the environment during runtime startup, the parent is the only place
+that can shape the child's reservation: it now exports
+
+```
+DOTNET_GCRegionRange=400000000
+```
+
+for the child before `CreateProcessW`, using the same set/restore pattern
+as `SHARPEMU_MITIGATED_CHILD`. CLR configuration numbers are hexadecimal,
+so `400000000` is 16 GiB. Starting from the worst-case low placement
+(~2 GB), a 16 GiB reservation ends around 18 GiB and can no longer reach
+the main-image base at 32 GiB.
+
+The value only caps the address-space reservation for the managed heap.
+Guest memory, GPU buffers, and JIT code live in native allocations outside
+the managed heap, so 16 GiB of managed-heap address space is generous for
+the emulator's bookkeeping.
+
+A value already present in the user's environment is respected, and the
+parent's environment is restored after the child is created. The
+main-image allocation failure message also suggests setting the variable
+manually, which covers hosts running with
+`SHARPEMU_DISABLE_MITIGATION_RELAUNCH=1`. Linux and macOS place the CLR
+reservation high in the address space (`0x7F...`), far from the 32 GiB
+mark, so they are unaffected by the reported failure mode.
+
+## Verification
+
+- A standalone probe (VirtualQuery walk plus the same RWX commit the
+  loader performs) shows the GC reservation shrinking from ~32 GB to
+  exactly 16 GiB on .NET 10 when the variable is set.
+- A temporarily instrumented build confirms the mitigated child inherits
+  `DOTNET_GCRegionRange=400000000` while the parent process and its
+  environment stay untouched.
+- The full solution test suite passes (451 tests).
+
+## Residual risk and possible follow-up
+
+ASLR could in principle still place the 16 GiB reservation so that it
+starts between 16 GiB and 32 GiB and overlaps the image base. That window
+is small, but a bulletproof follow-up exists: create the mitigated child
+suspended, pre-reserve the guest window in it with `VirtualAllocEx`, and
+teach the allocator to commit into that reservation. That touches
+`PhysicalVirtualMemory` and was intentionally left out of the first,
+focused change.

--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -28,6 +28,8 @@ internal static partial class Program
     private const int STARTF_USESTDHANDLES = 0x00000100;
     private const uint HANDLE_FLAG_INHERIT = 0x00000001;
     private const string MitigatedChildEnvironment = "SHARPEMU_MITIGATED_CHILD";
+    private const string GcRegionRangeEnvironment = "DOTNET_GCRegionRange";
+    private const string MitigatedChildGcRegionRange = "400000000";
     private const ulong PROCESS_CREATION_MITIGATION_POLICY_CONTROL_FLOW_GUARD_ALWAYS_OFF = 0x00000002UL << 40;
     private const ulong PROCESS_CREATION_MITIGATION_POLICY2_CET_USER_SHADOW_STACKS_ALWAYS_OFF = 0x00000002UL << 28;
     private const ulong PROCESS_CREATION_MITIGATION_POLICY2_USER_CET_SET_CONTEXT_IP_VALIDATION_ALWAYS_OFF = 0x00000002UL << 32;
@@ -566,6 +568,7 @@ internal static partial class Program
         nint attributeList = 0;
         nint mitigationPolicies = 0;
         var previousChildEnvironment = Environment.GetEnvironmentVariable(MitigatedChildEnvironment);
+        var previousGcRegionRange = Environment.GetEnvironmentVariable(GcRegionRangeEnvironment);
         try
         {
             nuint attributeListSize = 0;
@@ -606,6 +609,15 @@ internal static partial class Program
             var cmdLineBuilder = new StringBuilder(commandLine);
             nint jobHandle = 0;
             Environment.SetEnvironmentVariable(MitigatedChildEnvironment, "1");
+            if (string.IsNullOrEmpty(previousGcRegionRange))
+            {
+                // The child's GC reserves its region range before any managed
+                // code runs. Capping it at 16 GiB keeps that reservation from
+                // covering the fixed PS5 main-image base at 0x8_0000_0000 when
+                // the host places it low in the address space.
+                Environment.SetEnvironmentVariable(GcRegionRangeEnvironment, MitigatedChildGcRegionRange);
+            }
+
             var created = CreateProcessW(
                 null,
                 cmdLineBuilder,
@@ -618,6 +630,10 @@ internal static partial class Program
                 ref startupInfoEx,
                 out var processInfo);
             Environment.SetEnvironmentVariable(MitigatedChildEnvironment, previousChildEnvironment);
+            if (string.IsNullOrEmpty(previousGcRegionRange))
+            {
+                Environment.SetEnvironmentVariable(GcRegionRangeEnvironment, previousGcRegionRange);
+            }
             if (!created)
             {
                 childExitCode = 5;
@@ -677,6 +693,10 @@ internal static partial class Program
         finally
         {
             Environment.SetEnvironmentVariable(MitigatedChildEnvironment, previousChildEnvironment);
+            if (string.IsNullOrEmpty(previousGcRegionRange))
+            {
+                Environment.SetEnvironmentVariable(GcRegionRangeEnvironment, previousGcRegionRange);
+            }
 
             if (attributeList != 0)
             {

--- a/src/SharpEmu.Core/Loader/SelfLoader.cs
+++ b/src/SharpEmu.Core/Loader/SelfLoader.cs
@@ -201,7 +201,9 @@ public sealed class SelfLoader : ISelfLoader
                 {
                     var reason = physicalVm.DescribeAddressForDiagnostics(imageBase);
                     throw new InvalidOperationException(
-                        $"Could not allocate main image at required base 0x{imageBase:X16} (size=0x{totalImageSize:X}): {reason}.");
+                        $"Could not allocate main image at required base 0x{imageBase:X16} (size=0x{totalImageSize:X}): {reason}. " +
+                        "If another host allocation owns this range (commonly the .NET GC reservation), " +
+                        "relaunch with the environment variable DOTNET_GCRegionRange=400000000 set.");
                 }
 
                 imageBase = allocatedBase;


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary
Fixes #235. First of all, apologies for my English; I am using Google Translate to make it easier to read.

The emulator was crashing on some Windows systems because the .NET GC's
virtual memory reservation would sometimes overlap with the fixed address
used by the PS5 executable. The fix limits this reservation in the child
process running the game. Details are in
docs/gc-region-range.md.

## Testing 
I was unable to reproduce the failure on my own machine because ASLR allocated the GC reservation at a high memory address in that environment. To validate the fix without direct reproduction, I:

Created a separate test tool confirming that the GC reservation is reduced from approximately 32 GB to exactly 16 GiB in .NET 10 when the variable is set.
Confirmed, using a special build, that the child process (subject to the mitigation) inherits the variable, while the parent process remains unchanged.
Ran the full test suite comprising 451 tests and all of them passed.

I would appreciate it if the person who reported issue #235 could confirm whether this resolves the problem on their machine, given that they volunteered to perform the testing.

If your changes do not affect runtime behavior (e.g. documentation, tooling, CI), write `N/A`.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
