### PR TITLE
PerGameSettings Null toggles

### DIFF
--- a/src/SharpEmu.GUI/PerGameSettings.cs
+++ b/src/SharpEmu.GUI/PerGameSettings.cs
@@ -49,7 +49,7 @@ public sealed class PerGameSettings
             var path = PathFor(titleId);
             if (File.Exists(path))
             {
-                return JsonSerializer.Deserialize<PerGameSettings>(File.ReadAllText(path), SerializerOptions);
+                return NormalizeFromJson(File.ReadAllText(path));
             }
         }
         catch (Exception)
@@ -57,6 +57,18 @@ public sealed class PerGameSettings
         }
 
         return null;
+    }
+
+    // A null list inherits global settings; only entries in a present list are sanitized.
+    internal static PerGameSettings? NormalizeFromJson(string json)
+    {
+        var settings = JsonSerializer.Deserialize<PerGameSettings>(json, SerializerOptions);
+        if (settings?.EnvironmentToggles is { } toggles)
+        {
+            settings.EnvironmentToggles = toggles.Where(entry => !string.IsNullOrEmpty(entry)).ToList();
+        }
+
+        return settings;
     }
 
     public void Save(string titleId)

--- a/tests/SharpEmu.Libs.Tests/GUI/PerGameSettingsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/GUI/PerGameSettingsTests.cs
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.GUI;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.GUI;
+
+public sealed class PerGameSettingsTests
+{
+    // Invalid entries must not reach Environment.SetEnvironmentVariable.
+    [Fact]
+    public void NormalizeFromJson_NullOrEmptyToggleEntries_AreFilteredOut()
+    {
+        const string json = """
+            { "EnvironmentToggles": [null, "SHARPEMU_TRACE", ""] }
+            """;
+
+        var settings = PerGameSettings.NormalizeFromJson(json);
+
+        Assert.NotNull(settings);
+        Assert.Equal(["SHARPEMU_TRACE"], settings.EnvironmentToggles);
+    }
+
+    // A null list means that the global setting should be inherited.
+    [Fact]
+    public void NormalizeFromJson_NullToggleList_StaysNull()
+    {
+        const string json = """{ "EnvironmentToggles": null }""";
+
+        var settings = PerGameSettings.NormalizeFromJson(json);
+
+        Assert.NotNull(settings);
+        Assert.Null(settings.EnvironmentToggles);
+    }
+
+    [Fact]
+    public void NormalizeFromJson_EmptyToggleList_StaysEmpty()
+    {
+        const string json = """{ "EnvironmentToggles": [] }""";
+
+        var settings = PerGameSettings.NormalizeFromJson(json);
+
+        Assert.NotNull(settings);
+        Assert.Empty(Assert.IsType<List<string>>(settings.EnvironmentToggles));
+    }
+
+    [Fact]
+    public void NormalizeFromJson_ValidToggles_ArePreserved()
+    {
+        const string json = """
+            { "EnvironmentToggles": ["SHARPEMU_TRACE", "SHARPEMU_NO_JIT"] }
+            """;
+
+        var settings = PerGameSettings.NormalizeFromJson(json);
+
+        Assert.NotNull(settings);
+        Assert.Equal(["SHARPEMU_TRACE", "SHARPEMU_NO_JIT"], settings.EnvironmentToggles);
+    }
+}


### PR DESCRIPTION
## Description

I had already fixed a similar issue in GuiSettings, and found the same pattern in PerGameSettings. EnvironmentToggles is a List<string>? (nullable). the list itself isn't null, but its elements can be, perGame.EnvironmentToggles = [null], and in that case the ?? operator in Resolve() never kicks in, since the list reference is non-null. So the [null] flows straight into EnvironmentToggles and breaks the same way as before, at Environment.SetEnvironmentVariable.

Since i had already fixed this pattern once, i applied the same fix to PerGameSettings and wrote a test in Tests SharpEmu.Libs.Tests/GUI, which I had already created for the GuiSettings fix.

One difference from the GuiSettings fix, here i didn't normalize a null list into an empty one. A null EnvironmentToggles list has a real meaning in this file, it tells Resolve() to inherit the global setting instead of overriding it. So I only filter out null/empty entries inside an existing list, and leave a null list untouched. 

## Testing

N/A. Dotnet test - all 508 passed

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
