### PR TITLE
[Kernel] Fix event-flag ABBA deadlock, add GC suspend bridge, recover Crunch decoder crash

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
@@ -128,6 +128,11 @@ public sealed partial class DirectExecutionBackend
 			{
 				return -1;
 			}
+			if (exceptionCode == 3221225477u &&
+				TryRecoverCrunchNullMipOutputWrite(exceptionRecord, contextRecord, rip))
+			{
+				return -1;
+			}
 			if (exceptionCode == StatusIllegalInstruction &&
 				TryRecoverIllegalInstruction(contextRecord, rip))
 			{
@@ -273,9 +278,13 @@ public sealed partial class DirectExecutionBackend
 					"1",
 					StringComparison.Ordinal))
 			{
-				Console.Error.WriteLine("[LOADER][INFO]   Full fault stack window (RSP-0x300..RSP+0x100):");
+				// Upper bound widened from +0x100 to +0x230: this crash class (Crunch
+				// DoDeCruncherJob null-pointer write, RIP 0x8008e3443) reads its output
+				// buffer pointer array from a local stack array at [rsp+0x210+i*8],
+				// outside the old window.
+				Console.Error.WriteLine("[LOADER][INFO]   Full fault stack window (RSP-0x300..RSP+0x230):");
 				var windowStart = rsp >= 0x300 ? rsp - 0x300 : 0;
-				for (var stackAddr = windowStart; stackAddr < rsp + 0x100; stackAddr += 8)
+				for (var stackAddr = windowStart; stackAddr < rsp + 0x230; stackAddr += 8)
 				{
 					if (!TryReadHostQword(stackAddr, out var value))
 					{
@@ -298,7 +307,12 @@ public sealed partial class DirectExecutionBackend
 			DumpPointerWindow("fault-register-rbx", rbx, 0x60);
 			DumpPointerWindow("fault-register-rsi", rsi, 0x60);
 			DumpPointerWindow("fault-register-rdi", rdi, 0x60);
-			DumpPointerWindow("fault-register-r13", r13, 0x60);
+			// Widened from 0x60: this crash class (Crunch DoDeCruncherJob null-pointer
+			// write, RIP 0x8008e3443) holds its working-buffer pointer in R13, and the
+			// suspect uninitialized/uncopied output-pointer array lives at offsets
+			// 0x110-0x160 within it. Reading past 0x60 shows whether those slots are
+			// all-zero (never initialized) or nonzero garbage (partially copied/raced).
+			DumpPointerWindow("fault-register-r13", r13, 0x190);
 			DumpPointerWindow("fault-register-r14", r14, 0x60);
 
 			try
@@ -526,6 +540,59 @@ public sealed partial class DirectExecutionBackend
 			Console.Error.WriteLine(
 				$"[LOADER][WARN] Guest allocator empty-node adapter recovery #{recovery}: " +
 				$"rip=0x{rip:X16} -> 0x{rip + emptyPoolFallbackDelta:X16}");
+			Console.Error.Flush();
+		}
+
+		return true;
+	}
+
+	// A large enough throwaway buffer that the Crunch recovery below can absorb
+	// many consecutive 0x10-byte inner-loop advances without itself walking off
+	// the end and faulting again.
+	private const int CrunchNullMipScratchSize = 0x10000;
+	private static readonly nuint _crunchNullMipScratchBuffer = AllocCrunchNullMipScratchBuffer();
+	private static int _crunchNullMipRecoveries;
+
+	private unsafe static nuint AllocCrunchNullMipScratchBuffer() =>
+		(nuint)NativeMemory.AllocZeroed((nuint)CrunchNullMipScratchSize);
+
+	// Cult of the Lamb's Unity Crunch texture decoder (DoDeCruncherJob) writes a
+	// decoded 4-uint entry through a per-mip output pointer read from a local
+	// array on its own stack frame. That array's slot is null for some textures
+	// (mip/channel count field disagrees with how many output buffers the
+	// caller actually populated — a guest-side data/logic issue, confirmed not
+	// a cross-thread race: the array lives on this call's own private stack, so
+	// no other thread can have raced its contents). Redirect R12 to a scratch
+	// buffer instead of trying to skip forward through the surrounding nested
+	// loop (whose exact bounds bookkeeping is easy to get subtly wrong): the
+	// same faulting instruction re-executes and succeeds, discarding the
+	// decoded texel data this title never had a real destination for.
+	private unsafe static bool TryRecoverCrunchNullMipOutputWrite(
+		EXCEPTION_RECORD* exceptionRecord,
+		void* contextRecord,
+		ulong rip)
+	{
+		const ulong faultRip = 0x8008E3443UL;
+		if (string.Equals(
+				Environment.GetEnvironmentVariable("SHARPEMU_DISABLE_CRUNCH_NULL_MIP_RECOVERY"),
+				"1",
+				StringComparison.Ordinal) ||
+			rip != faultRip ||
+			exceptionRecord->NumberParameters < 2 ||
+			exceptionRecord->ExceptionInformation[0] != 1 ||
+			exceptionRecord->ExceptionInformation[1] != 0 ||
+			ReadCtxU64(contextRecord, CTX_R12) != 0)
+		{
+			return false;
+		}
+
+		WriteCtxU64(contextRecord, CTX_R12, (ulong)_crunchNullMipScratchBuffer);
+		var recovery = Interlocked.Increment(ref _crunchNullMipRecoveries);
+		if (recovery <= 16 || (recovery & (recovery - 1)) == 0)
+		{
+			Console.Error.WriteLine(
+				$"[LOADER][WARN] Crunch null-mip output recovery #{recovery}: " +
+				$"redirected write at 0x{rip:X16} to scratch buffer 0x{_crunchNullMipScratchBuffer:X16}");
 			Console.Error.Flush();
 		}
 

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -38,6 +38,29 @@ public sealed partial class DirectExecutionBackend
 	private readonly Dictionary<string, int> _importResultLogSamples = new(StringComparer.Ordinal);
 	private int _il2CppExceptionDiagnosticCount;
 
+	// Unresolved-import telemetry: per-NID hit counts so hot missing exports are
+	// logged with full context a few times, then sampled, plus a periodic
+	// aggregated summary line ("unresolved_imports_hit=") for run-over-run diffs.
+	private readonly object _unresolvedImportLogGate = new();
+	private readonly Dictionary<string, long> _unresolvedImportCounts = new(StringComparer.Ordinal);
+	private long _unresolvedImportTotalHits;
+
+	private void LogUnresolvedImportSummary(long totalUnresolvedHits)
+	{
+		KeyValuePair<string, long>[] countsByNid;
+		lock (_unresolvedImportLogGate)
+		{
+			countsByNid = _unresolvedImportCounts.ToArray();
+		}
+		var summaryParts = countsByNid
+			.OrderByDescending(pair => pair.Value)
+			.Select(pair => Aerolib.Instance.TryGetName(pair.Key, out var name)
+				? $"{pair.Key}={name}x{pair.Value}"
+				: $"{pair.Key}=?x{pair.Value}");
+		Console.Error.WriteLine(
+			$"[LOADER][WARN] unresolved_imports_hit={totalUnresolvedHits} nids={string.Join(" ", summaryParts)}");
+	}
+
 	private static ulong ImportDispatchGatewayManaged(nint backendHandle, int importIndex, nint argPackPtr)
 	{
 		try
@@ -555,9 +578,28 @@ public sealed partial class DirectExecutionBackend
 				{
 					DumpIl2CppExceptionDiagnostic(cpuContext, value, num7);
 				}
-				Console.Error.WriteLine(
-					$"[LOADER][WARN] Import#{num} unresolved: nid={importStubEntry.Nid} ret=0x{num7:X16} " +
-					$"rdi=0x{value:X16} rsi=0x{value2:X16} rdx=0x{num3:X16} rcx=0x{num4:X16} r8=0x{num5:X16} r9=0x{num6:X16}");
+				long nidHitCount;
+				long totalUnresolvedHits;
+				lock (_unresolvedImportLogGate)
+				{
+					_unresolvedImportCounts.TryGetValue(importStubEntry.Nid, out nidHitCount);
+					_unresolvedImportCounts[importStubEntry.Nid] = ++nidHitCount;
+					totalUnresolvedHits = ++_unresolvedImportTotalHits;
+				}
+				if (nidHitCount <= 4 || nidHitCount % 100 == 0)
+				{
+					var catalogText = Aerolib.Instance.TryGetName(importStubEntry.Nid, out var catalogName)
+						? catalogName
+						: "?";
+					Console.Error.WriteLine(
+						$"[LOADER][WARN] Import#{num} unresolved: nid={importStubEntry.Nid} name={catalogText} " +
+						$"hits={nidHitCount} thread=0x{GuestThreadExecution.CurrentGuestThreadHandle:X16} ret=0x{num7:X16} " +
+						$"rdi=0x{value:X16} rsi=0x{value2:X16} rdx=0x{num3:X16} rcx=0x{num4:X16} r8=0x{num5:X16} r9=0x{num6:X16}");
+				}
+				if (totalUnresolvedHits % 256 == 0)
+				{
+					LogUnresolvedImportSummary(totalUnresolvedHits);
+				}
 				if (importStubEntry.Nid == "L-Q3LEjIbgA")
 				{
 					string value18 = string.Join(" ", importStubEntry.Nid.Select(delegate (char c)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -155,6 +155,15 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private const ulong GuestThreadStackSize = 0x0020_0000UL;
 
+	// PS libkernel carves each thread's pthread TCB out of the same allocation
+	// as its stack, directly above the stack top. Unity's stop-the-world
+	// suspend/GC machinery reads TCB fields of OTHER threads at
+	// stack-top-relative offsets (observed +0x2C0..0x3F0, run 121218): with the
+	// TCB region unmapped those reads access-violate intermittently during GC
+	// cycles. Keeping a zero-filled shadow block mapped above every guest
+	// thread stack absorbs them.
+	private const ulong GuestThreadStackShadowSize = 0x0001_0000UL;
+
 	private const ulong GuestThreadTlsSize = 0x0001_0000UL;
 
 	// Matches CpuDispatcher.TlsPrefixSize: static TLS blocks sit below the
@@ -4047,6 +4056,11 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			savedHasBlockedContinuation = target.HasBlockedContinuation;
 			savedBlockedContinuation = target.BlockedContinuation;
 			savedBlockWakeKey = target.BlockWakeKey;
+			// The waiter owns the interrupted wait's queue node. The signal
+			// handler runs guest code that can block on its own primitive and
+			// overwrite this field, so it must be saved and cleared here like
+			// every other Block* field, or the interrupted wait's node is
+			// orphaned in its queue and blocks every waiter behind it.
 			savedBlockWaiter = target.BlockWaiter;
 			savedBlockDeadlineTimestamp = target.BlockDeadlineTimestamp;
 
@@ -4487,7 +4501,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			error = "creator context memory is not backed by IVirtualMemory";
 			return false;
 		}
-		if (!TryMapGuestThreadRegion(virtualMemory, GuestThreadStackBaseAddress, GuestThreadStackSize, ProgramHeaderFlags.Read | ProgramHeaderFlags.Write, out var stackBase, out error))
+		if (!TryMapGuestThreadRegion(virtualMemory, GuestThreadStackBaseAddress, GuestThreadStackSize + GuestThreadStackShadowSize, ProgramHeaderFlags.Read | ProgramHeaderFlags.Write, out var stackBase, out error))
 		{
 			return false;
 		}
@@ -5937,6 +5951,9 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					{
 						foreach (var thread in _guestThreads.Values)
 						{
+							var waiterDetail = thread.BlockWakeKey is { } snapshotWakeKey
+								? GuestThreadExecution.DescribeBlockWaiter(snapshotWakeKey)
+								: null;
 							Console.Error.WriteLine(
 								$"[LOADER][TRACE] guest_thread.snapshot " +
 								$"handle=0x{thread.ThreadHandle:X16} name='{thread.Name}' " +
@@ -5946,6 +5963,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 								$"ret=0x{Volatile.Read(ref thread.LastReturnRip):X16} " +
 								$"block={thread.BlockReason ?? "none"} " +
 								$"wake={thread.BlockWakeKey ?? "none"} " +
+								$"waiter={waiterDetail ?? "none"} " +
 								$"host_managed={thread.HostThread?.ManagedThreadId ?? 0} " +
 								$"host_tid={Volatile.Read(ref thread.HostThreadId)}");
 						}

--- a/src/SharpEmu.HLE/GuestThreadExecution.cs
+++ b/src/SharpEmu.HLE/GuestThreadExecution.cs
@@ -221,6 +221,42 @@ public static class GuestThreadExecution
 
     public static IGuestThreadScheduler? Scheduler { get; set; }
 
+    // Diagnostic hooks: map a block wake key to a human-readable description of
+    // the underlying synchronization object (completion/grant/token state). Each
+    // HLE primitive layer registers the keys it owns; the scheduler's thread
+    // snapshots consume them so a lost wake (a parked thread whose wait is
+    // already satisfiable) is visible in logs.
+    private static readonly List<Func<string, string?>> _blockWaiterDescribers = new();
+
+    public static void AddBlockWaiterDescriber(Func<string, string?> describer)
+    {
+        lock (_blockWaiterDescribers)
+        {
+            _blockWaiterDescribers.Add(describer);
+        }
+    }
+
+    public static string? DescribeBlockWaiter(string wakeKey)
+    {
+        if (string.IsNullOrEmpty(wakeKey))
+        {
+            return null;
+        }
+
+        lock (_blockWaiterDescribers)
+        {
+            foreach (var describer in _blockWaiterDescribers)
+            {
+                if (describer(wakeKey) is { } description)
+                {
+                    return description;
+                }
+            }
+        }
+
+        return null;
+    }
+
     public static bool IsGuestThread => _currentGuestThreadHandle != 0;
 
     public static ulong CurrentGuestThreadHandle => _currentGuestThreadHandle;

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -8114,7 +8114,7 @@ public static partial class AgcExports
             return;
         }
 
-        var byteCount = VulkanVideoPresenter.GetGuestImageByteCount(
+        var byteCount = VulkanVideoPresenter.GetGuestTextureByteCount(
             target.Format,
             target.Width,
             target.Height);

--- a/src/SharpEmu.Libs/AvPlayer/AvPlayerExports.cs
+++ b/src/SharpEmu.Libs/AvPlayer/AvPlayerExports.cs
@@ -145,6 +145,23 @@ public static class AvPlayerExports
         return unchecked((int)handle);
     }
 
+    // Streaming-bandwidth hint; local file playback has no use for it, but the
+    // guest treats a missing symbol as a fatal init error.
+    [SysAbiExport(
+        Nid = "N6Oy-EjduiY",
+        ExportName = "sceAvPlayerSetAvailableBandwidth",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAvPlayer")]
+    public static int AvPlayerSetAvailableBandwidth(CpuContext ctx)
+    {
+        lock (StateGate)
+        {
+            return SetReturn(
+                ctx,
+                Players.ContainsKey(ctx[CpuRegister.Rdi]) ? 0 : InvalidParameters);
+        }
+    }
+
     [SysAbiExport(
         Nid = "HD1YKVU26-M",
         ExportName = "sceAvPlayerPostInit",
@@ -921,7 +938,36 @@ public static class AvPlayerExports
         player.LastGuestBuffer = bufferAddress;
         if (!ctx.Memory.TryWrite(bufferAddress, frameData))
         {
-            return false;
+            // The guest texture allocator can hand back memory the emulator
+            // cannot address (seen with Unity's MMVideoPlayer); swap to HLE
+            // buffers once instead of silently dropping every frame.
+            if (player.TextureAllocatorFailed)
+            {
+                Console.Error.WriteLine(
+                    $"[AVPLAYER][ERROR] video frame write failed data=0x{bufferAddress:X16} bytes={frameData.Length}");
+                return false;
+            }
+
+            Console.Error.WriteLine(
+                $"[AVPLAYER][WARN] guest-allocated video buffer 0x{bufferAddress:X16} is not writable; " +
+                "switching to HLE video buffers.");
+            player.TextureAllocatorFailed = true;
+            Array.Clear(player.GuestBuffers);
+            if (!AllocateGuestVideoBuffers(ctx, player, bufferStride))
+            {
+                return false;
+            }
+
+            player.GuestBufferStride = bufferStride;
+            bufferAddress = player.GuestBuffers[player.NextGuestBuffer];
+            player.NextGuestBuffer = (player.NextGuestBuffer + 1) % FrameBufferCount;
+            player.LastGuestBuffer = bufferAddress;
+            if (!ctx.Memory.TryWrite(bufferAddress, frameData))
+            {
+                Console.Error.WriteLine(
+                    $"[AVPLAYER][ERROR] video frame write failed on HLE buffer data=0x{bufferAddress:X16}");
+                return false;
+            }
         }
 
         Span<byte> info = extended
@@ -939,7 +985,14 @@ public static class AvPlayerExports
             info[64] = 8;
             info[65] = 8;
         }
-        return ctx.Memory.TryWrite(infoAddress, info);
+        if (!ctx.Memory.TryWrite(infoAddress, info))
+        {
+            Console.Error.WriteLine(
+                $"[AVPLAYER][ERROR] video frame info write failed info=0x{infoAddress:X16}");
+            return false;
+        }
+
+        return true;
     }
 
     private static bool AllocateGuestVideoBuffers(CpuContext ctx, PlayerState player, int bufferSize)
@@ -1009,7 +1062,9 @@ public static class AvPlayerExports
         {
             return false;
         }
-        var ffprobe = Path.Combine(Path.GetDirectoryName(ffmpeg) ?? string.Empty, "ffprobe");
+        var ffprobe = Path.Combine(
+            Path.GetDirectoryName(ffmpeg) ?? string.Empty,
+            OperatingSystem.IsWindows() ? "ffprobe.exe" : "ffprobe");
         if (!File.Exists(ffprobe))
         {
             return false;
@@ -1106,6 +1161,24 @@ public static class AvPlayerExports
                 return candidate;
             }
         }
+
+        // Windows: resolve ffmpeg(.exe) through PATH.
+        var executableName = OperatingSystem.IsWindows() ? "ffmpeg.exe" : "ffmpeg";
+        var pathDirectories = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator) ?? [];
+        foreach (var directory in pathDirectories)
+        {
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                continue;
+            }
+
+            var candidate = Path.Combine(directory.Trim(), executableName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
         return null;
     }
 

--- a/src/SharpEmu.Libs/ContentExport/ContentExportExports.cs
+++ b/src/SharpEmu.Libs/ContentExport/ContentExportExports.cs
@@ -1,18 +1,50 @@
-// Copyright (C) 2026 SharpEmu Emulator Project
+﻿// Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
 
 namespace SharpEmu.Libs.ContentExport;
 
-// No host media library exists to export captures into, so initialization
-// reports success.
+/// <summary>
+/// Minimal libSceContentExport surface: Cult of the Lamb initializes the PSN
+/// content export API at boot and terminates it right after. No content is
+/// ever exported, so init/term only track state and report success.
+/// </summary>
 public static class ContentExportExports
 {
+    private static int _initialized;
+
     [SysAbiExport(
         Nid = "0GnN4QCgIfs",
         ExportName = "sceContentExportInit2",
-        Target = Generation.Gen5,
+        Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libSceContentExport")]
-    public static int ContentExportInit2(CpuContext ctx) => ctx.SetReturn(0);
+    public static int ContentExportInit2(CpuContext ctx)
+    {
+        Interlocked.Exchange(ref _initialized, 1);
+        TraceContentExport("init2");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "+KDWny9Y-6k",
+        ExportName = "sceContentExportTerm",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceContentExport")]
+    public static int ContentExportTerm(CpuContext ctx)
+    {
+        var wasInitialized = Interlocked.Exchange(ref _initialized, 0) != 0;
+        TraceContentExport(wasInitialized ? "term" : "term while not initialized");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    private static void TraceContentExport(string message)
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_SHARE"), "1", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        Console.Error.WriteLine($"[LOADER][TRACE] content_export.{message}");
+    }
 }

--- a/src/SharpEmu.Libs/ContentSearch/ContentSearchExports.cs
+++ b/src/SharpEmu.Libs/ContentSearch/ContentSearchExports.cs
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+
+namespace SharpEmu.Libs.ContentSearch;
+
+// No host media library exists to search, so initialization reports success
+// and the PSN content-management flow proceeds to its normal Terminate.
+public static class ContentSearchExports
+{
+    [SysAbiExport(
+        Nid = "dPj4ZtRcIWk",
+        ExportName = "sceContentSearchInit",
+        Target = Generation.Gen5,
+        LibraryName = "libSceContentSearch")]
+    public static int ContentSearchInit(CpuContext ctx) => ctx.SetReturn(0);
+}

--- a/src/SharpEmu.Libs/Kernel/KernelEventFlagCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventFlagCompatExports.cs
@@ -254,44 +254,68 @@ public static class KernelEventFlagCompatExports
             var managedThread = Environment.CurrentManagedThreadId;
             var blockedWaitResult = OrbisGen2Result.ORBIS_GEN2_OK;
             var satisfied = false;
-            var requestedBlock = GuestThreadExecution.RequestCurrentThreadBlock(
-                ctx,
-                "sceKernelWaitEventFlag",
-                GetEventFlagWakeKey(handle),
-                () =>
-                {
-                    if (satisfied)
+            // Release state.Gate across the scheduler registration. The resume
+            // and wake handlers below reacquire state.Gate themselves, so holding
+            // it here while RequestCurrentThreadBlock enters the scheduler gate
+            // inverts the lock order used by WakeBlockedThreads and the lost-wake
+            // sweep (both hold the scheduler gate, then call the wake predicate
+            // which takes state.Gate). That ABBA intermittently froze the entire
+            // scheduler — and disappeared under event-flag tracing, which shifts
+            // the timing. A SetEventFlag racing this window is still recovered by
+            // the park-time re-check in RunGuestThread and the periodic
+            // satisfied-wait sweep, exactly as the semaphore wait path relies on.
+            Monitor.Exit(state.Gate);
+            bool requestedBlock;
+            try
+            {
+                // Embedding the handle/name/pattern in the block reason lets a
+                // guest-thread scheduler snapshot (SHARPEMU_LOG_SUSPEND_THREADS)
+                // name the exact event flag and awaited bits directly, without a
+                // second SHARPEMU_LOG_EVENT_FLAG run to correlate by guest
+                // thread handle.
+                requestedBlock = GuestThreadExecution.RequestCurrentThreadBlock(
+                    ctx,
+                    $"sceKernelWaitEventFlag:0x{handle:X16}('{state.Name}') pattern=0x{pattern:X16} mode=0x{waitMode:X2}",
+                    GetEventFlagWakeKey(handle),
+                    () =>
                     {
-                        return (int)blockedWaitResult;
-                    }
+                        if (satisfied)
+                        {
+                            return (int)blockedWaitResult;
+                        }
 
-                    // Deadline expiry: report timeout with the current bits.
-                    if (timeoutAddress != 0)
+                        // Deadline expiry: report timeout with the current bits.
+                        if (timeoutAddress != 0)
+                        {
+                            _ = TryWriteUInt32(ctx, timeoutAddress, 0);
+                        }
+
+                        _ = TryWriteResultPattern(ctx, resultAddress, state.Bits);
+                        return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT;
+                    },
+                    () =>
                     {
-                        _ = TryWriteUInt32(ctx, timeoutAddress, 0);
-                    }
+                        if (!TryPrepareBlockedWait(
+                                ctx,
+                                state,
+                                pattern,
+                                waitMode,
+                                resultAddress,
+                                out var preparedResult))
+                        {
+                            return false;
+                        }
 
-                    _ = TryWriteResultPattern(ctx, resultAddress, state.Bits);
-                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT;
-                },
-                () =>
-                {
-                    if (!TryPrepareBlockedWait(
-                            ctx,
-                            state,
-                            pattern,
-                            waitMode,
-                            resultAddress,
-                            out var preparedResult))
-                    {
-                        return false;
-                    }
-
-                    blockedWaitResult = preparedResult;
-                    satisfied = true;
-                    return true;
-                },
-                deadline);
+                        blockedWaitResult = preparedResult;
+                        satisfied = true;
+                        return true;
+                    },
+                    deadline);
+            }
+            finally
+            {
+                Monitor.Enter(state.Gate);
+            }
             if (_traceEventFlag) TraceEventFlag($"wait-unsatisfied handle=0x{handle:X16} pattern=0x{pattern:X16} bits=0x{state.Bits:X16} guest_thread=0x{currentGuestThread:X16} fiber=0x{currentFiber:X16} managed={managedThread} block={requestedBlock} ret=0x{returnRip:X16} frames={FormatFrameChain(ctx)}");
             if (_traceEventFlag) TraceEventFlag($"wait-object handle=0x{handle:X16} name='{state.Name}' {FormatGuestWaitObject(ctx)}");
             if (!requestedBlock)
@@ -489,6 +513,34 @@ public static class KernelEventFlagCompatExports
 
     private static string GetEventFlagWakeKey(ulong handle) =>
         $"event_flag:0x{handle:X16}";
+
+    static KernelEventFlagCompatExports()
+    {
+        GuestThreadExecution.AddBlockWaiterDescriber(DescribeEventFlagByKey);
+    }
+
+    // Reports the bit pattern behind a parked sceKernelWaitEventFlag, so a
+    // snapshot distinguishes "nobody set the bits" from a missed wake.
+    private static string? DescribeEventFlagByKey(string wakeKey)
+    {
+        const string prefix = "event_flag:0x";
+        if (!wakeKey.StartsWith(prefix, StringComparison.Ordinal) ||
+            !ulong.TryParse(
+                wakeKey.AsSpan(prefix.Length),
+                System.Globalization.NumberStyles.HexNumber,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var handle) ||
+            !_eventFlags.TryGetValue(handle, out var state))
+        {
+            return null;
+        }
+
+        lock (state.Gate)
+        {
+            return $"evf '{state.Name}' bits=0x{state.Bits:X} attr=0x{state.Attributes:X} " +
+                $"waiters={state.WaitingThreads}";
+        }
+    }
 
     private static bool TryWriteResultPattern(CpuContext ctx, ulong address, ulong bits) =>
         address == 0 || ctx.TryWriteUInt64(address, bits);

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -4812,6 +4812,9 @@ public static partial class KernelMemoryCompatExports
         return guestPath;
     }
 
+    internal static bool TryResolveGuestMountPath(string guestPath, out string hostPath) =>
+        TryResolveRegisteredGuestMount(guestPath, out hostPath);
+
     private static bool TryResolveRegisteredGuestMount(string guestPath, out string hostPath)
     {
         hostPath = string.Empty;

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Collections.Concurrent;
+using System.Linq;
 using SharpEmu.HLE;
 using System.Buffers.Binary;
 using System.Diagnostics;
@@ -38,6 +39,53 @@ public static class KernelPthreadCompatExports
     private static readonly HashSet<ulong>? _tracePthreadMutexFilter = ParseTraceAddressFilter(
         Environment.GetEnvironmentVariable("SHARPEMU_LOG_PTHREAD_MUTEX_FILTER"));
     private static long _nextSynchronizationWaiterId;
+
+    // Lightweight lock-rate profiler. Off by default (zero per-call cost beyond a
+    // single volatile bool test). With SHARPEMU_PROFILE_MUTEX=1 it counts lock
+    // attempts per mutex address and dumps the hottest ones every 500k calls, so
+    // a guest busy-wait spin (one address hammered) is distinguishable from
+    // genuine spread-out lock traffic.
+    private static readonly bool _profileMutex =
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_PROFILE_MUTEX"), "1", StringComparison.Ordinal);
+    private static readonly ConcurrentDictionary<ulong, long> _mutexLockCounts = new();
+    private static long _mutexLockTotal;
+    private const long MutexProfileDumpInterval = 100_000;
+    // Time-based dump so the hot-mutex/owner snapshot appears regularly even
+    // when the lock rate collapses (a stall drops lock traffic to a trickle, so
+    // a pure count trigger would go silent exactly when the dump matters most).
+    private static readonly long MutexProfileDumpTicks =
+        System.Diagnostics.Stopwatch.Frequency * 2; // ~2 s
+    private static long _lastMutexProfileDumpTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+
+    private static void ProfileMutexLock(ulong resolvedAddress)
+    {
+        _mutexLockCounts.AddOrUpdate(resolvedAddress, 1, static (_, current) => current + 1);
+        var total = Interlocked.Increment(ref _mutexLockTotal);
+        var now = System.Diagnostics.Stopwatch.GetTimestamp();
+        var last = Volatile.Read(ref _lastMutexProfileDumpTimestamp);
+        var dueByTime = now - last >= MutexProfileDumpTicks &&
+            Interlocked.CompareExchange(ref _lastMutexProfileDumpTimestamp, now, last) == last;
+        if (total % MutexProfileDumpInterval != 0 && !dueByTime)
+        {
+            return;
+        }
+
+        // Include each hot mutex's current owner + waiter count so a spin-lock
+        // hang is diagnosable straight from the dump: the top mutex plus who
+        // holds it (and never releases) identifies the stuck producer.
+        var top = _mutexLockCounts
+            .OrderByDescending(pair => pair.Value)
+            .Take(5)
+            .Select(pair =>
+            {
+                var owner = _mutexStates.TryGetValue(pair.Key, out var st)
+                    ? $" owner=0x{st.OwnerThreadId:X} rec={st.RecursionCount} waiters={st.Waiters.Count}"
+                    : string.Empty;
+                return $"0x{pair.Key:X16}:{pair.Value}{owner}";
+            });
+        Console.Error.WriteLine(
+            $"[PROFILE] mutex lock total={total} distinct={_mutexLockCounts.Count} top5=[{string.Join(", ", top)}]");
+    }
 
     private sealed class PthreadMutexState
     {
@@ -124,6 +172,10 @@ public static class KernelPthreadCompatExports
         public ManualResetEventSlim? HostSignal { get; set; }
         public LinkedListNode<PthreadMutexWaiter>? Node { get; set; }
         public int Granted;
+        // Back-reference for diagnostics only (DescribeWaiterByKey): lets a
+        // guest-thread snapshot report the mutex's current owner/recursion/queue
+        // depth for a waiter without a second lookup by address.
+        public PthreadMutexState? OwnerState { get; init; }
     }
 
     private sealed class PthreadCondState
@@ -150,9 +202,58 @@ public static class KernelPthreadCompatExports
 
     private readonly record struct PthreadMutexAttrState(int Type, int Protocol);
 
+    // Diagnostic registry: wake key -> live waiter, consumed by the scheduler's
+    // guest-thread snapshots. A snapshot line showing a parked thread whose
+    // waiter is already signaled/granted is the signature of a lost wake.
+    private static readonly ConcurrentDictionary<string, object> _diagnosticWaitersByKey = new();
+
+    private static void RegisterDiagnosticWaiter(string wakeKey, object waiter)
+    {
+        if (!string.IsNullOrEmpty(wakeKey))
+        {
+            _diagnosticWaitersByKey[wakeKey] = waiter;
+        }
+    }
+
+    private static void UnregisterDiagnosticWaiter(string wakeKey)
+    {
+        if (!string.IsNullOrEmpty(wakeKey))
+        {
+            _diagnosticWaitersByKey.TryRemove(wakeKey, out _);
+        }
+    }
+
+    private static string? DescribeWaiterByKey(string wakeKey)
+    {
+        if (string.IsNullOrEmpty(wakeKey) ||
+            !_diagnosticWaitersByKey.TryGetValue(wakeKey, out var waiter))
+        {
+            return null;
+        }
+
+        return waiter switch
+        {
+            PthreadCondWaiter cond =>
+                $"cond completion={cond.CompletionState} " +
+                $"mutex_granted={(cond.MutexWaiter is null ? "none" : Volatile.Read(ref cond.MutexWaiter.Granted).ToString())} " +
+                $"mutex_owner=0x{cond.MutexState.OwnerThreadId:X}",
+            PthreadMutexWaiter mutex =>
+                $"mutex granted={Volatile.Read(ref mutex.Granted)} queued={(mutex.Node is not null ? 1 : 0)} " +
+                $"first={(mutex.Node is not null && ReferenceEquals(mutex.OwnerState?.Waiters.First, mutex.Node) ? 1 : 0)} " +
+                $"owner=0x{mutex.OwnerState?.OwnerThreadId ?? 0:X} " +
+                $"depth={mutex.OwnerState?.Waiters.Count ?? 0} " +
+                $"head=0x{mutex.OwnerState?.Waiters.First?.Value.ThreadId ?? 0:X} " +
+                $"head_granted={(mutex.OwnerState?.Waiters.First is { } head ? Volatile.Read(ref head.Value.Granted) : -1)} " +
+                $"head_coop={(mutex.OwnerState?.Waiters.First?.Value.Cooperative == true ? 1 : 0)} " +
+                $"head_key='{mutex.OwnerState?.Waiters.First?.Value.WakeKey}'",
+            _ => null,
+        };
+    }
+
     static KernelPthreadCompatExports()
     {
         RunSynchronizationSelfChecks();
+        GuestThreadExecution.AddBlockWaiterDescriber(DescribeWaiterByKey);
     }
 
     [SysAbiExport(
@@ -753,6 +854,11 @@ public static class KernelPthreadCompatExports
         {
             TracePthreadMutex(ctx, tryOnly ? "trylock" : "lock", mutexAddress, resolvedAddress, null, KernelPthreadState.GetCurrentThreadHandle(), (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND);
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+        }
+
+        if (_profileMutex)
+        {
+            ProfileMutexLock(resolvedAddress);
         }
 
         var currentThreadId = KernelPthreadState.GetCurrentThreadHandle();
@@ -1646,6 +1752,7 @@ public static class KernelPthreadCompatExports
                 ? wakeKey ?? $"pthread_mutex_waiter:{Interlocked.Increment(ref _nextSynchronizationWaiterId)}"
                 : string.Empty,
             HostSignal = cooperative ? null : new ManualResetEventSlim(initialState: false),
+            OwnerState = state,
         };
         waiter.Node = state.Waiters.AddLast(waiter);
         state.WaiterAddedLocked();
@@ -2080,11 +2187,23 @@ public static class KernelPthreadCompatExports
 
         _ = KernelMemoryCompatExports.TryReadUInt64Compat(ctx, mutexAddress, out var guestWord0);
         _ = KernelMemoryCompatExports.TryReadUInt64Compat(ctx, mutexAddress + 8, out var guestWord1);
+        // Identify the guest code looping on this mutex: return RIP of the current
+        // import call plus the caller's frame return (rbp+8) one level up.
+        var returnRip = GuestThreadExecution.TryGetCurrentImportCallFrame(out var frame)
+            ? frame.ReturnRip
+            : 0UL;
+        var callerReturnText = "?";
+        var rbp = ctx[CpuRegister.Rbp];
+        if (rbp != 0 && ctx.TryReadUInt64(rbp + 8, out var callerReturn))
+        {
+            callerReturnText = $"0x{callerReturn:X16}";
+        }
         Console.Error.WriteLine(
             $"[LOADER][TRACE] pthread_{operation}: mutex=0x{mutexAddress:X16} resolved=0x{resolvedAddress:X16} " +
             $"guest[0]=0x{guestWord0:X16} guest[8]=0x{guestWord1:X16} " +
             $"current=0x{currentThreadId:X16} owner=0x{(state?.OwnerThreadId ?? 0):X16} " +
-            $"recursion={(state?.RecursionCount ?? 0)} type={(state?.Type ?? 0)} result=0x{unchecked((uint)result):X8}");
+            $"recursion={(state?.RecursionCount ?? 0)} type={(state?.Type ?? 0)} result=0x{unchecked((uint)result):X8} " +
+            $"ret=0x{returnRip:X16} caller={callerReturnText}");
     }
 
     private static void TracePthreadCond(string operation, ulong condAddress, ulong mutexAddress, PthreadCondState? state, bool timed, int result)

--- a/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
@@ -24,6 +24,117 @@ public static class KernelSemaphoreCompatExports
         public int Count { get; set; }
         public int WaitingThreads { get; set; }
         public object Gate { get; } = new();
+
+        // --- Stop-the-world suspend bridge (temporary) ---
+        // Unity's GC coordinator waits on 'SuspendSemaphore' for one ack per
+        // mutator thread. Threads parked in an unrelated HLE wait cannot reach
+        // their cooperative safepoint to post that ack, so the handshake stalls
+        // one or two acks short forever. PendingWaitNeed records the largest
+        // needCount currently parked here; the watchdog fills a stalled deficit.
+        public int PendingWaitNeed { get; set; }
+        public int BridgeLastCount { get; set; } = -1;
+        public long BridgeStableTicks { get; set; }
+    }
+
+    // Semaphore name Unity uses for its stop-the-world GC suspend handshake.
+    private const string SuspendSemaphoreName = "SuspendSemaphore";
+    private static readonly bool _suspendBridgeEnabled = !string.Equals(
+        Environment.GetEnvironmentVariable("SHARPEMU_SUSPEND_BRIDGE"), "0", StringComparison.Ordinal);
+    private static readonly long SuspendBridgeStallTicks =
+        System.Diagnostics.Stopwatch.Frequency * 3 / 2; // ~1.5 s of no progress
+    private static Timer? _suspendBridgeTimer;
+
+    static KernelSemaphoreCompatExports()
+    {
+        GuestThreadExecution.AddBlockWaiterDescriber(DescribeSemaphoreByKey);
+        if (_suspendBridgeEnabled)
+        {
+            _suspendBridgeTimer = new Timer(
+                static _ => RunSuspendBridge(), null, 500, 500);
+        }
+    }
+
+    // Watchdog: a 'SuspendSemaphore' whose count sits below the parked waiter's
+    // needCount and stops advancing for ~1.5 s is a stop-the-world handshake
+    // waiting on HLE-blocked threads that will never reach a safepoint. Post the
+    // missing acks on their behalf; a blocked thread cannot touch the heap while
+    // parked, so counting it as already-suspended is safe. Bridge only — the
+    // faithful fix reproduces Baselib's per-thread GC-safe accounting.
+    private static void RunSuspendBridge()
+    {
+        foreach (var (handle, semaphore) in _semaphores)
+        {
+            if (!string.Equals(semaphore.Name, SuspendSemaphoreName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            int deficit;
+            lock (semaphore.Gate)
+            {
+                if (semaphore.WaitingThreads <= 0 || semaphore.PendingWaitNeed <= semaphore.Count)
+                {
+                    semaphore.BridgeLastCount = semaphore.Count;
+                    semaphore.BridgeStableTicks = System.Diagnostics.Stopwatch.GetTimestamp();
+                    continue;
+                }
+
+                var now = System.Diagnostics.Stopwatch.GetTimestamp();
+                if (semaphore.Count != semaphore.BridgeLastCount)
+                {
+                    semaphore.BridgeLastCount = semaphore.Count;
+                    semaphore.BridgeStableTicks = now;
+                    continue;
+                }
+
+                if (now - semaphore.BridgeStableTicks < SuspendBridgeStallTicks)
+                {
+                    continue;
+                }
+
+                deficit = Math.Min(
+                    semaphore.PendingWaitNeed - semaphore.Count,
+                    semaphore.MaxCount - semaphore.Count);
+                if (deficit <= 0)
+                {
+                    continue;
+                }
+
+                semaphore.Count += deficit;
+                semaphore.BridgeLastCount = semaphore.Count;
+                semaphore.BridgeStableTicks = now;
+                Monitor.PulseAll(semaphore.Gate);
+            }
+
+            Console.Error.WriteLine(
+                $"[BRIDGE] suspend handshake stalled on '{semaphore.Name}' (0x{handle:X}); " +
+                $"force-posted {deficit} ack(s) for HLE-blocked threads.");
+            _ = GuestThreadExecution.Scheduler?.WakeBlockedThreads(GetSemaphoreWakeKey(handle));
+        }
+    }
+
+    // Reports the token state behind a parked sceKernelWaitSema. A thread still
+    // blocked while count is high enough to satisfy it is a lost wake; count
+    // pinned at zero means no producer ever signaled.
+    private static string? DescribeSemaphoreByKey(string wakeKey)
+    {
+        const string prefix = "sceKernelWaitSema:";
+        if (!wakeKey.StartsWith(prefix, StringComparison.Ordinal) ||
+            !uint.TryParse(
+                wakeKey.AsSpan(prefix.Length),
+                System.Globalization.NumberStyles.HexNumber,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var handle) ||
+            !_semaphores.TryGetValue(handle, out var semaphore))
+        {
+            return null;
+        }
+
+        lock (semaphore.Gate)
+        {
+            return $"sema '{semaphore.Name}' count={semaphore.Count} max={semaphore.MaxCount} " +
+                $"waiters={semaphore.WaitingThreads}";
+        }
     }
 
     [SysAbiExport(
@@ -129,6 +240,12 @@ public static class KernelSemaphoreCompatExports
             }
 
             semaphore.WaitingThreads++;
+            if (needCount > semaphore.PendingWaitNeed)
+            {
+                // Record the coordinator's ack target so the suspend bridge can
+                // recognise a handshake stalled below it.
+                semaphore.PendingWaitNeed = needCount;
+            }
         }
 
         // Block cooperatively: the wake predicate atomically acquires the
@@ -147,6 +264,11 @@ public static class KernelSemaphoreCompatExports
                 {
                     semaphore.Count -= needCount;
                     semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
+                    if (semaphore.WaitingThreads == 0)
+                    {
+                        semaphore.PendingWaitNeed = 0;
+                    }
+
                     acquired = true;
                     return true;
                 }
@@ -664,14 +786,20 @@ public static class KernelSemaphoreCompatExports
         return true;
     }
 
-    // Call sites must check this before building the interpolated message; the trace
-    // strings would otherwise be allocated on every semaphore op even with tracing off.
     private static readonly bool _traceSema =
-        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_SEMA"), "1", StringComparison.Ordinal);
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_SEMA"), "1", StringComparison.Ordinal) ||
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_SEMAPHORE"), "1", StringComparison.Ordinal);
+
+    // FMOD's audio pump signals/waits its semaphores hundreds of times per
+    // second; those lines drown every other semaphore in the log. They stay
+    // hidden unless explicitly requested.
+    private static readonly bool _traceFmodSema =
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_SEMA_FMOD"), "1", StringComparison.Ordinal);
 
     private static void TraceSemaphore(string message)
     {
-        if (!_traceSema)
+        if (!_traceSema ||
+            (!_traceFmodSema && message.Contains("name='FMOD", StringComparison.Ordinal)))
         {
             return;
         }

--- a/src/SharpEmu.Libs/Network/Http2Exports.cs
+++ b/src/SharpEmu.Libs/Network/Http2Exports.cs
@@ -12,9 +12,13 @@ public static class Http2Exports
     private const int Http2ErrorInvalidArgument = unchecked((int)0x80436016);
 
     private static readonly ConcurrentDictionary<int, Http2Context> _contexts = new();
+    private static readonly ConcurrentDictionary<int, Http2Template> _templates = new();
     private static int _nextContextId;
+    private static int _nextTemplateId = 0x2000;
 
     private sealed record Http2Context(int NetId, int SslId, ulong PoolSize, int MaxRequests);
+
+    private sealed record Http2Template(int ContextId, ulong UserAgentAddress, int HttpVersion, bool AutoProxyConfig);
 
     [SysAbiExport(
         Nid = "3JCe3lCbQ8A",
@@ -54,9 +58,125 @@ public static class Http2Exports
             return ctx.SetReturn(Http2ErrorInvalidId);
         }
 
+        foreach (var pair in _templates)
+        {
+            if (pair.Value.ContextId == id)
+            {
+                _templates.TryRemove(pair.Key, out _);
+            }
+        }
+
         TraceHttp2("term", id, 0, 0, 0, 0);
         return ctx.SetReturn(0);
     }
+
+    [SysAbiExport(
+        Nid = "+wCt7fCijgk",
+        ExportName = "sceHttp2CreateTemplate",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2CreateTemplate(CpuContext ctx)
+    {
+        var contextId = unchecked((int)ctx[CpuRegister.Rdi]);
+        if (!_contexts.ContainsKey(contextId))
+        {
+            return ctx.SetReturn(Http2ErrorInvalidId);
+        }
+
+        var userAgentAddress = ctx[CpuRegister.Rsi];
+        var httpVersion = unchecked((int)ctx[CpuRegister.Rdx]);
+        var autoProxyConfig = ctx[CpuRegister.Rcx] != 0;
+        var id = Interlocked.Increment(ref _nextTemplateId);
+        _templates[id] = new Http2Template(contextId, userAgentAddress, httpVersion, autoProxyConfig);
+
+        TraceHttp2("create_template", id, unchecked((ulong)contextId), userAgentAddress, unchecked((ulong)httpVersion), autoProxyConfig ? 1UL : 0UL);
+        ctx[CpuRegister.Rax] = unchecked((ulong)id);
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "pDom5-078DA",
+        ExportName = "sceHttp2DeleteTemplate",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2DeleteTemplate(CpuContext ctx)
+    {
+        var templateId = unchecked((int)ctx[CpuRegister.Rdi]);
+        TraceHttp2("delete_template", templateId, 0, 0, 0, 0);
+        return _templates.TryRemove(templateId, out _)
+            ? ctx.SetReturn(0)
+            : ctx.SetReturn(Http2ErrorInvalidId);
+    }
+
+    // Per-template setters: no request is ever issued HLE-side, so accepting
+    // the value for a known template is all the behavior the callers need.
+    // Returning success for an id that does not exist is dangerous: the guest
+    // then dereferences its (nonexistent) template object and crashes at NULL
+    // right after the call (run 130053, sceHttp2SetSslCallback).
+    private static int SetTemplateOption(CpuContext ctx, string operation)
+    {
+        var templateId = unchecked((int)ctx[CpuRegister.Rdi]);
+        TraceHttp2(operation, templateId, ctx[CpuRegister.Rsi], ctx[CpuRegister.Rdx], 0, 0);
+        return _templates.ContainsKey(templateId)
+            ? ctx.SetReturn(0)
+            : ctx.SetReturn(Http2ErrorInvalidId);
+    }
+
+    [SysAbiExport(
+        Nid = "YrWX+DhPHQY",
+        ExportName = "sceHttp2SetSslCallback",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2SetSslCallback(CpuContext ctx) => SetTemplateOption(ctx, "set_ssl_callback");
+
+    [SysAbiExport(
+        Nid = "-HIO4VT87v8",
+        ExportName = "sceHttp2SetConnectTimeOut",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2SetConnectTimeOut(CpuContext ctx) => SetTemplateOption(ctx, "set_connect_timeout");
+
+    [SysAbiExport(
+        Nid = "XPtW45xiLHk",
+        ExportName = "sceHttp2SetSendTimeOut",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2SetSendTimeOut(CpuContext ctx) => SetTemplateOption(ctx, "set_send_timeout");
+
+    [SysAbiExport(
+        Nid = "izvHhqgDt44",
+        ExportName = "sceHttp2SetRecvTimeOut",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2SetRecvTimeOut(CpuContext ctx) => SetTemplateOption(ctx, "set_recv_timeout");
+
+    [SysAbiExport(
+        Nid = "jjFahkBPCYs",
+        ExportName = "sceHttp2SetAuthEnabled",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2SetAuthEnabled(CpuContext ctx) => SetTemplateOption(ctx, "set_auth_enabled");
+
+    [SysAbiExport(
+        Nid = "BJgi0CH7al4",
+        ExportName = "sceHttp2SetRedirectCallback",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2SetRedirectCallback(CpuContext ctx) => SetTemplateOption(ctx, "set_redirect_callback");
+
+    [SysAbiExport(
+        Nid = "EWcwMpbr5F8",
+        ExportName = "sceHttp2SslEnableOption",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2SslEnableOption(CpuContext ctx) => SetTemplateOption(ctx, "ssl_enable_option");
+
+    [SysAbiExport(
+        Nid = "B37SruheQ5Y",
+        ExportName = "sceHttp2SslDisableOption",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp2")]
+    public static int Http2SslDisableOption(CpuContext ctx) => SetTemplateOption(ctx, "ssl_disable_option");
 
     private static void TraceHttp2(string operation, int id, ulong arg0, ulong arg1, ulong arg2, ulong arg3)
     {

--- a/src/SharpEmu.Libs/Network/HttpExports.cs
+++ b/src/SharpEmu.Libs/Network/HttpExports.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
+using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Text;
 
 namespace SharpEmu.Libs.Network;
 
@@ -10,6 +12,9 @@ public static class HttpExports
 {
     private const int HttpErrorInvalidId = unchecked((int)0x80431100);
     private const int HttpErrorInvalidValue = unchecked((int)0x804311FE);
+    private const int HttpErrorInvalidUrl = unchecked((int)0x80431170);
+    private const int HttpErrorOutOfMemory = unchecked((int)0x80431022);
+    private const int MaxUriBytes = 4096;
 
     private static readonly ConcurrentDictionary<int, HttpContext> Contexts = new();
     private static readonly ConcurrentDictionary<int, HttpTemplate> Templates = new();
@@ -100,6 +105,223 @@ public static class HttpExports
         }
 
         return ctx.SetReturn(0);
+    }
+
+    // SceHttpUriElement layout (0x48 bytes): opaque i32 at 0x00, then scheme,
+    // username, password, hostname, path, query, fragment pointers at
+    // 0x08..0x38, port u16 at 0x40. Component strings live in the caller pool.
+    [SysAbiExport(
+        Nid = "IWalAn-guFs",
+        ExportName = "sceHttpUriParse",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceHttp")]
+    public static int HttpUriParse(CpuContext ctx)
+    {
+        var elementAddress = ctx[CpuRegister.Rdi];
+        var uriAddress = ctx[CpuRegister.Rsi];
+        var poolAddress = ctx[CpuRegister.Rdx];
+        var requireAddress = ctx[CpuRegister.Rcx];
+        var prepare = ctx[CpuRegister.R8];
+        if (uriAddress == 0)
+        {
+            return ctx.SetReturn(HttpErrorInvalidUrl);
+        }
+
+        if (!TryReadNullTerminatedAscii(ctx, uriAddress, MaxUriBytes, out var uri) ||
+            !TryParseUri(uri, out var parsed))
+        {
+            return ctx.SetReturn(HttpErrorInvalidUrl);
+        }
+
+        string?[] components = [parsed.Scheme, parsed.Username, parsed.Password, parsed.Hostname, parsed.Path, parsed.Query, parsed.Fragment];
+        var required = 0UL;
+        foreach (var component in components)
+        {
+            if (component is not null)
+            {
+                required += (ulong)component.Length + 1;
+            }
+        }
+
+        if (requireAddress != 0 && !TryWriteUInt64(ctx, requireAddress, required))
+        {
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        // Two-phase callers pass a null element/pool first to size the pool.
+        if (elementAddress == 0 || poolAddress == 0)
+        {
+            TraceHttp("uri_parse_size", 0, uriAddress, required, 0, 0);
+            return ctx.SetReturn(0);
+        }
+
+        // prepare=0 is observed in the wild with a caller-managed pool: treat
+        // it as "unchecked capacity" rather than failing the parse.
+        if (prepare != 0 && prepare < required)
+        {
+            return ctx.SetReturn(HttpErrorOutOfMemory);
+        }
+
+        Span<byte> element = stackalloc byte[0x48];
+        element.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(element, parsed.Opaque ? 1u : 0u);
+        BinaryPrimitives.WriteUInt16LittleEndian(element[0x40..], parsed.Port);
+
+        var cursor = poolAddress;
+        for (var i = 0; i < components.Length; i++)
+        {
+            var component = components[i];
+            if (component is null)
+            {
+                continue;
+            }
+
+            var bytes = Encoding.ASCII.GetBytes(component + '\0');
+            if (!ctx.Memory.TryWrite(cursor, bytes))
+            {
+                return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+
+            BinaryPrimitives.WriteUInt64LittleEndian(element[(0x08 + (i * 8))..], cursor);
+            cursor += (ulong)bytes.Length;
+        }
+
+        if (!ctx.Memory.TryWrite(elementAddress, element))
+        {
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceHttp("uri_parse", 0, uriAddress, poolAddress, required, parsed.Port);
+        return ctx.SetReturn(0);
+    }
+
+    private readonly record struct ParsedUri(
+        bool Opaque,
+        string Scheme,
+        string? Username,
+        string? Password,
+        string? Hostname,
+        string? Path,
+        string? Query,
+        string? Fragment,
+        ushort Port);
+
+    private static bool TryParseUri(string uri, out ParsedUri parsed)
+    {
+        parsed = default;
+        var schemeEnd = uri.IndexOf(':');
+        if (schemeEnd <= 0)
+        {
+            return false;
+        }
+
+        var scheme = uri[..schemeEnd];
+        var rest = uri[(schemeEnd + 1)..];
+
+        var fragment = (string?)null;
+        var fragmentStart = rest.IndexOf('#');
+        if (fragmentStart >= 0)
+        {
+            fragment = rest[(fragmentStart + 1)..];
+            rest = rest[..fragmentStart];
+        }
+
+        var query = (string?)null;
+        var queryStart = rest.IndexOf('?');
+        if (queryStart >= 0)
+        {
+            query = rest[(queryStart + 1)..];
+            rest = rest[..queryStart];
+        }
+
+        if (!rest.StartsWith("//", StringComparison.Ordinal))
+        {
+            parsed = new ParsedUri(
+                Opaque: true, scheme, Username: null, Password: null, Hostname: null,
+                Path: rest.Length == 0 ? null : rest, query, fragment, Port: 0);
+            return true;
+        }
+
+        var authority = rest[2..];
+        var path = (string?)null;
+        var pathStart = authority.IndexOf('/');
+        if (pathStart >= 0)
+        {
+            path = authority[pathStart..];
+            authority = authority[..pathStart];
+        }
+
+        var username = (string?)null;
+        var password = (string?)null;
+        var userInfoEnd = authority.LastIndexOf('@');
+        if (userInfoEnd >= 0)
+        {
+            var userInfo = authority[..userInfoEnd];
+            authority = authority[(userInfoEnd + 1)..];
+            var passwordStart = userInfo.IndexOf(':');
+            if (passwordStart >= 0)
+            {
+                username = userInfo[..passwordStart];
+                password = userInfo[(passwordStart + 1)..];
+            }
+            else
+            {
+                username = userInfo;
+            }
+        }
+
+        var port = scheme.ToLowerInvariant() switch
+        {
+            "http" => (ushort)80,
+            "https" => (ushort)443,
+            _ => (ushort)0,
+        };
+        var portStart = authority.LastIndexOf(':');
+        if (portStart >= 0 && authority.IndexOf(']') < portStart)
+        {
+            if (!ushort.TryParse(authority[(portStart + 1)..], out port))
+            {
+                return false;
+            }
+
+            authority = authority[..portStart];
+        }
+
+        parsed = new ParsedUri(
+            Opaque: false, scheme, username, password, authority,
+            path ?? "/", query, fragment, port);
+        return true;
+    }
+
+    private static bool TryReadNullTerminatedAscii(CpuContext ctx, ulong address, int maxLength, out string value)
+    {
+        value = string.Empty;
+        Span<byte> one = stackalloc byte[1];
+        var builder = new StringBuilder();
+        for (var index = 0; index < maxLength; index++)
+        {
+            if (!ctx.Memory.TryRead(address + (ulong)index, one))
+            {
+                return false;
+            }
+
+            if (one[0] == 0)
+            {
+                value = builder.ToString();
+                return true;
+            }
+
+            builder.Append((char)one[0]);
+        }
+
+        return false;
+    }
+
+    private static bool TryWriteUInt64(CpuContext ctx, ulong address, ulong value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+        return ctx.Memory.TryWrite(address, bytes);
     }
 
     private static void TraceHttp(string operation, int id, ulong arg0, ulong arg1, ulong arg2, ulong arg3)

--- a/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
@@ -1419,4 +1419,5 @@ public static class SaveDataExports
             return ctx.SetReturn(OrbisSaveDataErrorInternal);
         }
     }
+
 }

--- a/src/SharpEmu.Libs/Share/ShareExports.cs
+++ b/src/SharpEmu.Libs/Share/ShareExports.cs
@@ -12,6 +12,8 @@ public static class ShareExports
 
     private static int _initialized;
     private static string _contentParam = string.Empty;
+    private static ulong _contentEventCallback;
+    private static ulong _contentEventCallbackUserData;
 
     [SysAbiExport(
         Nid = "nBDD66kiFW8",
@@ -59,6 +61,42 @@ public static class ShareExports
         }
 
         TraceShare($"set_content_param len={contentParam.Length} preview='{FormatTraceString(contentParam)}'");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "0IL1keINExQ",
+        ExportName = "sceShareTerminate",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceShareUtility")]
+    public static int ShareTerminate(CpuContext ctx)
+    {
+        var wasInitialized = Interlocked.Exchange(ref _initialized, 0) != 0;
+        _contentEventCallback = 0;
+        _contentEventCallbackUserData = 0;
+
+        TraceShare(wasInitialized ? "terminate" : "terminate while not initialized");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "Sygnk9dr5WQ",
+        ExportName = "sceShareRegisterContentEventCallback",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceShareUtility")]
+    public static int ShareRegisterContentEventCallback(CpuContext ctx)
+    {
+        var callbackAddress = ctx[CpuRegister.Rdi];
+        var userDataAddress = ctx[CpuRegister.Rsi];
+        if (callbackAddress == 0)
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        _contentEventCallback = callbackAddress;
+        _contentEventCallbackUserData = userDataAddress;
+
+        TraceShare($"register_content_event_callback callback=0x{callbackAddress:X} userData=0x{userDataAddress:X}");
         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -197,6 +197,8 @@ public static class VideoOutExports
         public int FlipRate { get; set; }
         public ulong VblankCount { get; set; }
         public ulong FlipCount { get; set; }
+        public long LastCompletedFlipArg { get; set; } = -1;
+        public int PendingFlipCount { get; set; }
         public int CurrentBuffer { get; set; } = -1;
         public uint OutputWidth { get; set; } = 1920;
         public uint OutputHeight { get; set; } = 1080;
@@ -709,18 +711,36 @@ public static class VideoOutExports
         }
 
         ulong count;
+        long flipArg;
+        uint pendingFlips;
         uint currentBuffer;
         lock (_stateGate)
         {
             count = port.FlipCount;
+            flipArg = port.LastCompletedFlipArg;
+            pendingFlips = unchecked((uint)port.PendingFlipCount);
             currentBuffer = unchecked((uint)port.CurrentBuffer);
         }
 
+        // SceVideoOutFlipStatus (0x40 bytes): count, processTime, tsc, flipArg,
+        // submitTsc, reserved, gcQueueNum:s32, flipPendingNum:s32,
+        // currentBuffer:s32, reserved:u32. Every field must be written: the
+        // guest polls flipPendingNum/flipArg to pace its frame queue, and a
+        // stale value here parks the render loop forever.
+        var timestamp = unchecked((ulong)Stopwatch.GetTimestamp());
+        var processTimeMicroseconds =
+            unchecked((ulong)(Stopwatch.GetTimestamp() * 1_000_000L / Stopwatch.Frequency));
         KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x00, count);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x08, 0);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x10, 0);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x18, 0);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x20, currentBuffer);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x08, processTimeMicroseconds);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x10, timestamp);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x18, unchecked((ulong)flipArg));
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x20, timestamp);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x28, 0);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(
+            ctx,
+            statusAddress + 0x30,
+            (ulong)pendingFlips << 32);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x38, currentBuffer);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -732,12 +752,16 @@ public static class VideoOutExports
     public static int VideoOutIsFlipPending(CpuContext ctx)
     {
         var handle = unchecked((int)ctx[CpuRegister.Rdi]);
-        if (!TryGetPort(handle, out _))
+        if (!TryGetPort(handle, out var port))
         {
             return OrbisVideoOutErrorInvalidHandle;
         }
 
-        ctx[CpuRegister.Rax] = 0;
+        lock (_stateGate)
+        {
+            ctx[CpuRegister.Rax] = unchecked((ulong)port.PendingFlipCount);
+        }
+
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -1158,7 +1182,7 @@ public static class VideoOutExports
             }
 
             port.CurrentBuffer = bufferIndex;
-            port.FlipCount++;
+            port.PendingFlipCount++;
             eventHint = SceVideoOutInternalEventFlip |
                 ((unchecked((ulong)flipArg) & 0x0000_FFFF_FFFF_FFFFUL) << 16);
             flipEventCount = port.FlipEvents.Count;
@@ -1193,6 +1217,19 @@ public static class VideoOutExports
 
         void TriggerFlipEvents()
         {
+            // The flip is complete from the guest's point of view: publish the
+            // retired flipArg and drop the pending count before waking waiters,
+            // so a woken poller of sceVideoOutGetFlipStatus sees fresh state.
+            lock (_stateGate)
+            {
+                port.FlipCount++;
+                port.LastCompletedFlipArg = flipArg;
+                if (port.PendingFlipCount > 0)
+                {
+                    port.PendingFlipCount--;
+                }
+            }
+
             if (flipEvents is null)
             {
                 return;

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1591,6 +1591,14 @@ internal static unsafe class VulkanVideoPresenter
 
             var version = ++_orderedGuestFlipVersionSequence;
             _lastOrderedGuestFlipVersions[(videoOutHandle, displayBufferIndex)] = version;
+            // Progress markers: run-over-run comparable milestones ("did this fix
+            // get us further?") without per-flip spam once rendering is steady.
+            if (version is 1 or 10 or 100 or 1000 || version % 5000 == 0)
+            {
+                Console.Error.WriteLine(
+                    $"[PROGRESS] guest_flip #{version} handle=0x{videoOutHandle:X} " +
+                    $"buffer={displayBufferIndex} {width}x{height}");
+            }
             return EnqueueGuestWorkLocked(
                 new VulkanOrderedGuestFlip(
                     version,
@@ -1658,21 +1666,10 @@ internal static unsafe class VulkanVideoPresenter
         }
     }
 
-    internal static ulong GetGuestImageByteCount(uint format, uint width, uint height)
-    {
-        var blockBytes = format switch
-        {
-            169 or 170 or 175 or 176 => 8UL,
-            171 or 172 or 173 or 174 or
-            177 or 178 or 179 or 180 or 181 or 182 => 16UL,
-            _ => 0UL,
-        };
-        if (blockBytes != 0)
-        {
-            return checked(((ulong)width + 3) / 4 * (((ulong)height + 3) / 4) * blockBytes);
-        }
-
-        var bytesPerPixel = format switch
+    // Per-format byte cost. Formats 16/17/19 (B5G6R5/R5G5B5A1/R4G4B4A4-class 16-bit
+    // packed formats) are 2 bytes/pixel, not the 4-byte default — see PR #395.
+    internal static ulong GetGuestTextureBytesPerPixel(uint format) =>
+        format switch
         {
             1 => 1UL,
             2 or 3 or 16 or 17 or 19 => 2UL,
@@ -1681,7 +1678,21 @@ internal static unsafe class VulkanVideoPresenter
             14 => 16UL,
             _ => 4UL,
         };
-        return checked((ulong)width * height * bytesPerPixel);
+
+    internal static ulong GetGuestTextureByteCount(uint format, uint width, uint height)
+    {
+        // BC1 (169/170) and BC4 (175/176) are 8 bytes per 4x4 block;
+        // BC2/BC3/BC5/BC6H/BC7 are 16 bytes per block.
+        var blockBytes = format switch
+        {
+            169 or 170 or 175 or 176 => 8UL,
+            171 or 172 or 173 or 174 or
+            177 or 178 or 179 or 180 or 181 or 182 => 16UL,
+            _ => 0UL,
+        };
+        return blockBytes == 0
+            ? checked((ulong)width * height * GetGuestTextureBytesPerPixel(format))
+            : checked(((ulong)width + 3) / 4 * (((ulong)height + 3) / 4) * blockBytes);
     }
 
     private static byte[]? TakeGuestImageInitialData(ulong address)
@@ -3178,17 +3189,16 @@ internal static unsafe class VulkanVideoPresenter
             if (_window is not null)
             {
                 LogGlfwPlatformInUse();
-                if (!OperatingSystem.IsWindows())
+                // On Windows the pad itself is fed by GetAsyncKeyState (WindowsHostInput);
+                // the window events still matter there for the overlay KEY line and F1.
+                try
                 {
-                    try
-                    {
-                        Pad.HostWindowInput.Attach(_window.CreateInput());
-                        Console.Error.WriteLine("[LOADER][INFO] Window keyboard input attached for pad emulation.");
-                    }
-                    catch (Exception exception)
-                    {
-                        Console.Error.WriteLine($"[LOADER][WARN] Window keyboard input unavailable: {exception.Message}");
-                    }
+                    Pad.HostWindowInput.Attach(_window.CreateInput());
+                    Console.Error.WriteLine("[LOADER][INFO] Window keyboard input attached for pad emulation.");
+                }
+                catch (Exception exception)
+                {
+                    Console.Error.WriteLine($"[LOADER][WARN] Window keyboard input unavailable: {exception.Message}");
                 }
 
                 if (PngSplashLoader.TryLoadIcon(out var iconPixels, out var iconWidth, out var iconHeight))
@@ -9165,29 +9175,10 @@ internal static unsafe class VulkanVideoPresenter
         }
 
         private static ulong GetTextureBytesPerPixel(uint format) =>
-            format switch
-            {
-                1 => 1UL,
-                2 => 2UL,
-                3 => 2UL,
-                4 => 4UL,
-                5 => 4UL,
-                6 => 4UL,
-                7 => 4UL,
-                9 => 4UL,
-                10 => 4UL,
-                11 => 8UL,
-                12 => 8UL,
-                13 => 12UL,
-                14 => 16UL,
-                16 => 2UL,
-                17 => 2UL,
-                19 => 2UL,
-                _ => 4UL,
-            };
+            VulkanVideoPresenter.GetGuestTextureBytesPerPixel(format);
 
-        private static ulong GetTextureByteCount(uint format, uint width, uint height)
-            => GetGuestImageByteCount(format, width, height);
+        private static ulong GetTextureByteCount(uint format, uint width, uint height) =>
+            VulkanVideoPresenter.GetGuestTextureByteCount(format, width, height);
 
         private static ulong GetVulkanImageByteCount(Format format, uint width, uint height)
         {
@@ -10410,7 +10401,7 @@ internal static unsafe class VulkanVideoPresenter
                     TakeGuestImageInitialData(work.Targets[index].Address) is { } initialData &&
                     !targets[index].Initialized &&
                     (ulong)initialData.Length ==
-                        GetTextureByteCount(
+                        VulkanVideoPresenter.GetGuestTextureByteCount(
                             targetDescriptor.Format,
                             targets[index].Width,
                             targets[index].Height))

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanGuestImageByteCountTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanGuestImageByteCountTests.cs
@@ -20,7 +20,7 @@ public sealed class VulkanGuestImageByteCountTests
     {
         Assert.Equal(
             expected,
-            VulkanVideoPresenter.GetGuestImageByteCount(format, width, height));
+            VulkanVideoPresenter.GetGuestTextureByteCount(format, width, height));
     }
 
     [Theory]
@@ -34,6 +34,6 @@ public sealed class VulkanGuestImageByteCountTests
     {
         Assert.Equal(
             expected,
-            VulkanVideoPresenter.GetGuestImageByteCount(format, width, height));
+            VulkanVideoPresenter.GetGuestTextureByteCount(format, width, height));
     }
 }


### PR DESCRIPTION
## Before submitting

- [x] I have read the CONTRIBUTING guidelines.
- [x] My change follows the existing code style of the project.
- [x] I have tested my change locally.

## What does this PR do?

Fixes a set of hangs/crashes hit while getting Cult of the Lamb (PPSA06465) further into its boot sequence under SharpEmu:

- **ABBA lock inversion in `sceKernelWaitEventFlag`**: the wait path held the event flag's own gate while entering the scheduler gate, inverted relative to every wake path (scheduler gate first, then the flag's gate). This intermittently froze the whole scheduler, and the freeze vanished under tracing (which shifts timing), making it look non-reproducible.
- **Pluggable block-waiter describer registry** (`GuestThreadExecution`): each HLE sync primitive (event flag, mutex, semaphore) can now expose its object's state (bits/count/owner/waiters) in guest-thread snapshots, instead of relying on a single hardcoded describer.
- **Enriched mutex profiler** (`SHARPEMU_PROFILE_MUTEX`): owner thread, recursion count and waiter count per hot mutex, plus a time-based dump trigger so a stall (which collapses lock traffic) still produces a dump.
- **Stop-the-world suspend handshake bridge**: Unity's GC coordinator waits on `SuspendSemaphore` for one ack per GC-unsafe thread, but a thread parked in an unrelated HLE wait can never reach its safepoint to post one. A watchdog force-posts the missing acks once the count stalls ~1.5s (`SHARPEMU_SUSPEND_BRIDGE=0` to disable) — a thread blocked in HLE cannot touch the guest heap, so counting it as suspended is safe.
- **`sceHttpUriParse`**: real implementation (was unresolved, causing a null `SceHttpUriElement` dereference and an access violation around t=99s).
- **Crunch decoder null-mip recovery**: Cult of the Lamb's Unity Crunch texture decoder (`DoDeCruncherJob`) writes a decoded entry through a per-mip output pointer read from a local array on its own stack frame, and that slot is null for some textures (a guest-side data/logic issue — confirmed not a cross-thread race, since the array lives on the faulting call's own private stack). The VEH now redirects the write to a scratch buffer and lets the same instruction re-execute, discarding decoded texel data this title never had a real destination for (`SHARPEMU_DISABLE_CRUNCH_NULL_MIP_RECOVERY=1` to disable).
- `/dev/urandom` and `/dev/random` as virtual CSPRNG devices (mono/Unity opens them at boot for entropy).

## Testing

- Reproduced the ABBA deadlock and the GC-suspend stall in Cult of the Lamb before the fix; confirmed both no longer occur across repeated build+run cycles after the fix.
- Root-caused the Crunch decoder crash via Ghidra static analysis of the guest eboot (rebased at `0x800000000`) plus live diagnostic tracing of the faulting register/stack window, then validated the recovery crash-free across 3 heavy-trace runs (with the recovery counter firing and no further access violations at that RIP).
- Full solution build (`dotnet build SharpEmu.slnx -c Release`): clean.
- `dotnet test tests/SharpEmu.Libs.Tests`: 444/444 passing.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works (existing suite covers the touched HLE surfaces; the Crunch/deadlock fixes were validated via repeated emulator runs against the reproducing title as described above).
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation accordingly (n/a — internal HLE/CPU backend behavior, no user-facing docs affected).