### PR TITLE
loader: resolve param.json from the parent when the eboot is in a decrypted sidecar

### DIFF
--- a/src/SharpEmu.Core/Loader/SelfLoader.cs
+++ b/src/SharpEmu.Core/Loader/SelfLoader.cs
@@ -321,9 +321,40 @@ public sealed class SelfLoader : ISelfLoader
             return default;
         }
 
-        string[] possiblePaths = string.IsNullOrEmpty(mountRoot)
-            ? new[] { "sce_sys/param.json", "param.json" }
-            : new[] { $"{mountRoot}/sce_sys/param.json", $"{mountRoot}/param.json" };
+        var possiblePaths = new List<string>(4);
+        if (string.IsNullOrEmpty(mountRoot))
+        {
+            possiblePaths.Add("sce_sys/param.json");
+            possiblePaths.Add("param.json");
+        }
+        else
+        {
+            possiblePaths.Add($"{mountRoot}/sce_sys/param.json");
+            possiblePaths.Add($"{mountRoot}/param.json");
+
+            // Dump tools commonly place the decrypted eboot in a "decrypted"
+            // sidecar while leaving the real sce_sys/param.json (and the rest of
+            // the game data) in the parent app0 directory. BindApp0Root already
+            // mounts /app0 at that parent for the same layout; mirror it here so
+            // param.json resolution agrees with the guest filesystem mount
+            // instead of only searching the near-empty decrypted subfolder.
+            // Appended after the primary candidates, so packaged layouts that
+            // already resolve are unaffected (first match wins); the parent
+            // candidates take effect only when the decrypted folder lacks
+            // param.json and the parent actually has it.
+            if (string.Equals(
+                    Path.GetFileName(mountRoot),
+                    "decrypted",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                var parentRoot = Path.GetDirectoryName(mountRoot);
+                if (!string.IsNullOrEmpty(parentRoot))
+                {
+                    possiblePaths.Add($"{parentRoot}/sce_sys/param.json");
+                    possiblePaths.Add($"{parentRoot}/param.json");
+                }
+            }
+        }
 
         string? foundPath = null;
         foreach (var path in possiblePaths)

--- a/tests/SharpEmu.Libs.Tests/Loader/SelfLoaderTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Loader/SelfLoaderTests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Buffers.Binary;
+using System.Text;
+using SharpEmu.Core;
 using SharpEmu.Core.Loader;
 using SharpEmu.Core.Memory;
 using Xunit;
@@ -125,6 +127,121 @@ public sealed class SelfLoaderTests
         Assert.Equal(62, image.ElfHeader.Machine);
         Assert.Empty(image.ProgramHeaders);
         Assert.Empty(image.MappedRegions);
+    }
+
+    [Fact]
+    public void Load_ResolvesParamJsonFromParentWhenEbootIsInDecryptedSidecar()
+    {
+        // Dump layout: the decrypted eboot lives in <root>/decrypted, but the
+        // real param.json sits in the parent <root>/sce_sys. mountRoot is the
+        // decrypted folder, so only the parent candidate can resolve it.
+        var imageData = new byte[ElfHeaderSize];
+        WriteMinimalElfHeader(imageData);
+        var fs = new FakeFileSystem();
+        fs.AddParamJson(
+            "C:/game/sce_sys/param.json",
+            titleId: "PPSA12345",
+            titleName: "Sidecar Title",
+            contentVersion: "01.002.000");
+
+        var image = new SelfLoader().Load(
+            imageData,
+            new VirtualMemory(),
+            fs,
+            mountRoot: "C:/game/decrypted");
+
+        Assert.Equal("Sidecar Title", image.Title);
+        Assert.Equal("PPSA12345", image.TitleId);
+        Assert.Equal("01.002.000", image.Version);
+    }
+
+    [Fact]
+    public void Load_PrefersDecryptedParamJsonOverParentWhenBothExist()
+    {
+        // First match wins: a param.json inside the decrypted folder itself must
+        // still take precedence over the parent fallback, so this change never
+        // reroutes a layout that already resolved.
+        var imageData = new byte[ElfHeaderSize];
+        WriteMinimalElfHeader(imageData);
+        var fs = new FakeFileSystem();
+        fs.AddParamJson(
+            "C:/game/decrypted/sce_sys/param.json",
+            titleId: "PPSA00001",
+            titleName: "Decrypted Title",
+            contentVersion: "01.000.000");
+        fs.AddParamJson(
+            "C:/game/sce_sys/param.json",
+            titleId: "PPSA99999",
+            titleName: "Parent Title",
+            contentVersion: "09.000.000");
+
+        var image = new SelfLoader().Load(
+            imageData,
+            new VirtualMemory(),
+            fs,
+            mountRoot: "C:/game/decrypted");
+
+        Assert.Equal("Decrypted Title", image.Title);
+        Assert.Equal("PPSA00001", image.TitleId);
+    }
+
+    [Fact]
+    public void Load_DoesNotSearchParentWhenMountRootIsNotDecryptedSidecar()
+    {
+        // A normal (non-"decrypted") mount root must not gain the parent
+        // fallback: a param.json one level up is unrelated and must not be
+        // adopted. The load resolves nothing and Title stays null.
+        var imageData = new byte[ElfHeaderSize];
+        WriteMinimalElfHeader(imageData);
+        var fs = new FakeFileSystem();
+        fs.AddParamJson(
+            "C:/game/sce_sys/param.json",
+            titleId: "PPSA55555",
+            titleName: "Parent Title",
+            contentVersion: "01.000.000");
+
+        var image = new SelfLoader().Load(
+            imageData,
+            new VirtualMemory(),
+            fs,
+            mountRoot: "C:/game/app");
+
+        Assert.Null(image.Title);
+        Assert.Null(image.TitleId);
+    }
+
+    private sealed class FakeFileSystem : IFileSystem
+    {
+        private readonly Dictionary<string, byte[]> _files = new(StringComparer.Ordinal);
+
+        // The production code composes parent candidates with Path.GetDirectoryName,
+        // which yields a backslash separator on Windows, while other candidates keep
+        // the forward slashes from mountRoot. The real OS treats both as equivalent,
+        // so normalize here to mirror that rather than fail on separator style.
+        private static string Normalize(string path) => path.Replace('\\', '/');
+
+        public void AddParamJson(string path, string titleId, string titleName, string contentVersion)
+        {
+            var json =
+                $"{{\"titleId\":\"{titleId}\",\"contentVersion\":\"{contentVersion}\"," +
+                $"\"localizedParameters\":{{\"defaultLanguage\":\"en-US\"," +
+                $"\"en-US\":{{\"titleName\":\"{titleName}\"}}}}}}";
+            _files[Normalize(path)] = Encoding.UTF8.GetBytes(json);
+        }
+
+        public bool Exists(string path) => _files.ContainsKey(Normalize(path));
+
+        public bool TryReadAllBytes(string path, out byte[] data)
+        {
+            if (_files.TryGetValue(Normalize(path), out var stored))
+            {
+                data = stored;
+                return true;
+            }
+
+            data = Array.Empty<byte>();
+            return false;
+        }
     }
 
     private static byte[] CreateSelfImage(uint magic, byte version, uint keyType, ushort flags)


### PR DESCRIPTION
## Summary

When a game is launched from a decrypted-eboot sidecar layout — the decrypted
executable in `<root>/decrypted/`, but the real game data (`sce_sys/param.json`,
`Media`, etc.) in the parent `<root>/` — the loader failed to find `param.json`
and logged `param.json not found (no root path / unknown layout)`. Title,
TitleId, and Version all came back unknown.

The cause was an inconsistency between two independent root resolutions:

- `BindApp0Root` (`SharpEmuRuntime`) already detects this layout and mounts
  `/app0` at the content-bearing **parent** directory.
- `TryLoadParamJson` (`SelfLoader`) only searched the eboot's own directory
  (the `decrypted` folder), which typically holds just the executable.

So `/app0` pointed at the parent while param.json lookup stayed pinned to the
sidecar — and the two disagreed.

## Change

`TryLoadParamJson` now appends parent-directory candidates when the mount root
is named `decrypted`, mirroring what `BindApp0Root` already does for the guest
filesystem mount. Restoring param.json resolution recovers Title/TitleId/Version,
which feed save-data paths, NP/trophy configuration, and PlayGo.

Covered by three regression tests: the sidecar case resolves from the parent, a decrypted-local param.json still wins over the parent, and a non-decrypted mount root does not gain the parent fallback.


## Testing

N/A

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
