### PR TITLE
docs: fix XML documentation references

### DIFF
--- a/src/SharpEmu.Core/Cpu/Emulation/BmiInstructionEmulator.cs
+++ b/src/SharpEmu.Core/Cpu/Emulation/BmiInstructionEmulator.cs
@@ -18,7 +18,7 @@ namespace SharpEmu.Core.Cpu.Emulation;
 /// The methods deliberately operate on plain integers rather than on the OS CONTEXT record so the
 /// semantics can be unit-tested in isolation; the unsafe register/memory plumbing lives in the
 /// backend adapter. Each method returns the result already masked to the operand width and, where
-/// the instruction is defined to touch flags, updates <paramref name="eflags"/> in place. Flags
+/// the instruction is defined to touch flags, updates the <c>eflags</c> argument in place. Flags
 /// documented as "undefined" by the vendor manuals are left untouched so behaviour stays
 /// deterministic across hosts.
 /// </summary>

--- a/src/SharpEmu.HLE/Host/Posix/PosixHostInput.cs
+++ b/src/SharpEmu.HLE/Host/Posix/PosixHostInput.cs
@@ -7,7 +7,7 @@ namespace SharpEmu.HLE.Host.Posix;
 /// Bridges a window-provided input source into the host input seam. POSIX
 /// hosts have no user32/XInput/raw-HID readers; keyboard and gamepad state
 /// come from the presenter's GLFW window instead, which registers itself via
-/// <see cref="SetSource"/> once the window exists. Until then (and with no
+/// <see cref="PosixHostInput.SetSource(IPosixWindowInputSource)"/> once the window exists. Until then (and with no
 /// window at all, e.g. headless runs) every query reports neutral input.
 /// Rumble and lightbar are unsupported by the GLFW input layer and no-op.
 /// </summary>


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [CONTRIBUTING.md](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Changes

The `BmiInstructionEmulator` class documentation referenced `eflags` using `paramref`, even though it is not a parameter of the documented class.
The `PosixHostInput` documentation used an unresolved reference to `SetSource`. The reference now includes the declaring type and parameter type so the compiler can resolve it correctly.
These changes affect documentation only and do not change emulator behavior.

## Testing

- Game testing: N/A, because this change only affects documentation.
- `dotnet build`: passed.
- `dotnet test`: passed.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed [CONTRIBUTING.md](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md).
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).