### PR TITLE
ci: execute translated shader on Vulkan

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -203,6 +203,21 @@ jobs:
             "$SPIRV_TARGET_ENV" \
             artifacts/shader-dump
 
+      - name: Execute synthetic shader through Vulkan
+        if: matrix.rid == 'linux-x64'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends mesa-vulkan-drivers
+
+          lavapipe_icd="$(find /usr/share/vulkan/icd.d -maxdepth 1 -type f -name 'lvp_icd*.json' -print -quit)"
+          test -n "$lavapipe_icd"
+
+          VK_DRIVER_FILES="$lavapipe_icd" \
+            dotnet run \
+              --project tools/SharpEmu.Tools.GpuConformance/SharpEmu.Tools.GpuConformance.csproj \
+              -c Release -- artifacts/shader-dump/exec-cs.spv
+
       - name: Publish ${{ matrix.rid }} CLI
         run: dotnet publish src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r ${{ matrix.rid }} --self-contained true --no-restore -p:PublishDir="$PUBLISH_DIR"
 

--- a/tools/SharpEmu.Tools.GpuConformance/Program.cs
+++ b/tools/SharpEmu.Tools.GpuConformance/Program.cs
@@ -76,17 +76,20 @@ unsafe
     Check(vk.CreateInstance(in instanceInfo, null, out var instance), "vkCreateInstance");
 
     uint deviceCount = 0;
-    vk.EnumeratePhysicalDevices(instance, &deviceCount, null);
+    Check(
+        vk.EnumeratePhysicalDevices(instance, &deviceCount, null),
+        "vkEnumeratePhysicalDevices(count)");
     if (deviceCount == 0)
     {
-        Console.WriteLine("no Vulkan devices found");
-        return;
+        throw new InvalidOperationException("no Vulkan devices found");
     }
 
     var physicalDevices = new PhysicalDevice[deviceCount];
     fixed (PhysicalDevice* pDevices = physicalDevices)
     {
-        vk.EnumeratePhysicalDevices(instance, &deviceCount, pDevices);
+        Check(
+            vk.EnumeratePhysicalDevices(instance, &deviceCount, pDevices),
+            "vkEnumeratePhysicalDevices(devices)");
     }
 
     // Prefer the first discrete GPU; fall back to the first device.


### PR DESCRIPTION
## Before submitting

I read and followed [CONTRIBUTING.md](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md).

## What changed

- The Linux CI job now installs Mesa Vulkan drivers and runs the existing GPU conformance tool through Lavapipe.
- The conformance tool now checks the result of Vulkan device enumeration and fails if no Vulkan device is available.

## Why

The CI already validated the generated SPIR-V, but it did not execute the shader. The existing GPU conformance tool can execute the shader and compare its output with CPU-computed reference values.

Running it with Lavapipe allows this test to run in Linux CI without requiring a physical GPU. Failing when no Vulkan device is found also prevents the test from reporting success without actually running.

## Impact

This only affects CI and the conformance tool. Emulator runtime behavior is unchanged.

## Testing

Game testing: N/A (CI/tooling only).

- `dotnet build SharpEmu.slnx -c Release --no-incremental` — passed, with the existing NGS2 CA2014 warning.
- `dotnet test SharpEmu.slnx -c Release --no-build` — 530 passed.
- ShaderDump followed by GpuConformance on NVIDIA RTX 4080 SUPER — all values matched.
- The same generated shader on Ubuntu WSL with forced Lavapipe — all values matched.
- `actionlint .github/workflows/workflow.yml` — passed.
- `git diff --check` — passed.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
