### PR TITLE
[Gpu] Stop retrying array uploads that overrun their allocation

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -221,6 +221,7 @@ public static partial class AgcExports
         (ulong Es, ulong State, ulong AliasAlignment),
         IGuestCompiledShader> _depthOnlyVertexShaderCache = new();
     private static readonly Dictionary<ulong, ulong> _shaderHeadersByCode = new();
+    private static readonly ConcurrentDictionary<ulong, byte> _arrayUploadUnsupported = new();
     private static readonly bool _traceAgc = string.Equals(
         Environment.GetEnvironmentVariable("SHARPEMU_LOG_AGC"),
         "1",
@@ -7984,7 +7985,8 @@ public static partial class AgcExports
             descriptor.Address != 0 &&
             (descriptor.Type == Gen5TextureType2DArray ||
              descriptor.Type == Gen5TextureType1DArray) &&
-            descriptor.Depth > 1;
+            descriptor.Depth > 1 &&
+            !_arrayUploadUnsupported.ContainsKey(descriptor.Address);
         var arrayUploadLayers = wantsArrayUpload ? descriptor.Depth : 1u;
 
         // Upload-known (not plain availability): the presenter's answer goes
@@ -8213,6 +8215,8 @@ public static partial class AgcExports
                     return true;
                 }
             }
+
+            _arrayUploadUnsupported.TryAdd(descriptor.Address, 0);
         }
 
         var source = new byte[(int)physicalSourceByteCount];


### PR DESCRIPTION
- [x] I have read and followed `CONTRIBUTING.md`.

Fix for the performance of Demon souls, some textureArray had wrong addressing which would in turn default ArrayLayers to 1 creating a key mismatch. The texture would then get cached as one layer while the next draw looks up its depth layer and would, it then reread and in a loop.

Tested on Demon Souls and Dreaming Sarah