### PR TITLE
[VideoOut] Write SceVideoOutFlipStatus fields at their documented offsets

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -198,6 +198,10 @@ public static class VideoOutExports
         public ulong VblankCount { get; set; }
         public ulong FlipCount { get; set; }
         public int CurrentBuffer { get; set; } = -1;
+
+        // The flip token the guest passed to its most recent flip submission,
+        // reported back through SceVideoOutFlipStatus.flipArg.
+        public long LastFlipArg { get; set; }
         public uint OutputWidth { get; set; } = 1920;
         public uint OutputHeight { get; set; } = 1080;
         public uint RefreshRate { get; set; } = 60;
@@ -710,17 +714,32 @@ public static class VideoOutExports
 
         ulong count;
         uint currentBuffer;
+        long flipArg;
         lock (_stateGate)
         {
             count = port.FlipCount;
             currentBuffer = unchecked((uint)port.CurrentBuffer);
+            flipArg = port.LastFlipArg;
         }
 
+        // SceVideoOutFlipStatus is a 0x40-byte struct:
+        //   0x00 count, 0x08 processTime, 0x10 tsc, 0x18 flipArg,
+        //   0x20 submitTsc, 0x28 reserved0, 0x30 gcQueueNum,
+        //   0x34 flipPendingNum, 0x38 currentBuffer, 0x3C reserved1.
+        // currentBuffer was being written at 0x20 (the submitTsc slot), so its
+        // real field at 0x38 stayed stale and the flipArg the guest submitted
+        // was never reported. Titles that read flipArg/currentBuffer from this
+        // struct therefore saw wrong values.
         KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x00, count);
         KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x08, 0);
         KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x10, 0);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x18, 0);
-        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x20, currentBuffer);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x18, unchecked((ulong)flipArg));
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x20, 0);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x28, 0);
+        // gcQueueNum (0x30) and flipPendingNum (0x34) together in one 64-bit
+        // write, then currentBuffer (0x38) with reserved1 (0x3C) zeroed above it.
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x30, 0);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x38, currentBuffer);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
@@ -1159,6 +1178,7 @@ public static class VideoOutExports
 
             port.CurrentBuffer = bufferIndex;
             port.FlipCount++;
+            port.LastFlipArg = flipArg;
             eventHint = SceVideoOutInternalEventFlip |
                 ((unchecked((ulong)flipArg) & 0x0000_FFFF_FFFF_FFFFUL) << 16);
             flipEventCount = port.FlipEvents.Count;

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VideoOutFlipStatusTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VideoOutFlipStatusTests.cs
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VideoOutFlipStatusTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong StatusAddress = MemoryBase + 0x100;
+    private const int SceVideoOutBusTypeMain = 0;
+
+    // SceVideoOutFlipStatus field offsets.
+    private const int CountOffset = 0x00;
+    private const int FlipArgOffset = 0x18;
+    private const int SubmitTscOffset = 0x20;
+    private const int CurrentBufferOffset = 0x38;
+
+    [Fact]
+    public void GetFlipStatus_WritesCurrentBufferAndFlipArgAtDocumentedOffsets()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        // Open a main video-out port; a freshly opened port has CurrentBuffer -1.
+        context[CpuRegister.Rdi] = 0; // userId
+        context[CpuRegister.Rsi] = SceVideoOutBusTypeMain;
+        context[CpuRegister.Rdx] = 0; // index
+        var handle = VideoOutExports.VideoOutOpen(context);
+        Assert.True(handle > 0);
+
+        // Sentinel-fill the status structure so a field the export fails to
+        // populate is distinguishable from one it deliberately writes.
+        var sentinel = new byte[0x40];
+        Array.Fill(sentinel, (byte)0xCC);
+        Assert.True(memory.TryWrite(StatusAddress, sentinel));
+
+        context[CpuRegister.Rdi] = (ulong)handle;
+        context[CpuRegister.Rsi] = StatusAddress;
+        Assert.Equal(0, VideoOutExports.VideoOutGetFlipStatus(context));
+
+        var buffer = new byte[0x40];
+        Assert.True(memory.TryRead(StatusAddress, buffer));
+
+        // count starts at 0.
+        Assert.Equal(0UL, BitConverter.ToUInt64(buffer, CountOffset));
+        // No flip submitted yet, so flipArg is 0 (not the sentinel).
+        Assert.Equal(0UL, BitConverter.ToUInt64(buffer, FlipArgOffset));
+        // currentBuffer must land in its own field (0x38), reported as -1.
+        Assert.Equal(0xFFFF_FFFFu, BitConverter.ToUInt32(buffer, CurrentBufferOffset));
+        // The submitTsc slot (0x20) must not be clobbered with currentBuffer,
+        // which is the bug this test guards against.
+        Assert.Equal(0UL, BitConverter.ToUInt64(buffer, SubmitTscOffset));
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

`sceVideoOutGetFlipStatus` fills a `SceVideoOutFlipStatus` structure for the guest. Comparing what it writes against the struct layout, two fields landed in the wrong place:

- `currentBuffer` was written at offset `0x20`, which is the `submitTsc` field. The real `currentBuffer` field at `0x38` was never written, so a guest reading it got leftover memory.
- `flipArg` (offset `0x18`) was always written as `0`, even after the guest had submitted a flip with a non-zero argument.

This corrects the offsets: `currentBuffer` is now written at `0x38`, the argument from the most recent flip submission is kept on the port and reported at `0x18`, and the remaining fields are written as `0` at their documented offsets.

It is a struct-layout correctness fix — the values a guest reads back from this structure are now correct. I did not observe it changing how far any title gets.

## Testing

- Dead Cells (PPSA15552) – Boots and runs the loading screen; no crashes and a steady ~59–60 fps with ~3377 draws per interval over 90 s, matching a run without this change (no regression).
- Full unit test suite passes (496 tests), including a new test asserting `currentBuffer` is written at offset `0x38` and the `submitTsc` slot at `0x20` is not overwritten.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
