### PR TITLE
Kernel FS: close guest→host sandbox escapes in the path resolver

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
@@ -267,6 +267,11 @@ public static partial class KernelMemoryCompatExports
         }
 
         var hostPath = ResolveGuestPath(guestPath);
+        if (string.IsNullOrEmpty(hostPath))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+        }
+
         try
         {
             using var stream = new FileStream(hostPath, FileMode.Open, FileAccess.Write, FileShare.ReadWrite);
@@ -310,6 +315,11 @@ public static partial class KernelMemoryCompatExports
 
         var fromHost = ResolveGuestPath(fromGuest);
         var toHost = ResolveGuestPath(toGuest);
+        if (string.IsNullOrEmpty(fromHost) || string.IsNullOrEmpty(toHost))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+        }
+
         try
         {
             if (Directory.Exists(fromHost))

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -4787,13 +4787,13 @@ public static partial class KernelMemoryCompatExports
         if (guestPath.StartsWith("/devlog/app/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["/devlog/app/".Length..]);
-            return Path.Combine(ResolveDevlogAppRoot(), relative);
+            return CombineWithinMount(ResolveDevlogAppRoot(), relative);
         }
 
         if (guestPath.StartsWith("devlog/app/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["devlog/app/".Length..]);
-            return Path.Combine(ResolveDevlogAppRoot(), relative);
+            return CombineWithinMount(ResolveDevlogAppRoot(), relative);
         }
 
         if (string.Equals(guestPath, "/devlog/app", StringComparison.OrdinalIgnoreCase) ||
@@ -4805,7 +4805,7 @@ public static partial class KernelMemoryCompatExports
         if (guestPath.StartsWith("/temp0/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["/temp0/".Length..]);
-            return Path.Combine(ResolveTemp0Root(), relative);
+            return CombineWithinMount(ResolveTemp0Root(), relative);
         }
 
         if (string.Equals(guestPath, "/temp0", StringComparison.OrdinalIgnoreCase))
@@ -4816,13 +4816,13 @@ public static partial class KernelMemoryCompatExports
         if (guestPath.StartsWith("/download0/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["/download0/".Length..]);
-            return Path.Combine(ResolveDownload0Root(), relative);
+            return CombineWithinMount(ResolveDownload0Root(), relative);
         }
 
         if (guestPath.StartsWith("download0/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["download0/".Length..]);
-            return Path.Combine(ResolveDownload0Root(), relative);
+            return CombineWithinMount(ResolveDownload0Root(), relative);
         }
 
         if (string.Equals(guestPath, "/download0", StringComparison.OrdinalIgnoreCase) ||
@@ -4834,13 +4834,13 @@ public static partial class KernelMemoryCompatExports
         if (guestPath.StartsWith("/hostapp/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["/hostapp/".Length..]);
-            return Path.Combine(ResolveHostappRoot(), relative);
+            return CombineWithinMount(ResolveHostappRoot(), relative);
         }
 
         if (guestPath.StartsWith("hostapp/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["hostapp/".Length..]);
-            return Path.Combine(ResolveHostappRoot(), relative);
+            return CombineWithinMount(ResolveHostappRoot(), relative);
         }
 
         if (string.Equals(guestPath, "/hostapp", StringComparison.OrdinalIgnoreCase) ||
@@ -4863,7 +4863,7 @@ public static partial class KernelMemoryCompatExports
                 guestPath.StartsWith("$\\", StringComparison.Ordinal))
             {
                 var relative = NormalizeMountRelativePath(guestPath[2..]);
-                return Path.Combine(app0Root, relative);
+                return CombineWithinMount(app0Root, relative);
             }
 
             if (string.Equals(guestPath, "/app0", StringComparison.OrdinalIgnoreCase) ||
@@ -4875,13 +4875,13 @@ public static partial class KernelMemoryCompatExports
             if (guestPath.StartsWith("/app0/", StringComparison.OrdinalIgnoreCase))
             {
                 var relative = NormalizeMountRelativePath(guestPath["/app0/".Length..]);
-                return Path.Combine(app0Root, relative);
+                return CombineWithinMount(app0Root, relative);
             }
 
             if (guestPath.StartsWith("app0/", StringComparison.OrdinalIgnoreCase))
             {
                 var relative = NormalizeMountRelativePath(guestPath["app0/".Length..]);
-                return Path.Combine(app0Root, relative);
+                return CombineWithinMount(app0Root, relative);
             }
 
             if (!Path.IsPathFullyQualified(guestPath) &&
@@ -4889,7 +4889,7 @@ public static partial class KernelMemoryCompatExports
                 !guestPath.StartsWith("\\", StringComparison.Ordinal))
             {
                 var relative = NormalizeMountRelativePath(guestPath);
-                return Path.Combine(app0Root, relative);
+                return CombineWithinMount(app0Root, relative);
             }
         }
 
@@ -5003,6 +5003,30 @@ public static partial class KernelMemoryCompatExports
         }
 
         return string.Join(Path.DirectorySeparatorChar, resolved);
+    }
+
+    // Combines a mount-relative guest path onto a built-in mount root and
+    // re-verifies the result stays under that root. NormalizeMountRelativePath
+    // strips "." / ".." but splits only on separators, so a drive-qualified
+    // token like "C:" survives as a segment; Path.Combine then DISCARDS the
+    // mount root because its second argument is drive-rooted, yielding a raw
+    // host path such as "C:\Windows\...". Re-resolving with Path.GetFullPath and
+    // checking containment (the same guard TryResolveRegisteredGuestMount uses)
+    // rejects that escape. Returns string.Empty on denial, which callers treat
+    // as an unresolved path.
+    private static string CombineWithinMount(string mountRoot, string relative)
+    {
+        var candidate = Path.GetFullPath(Path.Combine(mountRoot, relative));
+        var rootWithSeparator =
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(mountRoot)) +
+            Path.DirectorySeparatorChar;
+        if (!string.Equals(candidate, Path.GetFullPath(mountRoot), HostFsPathComparison) &&
+            !candidate.StartsWith(rootWithSeparator, HostFsPathComparison))
+        {
+            return string.Empty;
+        }
+
+        return candidate;
     }
 
     private static string ResolveDevlogAppRoot()

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -4785,9 +4785,20 @@ public static partial class KernelMemoryCompatExports
             return guestPath;
         }
 
-        if (TryResolveRegisteredGuestMount(guestPath, out var mountedPath))
+        if (TryResolveRegisteredGuestMount(guestPath, out var mountedPath, out var mountPrefixMatched))
         {
             return mountedPath;
+        }
+
+        // A registered mount claimed this path by prefix but denied it (failed
+        // containment or a reparse point inside the mount). That denial is
+        // authoritative: do NOT fall through to the built-in branches below,
+        // which could re-resolve an overlapping prefix (e.g. a registered
+        // "/app0" vs the built-in SHARPEMU_APP0_DIR branch) against a different
+        // root and turn the denial back into a resolution.
+        if (mountPrefixMatched)
+        {
+            return string.Empty;
         }
 
         if (guestPath.StartsWith("/devlog/app/", StringComparison.OrdinalIgnoreCase))
@@ -4908,9 +4919,13 @@ public static partial class KernelMemoryCompatExports
         return string.Empty;
     }
 
-    private static bool TryResolveRegisteredGuestMount(string guestPath, out string hostPath)
+    private static bool TryResolveRegisteredGuestMount(
+        string guestPath,
+        out string hostPath,
+        out bool mountPrefixMatched)
     {
         hostPath = string.Empty;
+        mountPrefixMatched = false;
         var normalizedGuestPath = NormalizeGuestStatCachePath(guestPath);
         if (normalizedGuestPath is null)
         {
@@ -4937,6 +4952,12 @@ public static partial class KernelMemoryCompatExports
         {
             return false;
         }
+
+        // A registered mount owns this prefix. Whatever the outcome below
+        // (containment or reparse denial), the caller must NOT fall through to a
+        // built-in branch for the same prefix, or a denied path could be
+        // re-resolved against a different root.
+        mountPrefixMatched = true;
 
         var relativePath = normalizedGuestPath[matchedMountPoint.Length..].TrimStart('/');
         string candidate;

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -4947,6 +4947,14 @@ public static partial class KernelMemoryCompatExports
             return false;
         }
 
+        // Textual containment does not follow symlinks/junctions; refuse a
+        // reparse point planted inside the mount that would redirect onto the
+        // host filesystem. See EscapesMountViaReparsePoint.
+        if (EscapesMountViaReparsePoint(Path.GetFullPath(matchedHostRoot), candidate))
+        {
+            return false;
+        }
+
         hostPath = candidate;
         return true;
     }
@@ -5026,7 +5034,66 @@ public static partial class KernelMemoryCompatExports
             return string.Empty;
         }
 
+        if (EscapesMountViaReparsePoint(Path.GetFullPath(mountRoot), candidate))
+        {
+            return string.Empty;
+        }
+
         return candidate;
+    }
+
+    // Lexical containment (Path.GetFullPath + StartsWith) proves the TEXTUAL
+    // path stays under the mount root, but it does not follow symlinks or
+    // Windows junctions. A malicious game dump can plant a reparse point inside
+    // an otherwise-contained mount (e.g. "/app0/link" -> "/") so that
+    // "/app0/link/etc/passwd" passes the textual check yet resolves onto the
+    // host filesystem. Walk each already-existing component from the mount root
+    // down to the candidate and refuse if any is a reparse point. Components
+    // that do not yet exist (e.g. an O_CREAT target and its parents) carry no
+    // link to follow and are simply skipped. Mirrors the reparse rejection in
+    // AvPlayerExports.TryResolveSandboxedFile.
+    private static bool EscapesMountViaReparsePoint(string mountRoot, string candidate)
+    {
+        var rootTrimmed = Path.TrimEndingDirectorySeparator(mountRoot);
+        if (string.Equals(candidate, rootTrimmed, HostFsPathComparison))
+        {
+            return false;
+        }
+
+        var relative = Path.GetRelativePath(rootTrimmed, candidate);
+        if (relative == "." || Path.IsPathRooted(relative) ||
+            relative.StartsWith("..", StringComparison.Ordinal))
+        {
+            // Not actually under the root (should have been caught lexically);
+            // treat as an escape rather than walk outside it.
+            return true;
+        }
+
+        var current = rootTrimmed;
+        foreach (var segment in relative.Split(
+                     Path.DirectorySeparatorChar,
+                     StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = Path.Combine(current, segment);
+            try
+            {
+                if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+                {
+                    return true;
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                // Component does not exist yet (create path); nothing to follow.
+                break;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                break;
+            }
+        }
+
+        return false;
     }
 
     private static string ResolveDevlogAppRoot()

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -1448,6 +1448,13 @@ public static partial class KernelMemoryCompatExports
         var hostPath = ResolveGuestPath(guestPath);
         var access = ResolveOpenAccess(flags);
         var mode = ResolveOpenMode(flags, access);
+        // A denied path (empty host path) must not reach FileStream, which would
+        // throw an ArgumentException the catch below does not cover.
+        if (string.IsNullOrEmpty(hostPath))
+        {
+            LogOpenTrace($"_open denied path='{guestPath}' flags=0x{flags:X8}");
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+        }
         try
         {
             if (Bink2MovieBridge.ShouldSkipGuestMovie(hostPath))
@@ -4886,7 +4893,13 @@ public static partial class KernelMemoryCompatExports
             }
         }
 
-        return guestPath;
+        // Default-deny: a guest path that matched no mount prefix must NOT be
+        // handed back verbatim as a host path. Returning it raw let any absolute
+        // guest path address the host filesystem directly ("/etc/passwd",
+        // "C:\\Windows\\...") because it is already fully qualified and skips the
+        // relative-path app0 fallback above. Callers treat an empty host path as
+        // "resolves to nothing" and fail the syscall with NOT_FOUND.
+        return string.Empty;
     }
 
     private static bool TryResolveRegisteredGuestMount(string guestPath, out string hostPath)

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -4933,9 +4933,23 @@ public static partial class KernelMemoryCompatExports
         }
 
         var relativePath = normalizedGuestPath[matchedMountPoint.Length..].TrimStart('/');
-        var candidate = Path.GetFullPath(Path.Combine(
-            matchedHostRoot,
-            NormalizeMountRelativePath(relativePath)));
+        string candidate;
+        try
+        {
+            candidate = Path.GetFullPath(Path.Combine(
+                matchedHostRoot,
+                NormalizeMountRelativePath(relativePath)));
+        }
+        catch (Exception ex) when (
+            ex is IOException or ArgumentException or NotSupportedException)
+        {
+            // The relative part comes from an untrusted guest path; a crafted
+            // over-long or invalid path can make GetFullPath throw. Fail closed
+            // rather than propagate out of ResolveGuestPath (which callers invoke
+            // outside their try blocks).
+            return false;
+        }
+
         var rootWithSeparator = Path.TrimEndingDirectorySeparator(matchedHostRoot) + Path.DirectorySeparatorChar;
         // Host-semantics comparison: an ignore-case check on a case-sensitive
         // host would let a relative path escape into a sibling directory that
@@ -5024,17 +5038,32 @@ public static partial class KernelMemoryCompatExports
     // as an unresolved path.
     private static string CombineWithinMount(string mountRoot, string relative)
     {
-        var candidate = Path.GetFullPath(Path.Combine(mountRoot, relative));
+        string fullRoot;
+        string candidate;
+        try
+        {
+            fullRoot = Path.GetFullPath(mountRoot);
+            candidate = Path.GetFullPath(Path.Combine(fullRoot, relative));
+        }
+        catch (Exception ex) when (
+            ex is IOException or ArgumentException or NotSupportedException)
+        {
+            // The relative part comes from an untrusted guest path; a crafted
+            // over-long or invalid path can make GetFullPath throw. Fail closed
+            // rather than propagate out of ResolveGuestPath (which callers invoke
+            // outside their try blocks).
+            return string.Empty;
+        }
+
         var rootWithSeparator =
-            Path.TrimEndingDirectorySeparator(Path.GetFullPath(mountRoot)) +
-            Path.DirectorySeparatorChar;
-        if (!string.Equals(candidate, Path.GetFullPath(mountRoot), HostFsPathComparison) &&
+            Path.TrimEndingDirectorySeparator(fullRoot) + Path.DirectorySeparatorChar;
+        if (!string.Equals(candidate, fullRoot, HostFsPathComparison) &&
             !candidate.StartsWith(rootWithSeparator, HostFsPathComparison))
         {
             return string.Empty;
         }
 
-        if (EscapesMountViaReparsePoint(Path.GetFullPath(mountRoot), candidate))
+        if (EscapesMountViaReparsePoint(fullRoot, candidate))
         {
             return string.Empty;
         }
@@ -5061,8 +5090,13 @@ public static partial class KernelMemoryCompatExports
         }
 
         var relative = Path.GetRelativePath(rootTrimmed, candidate);
-        if (relative == "." || Path.IsPathRooted(relative) ||
-            relative.StartsWith("..", StringComparison.Ordinal))
+        // A leading ".." segment means the candidate is not under the root. Match
+        // the segment precisely: bare ".." or a "../" prefix, NOT a legitimate
+        // file merely named "..foo". This branch is a defensive fallback (lexical
+        // containment already passed before it runs), so it fails closed.
+        if (relative == "." || relative == ".." || Path.IsPathRooted(relative) ||
+            relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
+            relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
         {
             // Not actually under the root (should have been caught lexically);
             // treat as an escape rather than walk outside it.
@@ -5082,14 +5116,21 @@ public static partial class KernelMemoryCompatExports
                     return true;
                 }
             }
-            catch (FileNotFoundException)
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
             {
                 // Component does not exist yet (create path); nothing to follow.
                 break;
             }
-            catch (DirectoryNotFoundException)
+            catch (Exception ex) when (
+                ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
             {
-                break;
+                // The path comes from an untrusted dump, so a crafted over-long,
+                // invalid-char, or unreadable intermediate component can make
+                // GetAttributes throw. Fail closed: if containment cannot be
+                // verified, treat it as an escape rather than let the exception
+                // crash the syscall (ResolveGuestPath runs outside the callers'
+                // try blocks).
+                return true;
             }
         }
 

--- a/tests/SharpEmu.Libs.Tests/Ampr/AprStreamingContractTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ampr/AprStreamingContractTests.cs
@@ -24,14 +24,25 @@ public sealed class AprStreamingContractTests
         const ulong destinationAddress = memoryBase + 0x2000;
         const ulong stackAddress = memoryBase + 0x3000;
         byte[] fileContents = [10, 11, 12, 13, 14, 15, 16, 17];
-        var hostPath = Path.GetTempFileName();
+        // The kernel FS resolver default-denies raw absolute host paths, so the
+        // guest addresses the file through a registered mount instead of handing
+        // in a bare host temp path.
+        var mountRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"sharpemu-apr-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(mountRoot);
+        var mountPoint = $"/sharpemu_apr_mnt_{Guid.NewGuid():N}";
+        const string fileName = "asset.bin";
+        var hostPath = Path.Combine(mountRoot, fileName);
+        var guestPath = $"{mountPoint}/{fileName}";
 
         try
         {
             File.WriteAllBytes(hostPath, fileContents);
+            KernelMemoryCompatExports.RegisterGuestPathMount(mountPoint, mountRoot);
             var memory = new FakeCpuMemory(memoryBase, 0x4000);
             var context = new CpuContext(memory, Generation.Gen5);
-            memory.WriteCString(pathAddress, hostPath);
+            memory.WriteCString(pathAddress, guestPath);
             WriteUInt64(memory, pathListAddress, pathAddress);
 
             context[CpuRegister.Rdi] = pathListAddress;
@@ -86,7 +97,11 @@ public sealed class AprStreamingContractTests
         }
         finally
         {
-            File.Delete(hostPath);
+            KernelMemoryCompatExports.UnregisterGuestPathMount(mountPoint);
+            if (Directory.Exists(mountRoot))
+            {
+                Directory.Delete(mountRoot, recursive: true);
+            }
         }
     }
 

--- a/tests/SharpEmu.Libs.Tests/Ampr/AprStreamingContractTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ampr/AprStreamingContractTests.cs
@@ -171,19 +171,29 @@ public sealed class AprStreamingContractTests
         const ulong sizesAddress = memoryBase + 0x880;
         const ulong errorIndexAddress = memoryBase + 0x8F0;
         byte[] fileContents = [1, 2, 3, 4, 5];
-        var hostPath = Path.GetTempFileName();
-        var missingHostPath = Path.Combine(
+        // Entries 0 and 2 must resolve to a real file; the kernel FS resolver
+        // default-denies raw absolute host paths, so the present file is reached
+        // through a registered mount. The missing entry stays an unresolvable
+        // path so the batch fails mid-way at index 1.
+        var mountRoot = Path.Combine(
             Path.GetTempPath(),
-            $"sharpemu-apr-missing-{Guid.NewGuid():N}.bin");
+            $"sharpemu-apr-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(mountRoot);
+        var mountPoint = $"/sharpemu_apr_mnt_{Guid.NewGuid():N}";
+        const string fileName = "asset.bin";
+        var hostPath = Path.Combine(mountRoot, fileName);
+        var guestPath = $"{mountPoint}/{fileName}";
+        var missingGuestPath = $"{mountPoint}/missing-{Guid.NewGuid():N}.bin";
 
         try
         {
             File.WriteAllBytes(hostPath, fileContents);
+            KernelMemoryCompatExports.RegisterGuestPathMount(mountPoint, mountRoot);
             var memory = new FakeCpuMemory(memoryBase, 0x4000);
             var context = new CpuContext(memory, Generation.Gen5);
-            memory.WriteCString(memoryBase + 0x200, hostPath);
-            memory.WriteCString(memoryBase + 0x400, missingHostPath);
-            memory.WriteCString(memoryBase + 0x600, hostPath);
+            memory.WriteCString(memoryBase + 0x200, guestPath);
+            memory.WriteCString(memoryBase + 0x400, missingGuestPath);
+            memory.WriteCString(memoryBase + 0x600, guestPath);
             WriteUInt64(memory, pathListAddress, memoryBase + 0x200);
             WriteUInt64(memory, pathListAddress + 8, memoryBase + 0x400);
             WriteUInt64(memory, pathListAddress + 16, memoryBase + 0x600);
@@ -207,7 +217,11 @@ public sealed class AprStreamingContractTests
         }
         finally
         {
-            File.Delete(hostPath);
+            KernelMemoryCompatExports.UnregisterGuestPathMount(mountPoint);
+            if (Directory.Exists(mountRoot))
+            {
+                Directory.Delete(mountRoot, recursive: true);
+            }
         }
     }
 

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
@@ -163,4 +163,25 @@ public sealed class KernelSandboxEscapeTests : IDisposable
         var rootWithSep = Path.TrimEndingDirectorySeparator(_app0Root) + Path.DirectorySeparatorChar;
         Assert.StartsWith(rootWithSep, Path.GetFullPath(resolved));
     }
+
+    // The containment guard resolves paths via Path.GetFullPath / File.GetAttributes,
+    // which throw on a crafted over-long or invalid path. Because ResolveGuestPath
+    // runs outside the callers' try blocks, an uncaught throw would crash the
+    // syscall on untrusted input. The resolver must instead fail closed: return an
+    // empty host path (which callers map to NOT_FOUND), never throw.
+    [Theory]
+    [InlineData("/app0/")]     // filled with a long segment below
+    [InlineData("/app0/bad\0name")]
+    public void ResolveGuestPath_MalformedPathUnderMountFailsClosed(string prefix)
+    {
+        var guestPath = prefix.EndsWith('/')
+            ? prefix + new string('a', 40_000)
+            : prefix;
+
+        // The contract is "no throw"; denial (empty) is the expected outcome, but
+        // a contained resolution would also be acceptable as long as it doesn't crash.
+        var resolved = KernelMemoryCompatExports.ResolveGuestPath(guestPath);
+
+        Assert.NotNull(resolved);
+    }
 }

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
@@ -47,17 +47,35 @@ public sealed class KernelSandboxEscapeTests : IDisposable
     }
 
     // Finding #1: an absolute guest path that matches no mount prefix used to be
-    // returned verbatim, letting the guest open arbitrary host files.
+    // returned verbatim, letting the guest open arbitrary host files. These forms
+    // are absolute (or a UNC/backslash root) on every host, so they are denied
+    // everywhere.
     [Theory]
     [InlineData("/etc/passwd")]
     [InlineData("/etc/shadow")]
     [InlineData("/root/.ssh/id_rsa")]
-    [InlineData("C:\\Windows\\System32\\drivers\\etc\\hosts")]
     [InlineData("\\\\server\\share\\secret")]
     [InlineData("/proc/self/mem")]
     public void ResolveGuestPath_UnmappedAbsolutePathIsDenied(string guestPath)
     {
         Assert.Equal(string.Empty, KernelMemoryCompatExports.ResolveGuestPath(guestPath));
+    }
+
+    // A Windows drive-qualified path (e.g. "C:\Windows\...") is only absolute on
+    // Windows. On Unix "C:" is an ordinary relative filename, so the resolver
+    // legitimately contains it under app0 rather than denying it; this escape is
+    // therefore Windows-specific.
+    [Fact]
+    public void ResolveGuestPath_UnmappedWindowsDrivePathIsDenied()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Assert.Equal(
+            string.Empty,
+            KernelMemoryCompatExports.ResolveGuestPath("C:\\Windows\\System32\\drivers\\etc\\hosts"));
     }
 
     // A recognized mount prefix must still resolve to a path under its root, so

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
@@ -1,0 +1,67 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+// The kernel path resolver is the guest->host sandbox boundary: every real
+// file syscall (open/stat/unlink/mkdir/rmdir/rename/chmod) maps a guest path
+// to a host path through KernelMemoryCompatExports.ResolveGuestPath and then
+// hands the result straight to the host filesystem. These tests pin the
+// containment guarantees: an unmapped or absolute guest path must resolve to
+// nothing (default-deny), and a mount-relative path must never escape its root.
+[Collection(KernelMemoryCompatStateCollection.Name)]
+public sealed class KernelSandboxEscapeTests : IDisposable
+{
+    private readonly string? _originalApp0;
+    private readonly string _tempRoot;
+    private readonly string _app0Root;
+
+    public KernelSandboxEscapeTests()
+    {
+        _originalApp0 = Environment.GetEnvironmentVariable("SHARPEMU_APP0_DIR");
+        _tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"sharpemu-sandbox-{Guid.NewGuid():N}");
+        _app0Root = Path.Combine(_tempRoot, "app0");
+        Directory.CreateDirectory(_app0Root);
+        Environment.SetEnvironmentVariable("SHARPEMU_APP0_DIR", _app0Root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("SHARPEMU_APP0_DIR", _originalApp0);
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    // Finding #1: an absolute guest path that matches no mount prefix used to be
+    // returned verbatim, letting the guest open arbitrary host files.
+    [Theory]
+    [InlineData("/etc/passwd")]
+    [InlineData("/etc/shadow")]
+    [InlineData("/root/.ssh/id_rsa")]
+    [InlineData("C:\\Windows\\System32\\drivers\\etc\\hosts")]
+    [InlineData("\\\\server\\share\\secret")]
+    [InlineData("/proc/self/mem")]
+    public void ResolveGuestPath_UnmappedAbsolutePathIsDenied(string guestPath)
+    {
+        Assert.Equal(string.Empty, KernelMemoryCompatExports.ResolveGuestPath(guestPath));
+    }
+
+    // A recognized mount prefix must still resolve to a path under its root, so
+    // the default-deny does not regress legitimate access.
+    [Fact]
+    public void ResolveGuestPath_App0PathResolvesUnderApp0Root()
+    {
+        var resolved = KernelMemoryCompatExports.ResolveGuestPath("/app0/game.bin");
+
+        Assert.False(string.IsNullOrEmpty(resolved));
+        var rootWithSep = Path.TrimEndingDirectorySeparator(_app0Root) + Path.DirectorySeparatorChar;
+        Assert.StartsWith(rootWithSep, Path.GetFullPath(resolved));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
@@ -28,10 +28,17 @@ public sealed class KernelSandboxEscapeTests : IDisposable
         _app0Root = Path.Combine(_tempRoot, "app0");
         Directory.CreateDirectory(_app0Root);
         Environment.SetEnvironmentVariable("SHARPEMU_APP0_DIR", _app0Root);
+
+        // ResolveApp0Root caches _cachedApp0Root once, so a per-test env var is
+        // ignored after an earlier test populates it. Registering an explicit
+        // mount routes /app0 through the updatable mount table instead, which is
+        // the pattern KernelPathCaseSensitivityTests uses for the same reason.
+        KernelMemoryCompatExports.RegisterGuestPathMount("/app0", _app0Root);
     }
 
     public void Dispose()
     {
+        KernelMemoryCompatExports.UnregisterGuestPathMount("/app0");
         Environment.SetEnvironmentVariable("SHARPEMU_APP0_DIR", _originalApp0);
         if (Directory.Exists(_tempRoot))
         {
@@ -59,6 +66,51 @@ public sealed class KernelSandboxEscapeTests : IDisposable
     public void ResolveGuestPath_App0PathResolvesUnderApp0Root()
     {
         var resolved = KernelMemoryCompatExports.ResolveGuestPath("/app0/game.bin");
+
+        Assert.False(string.IsNullOrEmpty(resolved));
+        var rootWithSep = Path.TrimEndingDirectorySeparator(_app0Root) + Path.DirectorySeparatorChar;
+        Assert.StartsWith(rootWithSep, Path.GetFullPath(resolved));
+    }
+
+    // Drive-letter injection: NormalizeMountRelativePath clamps "." / ".." but
+    // splits only on separators, so a "C:" token survives as a segment.
+    // Path.Combine then discards the mount root because the tail is drive-rooted,
+    // yielding a raw host path. A resolved path outside the mount root must be
+    // denied. On non-Windows hosts "C:" is an ordinary directory name and stays
+    // contained, so this specifically pins the Windows escape.
+    [Theory]
+    [InlineData("app0/C:/Windows/Temp/evil.dll")]
+    [InlineData("/app0/C:/Windows/Temp/evil.dll")]
+    [InlineData("download0/C:/Windows/Temp/evil.dll")]
+    [InlineData("/temp0/C:/Windows/Temp/evil.dll")]
+    public void ResolveGuestPath_DriveLetterInjectionCannotEscapeMount(string guestPath)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var resolved = KernelMemoryCompatExports.ResolveGuestPath(guestPath);
+
+        // Either denied outright, or (defensively) still under a SharpEmu mount
+        // root — never a bare "C:\Windows\..." host path.
+        if (!string.IsNullOrEmpty(resolved))
+        {
+            Assert.DoesNotContain("Windows", Path.GetFullPath(resolved), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    // A "C:"-style token under app0 must resolve inside the app0 root, not to the
+    // host drive root.
+    [Fact]
+    public void ResolveGuestPath_DriveTokenStaysUnderApp0OnNonWindows()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var resolved = KernelMemoryCompatExports.ResolveGuestPath("/app0/C:/data.bin");
 
         Assert.False(string.IsNullOrEmpty(resolved));
         var rootWithSep = Path.TrimEndingDirectorySeparator(_app0Root) + Path.DirectorySeparatorChar;

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
@@ -116,4 +116,51 @@ public sealed class KernelSandboxEscapeTests : IDisposable
         var rootWithSep = Path.TrimEndingDirectorySeparator(_app0Root) + Path.DirectorySeparatorChar;
         Assert.StartsWith(rootWithSep, Path.GetFullPath(resolved));
     }
+
+    // Finding #3: lexical containment does not follow symlinks/junctions. A dump
+    // that plants a reparse point inside app0 pointing outside it must not let a
+    // guest path through it escape onto the host filesystem. Creating a symlink
+    // can require privilege (Windows without Developer Mode); skip if it fails.
+    [Fact]
+    public void ResolveGuestPath_ReparsePointInsideMountIsDenied()
+    {
+        var outsideDir = Path.Combine(_tempRoot, "outside");
+        Directory.CreateDirectory(outsideDir);
+        File.WriteAllBytes(Path.Combine(outsideDir, "secret.bin"), [1, 2, 3]);
+
+        var linkPath = Path.Combine(_app0Root, "link");
+        try
+        {
+            Directory.CreateSymbolicLink(linkPath, outsideDir);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Unprivileged host cannot create the link; nothing to assert.
+            return;
+        }
+
+        // Sanity: the link genuinely redirects outside the mount, so a resolver
+        // that followed it would reach the planted secret.
+        Assert.True(File.Exists(Path.Combine(linkPath, "secret.bin")));
+
+        var resolved = KernelMemoryCompatExports.ResolveGuestPath("/app0/link/secret.bin");
+
+        Assert.Equal(string.Empty, resolved);
+    }
+
+    // The reparse defense must not break a legitimate real (non-link) file that
+    // happens to sit deep under the mount root.
+    [Fact]
+    public void ResolveGuestPath_RealNestedFileUnderMountResolves()
+    {
+        var nested = Path.Combine(_app0Root, "a", "b");
+        Directory.CreateDirectory(nested);
+        File.WriteAllBytes(Path.Combine(nested, "c.bin"), [9]);
+
+        var resolved = KernelMemoryCompatExports.ResolveGuestPath("/app0/a/b/c.bin");
+
+        Assert.False(string.IsNullOrEmpty(resolved));
+        var rootWithSep = Path.TrimEndingDirectorySeparator(_app0Root) + Path.DirectorySeparatorChar;
+        Assert.StartsWith(rootWithSep, Path.GetFullPath(resolved));
+    }
 }

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelSandboxEscapeTests.cs
@@ -178,10 +178,11 @@ public sealed class KernelSandboxEscapeTests : IDisposable
             ? prefix + new string('a', 40_000)
             : prefix;
 
-        // The contract is "no throw"; denial (empty) is the expected outcome, but
-        // a contained resolution would also be acceptable as long as it doesn't crash.
+        // Fail closed: the resolver must return an empty host path (never throw,
+        // never a non-empty resolution). A 40k-char segment exceeds NAME_MAX on
+        // Linux and a NUL trips GetFullPath on Windows; both must deny.
         var resolved = KernelMemoryCompatExports.ResolveGuestPath(guestPath);
 
-        Assert.NotNull(resolved);
+        Assert.Equal(string.Empty, resolved);
     }
 }


### PR DESCRIPTION
## Summary

`KernelMemoryCompatExports.ResolveGuestPath` maps every guest file syscall
(`open`, `stat`, `unlink`, `mkdir`, `rmdir`, `rename`, `chmod`, APR resolve)
onto a host path, and callers pass that path straight to `FileStream` /
`File.*` / `Directory.*`. A security audit found the resolver was
**default-allow**: several classes of guest path escaped the mount sandbox
and reached arbitrary host files. Since guest paths originate from an
untrusted game dump, these are attacker-controlled.

This PR closes the escapes and hardens the resolver to fail closed.

## Vulnerabilities fixed

1. **Absolute-path passthrough (critical).** Any guest path matching no mount
   prefix was returned verbatim as a host path, so `open("/etc/passwd")` or
   `open("C:\Windows\System32\drivers\etc\hosts")` hit the real host file.
   The resolver now default-denies: unmapped paths resolve to empty, which
   callers map to `NOT_FOUND`.

2. **Windows drive-letter injection (critical).** The built-in mount branches
   combined the guest tail onto the mount root with `Path.Combine`, but a
   surviving `C:` segment made `Path.Combine` discard the root and yield a raw
   host path (`download0/C:/Windows/Temp/evil.dll` → arbitrary host write).
   All built-in branches now route through `CombineWithinMount`, which
   re-resolves with `Path.GetFullPath` and re-checks containment — the same
   guard the registered-mount path already used.

3. **Symlink/junction escape (high).** Lexical containment does not follow
   reparse points, so a dump that plants `link -> /` inside a mount let
   `open("/app0/link/etc/passwd")` escape. `EscapesMountViaReparsePoint` now
   walks each existing component below the mount root and rejects reparse
   points, mirroring the existing `AvPlayerExports` model.

## Hardening

- The containment guards call `Path.GetFullPath` / `File.GetAttributes` on
  untrusted input, which throw on crafted over-long or invalid-char paths.
  Because `ResolveGuestPath` runs outside the syscalls' try blocks, that was a
  guest-triggerable crash. All three resolution paths now **fail closed**:
  an access/format failure is treated as a denial, never propagated.
- The three syscalls whose catch blocks don't cover `ArgumentException`
  (`open`, `truncate`, `rename`) get an explicit empty-path guard so a denied
  path returns `NOT_FOUND` instead of throwing.
## Testing

No games tested.

- New `KernelSandboxEscapeTests` covering absolute-path denial, drive-letter
  injection, reparse-point escape, malformed-path fail-closed, plus positive
  tests confirming legitimate deep/nested mount access still resolves.
- Updated `AprStreamingContractTests`, which previously relied on the
  absolute-path passthrough being fixed — it now addresses the file through a
  registered mount, as a real guest would.

## Verification

- Build clean on .NET 10.
- Full `SharpEmu.Libs.Tests` suite passes (494 tests).


## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
