### PR TITLE
SaveData: handle Demon's Souls transaction resource call shape

### DIFF
--- a/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
@@ -787,6 +787,34 @@ public static class SaveDataExports
         LibraryName = "libSceSaveData")]
     public static int SaveDataCreateTransactionResource(CpuContext ctx)
     {
+        // Demon's Souls first-run call:
+        // RDI = 0xC0000, RSI = RDX + 8, RDX = resource output.
+        // Writing integer handle 1 makes the title dereference [1 + 8],
+        // causing the repeatable access violation at guest address 0x9.
+        var desWorkSize = ctx[CpuRegister.Rdi];
+        var desWorkAddress = ctx[CpuRegister.Rsi];
+        var desResourceAddress = ctx[CpuRegister.Rdx];
+
+        if (desWorkSize == 0xC0000 &&
+            desResourceAddress != 0 &&
+            desResourceAddress <= ulong.MaxValue - sizeof(ulong) &&
+            desWorkAddress == desResourceAddress + sizeof(ulong))
+        {
+            if (!ctx.TryWriteUInt64(desResourceAddress, 0))
+            {
+                return SetReturn(
+                    ctx,
+                    (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+
+            TraceSaveData(
+                $"create_transaction_resource_des_guard " +
+                $"work_size=0x{desWorkSize:X} " +
+                $"work=0x{desWorkAddress:X} " +
+                $"resource_addr=0x{desResourceAddress:X} resource=0x0");
+
+            return SetReturn(ctx, 0);
+        }
         var userId = unchecked((int)ctx[CpuRegister.Rdi]);
         var reserved = ctx[CpuRegister.Rsi];
 


### PR DESCRIPTION
## Summary

Demon's Souls crashes during the fresh-save initialization path after calling `sceSaveDataCreateTransactionResource`.

The current implementation writes a small integer transaction-resource handle to the guest output address. For the call shape observed in Demon's Souls, the game treats this value as a guest pointer and follows the field at `+0x08`.

When the first generated handle is `1`, this results in a read from address `0x9` and a `0xC0000005` access violation.

## Change

For the observed call shape:

- `RDI == 0xC0000`
- `RSI == RDX + 8`
- `RDX` contains the resource output address

The implementation writes a 64-bit null resource and returns success instead of exposing the small integer handle to the guest.

The existing transaction-resource behavior remains unchanged for all other call shapes.

## Before

With the Demon's Souls save-data directory removed, the game consistently crashed with:

```text
Guest RIP: 0x0000000800802683
RCX:       0x1
AV target: 0x9
Exception: 0xC0000005
```

## After

With the same fresh-save test, the game continued through:

```text
sceSaveDataCreateTransactionResource
sceSaveDataMount3
sceSaveDataSetParam
sceSaveDataCommit
Save Data dialog initialization
sceSaveDataDeleteTransactionResource
```

The previous access violation at guest address `0x9` no longer occurred.

## Testing

### Demon's Souls

- Title ID: `PPSA01341`
- Version: `01.004.000`
- Tested with the existing save-data directory removed
- First-run save path completed without the previous crash

### Dreaming Sarah

- Title ID: `PPSA02929`
- Booted and ran normally on the same build
- No regression was observed during testing

### Build

- Release `win-x64`

## Notes

This is intentionally a narrow compatibility guard for the confirmed call shape. It is not intended to be a complete implementation of the transaction-resource ABI.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).