### PR TITLE
[Shader] Reuse zero storage for unbound buffer fallbacks

### DIFF
--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -33,8 +33,9 @@ public static class Gen5ShaderScalarEvaluator
             Environment.GetEnvironmentVariable("SHARPEMU_STRICT_BUFFER_LOAD"),
             "1",
             StringComparison.Ordinal);
-    private static readonly object _scalarFallbackTraceGate = new();
+    private static readonly object _fallbackTraceGate = new();
     private static readonly HashSet<(ulong Shader, uint Pc)> _tracedScalarFallbacks = [];
+    private static readonly HashSet<(ulong Shader, uint Pc)> _tracedBufferFallbacks = [];
 
     // Uniform forward branches select material/resource bodies that remain
     // statically present in the translated shader. Discover the skipped body's
@@ -457,11 +458,12 @@ public static class Gen5ShaderScalarEvaluator
                             bufferMemory.ScalarResource,
                             0,
                             new List<uint> { instruction.Pc },
-                            new byte[sizeof(uint)],
+                            RentZeroedGlobalMemory(sizeof(uint)),
                             sizeof(uint),
-                            DataPooled: false)
+                            DataPooled: true)
                         {
                             Writable = writable,
+                            WriteBackToGuest = false,
                         };
                         globalMemoryByAddress.Add(nullKey, binding);
                         globalMemoryBindings.Add(binding);
@@ -542,7 +544,7 @@ public static class Gen5ShaderScalarEvaluator
                 }
                 else
                 {
-                    var dataPooled = true;
+                    var writeBackToGuest = true;
                     if (!TryReadGlobalMemory(
                             ctx,
                             bufferDescriptor.BaseAddress,
@@ -550,12 +552,11 @@ public static class Gen5ShaderScalarEvaluator
                             out var data,
                             out var dataLength))
                     {
-                        var descriptorWords = string.Join(
-                            ':',
-                            Enumerable.Range(0, 4).Select(index =>
-                                $"{scalarRegisters[bufferMemory.ScalarResource + (uint)index]:X8}"));
                         if (_strictBufferLoad)
                         {
+                            var descriptorWords = FormatBufferDescriptorWords(
+                                scalarRegisters,
+                                bufferMemory.ScalarResource);
                             error =
                                 $"buffer-memory-read-failed pc=0x{instruction.Pc:X} " +
                                 $"address=0x{bufferDescriptor.BaseAddress:X16} " +
@@ -568,14 +569,15 @@ public static class Gen5ShaderScalarEvaluator
                         dataLength = checked((int)Math.Min(
                             bufferDescriptor.SizeBytes,
                             (ulong)MaxGlobalMemoryBindingBytes));
-                        data = new byte[Math.Max(dataLength, sizeof(uint))];
-                        dataLength = data.Length;
-                        dataPooled = false;
-                        Console.Error.WriteLine(
-                            $"[LOADER][WARN] AGC buffer read unavailable; using zero buffer " +
-                            $"pc=0x{instruction.Pc:X} address=0x{bufferDescriptor.BaseAddress:X16} " +
-                            $"bytes={bufferDescriptor.SizeBytes} guest_writeback=disabled " +
-                            $"s{bufferMemory.ScalarResource}=[{descriptorWords}]");
+                        dataLength = Math.Max(dataLength, sizeof(uint));
+                        data = RentZeroedGlobalMemory(dataLength);
+                        writeBackToGuest = false;
+                        TraceBufferFallback(
+                            state,
+                            instruction,
+                            bufferMemory.ScalarResource,
+                            bufferDescriptor,
+                            scalarRegisters);
                     }
 
                     var binding = new Gen5GlobalMemoryBinding(
@@ -584,10 +586,10 @@ public static class Gen5ShaderScalarEvaluator
                         new List<uint> { instruction.Pc },
                         data,
                         dataLength,
-                        DataPooled: dataPooled)
+                        DataPooled: true)
                     {
                         Writable = writable,
-                        WriteBackToGuest = dataPooled,
+                        WriteBackToGuest = writeBackToGuest,
                     };
                     globalMemoryByAddress.Add(key, binding);
                     globalMemoryBindings.Add(binding);
@@ -988,6 +990,14 @@ public static class Gen5ShaderScalarEvaluator
     public static void EndGlobalMemoryReadScope()
     {
     }
+
+    private static byte[] RentZeroedGlobalMemory(int dataLength)
+    {
+        var data = GlobalMemoryPool.Rent(Math.Max(dataLength, sizeof(uint)));
+        data.AsSpan(0, Math.Max(dataLength, sizeof(uint))).Clear();
+        return data;
+    }
+
     private static bool TryReadGlobalMemory(
         CpuContext ctx,
         ulong baseAddress,
@@ -2066,7 +2076,7 @@ public static class Gen5ShaderScalarEvaluator
         ulong baseAddress,
         ulong dynamicOffset)
     {
-        lock (_scalarFallbackTraceGate)
+        lock (_fallbackTraceGate)
         {
             if (!_tracedScalarFallbacks.Add((state.Program.Address, instruction.Pc)))
             {
@@ -2102,6 +2112,37 @@ public static class Gen5ShaderScalarEvaluator
             $"user_data=[{userData}] metadata=" +
             $"{(state.Metadata is null ? "missing" : $"srt={state.Metadata.ShaderResourceTableSizeDwords},eud={state.Metadata.ExtendedUserDataSizeDwords}")}");
     }
+
+    private static void TraceBufferFallback(
+        Gen5ShaderState state,
+        Gen5ShaderInstruction instruction,
+        uint scalarResource,
+        BufferDescriptor descriptor,
+        IReadOnlyList<uint> scalarRegisters)
+    {
+        lock (_fallbackTraceGate)
+        {
+            if (!_tracedBufferFallbacks.Add((state.Program.Address, instruction.Pc)))
+            {
+                return;
+            }
+        }
+
+        Console.Error.WriteLine(
+            $"[LOADER][WARN] AGC buffer read unavailable; using zero buffer " +
+            $"shader=0x{state.Program.Address:X16} pc=0x{instruction.Pc:X} " +
+            $"address=0x{descriptor.BaseAddress:X16} bytes={descriptor.SizeBytes} " +
+            $"guest_writeback=disabled s{scalarResource}=" +
+            $"[{FormatBufferDescriptorWords(scalarRegisters, scalarResource)}]");
+    }
+
+    private static string FormatBufferDescriptorWords(
+        IReadOnlyList<uint> scalarRegisters,
+        uint scalarResource) =>
+        $"{scalarRegisters[(int)scalarResource]:X8}:" +
+        $"{scalarRegisters[(int)scalarResource + 1]:X8}:" +
+        $"{scalarRegisters[(int)scalarResource + 2]:X8}:" +
+        $"{scalarRegisters[(int)scalarResource + 3]:X8}";
 
     [Conditional("DEBUG")]
     private static void RunScalarLoadSelfChecks()

--- a/tests/SharpEmu.Libs.Tests/Agc/Gen5BufferFallbackPoolingTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/Gen5BufferFallbackPoolingTests.cs
@@ -1,0 +1,104 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class Gen5BufferFallbackPoolingTests
+{
+    private const ulong ShaderAddress = 0x2_0000_0000;
+    private const ulong UnmappedBufferAddress = 0x4_0000_0000;
+    private const int BufferSize = 1024 * 1024;
+
+    [Fact]
+    public void RepeatedUnmappedBufferFallbacksReuseZeroedTransferStorage()
+    {
+        var state = CreateBufferLoadState();
+        var ctx = new CpuContext(
+            new FakeCpuMemory(0x1_0000_0000, 0x1000),
+            Generation.Gen5);
+
+        var warmup = Evaluate(ctx, state);
+        var warmupBinding = Assert.Single(warmup.GlobalMemoryBindings);
+        Assert.True(warmupBinding.DataPooled);
+        Assert.False(warmupBinding.WriteBackToGuest);
+        Assert.Equal(BufferSize, warmupBinding.DataLength);
+        warmupBinding.Data.AsSpan(0, warmupBinding.DataLength).Fill(0xA5);
+        Gen5ShaderScalarEvaluator.GlobalMemoryPool.Return(warmupBinding.Data);
+
+        const int iterations = 12;
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var iteration = 0; iteration < iterations; iteration++)
+        {
+            var evaluation = Evaluate(ctx, state);
+            var binding = Assert.Single(evaluation.GlobalMemoryBindings);
+            Assert.True(binding.DataPooled);
+            Assert.False(binding.WriteBackToGuest);
+            Assert.Equal(BufferSize, binding.DataLength);
+            Assert.True(
+                binding.Data.AsSpan(0, binding.DataLength).IndexOfAnyExcept((byte)0) < 0,
+                "Synthetic fallback storage must be cleared after it is reused.");
+            Gen5ShaderScalarEvaluator.GlobalMemoryPool.Return(binding.Data);
+        }
+
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        Assert.True(
+            allocated < BufferSize,
+            $"Repeated fallbacks allocated {allocated:N0} bytes after pool warmup.");
+    }
+
+    private static Gen5ShaderEvaluation Evaluate(
+        CpuContext ctx,
+        Gen5ShaderState state)
+    {
+        Assert.True(
+            Gen5ShaderScalarEvaluator.TryEvaluate(
+                ctx,
+                state,
+                out var evaluation,
+                out var error),
+            error);
+        return evaluation;
+    }
+
+    private static Gen5ShaderState CreateBufferLoadState()
+    {
+        var load = new Gen5ShaderInstruction(
+            0,
+            Gen5ShaderEncoding.Mubuf,
+            "BufferLoadDword",
+            [],
+            [],
+            [],
+            new Gen5BufferMemoryControl(
+                1,
+                0,
+                0,
+                0,
+                0,
+                IndexEnabled: false,
+                OffsetEnabled: false,
+                Glc: false,
+                Slc: false));
+        var end = new Gen5ShaderInstruction(
+            4,
+            Gen5ShaderEncoding.Sopp,
+            "SEndpgm",
+            [],
+            [],
+            [],
+            null);
+        return new Gen5ShaderState(
+            new Gen5ShaderProgram(ShaderAddress, [load, end]),
+            [
+                unchecked((uint)UnmappedBufferAddress),
+                (uint)(UnmappedBufferAddress >> 32),
+                BufferSize,
+                0,
+            ],
+            null);
+    }
+}


### PR DESCRIPTION
## Before submitting

I read `CONTRIBUTING.md` and kept this change focused on one shader-evaluation fallback.

## What changed

A decoded buffer descriptor can temporarily point at memory SharpEmu cannot read. Non-strict mode intentionally keeps the pass alive by binding zero-filled storage, but that path allocated a fresh managed array on every evaluation. One fallback could allocate up to 16 MiB, and the same warning was formatted and written for every draw.

This PR:

- rents synthetic zero buffers from the existing bounded guest transfer pool;
- clears the active range before every use, so data from an earlier binding cannot leak;
- keeps synthetic storage shader-writable while explicitly disabling guest-memory writeback;
- applies the same ownership rules to null descriptors; and
- reports an unreadable descriptor once per shader instruction instead of once per draw.

This is not a persistent guest-buffer cache. Valid descriptors are still read from guest memory for every evaluation, so CPU writes cannot be hidden by stale cached contents.

## Why

The fallback is useful for optional resources and temporarily stale material descriptors, but it should be cheap after warmup. Repeated large `byte[]` allocations feed the LOH/GC and can become expensive in draw-heavy scenes. Pooling only the synthetic storage removes that pressure without changing which guest bytes a valid binding observes.

## Testing

- `dotnet restore SharpEmu.slnx --locked-mode`
- `dotnet build SharpEmu.slnx -c Release --no-restore` — 0 warnings, 0 errors
- `SharpEmu.Libs.Tests` — 512 passed
- `SharpEmu.SourceGenerators.Tests` — 33 passed
- `SharpEmu.ShaderCompiler.Metal.Tests` — 27 passed
- Added a regression test that repeatedly evaluates an unmapped 1 MiB descriptor. It dirties the returned array before reuse, verifies the next binding is fully zeroed and non-writeback, and keeps twelve warmed evaluations below 1 MiB of managed allocation.
- Real-game testing: N/A on my hardware. The automated Dead Cells/Dreaming Sarah run should provide the first gameplay regression check; an allocation-rate A/B in a title that exercises this fallback would be useful.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes as described above.
- [x] I reviewed and wrote the final pull request description myself.
- [x] I listed game testing as N/A and stated the validation still needed.