### PR TITLE
optimization: single-pass region-offset resolution on the memory access hot path

### DIFF
--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -931,13 +931,8 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         _gate.EnterReadLock();
         try
         {
-            var region = FindRegion(virtualAddress, (ulong)destination.Length);
-            if (region is not null &&
-                TryResolveRegionOffset(
-                    virtualAddress,
-                    (ulong)destination.Length,
-                    region,
-                    out var offset))
+            var region = FindRegion(virtualAddress, (ulong)destination.Length, out var offset);
+            if (region is not null)
             {
                 var srcPtr = (void*)(region.VirtualAddress + offset);
                 if (destination.IsEmpty)
@@ -994,13 +989,8 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         _gate.EnterReadLock();
         try
         {
-            var region = FindRegion(virtualAddress, (ulong)expected.Length);
-            if (region is null ||
-                !TryResolveRegionOffset(
-                    virtualAddress,
-                    (ulong)expected.Length,
-                    region,
-                    out var offset))
+            var region = FindRegion(virtualAddress, (ulong)expected.Length, out var offset);
+            if (region is null)
             {
                 return false;
             }
@@ -1045,13 +1035,8 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         _gate.EnterReadLock();
         try
         {
-            var region = FindRegion(virtualAddress, (ulong)source.Length);
-            if (region is not null &&
-                TryResolveRegionOffset(
-                    virtualAddress,
-                    (ulong)source.Length,
-                    region,
-                    out var offset))
+            var region = FindRegion(virtualAddress, (ulong)source.Length, out var offset);
+            if (region is not null)
             {
                 var destPtr = (void*)(region.VirtualAddress + offset);
                 if (source.IsEmpty)
@@ -1130,11 +1115,9 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         _gate.EnterReadLock();
         try
         {
-            var sourceRegion = FindRegion(sourceAddress, length);
-            var destinationRegion = FindRegion(destinationAddress, length);
-            if (sourceRegion is null || destinationRegion is null ||
-                !TryResolveRegionOffset(sourceAddress, length, sourceRegion, out var sourceOffset) ||
-                !TryResolveRegionOffset(destinationAddress, length, destinationRegion, out var destinationOffset))
+            var sourceRegion = FindRegion(sourceAddress, length, out var sourceOffset);
+            var destinationRegion = FindRegion(destinationAddress, length, out var destinationOffset);
+            if (sourceRegion is null || destinationRegion is null)
             {
                 return false;
             }
@@ -1168,13 +1151,8 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
 
     private bool TryReadExclusive(ulong virtualAddress, Span<byte> destination)
     {
-        var region = FindRegion(virtualAddress, (ulong)destination.Length);
-        if (region is not null &&
-            TryResolveRegionOffset(
-                virtualAddress,
-                (ulong)destination.Length,
-                region,
-                out var offset))
+        var region = FindRegion(virtualAddress, (ulong)destination.Length, out var offset);
+        if (region is not null)
         {
             var srcPtr = (void*)(region.VirtualAddress + offset);
             if (!EnsureRangeCommitted((ulong)srcPtr, (ulong)destination.Length, region))
@@ -1217,13 +1195,8 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
 
     private bool TryWriteExclusive(ulong virtualAddress, ReadOnlySpan<byte> source)
     {
-        var region = FindRegion(virtualAddress, (ulong)source.Length);
-        if (region is not null &&
-            TryResolveRegionOffset(
-                virtualAddress,
-                (ulong)source.Length,
-                region,
-                out var offset))
+        var region = FindRegion(virtualAddress, (ulong)source.Length, out var offset);
+        if (region is not null)
         {
             var destPtr = (void*)(region.VirtualAddress + offset);
             if (!EnsureRangeCommitted((ulong)destPtr, (ulong)source.Length, region))
@@ -1310,8 +1283,16 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         }
     }
 
-    private MemoryRegion? FindRegion(ulong address, ulong size)
+    private MemoryRegion? FindRegion(ulong address, ulong size) =>
+        FindRegion(address, size, out _);
+
+    // Locates the region containing [address, address+size) and reports the
+    // in-region byte offset in the same pass. Callers on the hot read/write path
+    // need that offset immediately, so returning it here avoids a second,
+    // identical TryResolveRegionOffset walk right after the lookup.
+    private MemoryRegion? FindRegion(ulong address, ulong size, out ulong offset)
     {
+        offset = 0;
         var low = 0;
         var high = _regions.Count - 1;
         MemoryRegion? candidate = null;
@@ -1331,7 +1312,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         }
 
         return candidate is not null &&
-            TryResolveRegionOffset(address, size, candidate, out _)
+            TryResolveRegionOffset(address, size, candidate, out offset)
                 ? candidate
                 : null;
     }


### PR DESCRIPTION
## Summary

The redundancy

FindRegion(address, size) is the lookup behind every guest memory read, write, and compare in the emulator. To validate that a candidate region actually contains the requested range, it called TryResolveRegionOffset(address, size, candidate, out _) — and discarded the computed offset. Then every caller (TryRead, TryWrite, TryCompare, TryCopy, TryReadExclusive, TryWriteExclusive) turned around and called TryResolveRegionOffset again with the same arguments to get the offset it needed.

So each memory access did the offset resolution twice — once to validate, once to actually use. TryCopy did it four times (two regions × two calls).

The fix

Added a FindRegion(address, size, out ulong offset) overload that returns the offset it already computes, with the old signature delegating to it. Threaded the offset through all seven call sites. This also let the caller-side region is not null && TryResolveRegionOffset(...) checks collapse into a plain region is not null — so the code got shorter and faster.


## Testing

N/A

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
