### PR TITLE
cold-path optimization: import-stub NID collection in the SELF loader

### DIFF
--- a/src/SharpEmu.Core/Loader/SelfLoader.cs
+++ b/src/SharpEmu.Core/Loader/SelfLoader.cs
@@ -714,8 +714,9 @@ public sealed class SelfLoader : ISelfLoader
 
         importedRelocations = BuildImportedRelocations(descriptors);
 
+        var stubEligibleNids = CollectStubEligibleNids(descriptors, moduleManager);
         var stubImportNids = orderedImportNids
-            .Where(nid => ShouldCreateImportStub(nid, descriptors, moduleManager))
+            .Where(stubEligibleNids.Contains)
             .ToArray();
         var stubsByAddress = CreateImportStubMapping(virtualMemory, stubImportNids);
         Console.WriteLine($"[LOADER] Created {stubsByAddress.Count} import stubs");
@@ -1158,6 +1159,35 @@ public sealed class SelfLoader : ISelfLoader
             IsDataImport: GetSymbolType(symbol.Info) == SymbolTypeObject,
             writeKind,
             isWeak);
+    }
+
+    // Collects every NID that needs a trap import stub in a single pass over the
+    // descriptors. This mirrors ShouldCreateImportStub applied per NID, but avoids
+    // the O(nids * descriptors) rescan that filtering each unique NID against the
+    // full descriptor list would incur on large modules. A NID qualifies as soon as
+    // one of its descriptors is non-weak, or is weak but resolvable via the module
+    // manager.
+    private static HashSet<string> CollectStubEligibleNids(
+        IReadOnlyList<RelocationDescriptor> descriptors,
+        IModuleManager? moduleManager)
+    {
+        var eligible = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < descriptors.Count; i++)
+        {
+            var descriptor = descriptors[i];
+            var nid = descriptor.ImportNid;
+            if (nid is null || eligible.Contains(nid))
+            {
+                continue;
+            }
+
+            if (!descriptor.IsWeak || moduleManager?.TryGetExport(nid, out _) == true)
+            {
+                eligible.Add(nid);
+            }
+        }
+
+        return eligible;
     }
 
     private static bool ShouldCreateImportStub(
@@ -2431,6 +2461,19 @@ public sealed class SelfLoader : ISelfLoader
         Debug.Assert(
             !ShouldCreateImportStub("weak", [weak], moduleManager: null),
             "An unresolved weak symbol incorrectly received a trap import stub.");
+
+        var strong = new RelocationDescriptor(
+            TargetAddress: 0x3000,
+            Addend: 0,
+            ImportNid: "strong",
+            SymbolValue: 0,
+            RelocationValueKind.Pointer,
+            IsDataImport: false);
+        var mixed = new List<RelocationDescriptor> { weak, strong };
+        var eligible = CollectStubEligibleNids(mixed, moduleManager: null);
+        Debug.Assert(
+            eligible.Contains("strong") && !eligible.Contains("weak"),
+            "CollectStubEligibleNids disagreed with the per-NID stub eligibility rule.");
     }
 
     private static ulong AlignUp(ulong value, ulong alignment)


### PR DESCRIPTION
The cold path
BuildImportStubs runs once per module during binary load — startup, never in the hot execution loop. That's exactly the "run once, then never" territory where an intermediate-level algorithmic fix pays off without touching perf-sensitive code.

The problem
The stub-eligible NID filter was:
orderedImportNids.Where(nid => ShouldCreateImportStub(nid, descriptors, moduleManager)).ToArray()
ShouldCreateImportStub linearly scans the entire descriptors list. Called once per unique NID, that's O(nids × descriptors) ordinal string comparisons. On a real game SELF both counts reach into the thousands, so this is millions of comparisons on load.

The fix
One pass over descriptors builds a HashSet<string> of eligible NIDs, then the filter becomes O(1) membership — overall O(descriptors). Semantics are byte-for-byte identical: a NID qualifies when any of its descriptors is non-weak, or is weak but resolvable via the module manager.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
