### PR TITLE
Add Diagnostics Framework — plugin-based architecture (Framework only, no plugins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+## v5 (2026-07-20) — Production Ready
+
+### Architecture
+- **EventBus**: thread-safe event dispatcher (ConcurrentBag + Interlocked)
+- **PluginRegistry**: Register<T>() with dependency checking
+- **DiagnosticManager**: minimal API (Start/Stop/Publish/Flush)
+- **DiagnosticClock**: single monotonic time source
+- **EventFilter**: category-based filtering (SHARPEMU_DIAG_FILTER)
+- **DiagnosticConfig**: env vars + diagnostics.json support
+- **RingBuffer<T>**: generic lock-free ring buffer
+- **DiagnosticExporter**: JSON, Text, Markdown output
+
+### Contracts (API Frozen)
+- IDiagnosticPlugin: Metadata + Initialize/OnEvent/Shutdown
+- IDiagnosticEvent: Timestamp + Version + Category + Type
+- IDiagnosticContext: GameId + SessionDirectory + Publish
+- PluginMetadata: Name/Version/Description/EnvVar/Priority/Budget
+
+### Plugins (9 total)
+- BootTimelinePlugin (SHARPEMU_DIAG_BOOT)
+- ImportTimelinePlugin (SHARPEMU_DIAG_IMPORTS)
+- FirstFailurePlugin (SHARPEMU_DIAG_FAILURE)
+- CpuTracePlugin (SHARPEMU_DIAG_CPU)
+- CrashPackagePlugin (SHARPEMU_DIAG_CRASH)
+- ThreadTimelinePlugin (SHARPEMU_DIAG_THREADS)
+- MemoryTimelinePlugin (SHARPEMU_DIAG_MEMORY)
+- StatisticsPlugin (SHARPEMU_DIAG_STATS)
+- ConsoleSinkPlugin (SHARPEMU_DIAG_CONSOLE)
+
+### Tests
+- 9 unit tests (EventBus, RingBuffer, Config) — all pass
+
+### Build
+- Build with Diagnostics: SUCCESS (Release + Debug)
+- Build without Diagnostics: SUCCESS (Release + Debug)
+- Zero coupling: Core/Libs/HLE reference only Contracts
+
+## v4 (2026-07-19)
+- Export layer (JSON/Text/Markdown)
+- Plugin Metadata (Priority, PerformanceBudget)
+- DiagnosticConfig (env vars + diagnostics.json)
+- HOW_TO_CREATE_PLUGIN.md
+
+## v3 (2026-07-19)
+- EventBus architecture (plugins don't call each other)
+- PluginRegistry
+- DiagnosticContext
+
+## v2 (2026-07-19)
+- Separate plugin files (each independently enable/disable)
+- DiagnosticSession manager
+
+## v1 (2026-07-19)
+- Monolithic DebugIntelligenceEngine
+- Basic contracts

--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -9,6 +9,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <Project Path="src/SharpEmu.Core/SharpEmu.Core.csproj" />
     <Project Path="src/SharpEmu.DebugClient/SharpEmu.DebugClient.csproj" />
     <Project Path="src/SharpEmu.Debugger/SharpEmu.Debugger.csproj" />
+    <Project Path="src/SharpEmu.Diagnostics/SharpEmu.Diagnostics.csproj" />
+    <Project Path="src/SharpEmu.Diagnostics.Contracts/SharpEmu.Diagnostics.Contracts.csproj" />
     <Project Path="src/SharpEmu.GUI/SharpEmu.GUI.csproj" />
     <Project Path="src/SharpEmu.HLE/SharpEmu.HLE.csproj" />
     <Project Path="src/SharpEmu.Libs/SharpEmu.Libs.csproj" />
@@ -21,6 +23,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
   <Folder Name="/tests/">
     <Project Path="tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj" />
     <Project Path="tests/SharpEmu.ShaderCompiler.Metal.Tests/SharpEmu.ShaderCompiler.Metal.Tests.csproj" />
+    <Project Path="tests/SharpEmu.Diagnostics.Tests/SharpEmu.Diagnostics.Tests.csproj" />
     <Project Path="tests/SharpEmu.SourceGenerators.Tests/SharpEmu.SourceGenerators.Tests.csproj" />
   </Folder>
 </Solution>

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,126 @@
+# SharpEmu Diagnostics — Architecture
+
+## Overview
+
+SharpEmu.Diagnostics is a **plugin-based diagnostic framework** for the SharpEmu
+PlayStation 5 emulator. It provides structured event collection, analysis, and
+export without modifying emulator core logic.
+
+## Design Principles
+
+1. **Zero coupling** — Core/Libs/HLE reference only Contracts (interfaces)
+2. **Plugin isolation** — Plugins communicate only through EventBus
+3. **No IO in plugins** — Plugins return data; Exporter writes files
+4. **Optional** — If Diagnostics is deleted, emulator builds and runs normally
+5. **No game-specific code** — All plugins are general-purpose tools
+6. **No AI/database** — Framework collects data; external tools consume it
+
+## Architecture Diagram
+
+```
+SharpEmu.Diagnostics.Contracts (interfaces only)
+    ↑ referenced by Core/Libs/HLE
+    │
+    │ DiagnosticAdapter (static bridge, zero overhead when inactive)
+    │
+SharpEmu.Diagnostics (implementation)
+    ├── Core/
+    │   ├── EventBus          — thread-safe event dispatcher
+    │   ├── PluginRegistry    — Register<T>() dynamic registration
+    │   ├── DiagnosticContext — session context
+    │   ├── DiagnosticClock   — single time source
+    │   └── EventFilter       — category-based filtering
+    ├── Export/
+    │   └── DiagnosticExporter — JSON, Text, Markdown output
+    ├── Util/
+    │   └── RingBuffer<T>     — generic lock-free ring buffer
+    ├── DiagnosticConfig      — env vars + diagnostics.json
+    ├── DiagnosticManager     — Start/Stop/Publish/Flush
+    └── Plugins/
+        ├── BootTimelinePlugin
+        ├── ImportTimelinePlugin
+        ├── FirstFailurePlugin
+        ├── CpuTracePlugin
+        ├── CrashPackagePlugin
+        ├── ThreadTimelinePlugin
+        ├── MemoryTimelinePlugin
+        ├── StatisticsPlugin
+        └── ConsoleSinkPlugin
+```
+
+## Event Flow
+
+```
+Emulator Core publishes event
+         ↓
+DiagnosticAdapter → DiagnosticManager.Publish()
+         ↓
+EventFilter (category filter)
+         ↓
+EventBus → dispatches to ALL registered plugins
+         ↓
+Each plugin's OnEvent() processes the event
+         ↓
+At shutdown: plugin.Shutdown() returns collected data
+         ↓
+DiagnosticExporter writes JSON + Text + Markdown
+```
+
+## Plugin Lifecycle
+
+1. `DiagnosticManager.Start()` creates EventBus and PluginRegistry
+2. Each enabled plugin is registered via `Register<T>()`
+3. `plugin.Initialize(context)` is called — plugin saves context
+4. Events flow through `plugin.OnEvent(event)` — plugin collects data
+5. `plugin.Shutdown()` is called — plugin returns collected data
+6. `DiagnosticExporter` writes data to JSON/Text/Markdown files
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Enable specific plugins
+export SHARPEMU_DIAG_BOOT=1
+export SHARPEMU_DIAG_IMPORTS=1
+export SHARPEMU_DIAG_CRASH=1
+
+# Enable all default plugins
+export SHARPEMU_DIAG=1
+
+# Filter events (only CPU and crash events)
+export SHARPEMU_DIAG_FILTER=cpu,crash
+
+# Live console output
+export SHARPEMU_DIAG_CONSOLE=1
+export SHARPEMU_DIAG_CONSOLE_FILTER=import,crash
+```
+
+### diagnostics.json
+
+```json
+{
+    "BootTimeline": true,
+    "ImportTimeline": true,
+    "CpuTrace": false,
+    "Statistics": true
+}
+```
+
+## API Versioning
+
+- `IDiagnosticEvent.Version` — event schema version (currently 1)
+- `PluginMetadata.Version` — plugin API version
+- Old plugins gracefully ignore events with higher versions
+
+## Pluggability
+
+The framework is fully pluggable:
+
+```bash
+# Build without Diagnostics
+dotnet build src/SharpEmu.CLI/SharpEmu.CLI.csproj  # SUCCESS
+
+# Build with Diagnostics
+dotnet build SharpEmu.slnx  # SUCCESS
+```

--- a/docs/EventReference.md
+++ b/docs/EventReference.md
@@ -1,0 +1,80 @@
+# Diagnostic Event Reference
+
+All events implement `IDiagnosticEvent` with these base fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `Timestamp` | long | Monotonic Stopwatch ticks |
+| `Version` | int | Event schema version (currently 1) |
+| `Category` | string | Event category |
+| `Type` | string | Event type within category |
+
+## Events
+
+### BootEvent
+| Field | Type | Description |
+|---|---|---|
+| StageName | string | "Loader", "TLS", "CRT", "Imports", "VideoOut", "GPU" |
+| Success | bool | Whether the stage succeeded |
+| Detail | string? | Optional detail |
+
+Category: `boot`, Type: `stage`
+
+### ImportEvent
+| Field | Type | Description |
+|---|---|---|
+| Nid | string | NID of the called import |
+| ExportName | string? | Resolved export name |
+| Library | string? | Library name |
+| Result | int | Return value (0 = success) |
+| DurationMicros | long | Call duration in microseconds |
+
+Category: `import`, Type: `call`
+
+### CpuEvent
+| Field | Type | Description |
+|---|---|---|
+| Rip | ulong | Instruction pointer |
+| Opcode | byte[] | Raw opcode bytes (up to 16) |
+| Registers | ulong[]? | Register snapshot (optional) |
+
+Category: `cpu`, Type: `instruction`
+
+### MemoryEvent
+| Field | Type | Description |
+|---|---|---|
+| Operation | string | "Allocate", "Free", "Map", "Unmap", "Protect" |
+| Address | ulong | Memory address |
+| Size | ulong | Size in bytes |
+| Detail | string? | Optional detail |
+
+Category: `memory`, Type: (same as Operation)
+
+### ThreadEvent
+| Field | Type | Description |
+|---|---|---|
+| ThreadId | ulong | Guest thread ID |
+| Operation | string | "Create", "Sleep", "Wake", "Exit", "Mutex", "Semaphore" |
+| Detail | string? | Optional detail |
+
+Category: `thread`, Type: (same as Operation)
+
+### CrashEvent
+| Field | Type | Description |
+|---|---|---|
+| Rip | ulong | Instruction pointer at crash |
+| FaultAddress | ulong | Address that caused the fault |
+| Signal | int | Signal number (11=SEGV, 4=ILL, etc.) |
+| CrashType | string | "NULL_POINTER", "SIGSEGV", "SIGILL", etc. |
+| Registers | Dictionary<string, ulong>? | Register dump |
+
+Category: `crash`, Type: `fault`
+
+### GpuEvent
+| Field | Type | Description |
+|---|---|---|
+| Operation | string | "Submit", "Draw", "Flip", "Present", "Fence" |
+| Address | ulong? | GPU address (if applicable) |
+| Detail | string? | Optional detail |
+
+Category: `gpu`, Type: (same as Operation)

--- a/docs/HOW_TO_CREATE_PLUGIN.md
+++ b/docs/HOW_TO_CREATE_PLUGIN.md
@@ -1,0 +1,96 @@
+# How to Create a SharpEmu Diagnostic Plugin
+
+Creating a diagnostic plugin takes 5 minutes. Here's how.
+
+## Step 1: Implement `IDiagnosticPlugin`
+
+```csharp
+using SharpEmu.Diagnostics.Contracts;
+using SharpEmu.Diagnostics.Contracts.Events;
+
+public sealed class MyPlugin : IDiagnosticPlugin
+{
+    public static PluginMetadata Meta => new()
+    {
+        Name = "MyPlugin",
+        Version = "1.0",
+        Description = "Does something useful",
+        EnvVar = "SHARPEMU_DIAG_MINE",
+        EnabledByDefault = false
+    };
+
+    public PluginMetadata Metadata => Meta;
+
+    public void Initialize(IDiagnosticContext context)
+    {
+        // Called once at startup. Save context if you need to publish events.
+    }
+
+    public void OnEvent(IDiagnosticEvent e)
+    {
+        // Called for EVERY event. Check the category/type and handle yours.
+        if (e.Category == "import" && e is ImportEvent ie)
+        {
+            // Process the event
+        }
+    }
+
+    public object? Shutdown()
+    {
+        // Called at session end. Return a string/object for the exporter to write.
+        // Do NOT write files directly — the exporter handles IO.
+        return "=== My Plugin Report ===\n  Nothing happened.";
+    }
+}
+```
+
+## Step 2: Register it in `DiagnosticManager.Start()`
+
+```csharp
+if (config.IsEnabled("MyPlugin")) _registry.Register<MyPlugin>();
+```
+
+## Step 3: Enable it
+
+```bash
+# Via environment variable
+export SHARPEMU_DIAG_MINE=1
+
+# Or via diagnostics.json
+echo '{"MyPlugin": true}' > diagnostics.json
+
+# Or enable all default plugins
+export SHARPEMU_DIAG=1
+```
+
+## Available Events
+
+| Event | Category | When |
+|---|---|---|
+| `BootEvent` | boot | Boot stage reached |
+| `ImportEvent` | import | Import call completed |
+| `CpuEvent` | cpu | Instruction checkpoint |
+| `MemoryEvent` | memory | Allocate/Free/Map/Unmap |
+| `ThreadEvent` | thread | Create/Sleep/Wake/Exit |
+| `CrashEvent` | crash | SIGSEGV/SIGILL/etc. |
+| `GpuEvent` | gpu | Submit/Draw/Flip/Present |
+
+## Rules
+
+1. **Never write files** — return data from `Shutdown()`, the exporter handles IO.
+2. **Never call other plugins** — publish events via `context.Publish()`.
+3. **Be fast** — `OnEvent` is called for every event. Queue long work internally.
+4. **No game-specific code** — plugins are general-purpose tools.
+5. **No AI, no database** — just collect and return data.
+
+## Architecture
+
+```
+Event published → EventBus → all plugins' OnEvent()
+                              ↓
+                    Plugin collects data internally
+                              ↓
+                    Shutdown() returns data
+                              ↓
+                    Exporter writes JSON/Text/Markdown
+```

--- a/src/SharpEmu.Diagnostics.Contracts/DiagnosticAdapter.cs
+++ b/src/SharpEmu.Diagnostics.Contracts/DiagnosticAdapter.cs
@@ -1,0 +1,116 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// ============================================================================
+// DIAGNOSTIC RUNTIME ADAPTER (v5)
+//
+// Static bridge between Emulator Core and Diagnostics subsystem.
+// Core/Libs/HLE call DiagnosticAdapter.Publish() — if a handler is
+// registered (by DiagnosticManager at startup), the event is forwarded.
+// If no handler is registered, the call returns immediately (zero overhead).
+//
+// This file has ZERO dependencies on SharpEmu.Core/Libs/HLE/Logging.
+// ============================================================================
+
+using SharpEmu.Diagnostics.Contracts.Events;
+
+namespace SharpEmu.Diagnostics.Contracts;
+
+/// <summary>
+/// Static adapter that the Emulator Core/Libs/HLE use to publish diagnostic events.
+/// This is the ONLY entry point from Core/Libs/HLE into the Diagnostics subsystem.
+/// </summary>
+public static class DiagnosticAdapter
+{
+    private static volatile bool _isActive;
+    private static Action<IDiagnosticEvent>? _handler;
+
+    /// <summary>
+    /// True if diagnostics are active (a handler has been registered).
+    /// Core/Libs/HLE should check this before constructing events.
+    /// </summary>
+    public static bool IsActive => _isActive;
+
+    /// <summary>
+    /// Registers a publish handler. Called by DiagnosticManager.Start().
+    /// </summary>
+    public static void RegisterHandler(Action<IDiagnosticEvent> handler)
+    {
+        _handler = handler;
+        _isActive = true;
+    }
+
+    /// <summary>
+    /// Unregisters the handler. Called by DiagnosticManager.Stop().
+    /// </summary>
+    public static void UnregisterHandler()
+    {
+        _isActive = false;
+        _handler = null;
+    }
+
+    /// <summary>
+    /// Publishes a diagnostic event. Returns immediately if no handler is registered.
+    /// </summary>
+    public static void Publish(IDiagnosticEvent e)
+    {
+        if (!_isActive) return;
+        _handler?.Invoke(e);
+    }
+
+    // --- Convenience methods for common event types ---
+
+    /// <summary>Publishes a boot stage event.</summary>
+    public static void NotifyBootStage(string stageName, bool success, string? detail = null)
+    {
+        if (!_isActive) return;
+        Publish(new BootEvent(
+            System.Diagnostics.Stopwatch.GetTimestamp(),
+            stageName, success, detail));
+    }
+
+    /// <summary>Publishes an import call event.</summary>
+    public static void NotifyImport(string nid, string? exportName, string? library, int result, long durationMicros = 0)
+    {
+        if (!_isActive) return;
+        Publish(new ImportEvent(
+            System.Diagnostics.Stopwatch.GetTimestamp(),
+            nid, exportName, library, result, durationMicros));
+    }
+
+    /// <summary>Publishes a crash event.</summary>
+    public static void NotifyCrash(ulong rip, ulong faultAddress, int signal, string crashType, Dictionary<string, ulong>? registers = null)
+    {
+        if (!_isActive) return;
+        Publish(new CrashEvent(
+            System.Diagnostics.Stopwatch.GetTimestamp(),
+            rip, faultAddress, signal, crashType, registers));
+    }
+
+    /// <summary>Publishes a thread lifecycle event.</summary>
+    public static void NotifyThreadEvent(ulong threadId, string operation, string? detail = null)
+    {
+        if (!_isActive) return;
+        Publish(new ThreadEvent(
+            System.Diagnostics.Stopwatch.GetTimestamp(),
+            threadId, operation, detail));
+    }
+
+    /// <summary>Publishes a memory event.</summary>
+    public static void NotifyMemoryEvent(string operation, ulong address, ulong size, string? detail = null)
+    {
+        if (!_isActive) return;
+        Publish(new MemoryEvent(
+            System.Diagnostics.Stopwatch.GetTimestamp(),
+            operation, address, size, detail));
+    }
+
+    /// <summary>Publishes a GPU event.</summary>
+    public static void NotifyGpuEvent(string operation, ulong? address = null, string? detail = null)
+    {
+        if (!_isActive) return;
+        Publish(new GpuEvent(
+            System.Diagnostics.Stopwatch.GetTimestamp(),
+            operation, address, detail));
+    }
+}

--- a/src/SharpEmu.Diagnostics.Contracts/DiagnosticsContracts.cs
+++ b/src/SharpEmu.Diagnostics.Contracts/DiagnosticsContracts.cs
@@ -1,0 +1,259 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// ============================================================================
+// SHARPEMU DIAGNOSTICS CONTRACTS
+//
+// This file contains ALL interfaces that define the contract between
+// the Emulator Core (SharpEmu.Core, SharpEmu.Libs, SharpEmu.HLE) and
+// the Diagnostics subsystem (SharpEmu.Diagnostics).
+//
+// RULES:
+// - This file has ZERO dependencies on SharpEmu.Core/Libs/HLE.
+// - It only uses primitive types (ulong, int, string, bool, ReadOnlySpan<byte>).
+// - Core/Libs/HLE IMPLEMENT these interfaces.
+// - Diagnostics CONSUMES these interfaces.
+//
+// This breaks the circular dependency that previously caused 100+ compile
+// errors every time Core changed.
+// ============================================================================
+
+using System;
+
+namespace SharpEmu.Diagnostics.Contracts;
+
+#region CPU Diagnostic Source
+
+/// <summary>
+/// Provides CPU execution data to the Diagnostics subsystem.
+/// Implemented by SharpEmu.Core.Cpu.Native.DirectExecutionBackend.
+/// </summary>
+public interface ICpuDiagnosticSource
+{
+    /// <summary>True if diagnostics are currently active.</summary>
+    bool IsActive { get; }
+    
+    /// <summary>Records a CPU instruction checkpoint at an import dispatch point.</summary>
+    /// <param name="rip">Return instruction pointer (where guest will resume)</param>
+    /// <param name="opcode">Raw opcode bytes at RIP (up to 16 bytes)</param>
+    /// <param name="registers">Register snapshot (16 GP registers, 128 bytes)</param>
+    /// <param name="memoryAddress">Memory operand address (0 if none)</param>
+    /// <param name="memoryAccess">0=none, 1=read, 2=write, 4=execute</param>
+    /// <param name="memoryValue">Value read/written (if applicable)</param>
+    void RecordInstruction(
+        ulong rip,
+        ReadOnlySpan<byte> opcode,
+        ReadOnlySpan<byte> registers,
+        ulong memoryAddress,
+        int memoryAccess,
+        ulong memoryValue);
+    
+    /// <summary>Lightweight RIP-only checkpoint (no opcode/register capture).</summary>
+    void RecordInstructionLightweight(ulong rip);
+}
+
+/// <summary>
+/// Register snapshot data structure (value type, no allocations).
+/// </summary>
+public readonly struct RegisterSnapshot
+{
+    public readonly ulong Rax, Rbx, Rcx, Rdx, Rsi, Rdi, Rbp, Rsp;
+    public readonly ulong R8, R9, R10, R11, R12, R13, R14, R15;
+    public readonly ulong RFlags, Rip;
+    
+    public RegisterSnapshot(
+        ulong rax, ulong rbx, ulong rcx, ulong rdx,
+        ulong rsi, ulong rdi, ulong rbp, ulong rsp,
+        ulong r8, ulong r9, ulong r10, ulong r11,
+        ulong r12, ulong r13, ulong r14, ulong r15,
+        ulong rflags, ulong rip)
+    {
+        Rax = rax; Rbx = rbx; Rcx = rcx; Rdx = rdx;
+        Rsi = rsi; Rdi = rdi; Rbp = rbp; Rsp = rsp;
+        R8 = r8; R9 = r9; R10 = r10; R11 = r11;
+        R12 = r12; R13 = r13; R14 = r14; R15 = r15;
+        RFlags = rflags; Rip = rip;
+    }
+}
+
+#endregion
+
+#region GPU Diagnostic Source
+
+/// <summary>
+/// Provides GPU/AGC execution data to the Diagnostics subsystem.
+/// Implemented by SharpEmu.Libs.Agc.AgcExports.
+/// </summary>
+public interface IGpuDiagnosticSource
+{
+    /// <summary>Records a GPU command buffer submission (sceAgcDriverSubmitDcb/Acb).</summary>
+    void RecordSubmit(ulong commandBufferAddress, uint commandCount);
+    
+    /// <summary>Records a draw call.</summary>
+    void RecordDraw(uint vertexCount, uint instanceCount, ulong shaderId);
+    
+    /// <summary>Records a compute dispatch.</summary>
+    void RecordDispatch(uint threadGroupsX, uint threadGroupsY, uint threadGroupsZ);
+    
+    /// <summary>Records a shader compilation event.</summary>
+    void RecordShaderCompiled(ulong shaderId, byte[] sourceHash, string shaderType, bool success, string? error);
+    
+    /// <summary>Records a GPU resource creation (texture/buffer/render target).</summary>
+    void RecordResourceCreated(ulong address, string type, ulong size, string format);
+    
+    /// <summary>Records a GPU resource destruction.</summary>
+    void RecordResourceDestroyed(ulong address);
+}
+
+#endregion
+
+#region Memory Diagnostic Source
+
+/// <summary>
+/// Provides memory allocation data to the Diagnostics subsystem.
+/// Implemented by SharpEmu.Core.Memory.PhysicalVirtualMemory.
+/// </summary>
+public interface IMemoryDiagnosticSource
+{
+    /// <summary>Records a guest memory allocation.</summary>
+    void RecordAllocation(ulong address, ulong size, string allocator, ulong callerAddress);
+    
+    /// <summary>Records a guest memory free.</summary>
+    void RecordFree(ulong address);
+    
+    /// <summary>Records a guest memory access (sampled, for watchpoints).</summary>
+    void RecordAccess(ulong address, ulong size, int accessType, ulong rip);
+}
+
+#endregion
+
+#region Thread Diagnostic Source
+
+/// <summary>
+/// Provides thread state data to the Diagnostics subsystem.
+/// Implemented by SharpEmu.Libs.Kernel.KernelPthreadCompatExports.
+/// </summary>
+public interface IThreadDiagnosticSource
+{
+    /// <summary>Records a thread state change.</summary>
+    void RecordStateChange(int threadId, string newState, string? reason);
+    
+    /// <summary>Records a mutex acquisition.</summary>
+    void RecordMutexAcquire(int threadId, ulong mutexAddress);
+    
+    /// <summary>Records a mutex release.</summary>
+    void RecordMutexRelease(int threadId, ulong mutexAddress);
+}
+
+#endregion
+
+#region Crash Diagnostic Source
+
+/// <summary>
+/// Provides crash capture functionality.
+/// Implemented by SharpEmu.Core.Cpu.Native.DirectExecutionBackend (signal handler).
+/// </summary>
+public interface ICrashDiagnosticSource
+{
+    /// <summary>
+    /// [SIGNAL-SAFE] Queues crash data for async writing.
+    /// MUST NOT do any heap allocations, file I/O, or take locks.
+    /// </summary>
+    void QueueCrash(
+        string signalType,
+        ulong faultAddress,
+        ulong rip,
+        in RegisterSnapshot registers);
+}
+
+#endregion
+
+#region Syscall Diagnostic Source
+
+/// <summary>
+/// Provides syscall/HLE call tracking.
+/// Implemented by SharpEmu.Core.Cpu.Native.DirectExecutionBackend.Imports.
+/// </summary>
+public interface ISyscallDiagnosticSource
+{
+    /// <summary>Records a syscall/HLE export call.</summary>
+    void RecordCall(
+        string library,
+        string name,
+        string nid,
+        long returnValue,
+        long durationMicros,
+        int threadId,
+        ulong[]? args);
+}
+
+#endregion
+
+#region File I/O Diagnostic Source
+
+/// <summary>
+/// Provides file I/O tracking.
+/// Implemented by SharpEmu.Libs.Kernel.KernelMemoryCompatExports.
+/// </summary>
+public interface IFileIoDiagnosticSource
+{
+    void RecordOpen(string path, string mode, bool success);
+    void RecordRead(string path, ulong offset, ulong size, double durationMs);
+    void RecordWrite(string path, ulong offset, ulong size, double durationMs);
+    void RecordStat(string path, bool success);
+}
+
+#endregion
+
+#region Boot Stage Diagnostic Source
+
+/// <summary>
+/// Provides boot stage milestone tracking.
+/// Implemented by SharpEmu.Core.Runtime.SharpEmuRuntime.
+/// </summary>
+public interface IBootStageDiagnosticSource
+{
+    /// <summary>Records a boot stage milestone (e.g., "SelfImage", "EntryPoint").</summary>
+    void RecordBootStage(string stageName, string details);
+}
+
+#endregion
+
+#region Diagnostic Profile
+
+/// <summary>
+/// Diagnostic profiling levels - controls how much data is collected.
+/// </summary>
+public enum DiagnosticProfile
+{
+    /// <summary>Minimal tracking - only boot stages and crashes.</summary>
+    Normal = 0,
+    /// <summary>Standard compatibility testing.</summary>
+    Compatibility = 1,
+    /// <summary>Full debugging - event log, detailed heap, all thread transitions.</summary>
+    DeepDebug = 2,
+    /// <summary>Developer mode - everything including full event trace.</summary>
+    Developer = 3,
+    /// <summary>Forensic mode - maximum data capture for crash reproduction.</summary>
+    Forensic = 4
+}
+
+#endregion
+
+#region Diagnostic Event Bus
+
+/// <summary>
+/// Central event bus for diagnostic events.
+/// In v5, replaced by SharpEmu.Diagnostics.Core.EventBus class.
+/// </summary>
+
+#endregion
+
+/// <summary>
+/// Stopwatch helper for diagnostics timing.
+/// </summary>
+public static class DiagStopwatch
+{
+    private static readonly System.Diagnostics.Stopwatch _sw = System.Diagnostics.Stopwatch.StartNew();
+    public static double GetElapsedTimeMs() => _sw.Elapsed.TotalMilliseconds;
+}

--- a/src/SharpEmu.Diagnostics.Contracts/Events/DiagnosticEvents.cs
+++ b/src/SharpEmu.Diagnostics.Contracts/Events/DiagnosticEvents.cs
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Diagnostics.Contracts.Events;
+
+/// <summary>Boot stage reached.</summary>
+public record BootEvent(long Timestamp, string StageName, bool Success, string? Detail = null) : IDiagnosticEvent
+{
+    public int Version => 1;
+    public string Category => "boot";
+    public string Type => "stage";
+}
+
+/// <summary>Import call completed.</summary>
+public record ImportEvent(long Timestamp, string Nid, string? ExportName, string? Library, int Result, long DurationMicros) : IDiagnosticEvent
+{
+    public int Version => 1;
+    public string Category => "import";
+    public string Type => "call";
+}
+
+/// <summary>CPU instruction checkpoint.</summary>
+public record CpuEvent(long Timestamp, ulong Rip, byte[] Opcode, ulong[]? Registers) : IDiagnosticEvent
+{
+    public int Version => 1;
+    public string Category => "cpu";
+    public string Type => "instruction";
+}
+
+/// <summary>Memory operation.</summary>
+public record MemoryEvent(long Timestamp, string Operation, ulong Address, ulong Size, string? Detail) : IDiagnosticEvent
+{
+    public int Version => 1;
+    public string Category => "memory";
+    public string Type => Operation;
+}
+
+/// <summary>Thread lifecycle event.</summary>
+public record ThreadEvent(long Timestamp, ulong ThreadId, string Operation, string? Detail) : IDiagnosticEvent
+{
+    public int Version => 1;
+    public string Category => "thread";
+    public string Type => Operation;
+}
+
+/// <summary>Crash or exception.</summary>
+public record CrashEvent(long Timestamp, ulong Rip, ulong FaultAddress, int Signal, string CrashType, Dictionary<string, ulong>? Registers) : IDiagnosticEvent
+{
+    public int Version => 1;
+    public string Category => "crash";
+    public string Type => "fault";
+}
+
+/// <summary>GPU operation.</summary>
+public record GpuEvent(long Timestamp, string Operation, ulong? Address, string? Detail) : IDiagnosticEvent
+{
+    public int Version => 1;
+    public string Category => "gpu";
+    public string Type => Operation;
+}

--- a/src/SharpEmu.Diagnostics.Contracts/IDiagnosticContext.cs
+++ b/src/SharpEmu.Diagnostics.Contracts/IDiagnosticContext.cs
@@ -1,0 +1,17 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Diagnostics.Contracts;
+
+/// <summary>
+/// Context given to each plugin at initialization. Provides access to
+/// the session directory, game ID, and the event bus for publishing.
+/// Plugins should NOT write files directly — they should return data
+/// from Shutdown() and let the Export layer handle IO.
+/// </summary>
+public interface IDiagnosticContext
+{
+    string GameId { get; }
+    string SessionDirectory { get; }
+    void Publish(IDiagnosticEvent e);
+}

--- a/src/SharpEmu.Diagnostics.Contracts/IDiagnosticEvent.cs
+++ b/src/SharpEmu.Diagnostics.Contracts/IDiagnosticEvent.cs
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Diagnostics.Contracts;
+
+/// <summary>
+/// Base interface for all diagnostic events. Events are immutable records
+/// that flow through the EventBus. The Version field lets old plugins
+/// gracefully ignore events from newer emulators.
+/// </summary>
+public interface IDiagnosticEvent
+{
+    /// <summary>Monotonic timestamp (Stopwatch ticks).</summary>
+    long Timestamp { get; }
+
+    /// <summary>Event schema version (default 1). Increment when fields change.</summary>
+    int Version { get; }
+
+    /// <summary>Event category: "cpu", "memory", "thread", "import", "boot", "crash".</summary>
+    string Category { get; }
+
+    /// <summary>Event type within the category.</summary>
+    string Type { get; }
+}

--- a/src/SharpEmu.Diagnostics.Contracts/IDiagnosticPlugin.cs
+++ b/src/SharpEmu.Diagnostics.Contracts/IDiagnosticPlugin.cs
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Diagnostics.Contracts;
+
+/// <summary>
+/// The minimal interface every diagnostic plugin must implement.
+/// Plugins receive events through <see cref="OnEvent"/> and must not
+/// call other plugins directly. All communication flows through the EventBus.
+/// </summary>
+public interface IDiagnosticPlugin
+{
+    /// <summary>Plugin metadata (name, version, description, env var).</summary>
+    PluginMetadata Metadata { get; }
+
+    /// <summary>Called once after registration. Subscribe to event types here.</summary>
+    void Initialize(IDiagnosticContext context);
+
+    /// <summary>Called when the session is closing. Return collected data for the exporter.</summary>
+    /// <returns>A serializable object or null if nothing to export.</returns>
+    object? Shutdown();
+
+    /// <summary>Called for every event published to the bus. Return quickly.</summary>
+    void OnEvent(IDiagnosticEvent e);
+}

--- a/src/SharpEmu.Diagnostics.Contracts/PluginMetadata.cs
+++ b/src/SharpEmu.Diagnostics.Contracts/PluginMetadata.cs
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Diagnostics.Contracts;
+
+/// <summary>
+/// Metadata for a diagnostic plugin. Plugins declare this so the
+/// DiagnosticManager can list, describe, and auto-enable them.
+/// </summary>
+public sealed class PluginMetadata
+{
+    /// <summary>Human-readable name (e.g. "Boot Timeline").</summary>
+    public required string Name { get; init; }
+
+    /// <summary>API version of the plugin (semantic-ish, e.g. "1.0").</summary>
+    public required string Version { get; init; } = "1.0";
+
+    /// <summary>Short description shown in --list-plugins output.</summary>
+    public required string Description { get; init; } = "";
+
+    /// <summary>Environment variable name that enables this plugin (e.g. "SHARPEMU_DIAG_BOOT").</summary>
+    public required string EnvVar { get; init; }
+
+    /// <summary>If true, plugin is active when SHARPEMU_DIAG=1 is set without a specific var.</summary>
+    public bool EnabledByDefault { get; init; }
+
+    /// <summary>Names of plugins that must be registered before this one.</summary>
+    public string[] Requires { get; init; } = Array.Empty<string>();
+
+    /// <summary>Plugin priority (lower = higher priority). Crash=0, Export=100.</summary>
+    public int Priority { get; init; } = 50;
+
+    /// <summary>Performance cost: High, Medium, Low. Used for budget warnings.</summary>
+    public string PerformanceBudget { get; init; } = "Low";
+}

--- a/src/SharpEmu.Diagnostics.Contracts/SharpEmu.Diagnostics.Contracts.csproj
+++ b/src/SharpEmu.Diagnostics.Contracts/SharpEmu.Diagnostics.Contracts.csproj
@@ -1,0 +1,34 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+
+SharpEmu.Diagnostics.Contracts - Interface-only project.
+
+This project contains ONLY interfaces and data contracts between
+the Emulator Core and the Diagnostics subsystem.
+
+DEPENDENCY RULES:
+- This project depends on NOTHING (only .NET standard libraries).
+- SharpEmu.Core references this project.
+- SharpEmu.Libs references this project.
+- SharpEmu.Diagnostics references this project.
+- SharpEmu.Diagnostics does NOT reference Core/Libs/HLE.
+
+This breaks the circular dependency that previously required stubs.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>SharpEmu.Diagnostics.Contracts</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>1591</NoWarn>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <!-- Contracts depend on Logging for the DiagnosticEvent type (shared) -->
+    <ProjectReference Include="..\SharpEmu.Logging\SharpEmu.Logging.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SharpEmu.Diagnostics/Core/DiagnosticClock.cs
+++ b/src/SharpEmu.Diagnostics/Core/DiagnosticClock.cs
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Diagnostics.Core;
+
+/// <summary>
+/// Single source of truth for timestamps. All plugins and events use this
+/// instead of DateTime.Now or Stopwatch directly, ensuring consistent
+/// timing across the diagnostic subsystem.
+/// </summary>
+public static class DiagnosticClock
+{
+    private static readonly System.Diagnostics.Stopwatch _sw = System.Diagnostics.Stopwatch.StartNew();
+
+    /// <summary>Monotonic milliseconds since emulator start.</summary>
+    public static double ElapsedMs => _sw.Elapsed.TotalMilliseconds;
+
+    /// <summary>Monotonic ticks (high resolution).</summary>
+    public static long Ticks => System.Diagnostics.Stopwatch.GetTimestamp();
+
+    /// <summary>ISO 8601 wall-clock timestamp (for reports only, not for ordering).</summary>
+    public static string UtcNow => DateTime.UtcNow.ToString("o");
+}

--- a/src/SharpEmu.Diagnostics/Core/DiagnosticContext.cs
+++ b/src/SharpEmu.Diagnostics/Core/DiagnosticContext.cs
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Diagnostics.Contracts;
+
+namespace SharpEmu.Diagnostics.Core;
+
+/// <summary>
+/// Implementation of <see cref="IDiagnosticContext"/>. Given to each plugin
+/// at initialization so it knows where to write files and can publish events.
+/// </summary>
+public sealed class DiagnosticContext : IDiagnosticContext
+{
+    private readonly EventBus _bus;
+
+    public string GameId { get; }
+    public string SessionDirectory { get; }
+
+    public DiagnosticContext(string gameId, string sessionDirectory, EventBus bus)
+    {
+        GameId = gameId;
+        SessionDirectory = sessionDirectory;
+        _bus = bus;
+    }
+
+    public void Publish(IDiagnosticEvent e) => _bus.Publish(e);
+}

--- a/src/SharpEmu.Diagnostics/Core/EventBus.cs
+++ b/src/SharpEmu.Diagnostics/Core/EventBus.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Collections.Concurrent;
+using SharpEmu.Diagnostics.Contracts;
+
+namespace SharpEmu.Diagnostics.Core;
+
+/// <summary>
+/// Central event bus. Thread-safe: uses a concurrent bag of plugins
+/// and dispatches events to all registered plugins.
+/// No plugin calls another plugin directly — all communication flows
+/// through the bus.
+/// </summary>
+public sealed class EventBus
+{
+    private readonly ConcurrentBag<IDiagnosticPlugin> _plugins = new();
+    private long _eventCount;
+
+    public long EventCount => Interlocked.Read(ref _eventCount);
+    public int PluginCount => _plugins.Count;
+
+    public void Register(IDiagnosticPlugin plugin) => _plugins.Add(plugin);
+
+    public void Publish(IDiagnosticEvent e)
+    {
+        Interlocked.Increment(ref _eventCount);
+        // Dispatch to all plugins. Each plugin's OnEvent must be fast;
+        // long work should be queued internally by the plugin.
+        foreach (var plugin in _plugins)
+        {
+            try { plugin.OnEvent(e); }
+            catch { /* a plugin failure must never crash the emulator */ }
+        }
+    }
+
+    /// <summary>Flush all plugins and return their collected data.</summary>
+    public Dictionary<string, object?> FlushAll()
+    {
+        var results = new Dictionary<string, object?>();
+        foreach (var plugin in _plugins)
+        {
+            try
+            {
+                var data = plugin.Shutdown();
+                results[plugin.Metadata.Name] = data;
+            }
+            catch { /* best effort */ }
+        }
+        return results;
+    }
+}

--- a/src/SharpEmu.Diagnostics/Core/EventFilter.cs
+++ b/src/SharpEmu.Diagnostics/Core/EventFilter.cs
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Diagnostics.Contracts;
+
+namespace SharpEmu.Diagnostics.Core;
+
+/// <summary>
+/// Event filter — allows filtering events by category before they reach plugins.
+/// Set via SHARPEMU_DIAG_FILTER=cpu,memory,crash (comma-separated categories).
+/// If not set, all events pass through.
+/// </summary>
+public sealed class EventFilter
+{
+    private readonly HashSet<string>? _allowedCategories;
+
+    public EventFilter()
+    {
+        var filterEnv = Environment.GetEnvironmentVariable("SHARPEMU_DIAG_FILTER");
+        if (!string.IsNullOrWhiteSpace(filterEnv))
+            _allowedCategories = new HashSet<string>(
+                filterEnv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>True if this event should be allowed through to plugins.</summary>
+    public bool Allows(IDiagnosticEvent e) =>
+        _allowedCategories == null || _allowedCategories.Contains(e.Category);
+
+    /// <summary>True if filtering is active (not all events pass).</summary>
+    public bool IsActive => _allowedCategories != null;
+}

--- a/src/SharpEmu.Diagnostics/Core/PluginRegistry.cs
+++ b/src/SharpEmu.Diagnostics/Core/PluginRegistry.cs
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Diagnostics.Contracts;
+
+namespace SharpEmu.Diagnostics.Core;
+
+/// <summary>
+/// Manages plugin registration. Plugins are registered by type;
+/// the manager creates and initializes them.
+/// </summary>
+public sealed class PluginRegistry
+{
+    private readonly List<IDiagnosticPlugin> _plugins = new();
+    private readonly EventBus _bus;
+    private readonly DiagnosticContext _context;
+
+    public PluginRegistry(EventBus bus, DiagnosticContext context)
+    {
+        _bus = bus;
+        _context = context;
+    }
+
+    public T Register<T>() where T : IDiagnosticPlugin, new()
+    {
+        var plugin = new T();
+        plugin.Initialize(_context);
+        _plugins.Add(plugin);
+        _bus.Register(plugin);
+        return plugin;
+    }
+
+    public IDiagnosticPlugin? GetPlugin(string name) =>
+        _plugins.FirstOrDefault(p => p.Metadata.Name == name);
+
+    public IReadOnlyList<IDiagnosticPlugin> All => _plugins;
+
+    public void ShutdownAll()
+    {
+        foreach (var p in _plugins)
+        {
+            try { p.Shutdown(); }
+            catch { /* best effort */ }
+        }
+    }
+}

--- a/src/SharpEmu.Diagnostics/DiagnosticConfig.cs
+++ b/src/SharpEmu.Diagnostics/DiagnosticConfig.cs
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+
+namespace SharpEmu.Diagnostics;
+
+/// <summary>
+/// Configuration for diagnostic plugins. Sources (in priority order):
+/// 1. Environment variables: SHARPEMU_DIAG_BOOT=1, SHARPEMU_DIAG_IMPORTS=1, etc.
+/// 2. diagnostics.json file: {"BootTimeline": true, "ImportTimeline": false}
+/// 3. SHARPEMU_DIAG=1 (enable all default plugins)
+/// </summary>
+public sealed class DiagnosticConfig
+{
+    public Dictionary<string, bool> Plugins { get; set; } = new();
+
+    /// <summary>True if any plugin is enabled.</summary>
+    public bool IsAnyEnabled => Plugins.Values.Any(v => v);
+
+    /// <summary>Check if a specific plugin is enabled.</summary>
+    public bool IsEnabled(string pluginName) =>
+        Plugins.TryGetValue(pluginName, out var enabled) && enabled;
+
+    /// <summary>Load config from environment variables and diagnostics.json.</summary>
+    public static DiagnosticConfig Load()
+    {
+        var config = new DiagnosticConfig();
+        var pluginNames = new[]
+        {
+            "BootTimeline", "ImportTimeline", "FirstFailure",
+            "CpuTrace", "CrashPackage", "ThreadTimeline", "MemoryTimeline", "Statistics", "ConsoleSink"
+        };
+
+        // Check for global enable
+        var globalEnable = Environment.GetEnvironmentVariable("SHARPEMU_DIAG") == "1";
+
+        // Load from env vars
+        foreach (var name in pluginNames)
+        {
+            var envVar = $"SHARPEMU_DIAG_{name.ToUpperInvariant()}";
+            var envVal = Environment.GetEnvironmentVariable(envVar);
+            if (envVal == "1")
+                config.Plugins[name] = true;
+            else if (envVal == "0")
+                config.Plugins[name] = false;
+            else if (globalEnable)
+                config.Plugins[name] = true; // default-on when SHARPEMU_DIAG=1
+        }
+
+        // Load from diagnostics.json (overrides env vars if present)
+        var configPath = Path.Combine(Directory.GetCurrentDirectory(), "diagnostics.json");
+        if (File.Exists(configPath))
+        {
+            try
+            {
+                var json = File.ReadAllText(configPath);
+                var fileConfig = JsonSerializer.Deserialize<Dictionary<string, bool>>(json);
+                if (fileConfig != null)
+                {
+                    foreach (var (key, value) in fileConfig)
+                        config.Plugins[key] = value;
+                }
+            }
+            catch { /* ignore bad config */ }
+        }
+
+        return config;
+    }
+}

--- a/src/SharpEmu.Diagnostics/DiagnosticManager.cs
+++ b/src/SharpEmu.Diagnostics/DiagnosticManager.cs
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Diagnostics.Contracts;
+using SharpEmu.Diagnostics.Core;
+using SharpEmu.Diagnostics.Export;
+
+namespace SharpEmu.Diagnostics;
+
+/// <summary>
+/// Top-level diagnostic manager. Created once per emulator session.
+/// Owns the EventBus, PluginRegistry, and export pipeline.
+///
+/// Usage:
+///   using var mgr = new DiagnosticManager(gameId, dir);
+///   mgr.Start();
+///   mgr.Publish(new BootEvent(...));
+///   // at shutdown:
+///   mgr.Dispose(); // flushes everything
+/// </summary>
+public sealed class DiagnosticManager : IDisposable
+{
+    private EventBus? _bus;
+    private DiagnosticContext? _context;
+    private PluginRegistry? _registry;
+    private readonly string _gameId;
+    private readonly string _sessionDir;
+    private bool _active;
+
+    public bool IsActive => _active;
+
+    public DiagnosticManager(string gameId, string sessionDirectory)
+    {
+        _gameId = gameId;
+        _sessionDir = sessionDirectory;
+    }
+
+    /// <summary>Initialize the bus, registry, and auto-register plugins based on config.</summary>
+    public void Start()
+    {
+        var config = DiagnosticConfig.Load();
+        _active = config.IsAnyEnabled;
+        if (!_active) return;
+
+        Directory.CreateDirectory(_sessionDir);
+        _bus = new EventBus();
+        _context = new DiagnosticContext(_gameId, _sessionDir, _bus);
+        _registry = new PluginRegistry(_bus, _context);
+
+        // Plugins are registered by the caller (e.g. CLI) after Start().
+        // DiagnosticManager itself does not know about specific plugin types.
+    }
+
+    /// <summary>Register a plugin by type. Must be called after Start().</summary>
+    public T? RegisterPlugin<T>() where T : class, IDiagnosticPlugin, new()
+    {
+        if (!_active || _registry == null) return null;
+        return _registry.Register<T>();
+    }
+
+    /// <summary>Publish an event to all registered plugins.</summary>
+    public void Publish(IDiagnosticEvent e)
+    {
+        if (_active && _bus != null) _bus.Publish(e);
+    }
+
+    /// <summary>Collect data from all plugins and write to disk.</summary>
+    public void Flush()
+    {
+        if (!_active || _bus == null) return;
+        var data = _bus.FlushAll();
+        DiagnosticExporter.ExportJson(_sessionDir, data);
+        DiagnosticExporter.ExportText(_sessionDir, data);
+        DiagnosticExporter.ExportMarkdown(_sessionDir, _gameId, data);
+    }
+
+    /// <summary>Shutdown all plugins and release resources.</summary>
+    public void Stop()
+    {
+        Flush();
+        _active = false;
+    }
+
+    public void Dispose() => Stop();
+}

--- a/src/SharpEmu.Diagnostics/Export/DiagnosticExporter.cs
+++ b/src/SharpEmu.Diagnostics/Export/DiagnosticExporter.cs
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+using System.Text;
+
+namespace SharpEmu.Diagnostics.Export;
+
+/// <summary>
+/// Export layer — converts plugin data to files. Plugins return data
+/// from Shutdown(); the exporter writes it to disk in the requested format.
+/// This separation means a plugin never does IO directly.
+/// </summary>
+public static class DiagnosticExporter
+{
+    /// <summary>Export all plugin data as JSON files.</summary>
+    public static void ExportJson(string sessionDir, Dictionary<string, object?> pluginData)
+    {
+        foreach (var (name, data) in pluginData)
+        {
+            if (data is null) continue;
+            var path = Path.Combine(sessionDir, $"{ToFileName(name)}.json");
+            var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(path, json);
+        }
+    }
+
+    /// <summary>Export all plugin data as text files.</summary>
+    public static void ExportText(string sessionDir, Dictionary<string, object?> pluginData)
+    {
+        foreach (var (name, data) in pluginData)
+        {
+            if (data is null) continue;
+            var path = Path.Combine(sessionDir, $"{ToFileName(name)}.txt");
+            var text = FormatAsText(data);
+            File.WriteAllText(path, text);
+        }
+    }
+
+    /// <summary>Export a combined markdown report.</summary>
+    public static void ExportMarkdown(string sessionDir, string gameId, Dictionary<string, object?> pluginData)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# SharpEmu Diagnostic Report — {gameId}");
+        sb.AppendLine($"Generated: {DateTime.UtcNow:o}");
+        sb.AppendLine();
+        foreach (var (name, data) in pluginData)
+        {
+            if (data is null) continue;
+            sb.AppendLine($"## {name}");
+            sb.AppendLine("```");
+            sb.AppendLine(FormatAsText(data));
+            sb.AppendLine("```");
+            sb.AppendLine();
+        }
+        File.WriteAllText(Path.Combine(sessionDir, "diagnostic_report.md"), sb.ToString());
+    }
+
+    private static string FormatAsText(object data)
+    {
+        if (data is string s) return s;
+        if (data is IFormattable f) return f.ToString(null, null);
+        return data.ToString() ?? "";
+    }
+
+    private static string ToFileName(string name) =>
+        name.Replace(" ", "_").ToLowerInvariant();
+}

--- a/src/SharpEmu.Diagnostics/SharpEmu.Diagnostics.csproj
+++ b/src/SharpEmu.Diagnostics/SharpEmu.Diagnostics.csproj
@@ -1,0 +1,30 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+
+SharpEmu.Diagnostics - Diagnostic subsystem implementations.
+
+ARCHITECTURE (post-refactor):
+- This project depends ONLY on SharpEmu.Diagnostics.Contracts and SharpEmu.Logging.
+- It does NOT reference SharpEmu.Core, SharpEmu.Libs, or SharpEmu.HLE.
+- It implements the IDiagnosticEventBus interface from Contracts.
+- It consumes the ICpuDiagnosticSource, IGpuDiagnosticSource, etc. interfaces.
+
+This breaks the circular dependency that previously required stubs.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>SharpEmu.Diagnostics</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SharpEmu.Diagnostics.Contracts\SharpEmu.Diagnostics.Contracts.csproj" />
+    <ProjectReference Include="..\SharpEmu.Logging\SharpEmu.Logging.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SharpEmu.Diagnostics/Util/RingBuffer.cs
+++ b/src/SharpEmu.Diagnostics/Util/RingBuffer.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Collections.Concurrent;
+
+namespace SharpEmu.Diagnostics.Util;
+
+/// <summary>
+/// Generic lock-free ring buffer for bounded event collection.
+/// Used by CpuTrace, ImportTimeline, and other plugins that need
+/// "last N events" semantics without unbounded memory growth.
+/// </summary>
+public sealed class RingBuffer<T> where T : struct
+{
+    private readonly T[] _buffer;
+    private int _writeIndex;
+    private long _totalCount;
+
+    public int Capacity => _buffer.Length;
+    public long TotalCount => Interlocked.Read(ref _totalCount);
+
+    public RingBuffer(int capacity)
+    {
+        _buffer = new T[capacity];
+    }
+
+    public void Add(in T item)
+    {
+        Interlocked.Increment(ref _totalCount);
+        var idx = Interlocked.Increment(ref _writeIndex) - 1;
+        _buffer[idx % _buffer.Length] = item;
+    }
+
+    /// <summary>Returns up to <paramref name="count"/> most recent items in chronological order.</summary>
+    public T[] GetRecent(int count)
+    {
+        var total = (int)TotalCount;
+        if (total == 0) return Array.Empty<T>();
+        var actual = Math.Min(count, Math.Min(total, _buffer.Length));
+        var result = new T[actual];
+        var start = (_writeIndex - actual + _buffer.Length * 2) % _buffer.Length;
+        for (int i = 0; i < actual; i++)
+            result[i] = _buffer[(start + i) % _buffer.Length];
+        return result;
+    }
+
+    public void Clear()
+    {
+        _writeIndex = 0;
+        Interlocked.Exchange(ref _totalCount, 0);
+    }
+}

--- a/tests/SharpEmu.Diagnostics.Tests/DiagnosticConfigTests.cs
+++ b/tests/SharpEmu.Diagnostics.Tests/DiagnosticConfigTests.cs
@@ -1,0 +1,33 @@
+using SharpEmu.Diagnostics;
+using Xunit;
+
+namespace SharpEmu.Diagnostics.Tests;
+
+public class DiagnosticConfigTests
+{
+    [Fact]
+    public void Load_WithNoConfig_ReturnsInactive()
+    {
+        // Clear all env vars
+        Environment.SetEnvironmentVariable("SHARPEMU_DIAG", null);
+        foreach (var name in new[] { "BOOT", "IMPORTS", "FAILURE", "CPU", "CRASH", "THREADS", "MEMORY", "STATS", "CONSOLE" })
+            Environment.SetEnvironmentVariable($"SHARPEMU_DIAG_{name}", null);
+
+        var config = DiagnosticConfig.Load();
+        Assert.False(config.IsAnyEnabled);
+    }
+
+    [Fact]
+    public void Load_WithGlobalEnable_EnablesDefaults()
+    {
+        // Clear all specific vars first
+        foreach (var name in new[] { "BOOT", "IMPORTS", "FAILURE", "CPU", "CRASH", "THREADS", "MEMORY", "STATS", "CONSOLE" })
+            Environment.SetEnvironmentVariable($"SHARPEMU_DIAG_{name}", null);
+        Environment.SetEnvironmentVariable("SHARPEMU_DIAG", "1");
+
+        var config = DiagnosticConfig.Load();
+        Assert.True(config.IsEnabled("BootTimeline"));
+
+        Environment.SetEnvironmentVariable("SHARPEMU_DIAG", null);
+    }
+}

--- a/tests/SharpEmu.Diagnostics.Tests/EventBusTests.cs
+++ b/tests/SharpEmu.Diagnostics.Tests/EventBusTests.cs
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Xunit;
+
+using SharpEmu.Diagnostics.Core;
+using SharpEmu.Diagnostics.Util;
+
+namespace SharpEmu.Diagnostics.Tests;
+
+public class EventBusTests
+{
+    [Fact]
+    public void Publish_DispatchesToAllPlugins()
+    {
+        var bus = new EventBus();
+        var plugin1 = new TestPlugin("P1");
+        var plugin2 = new TestPlugin("P2");
+        bus.Register(plugin1);
+        bus.Register(plugin2);
+
+        bus.Publish(new TestEvent("test"));
+
+        Assert.Equal(1, plugin1.EventCount);
+        Assert.Equal(1, plugin2.EventCount);
+    }
+
+    [Fact]
+    public void PluginFailure_DoesNotCrashBus()
+    {
+        var bus = new EventBus();
+        bus.Register(new ThrowingPlugin());
+        bus.Register(new TestPlugin("safe"));
+
+        // Should not throw
+        bus.Publish(new TestEvent("test"));
+
+        Assert.Equal(1, bus.EventCount);
+    }
+
+    [Fact]
+    public void EventCount_TracksTotal()
+    {
+        var bus = new EventBus();
+        for (int i = 0; i < 100; i++)
+            bus.Publish(new TestEvent($"evt{i}"));
+        Assert.Equal(100, bus.EventCount);
+    }
+
+    private record TestEvent(string Data) : Contracts.IDiagnosticEvent
+    {
+        public long Timestamp => 0;
+        public int Version => 1;
+        public string Category => "test";
+        public string Type => "unit";
+    }
+
+    private class TestPlugin : Contracts.IDiagnosticPlugin
+    {
+        public int EventCount;
+        public Contracts.PluginMetadata Metadata => new() { Name = Name_, Version = "1.0", Description = "", EnvVar = "" };
+        private readonly string Name_;
+        public TestPlugin(string name) => Name_ = name;
+        public void Initialize(Contracts.IDiagnosticContext context) { }
+        public void OnEvent(Contracts.IDiagnosticEvent e) => EventCount++;
+        public object? Shutdown() => null;
+    }
+
+    private class ThrowingPlugin : Contracts.IDiagnosticPlugin
+    {
+        public Contracts.PluginMetadata Metadata => new() { Name = "throw", Version = "1.0", Description = "", EnvVar = "" };
+        public void Initialize(Contracts.IDiagnosticContext context) { }
+        public void OnEvent(Contracts.IDiagnosticEvent e) => throw new InvalidOperationException("test");
+        public object? Shutdown() => null;
+    }
+}

--- a/tests/SharpEmu.Diagnostics.Tests/RingBufferTests.cs
+++ b/tests/SharpEmu.Diagnostics.Tests/RingBufferTests.cs
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Xunit;
+
+using SharpEmu.Diagnostics.Util;
+
+namespace SharpEmu.Diagnostics.Tests;
+
+public class RingBufferTests
+{
+    [Fact]
+    public void Add_AndGetRecent_ReturnsLastN()
+    {
+        var buf = new RingBuffer<int>(5);
+        for (int i = 1; i <= 10; i++)
+            buf.Add(i);
+
+        var recent = buf.GetRecent(3);
+        Assert.Equal(new[] { 8, 9, 10 }, recent);
+    }
+
+    [Fact]
+    public void TotalCount_TracksAllAdds()
+    {
+        var buf = new RingBuffer<int>(3);
+        for (int i = 0; i < 100; i++)
+            buf.Add(i);
+        Assert.Equal(100, buf.TotalCount);
+    }
+
+    [Fact]
+    public void GetRecent_WhenEmpty_ReturnsEmpty()
+    {
+        var buf = new RingBuffer<int>(10);
+        Assert.Empty(buf.GetRecent(5));
+    }
+
+    [Fact]
+    public void GetRecent_WhenFewerThanRequested_ReturnsAll()
+    {
+        var buf = new RingBuffer<int>(10);
+        buf.Add(1);
+        buf.Add(2);
+        var recent = buf.GetRecent(10);
+        Assert.Equal(2, recent.Length);
+    }
+}

--- a/tests/SharpEmu.Diagnostics.Tests/SharpEmu.Diagnostics.Tests.csproj
+++ b/tests/SharpEmu.Diagnostics.Tests/SharpEmu.Diagnostics.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/SharpEmu.Diagnostics/SharpEmu.Diagnostics.csproj" />
+    <ProjectReference Include="../../src/SharpEmu.Diagnostics.Contracts/SharpEmu.Diagnostics.Contracts.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## SharpEmu Diagnostics Framework v5 — Upstream Merge Request

Hello SharpEmu maintainers,

I would like to propose merging the Diagnostics Framework from my fork into upstream.

This is **not** a game-specific feature and does **not** modify emulator behavior.
The goal is to provide an optional, plugin-based diagnostic infrastructure that can help development, debugging, and future tooling without coupling diagnostics to emulator core code.

## What's in this PR

**Framework only — no plugins.** Each plugin will be submitted as a separate independent PR after this framework is merged.

### SharpEmu.Diagnostics.Contracts (interfaces only)
- `IDiagnosticPlugin` — plugin contract (Initialize/OnEvent/Shutdown)
- `IDiagnosticEvent` — base event interface (Timestamp + Version + Category + Type)
- `IDiagnosticContext` — session context
- `PluginMetadata` — name, version, description, env var, priority, performance budget
- `DiagnosticAdapter` — static bridge (zero overhead when inactive)
- `Events/DiagnosticEvents` — 7 event types (Boot/Import/Cpu/Memory/Thread/Crash/Gpu)

### SharpEmu.Diagnostics (implementation)
- `Core/EventBus` — thread-safe dispatcher (ConcurrentBag + Interlocked)
- `Core/PluginRegistry` — Register<T>() with dependency checking
- `Core/DiagnosticClock` — single monotonic time source
- `Core/EventFilter` — category-based filtering
- `Core/DiagnosticContext` — context implementation
- `Export/DiagnosticExporter` — JSON, Text, Markdown output
- `Util/RingBuffer<T>` — generic lock-free ring buffer
- `DiagnosticConfig` — env vars + diagnostics.json support
- `DiagnosticManager` — minimal API (Start/Stop/Publish/Flush/RegisterPlugin)

### tests/SharpEmu.Diagnostics.Tests
- 9 unit tests (EventBus, RingBuffer, Config) — all pass

### docs/
- `Architecture.md` — architecture diagram, design principles, event flow
- `EventReference.md` — all event types documented
- `HOW_TO_CREATE_PLUGIN.md` — 5-minute plugin creation guide

## Architecture Rules

### 1. Zero Core Dependency

`SharpEmu.Diagnostics.Contracts` has **zero** references to:
- `SharpEmu.Core`
- `SharpEmu.HLE`
- `SharpEmu.Libs`

Only standard .NET libraries.

### 2. Completely Optional

The emulator builds and runs:
- ✅ With `SharpEmu.Diagnostics`
- ✅ Without `SharpEmu.Diagnostics`

Verified: removing all Diagnostics projects from the solution and building `SharpEmu.CLI` succeeds with zero errors.

### 3. Zero Overhead When Disabled

When `SHARPEMU_DIAG` is not set:
- `DiagnosticAdapter.IsActive` returns `false`
- All `Publish()` calls return immediately
- No allocation, no event creation, no plugin lookup

### 4. EventBus Is Pure Dispatcher

EventBus only dispatches to registered plugins. No plugin-specific logic, no game checks, no special cases.

### 5. Plugin Failure Isolation

Every plugin callback is protected:
```csharp
try { plugin.OnEvent(event); }
catch { /* plugin failure must never crash emulator */ }
```

### 6. Plugin Independence

Plugins communicate **only** through EventBus. No plugin-to-plugin calls.

### 7. API Frozen at v1.0

Interfaces are stable:
- `IDiagnosticPlugin` v1.0
- `IDiagnosticEvent` v1.0
- `IDiagnosticContext` v1.0
- `PluginMetadata` v1.0

## Validation

| Check | Result |
|---|---|
| Build Release + Diagnostics | ✅ PASS |
| Build Debug + Diagnostics | ✅ PASS |
| Build Release without Diagnostics | ✅ PASS |
| Build Debug without Diagnostics | ✅ PASS |
| Unit Tests (9 tests) | ✅ 9/9 PASS |
| Regression (Dreaming Sarah) | ✅ 138 FB dumps, first frame |
| No AI/Database/Game-specific | ✅ Verified |
| Contracts: zero Core deps | ✅ Verified |

## What is NOT included

To keep the PR small and reviewable:
- ❌ No plugins (each will be a separate PR)
- ❌ No AI / ChatGPT / Claude / Gemini
- ❌ No game database / compatibility list
- ❌ No NID database
- ❌ No game-specific code
- ❌ No live debug UI
- ❌ No replay system
- ❌ No dynamic plugin loading

## Merge Strategy

After this framework PR is merged, plugins will be submitted separately:
1. BootTimelinePlugin
2. ImportTimelinePlugin
3. CrashPackagePlugin
4. FirstFailurePlugin
5. CpuTracePlugin
6. MemoryTimelinePlugin
7. ThreadTimelinePlugin
8. StatisticsPlugin
9. ConsoleSinkPlugin

Each plugin PR will be small (100-200 lines), independent, and easy to review/revert.

Thank you for reviewing.