### PR TITLE
[NpWebApi2] Add sceNpWebApi2PushEventCreateFilter stub

### DIFF
--- a/src/SharpEmu.Libs/Np/NpWebApi2Exports.cs
+++ b/src/SharpEmu.Libs/Np/NpWebApi2Exports.cs
@@ -38,6 +38,24 @@ public static class NpWebApi2Exports
     }
 
     [SysAbiExport(
+        Nid = "MsaFhR+lPE4",
+        ExportName = "sceNpWebApi2PushEventCreateFilter",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceNpWebApi2")]
+    public static int NpWebApi2PushEventCreateFilter(CpuContext ctx)
+    {
+        var libraryContextId = unchecked((int)ctx[CpuRegister.Rdi]);
+        if (!IsValidLibraryContextId(libraryContextId))
+        {
+            return ctx.SetReturn(NpWebApi2ErrorInvalidArgument);
+        }
+
+        var filterHandle = Interlocked.Increment(ref _nextPushEventHandle);
+        TraceNpWebApi2("push-event-create-filter", libraryContextId, (ulong)filterHandle);
+        return ctx.SetReturn(filterHandle);
+    }
+
+    [SysAbiExport(
         Nid = "WV1GwM32NgY",
         ExportName = "sceNpWebApi2PushEventCreateHandle",
         Target = Generation.Gen4 | Generation.Gen5,


### PR DESCRIPTION
## What this does

Adds `sceNpWebApi2PushEventCreateFilter` (NID: `MsaFhR+lPE4`) to the `libSceNpWebApi2` module. This function is called by Unity games during initialization and was previously unresolved, causing an import warning and returning `ORBIS_GEN2_ERROR_NOT_FOUND`.

## Why it's needed

Asterix & Obelix Slap Them All (PPSA08576) — a Unity game — logs:\n```\n[LOADER][WARN] Import#486818 unresolved: nid=MsaFhR+lPE4\n```

This unresolved NID is one of several blocking Unity games from progressing past initialization. The function creates a push event filter handle used by the NP Web API for network event subscriptions.

## How it was verified

- NID sourced via `python scripts/aerolib_catalog.py lookup MsaFhR+lPE4` → `sceNpWebApi2PushEventCreateFilter`
- Implementation follows the same pattern as the existing `sceNpWebApi2PushEventCreateHandle`: validate library context, create handle, return success
- The stub returns an incrementing filter handle, allowing the game to proceed

## Testing

N/A — the host lacks the .NET SDK to run a build. The CI will verify.