### PR TITLE
[Logging] Serialize loader console output

### DIFF
--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -74,6 +74,7 @@ internal static partial class Program
         // itself to a console before the first write.
         EnsureCliConsole();
         UseUtf8ConsoleOutput();
+        Console.SetError(Console.Out);
         if (isMitigatedChild && TryGetLogFileArgument(args, out var earlyLogFilePath))
         {
             TryEnableConsoleFileMirror(earlyLogFilePath);
@@ -860,7 +861,7 @@ internal static partial class Program
                 };
 
                 Console.SetOut(new TeeTextWriter(Console.Out, _consoleMirrorFile));
-                Console.SetError(new TeeTextWriter(Console.Error, _consoleMirrorFile));
+                Console.SetError(Console.Out);
                 Console.Error.WriteLine($"[DEBUG] Log file: {Path.GetFullPath(path)}");
             }
             catch (Exception ex)

--- a/src/SharpEmu.Logging/ConsoleLogSink.cs
+++ b/src/SharpEmu.Logging/ConsoleLogSink.cs
@@ -7,8 +7,6 @@ namespace SharpEmu.Logging;
 
 public sealed class ConsoleLogSink : ISharpEmuLogSink
 {
-    private readonly object _sync = new();
-
     public ConsoleLogSink(bool useColors = true, bool includeTimestamp = false)
     {
         UseColors = useColors;
@@ -21,9 +19,10 @@ public sealed class ConsoleLogSink : ISharpEmuLogSink
 
     public void Write(in LogEntry entry)
     {
-        lock (_sync)
+        var writer = entry.Level >= LogLevel.Error ? Console.Error : Console.Out;
+
+        lock (writer)
         {
-            var writer = entry.Level >= LogLevel.Error ? Console.Error : Console.Out;
             if (IncludeTimestamp)
             {
                 writer.Write('[');


### PR DESCRIPTION
## Summary

Serialize console log entries and route `TryLoadTableBytes` diagnostics through the project logger so concurrent loader threads cannot interleave individual log lines across stdout and stderr.

## Testing

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Debug --no-restore --filter FullyQualifiedName~Logging|FullyQualifiedName~Loader.SelfLoaderTests`
- Game testing: N/A (console logging only).

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).