### PR TITLE
[Cpu] Restore filtered Windows fault handlers

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
@@ -30,12 +30,15 @@ public sealed partial class DirectExecutionBackend
 
 		if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_DISABLE_RAW_HANDLER"), "1", StringComparison.Ordinal))
 		{
-			_rawExceptionHandlerStub = CreateExceptionHandlerTrampoline(RawVectoredHandlerPtrManaged);
+			_rawExceptionHandlerStub = _faultHandling.CreateHandlerThunk(
+				RawVectoredHandlerPtrManaged,
+				_hostRspSlotTlsIndex,
+				_tlsGetValueAddress);
 			if (_rawExceptionHandlerStub == 0)
 			{
 				throw new InvalidOperationException("Failed to create raw exception handler trampoline");
 			}
-			_rawExceptionHandler = (nint)AddVectoredExceptionHandler(1u, _rawExceptionHandlerStub);
+			_rawExceptionHandler = _faultHandling.AddFirstChanceHandler(_rawExceptionHandlerStub);
 			Console.Error.WriteLine($"[LOADER][INFO] Raw exception handler installed: 0x{_rawExceptionHandler:X16}");
 		}
 		else
@@ -45,22 +48,28 @@ public sealed partial class DirectExecutionBackend
 
 		_handlerDelegate = VectoredHandler;
 		_handlerHandle = GCHandle.Alloc(_handlerDelegate);
-		_exceptionHandlerStub = CreateExceptionHandlerTrampoline(Marshal.GetFunctionPointerForDelegate(_handlerDelegate));
+		_exceptionHandlerStub = _faultHandling.CreateHandlerThunk(
+			Marshal.GetFunctionPointerForDelegate(_handlerDelegate),
+			_hostRspSlotTlsIndex,
+			_tlsGetValueAddress);
 		if (_exceptionHandlerStub == 0)
 		{
 			throw new InvalidOperationException("Failed to create exception handler trampoline");
 		}
-		_exceptionHandler = (nint)AddVectoredExceptionHandler(1u, _exceptionHandlerStub);
+		_exceptionHandler = _faultHandling.AddFirstChanceHandler(_exceptionHandlerStub);
 		Console.Error.WriteLine($"[LOADER][INFO] Exception handler installed: 0x{_exceptionHandler:X16}");
 
 		_unhandledFilterDelegate = UnhandledExceptionFilter;
 		_unhandledFilterHandle = GCHandle.Alloc(_unhandledFilterDelegate);
-		_unhandledFilterStub = CreateExceptionHandlerTrampoline(Marshal.GetFunctionPointerForDelegate(_unhandledFilterDelegate));
+		_unhandledFilterStub = _faultHandling.CreateHandlerThunk(
+			Marshal.GetFunctionPointerForDelegate(_unhandledFilterDelegate),
+			_hostRspSlotTlsIndex,
+			_tlsGetValueAddress);
 		if (_unhandledFilterStub == 0)
 		{
 			throw new InvalidOperationException("Failed to create unhandled exception filter trampoline");
 		}
-		SetUnhandledExceptionFilter(_unhandledFilterStub);
+		_faultHandling.SetUnhandledFilter(_unhandledFilterStub);
 	}
 
 	private unsafe int UnhandledExceptionFilter(void* exceptionInfo)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -12,7 +12,9 @@ using SharpEmu.Core.Cpu;
 using SharpEmu.Core.Cpu.Debugging;
 using SharpEmu.Core.Loader;
 using SharpEmu.Core.Memory;
+using SharpEmu.Core.Cpu.Native.Windows;
 using SharpEmu.HLE;
+using SharpEmu.HLE.Host;
 
 namespace SharpEmu.Core.Cpu.Native;
 
@@ -187,6 +189,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	private const ulong TlsModuleAllocStride = 65536uL;
 
 	private readonly IModuleManager _moduleManager;
+
+	private readonly IHostFaultHandling _faultHandling;
 
 	private nint _tlsHandlerAddress;
 
@@ -1037,6 +1041,9 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	public unsafe DirectExecutionBackend(IModuleManager moduleManager)
 	{
 		_moduleManager = moduleManager ?? throw new ArgumentNullException("moduleManager");
+		_faultHandling = OperatingSystem.IsWindows()
+			? new WindowsFaultHandling(HostPlatform.Current.Memory)
+			: NullHostFaultHandling.Instance;
 		_selfHandle = GCHandle.Alloc(this);
 		_selfHandlePtr = GCHandle.ToIntPtr(_selfHandle);
 		_guestTlsBaseTlsIndex = TlsAlloc();
@@ -2405,98 +2412,6 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			VirtualFree(ptr, 0u, 32768u);
 			return 0;
 		}
-		FlushInstructionCache(GetCurrentProcess(), ptr, (nuint)offset);
-		return (nint)ptr;
-	}
-
-	private unsafe nint CreateExceptionHandlerTrampoline(nint managedHandler)
-	{
-		const uint stubSize = 256u;
-		void* ptr = VirtualAlloc(null, stubSize, 12288u, 64u);
-		if (ptr == null)
-		{
-			return 0;
-		}
-
-		byte* code = (byte*)ptr;
-		int offset = 0;
-		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x54); // push r12
-		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x55); // push r13
-		EmitByte(code, ref offset, 0x49); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xE4); // mov r12, rsp
-		EmitByte(code, ref offset, 0x49); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xCD); // mov r13, rcx
-		EmitByte(code, ref offset, 0x65); EmitByte(code, ref offset, 0x48); // mov rax, gs:[8]
-		EmitByte(code, ref offset, 0x8B); EmitByte(code, ref offset, 0x04); EmitByte(code, ref offset, 0x25);
-		EmitUInt32(code, ref offset, 8u);
-		EmitByte(code, ref offset, 0x49); EmitByte(code, ref offset, 0x39); EmitByte(code, ref offset, 0xC4); // cmp r12, rax
-		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x83); // jae guestStack
-		int aboveStackJump = offset;
-		EmitUInt32(code, ref offset, 0u);
-		EmitByte(code, ref offset, 0x65); EmitByte(code, ref offset, 0x48); // mov rax, gs:[0x10]
-		EmitByte(code, ref offset, 0x8B); EmitByte(code, ref offset, 0x04); EmitByte(code, ref offset, 0x25);
-		EmitUInt32(code, ref offset, 0x10u);
-		EmitByte(code, ref offset, 0x49); EmitByte(code, ref offset, 0x39); EmitByte(code, ref offset, 0xC4); // cmp r12, rax
-		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x82); // jb guestStack
-		int belowStackJump = offset;
-		EmitUInt32(code, ref offset, 0u);
-
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x28);
-		EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xE9); // mov rcx, r13
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xB8);
-		*(nint*)(code + offset) = managedHandler;
-		offset += sizeof(nint);
-		EmitByte(code, ref offset, 0xFF); EmitByte(code, ref offset, 0xD0);
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xC4); EmitByte(code, ref offset, 0x28);
-		EmitByte(code, ref offset, 0xE9);
-		int hostRestoreJump = offset;
-		EmitUInt32(code, ref offset, 0u);
-
-		int guestStackOffset = offset;
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x28);
-		EmitByte(code, ref offset, 0xB9);
-		EmitUInt32(code, ref offset, _hostRspSlotTlsIndex);
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xB8);
-		*(nint*)(code + offset) = _tlsGetValueAddress;
-		offset += sizeof(nint);
-		EmitByte(code, ref offset, 0xFF); EmitByte(code, ref offset, 0xD0);
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xC4); EmitByte(code, ref offset, 0x28);
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x85); EmitByte(code, ref offset, 0xC0); // test rax, rax
-		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x84);
-		int missingTlsJump = offset;
-		EmitUInt32(code, ref offset, 0u);
-		EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x8B); EmitByte(code, ref offset, 0x18); // mov r11, [rax]
-		EmitByte(code, ref offset, 0x4D); EmitByte(code, ref offset, 0x85); EmitByte(code, ref offset, 0xDB); // test r11, r11
-		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x84);
-		int missingHostStackJump = offset;
-		EmitUInt32(code, ref offset, 0u);
-		EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xDC); // mov rsp, r11
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x28);
-		EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xE9); // mov rcx, r13
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xB8);
-		*(nint*)(code + offset) = managedHandler;
-		offset += sizeof(nint);
-		EmitByte(code, ref offset, 0xFF); EmitByte(code, ref offset, 0xD0);
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xC4); EmitByte(code, ref offset, 0x28);
-		EmitByte(code, ref offset, 0xE9);
-		int guestRestoreJump = offset;
-		EmitUInt32(code, ref offset, 0u);
-
-		int passThroughOffset = offset;
-		EmitByte(code, ref offset, 0x31); EmitByte(code, ref offset, 0xC0); // xor eax, eax
-		int restoreOffset = offset;
-		EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xE4); // mov rsp, r12
-		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5D);
-		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5C);
-		EmitByte(code, ref offset, 0xC3);
-
-		*(int*)(code + aboveStackJump) = guestStackOffset - (aboveStackJump + sizeof(int));
-		*(int*)(code + belowStackJump) = guestStackOffset - (belowStackJump + sizeof(int));
-		*(int*)(code + hostRestoreJump) = restoreOffset - (hostRestoreJump + sizeof(int));
-		*(int*)(code + missingTlsJump) = passThroughOffset - (missingTlsJump + sizeof(int));
-		*(int*)(code + missingHostStackJump) = passThroughOffset - (missingHostStackJump + sizeof(int));
-		*(int*)(code + guestRestoreJump) = restoreOffset - (guestRestoreJump + sizeof(int));
-
-		uint oldProtect = default;
-		VirtualProtect(ptr, stubSize, 32u, &oldProtect);
 		FlushInstructionCache(GetCurrentProcess(), ptr, (nuint)offset);
 		return (nint)ptr;
 	}
@@ -6219,15 +6134,6 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	private static nint TlsGetValue(uint dwTlsIndex) =>
 		OperatingSystem.IsWindows() ? Win32TlsGetValue(dwTlsIndex) : PosixHostStubs.TlsGetValue(dwTlsIndex);
 
-	private unsafe static void* AddVectoredExceptionHandler(uint first, IntPtr handler) =>
-		OperatingSystem.IsWindows() ? Win32AddVectoredExceptionHandler(first, handler) : null;
-
-	private unsafe static uint RemoveVectoredExceptionHandler(void* handle) =>
-		OperatingSystem.IsWindows() ? Win32RemoveVectoredExceptionHandler(handle) : 0u;
-
-	private static IntPtr SetUnhandledExceptionFilter(IntPtr lpTopLevelExceptionFilter) =>
-		OperatingSystem.IsWindows() ? Win32SetUnhandledExceptionFilter(lpTopLevelExceptionFilter) : IntPtr.Zero;
-
 	private static uint GetCurrentThreadId() =>
 		OperatingSystem.IsWindows() ? Win32GetCurrentThreadId() : PosixHostStubs.GetCurrentThreadId();
 
@@ -6269,15 +6175,6 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	[DllImport("kernel32.dll", CharSet = CharSet.Ansi)]
 	private static extern nint GetProcAddress(nint hModule, string procName);
-
-	[DllImport("kernel32.dll", EntryPoint = "AddVectoredExceptionHandler")]
-	private unsafe static extern void* Win32AddVectoredExceptionHandler(uint first, IntPtr handler);
-
-	[DllImport("kernel32.dll", EntryPoint = "RemoveVectoredExceptionHandler")]
-	private unsafe static extern uint Win32RemoveVectoredExceptionHandler(void* handle);
-
-	[DllImport("kernel32.dll", EntryPoint = "SetUnhandledExceptionFilter")]
-	private static extern IntPtr Win32SetUnhandledExceptionFilter(IntPtr lpTopLevelExceptionFilter);
 
 	[DllImport("kernel32.dll", EntryPoint = "GetCurrentThreadId")]
 	private static extern uint Win32GetCurrentThreadId();
@@ -6381,28 +6278,28 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		StopStallWatchdog();
 		if (_exceptionHandler != 0)
 		{
-			RemoveVectoredExceptionHandler((void*)_exceptionHandler);
+			_faultHandling.RemoveHandler(_exceptionHandler);
 			_exceptionHandler = 0;
 		}
 		if (_rawExceptionHandler != 0)
 		{
-			RemoveVectoredExceptionHandler((void*)_rawExceptionHandler);
+			_faultHandling.RemoveHandler(_rawExceptionHandler);
 			_rawExceptionHandler = 0;
 		}
 		if (_rawExceptionHandlerStub != 0)
 		{
-			VirtualFree((void*)_rawExceptionHandlerStub, 0u, 32768u);
+			_faultHandling.FreeThunk(_rawExceptionHandlerStub);
 			_rawExceptionHandlerStub = 0;
 		}
 		if (_exceptionHandlerStub != 0)
 		{
-			VirtualFree((void*)_exceptionHandlerStub, 0u, 32768u);
+			_faultHandling.FreeThunk(_exceptionHandlerStub);
 			_exceptionHandlerStub = 0;
 		}
 		if (_unhandledFilterStub != 0)
 		{
-			SetUnhandledExceptionFilter(0);
-			VirtualFree((void*)_unhandledFilterStub, 0u, 32768u);
+			_faultHandling.SetUnhandledFilter(0);
+			_faultHandling.FreeThunk(_unhandledFilterStub);
 			_unhandledFilterStub = 0;
 		}
 		if (_handlerHandle.IsAllocated)

--- a/tests/SharpEmu.Libs.Tests/Cpu/WindowsFaultHandlingTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/WindowsFaultHandlingTests.cs
@@ -1,0 +1,108 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using SharpEmu.Core.Cpu.Native.Windows;
+using SharpEmu.HLE.Host;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+public sealed unsafe class WindowsFaultHandlingTests
+{
+    [Fact]
+    public void HandlerThunkFiltersExceptionsThatMustNotEnterManagedCode()
+    {
+        using var memory = new FakeHostMemory();
+        var handling = new WindowsFaultHandling(memory);
+
+        var thunk = handling.CreateHandlerThunk((nint)0x1234, 1, (nint)0x5678);
+
+        Assert.NotEqual(0, thunk);
+        var code = new ReadOnlySpan<byte>((void*)thunk, 256);
+        Assert.True(ContainsComparison(code, WindowsFaultCodes.ClrManagedException));
+        Assert.True(ContainsComparison(code, 0xE06D7363u));
+        Assert.True(ContainsComparison(code, WindowsFaultCodes.FastFail));
+        Assert.True(ContainsComparison(code, WindowsFaultCodes.StackOverflow));
+        Assert.Equal(HostPageProtection.ReadExecute, memory.LastProtection);
+        Assert.True(memory.Flushed);
+
+        handling.FreeThunk(thunk);
+    }
+
+    private static bool ContainsComparison(ReadOnlySpan<byte> code, uint exceptionCode)
+    {
+        for (var i = 0; i <= code.Length - 7; i++)
+        {
+            if (code[i] == 0x3D &&
+                BinaryPrimitives.ReadUInt32LittleEndian(code[(i + 1)..]) == exceptionCode &&
+                code[i + 5] == 0x74)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private sealed class FakeHostMemory : IHostMemory, IDisposable
+    {
+        private void* _allocation;
+
+        public HostPageProtection LastProtection { get; private set; }
+
+        public bool Flushed { get; private set; }
+
+        public ulong Allocate(ulong desiredAddress, ulong size, HostPageProtection protection)
+        {
+            _ = desiredAddress;
+            LastProtection = protection;
+            _allocation = NativeMemory.Alloc((nuint)size);
+            return (ulong)_allocation;
+        }
+
+        public bool Free(ulong address)
+        {
+            NativeMemory.Free((void*)address);
+            _allocation = null;
+            return true;
+        }
+
+        public bool Protect(ulong address, ulong size, HostPageProtection protection, out uint rawOldProtection)
+        {
+            _ = address;
+            _ = size;
+            LastProtection = protection;
+            rawOldProtection = 0;
+            return true;
+        }
+
+        public void FlushInstructionCache(ulong address, ulong size)
+        {
+            _ = address;
+            _ = size;
+            Flushed = true;
+        }
+
+        public ulong Reserve(ulong desiredAddress, ulong size, HostPageProtection protection) =>
+            throw new NotSupportedException();
+
+        public bool Commit(ulong address, ulong size, HostPageProtection protection) =>
+            throw new NotSupportedException();
+
+        public bool ProtectRaw(ulong address, ulong size, uint rawProtection, out uint rawOldProtection) =>
+            throw new NotSupportedException();
+
+        public bool Query(ulong address, out HostRegionInfo info) =>
+            throw new NotSupportedException();
+
+        public void Dispose()
+        {
+            if (_allocation != null)
+            {
+                NativeMemory.Free(_allocation);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Reconnect the Windows fault handlers to the existing native pre-filter thunk. CLR, MSVC C++, fast-fail, and stack-overflow exceptions now continue through the native handler chain without entering managed callbacks, while guest access-violation recovery remains enabled.

The obsolete unfiltered trampoline and duplicate Win32 registration wrappers are removed. A focused test verifies the emitted exception-code comparisons, RX protection, and instruction-cache flush.

## Testing

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Debug --no-restore` (518 passed)
- `dotnet build src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r win-x64 --no-restore`
- Manual Windows/Rider attach: raw handler remains enabled without the previous fatal CLR shutdown.
- Game tested: TODO — repository owner must add the title used during manual verification.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [ ] I listed the game(s) I tested (or marked the testing section as `N/A`).