### PR TITLE
Add ZArchive (.zar) support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <PackageVersion Include="Silk.NET.Windowing" Version="2.23.0" />
     <!-- Transitive of Avalonia.Desktop; pinned to fix GHSA-xrw6-gwf8-vvr9 -->
     <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
+    <PackageVersion Include="ZarSharp" Version="0.1.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -79,13 +79,21 @@ so compatibility and performance vary by game, operating system, and GPU driver.
 ## Using
 
 Download the release archive for your operating system, extract it, and launch
-SharpEmu with the path to a legally obtained game's `eboot.bin`.
+SharpEmu with the path to a legally obtained game's `eboot.bin` or a game folder
+stored as a ZArchive `.zar` file. ZArchive games are extracted to SharpEmu's local
+cache on first launch and reused while the source archive remains unchanged.
 
 Windows PowerShell:
 
 ```powershell
 .\SharpEmu.exe "C:\path\to\game\eboot.bin" 2>&1 |
   Tee-Object -FilePath "SharpEmu.log"
+```
+
+For a ZArchive game, pass the archive itself:
+
+```powershell
+.\SharpEmu.exe "C:\path\to\game.zar"
 ```
 
 Linux and macOS:

--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using SharpEmu.Core;
 using SharpEmu.Core.Runtime;
 using SharpEmu.Core.Cpu;
 using SharpEmu.GUI;
@@ -253,8 +254,24 @@ internal static partial class Program
 
         if (!File.Exists(ebootPath))
         {
-            Log.Error($"EBOOT file was not found: {ebootPath}");
+            Log.Error($"Game executable or archive was not found: {ebootPath}");
             return 2;
+        }
+
+        if (ZArchiveGame.IsArchivePath(ebootPath))
+        {
+            var archivePath = ebootPath;
+            try
+            {
+                Log.Info($"Loading ZArchive game: {archivePath}");
+                ebootPath = ZArchiveGame.ExtractToCache(archivePath);
+                Log.Info($"ZArchive game is available at: {Path.GetDirectoryName(ebootPath)}");
+            }
+            catch (Exception exception)
+            {
+                Log.Error($"Could not load ZArchive game '{archivePath}'.", exception);
+                return 2;
+            }
         }
 
         if (!TryGetDebugServerOptions(args, out var debugServerEnabled, out var debugServerOptions, out var debugServerError))
@@ -747,6 +764,25 @@ internal static partial class Program
 
         try
         {
+            if (ZArchiveGame.IsArchivePath(ebootPath))
+            {
+                var archiveInfo = ZArchiveGame.Inspect(ebootPath);
+                if (string.IsNullOrWhiteSpace(archiveInfo.ParamJson))
+                {
+                    return null;
+                }
+
+                using var archiveDocument = JsonDocument.Parse(archiveInfo.ParamJson);
+                if (archiveDocument.RootElement.TryGetProperty("titleId", out var archiveTitleId) &&
+                    archiveTitleId.ValueKind == JsonValueKind.String)
+                {
+                    var value = archiveTitleId.GetString();
+                    return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+                }
+
+                return null;
+            }
+
             var directory = Path.GetDirectoryName(Path.GetFullPath(ebootPath));
             if (string.IsNullOrEmpty(directory))
             {
@@ -1025,8 +1061,8 @@ internal static partial class Program
 
     private static void PrintUsage()
     {
-        Log.Info("Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] [--cpu-engine=<native>] [--log-level=<level>] [--log-file[=<path>]] [--debug-server[=host:port]] <path-to-eboot.bin>");
-        Log.Info(@"Example: SharpEmu.CLI --cpu-engine=native --trace-imports=64 --log-level=debug --log-file ""E:\Games\...\eboot.bin""");
+        Log.Info("Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] [--cpu-engine=<native>] [--log-level=<level>] [--log-file[=<path>]] [--debug-server[=host:port]] <path-to-eboot.bin-or-game.zar>");
+        Log.Info(@"Example: SharpEmu.CLI --cpu-engine=native --trace-imports=64 --log-level=debug --log-file ""E:\Games\game.zar""");
         Log.Info("Debug server: --debug-server starts a live debug listener (default 127.0.0.1:5714); connect with SharpEmu.DebugClient.");
     }
 

--- a/src/SharpEmu.Core/SharpEmu.Core.csproj
+++ b/src/SharpEmu.Core/SharpEmu.Core.csproj
@@ -12,6 +12,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
   <ItemGroup>
     <PackageReference Include="Iced" />
+    <PackageReference Include="ZarSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpEmu.Core/ZArchiveGame.cs
+++ b/src/SharpEmu.Core/ZArchiveGame.cs
@@ -1,0 +1,355 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using ZarSharp;
+
+namespace SharpEmu.Core;
+
+/// <summary>Metadata needed to display and launch a game stored in a ZArchive.</summary>
+public sealed record ZArchiveGameInfo(
+    string EbootEntryPath,
+    string? ParamJson,
+    long UncompressedSize,
+    string? CoverEntryPath,
+    string? BackgroundEntryPath);
+
+/// <summary>Inspects and materializes game folders stored as <c>.zar</c> files.</summary>
+public static class ZArchiveGame
+{
+    private const string ArchiveExtension = ".zar";
+    private const int CacheFormatVersion = 1;
+    private const string CacheDirectoryName = "zar";
+
+    /// <summary>Returns whether <paramref name="path"/> has the supported archive extension.</summary>
+    public static bool IsArchivePath(string? path) =>
+        string.Equals(Path.GetExtension(path), ArchiveExtension, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Reads game metadata without extracting the archive.</summary>
+    public static ZArchiveGameInfo Inspect(string archivePath)
+    {
+        var fullPath = ValidateArchivePath(archivePath);
+        using var archive = ZArchiveReader.Open(fullPath);
+        var eboot = FindEboot(archive);
+        var gameDirectory = ArchiveDirectoryName(eboot.FullName);
+        var paramJson = ReadTextEntry(archive, ArchiveCombine(gameDirectory, "sce_sys/param.json"))
+            ?? ReadTextEntry(archive, ArchiveCombine(gameDirectory, "param.json"));
+        var coverEntryPath = FindFirstFile(
+            archive,
+            gameDirectory,
+            "sce_sys/icon0.png",
+            "sce_sys/pic0.png");
+        var backgroundEntryPath = FindFirstFile(
+            archive,
+            gameDirectory,
+            "sce_sys/pic0.png",
+            "sce_sys/pic1.png");
+
+        long uncompressedSize = 0;
+        foreach (var entry in archive.Entries)
+        {
+            if (entry.EntryType == ZArchiveEntryType.File)
+            {
+                try
+                {
+                    uncompressedSize = checked(uncompressedSize + entry.Length);
+                }
+                catch (OverflowException exception)
+                {
+                    throw new InvalidDataException("The archive's uncompressed size is too large.", exception);
+                }
+            }
+        }
+
+        return new ZArchiveGameInfo(
+            eboot.FullName,
+            paramJson,
+            uncompressedSize,
+            coverEntryPath,
+            backgroundEntryPath);
+    }
+
+    /// <summary>Reads one file entry from an archive into memory.</summary>
+    public static byte[] ReadEntryBytes(string archivePath, string entryPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryPath);
+        var fullPath = ValidateArchivePath(archivePath);
+        using var archive = ZArchiveReader.Open(fullPath);
+        var entry = archive.GetEntry(entryPath);
+        if (entry is null || entry.EntryType != ZArchiveEntryType.File)
+        {
+            throw new FileNotFoundException(
+                $"The ZArchive entry was not found: {entryPath}",
+                entryPath);
+        }
+        if (entry.Length > int.MaxValue)
+        {
+            throw new InvalidDataException(
+                $"The ZArchive entry is too large to read into memory: {entryPath}");
+        }
+
+        var data = new byte[(int)entry.Length];
+        using var input = entry.Open();
+        input.ReadExactly(data);
+        return data;
+    }
+
+    /// <summary>
+    /// Extracts an archive into a persistent cache and returns the physical path to its
+    /// <c>eboot.bin</c>. A physical tree is required because guest file APIs currently
+    /// map <c>/app0</c> to host paths.
+    /// </summary>
+    public static string ExtractToCache(string archivePath, string? cacheRoot = null)
+    {
+        var fullPath = ValidateArchivePath(archivePath);
+        var archiveInfo = new FileInfo(fullPath);
+        cacheRoot = Path.GetFullPath(cacheRoot ?? GetDefaultCacheRoot());
+        Directory.CreateDirectory(cacheRoot);
+
+        var cacheIdentity = $"{fullPath}\n{archiveInfo.Length}\n{archiveInfo.LastWriteTimeUtc.Ticks}";
+        var key = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(cacheIdentity)));
+        var extractionRoot = Path.Combine(cacheRoot, key);
+        var statePath = Path.Combine(cacheRoot, $"{key}.json");
+        var lockPath = Path.Combine(cacheRoot, $"{key}.lock");
+
+        using var extractionLock = AcquireExtractionLock(lockPath);
+        if (TryGetCachedEboot(
+                extractionRoot,
+                statePath,
+                archiveInfo.Length,
+                archiveInfo.LastWriteTimeUtc.Ticks,
+                out var cachedEboot))
+        {
+            return cachedEboot;
+        }
+
+        if (Directory.Exists(extractionRoot))
+        {
+            Directory.Delete(extractionRoot, recursive: true);
+        }
+        if (File.Exists(statePath))
+        {
+            File.Delete(statePath);
+        }
+
+        var stagingRoot = $"{extractionRoot}.extracting-{Guid.NewGuid():N}";
+        Directory.CreateDirectory(stagingRoot);
+        try
+        {
+            using var archive = ZArchiveReader.Open(fullPath);
+            var eboot = FindEboot(archive);
+            foreach (var entry in archive.Entries)
+            {
+                var destination = GetSafeDestination(stagingRoot, entry.FullName);
+                if (entry.EntryType == ZArchiveEntryType.Directory)
+                {
+                    Directory.CreateDirectory(destination);
+                    continue;
+                }
+
+                var parent = Path.GetDirectoryName(destination);
+                if (!string.IsNullOrEmpty(parent))
+                {
+                    Directory.CreateDirectory(parent);
+                }
+
+                using var input = entry.Open();
+                using var output = new FileStream(
+                    destination,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None,
+                    1024 * 1024,
+                    FileOptions.SequentialScan);
+                input.CopyTo(output, 1024 * 1024);
+            }
+
+            var stagedEboot = GetSafeDestination(stagingRoot, eboot.FullName);
+            if (!File.Exists(stagedEboot))
+            {
+                throw new InvalidDataException("The archive's eboot.bin could not be extracted.");
+            }
+
+            Directory.Move(stagingRoot, extractionRoot);
+            var state = new CacheState(
+                CacheFormatVersion,
+                archiveInfo.Length,
+                archiveInfo.LastWriteTimeUtc.Ticks,
+                eboot.FullName);
+            File.WriteAllText(statePath, JsonSerializer.Serialize(state));
+            return GetSafeDestination(extractionRoot, eboot.FullName);
+        }
+        catch
+        {
+            if (Directory.Exists(stagingRoot))
+            {
+                Directory.Delete(stagingRoot, recursive: true);
+            }
+
+            throw;
+        }
+    }
+
+    private static string ValidateArchivePath(string archivePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(archivePath);
+        var fullPath = Path.GetFullPath(archivePath);
+        if (!IsArchivePath(fullPath))
+        {
+            throw new ArgumentException("The game archive must use the .zar extension.", nameof(archivePath));
+        }
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException("The game archive was not found.", fullPath);
+        }
+
+        return fullPath;
+    }
+
+    private static ZArchiveEntry FindEboot(ZArchiveReader archive)
+    {
+        var candidates = archive.Entries
+            .Where(static entry =>
+                entry.EntryType == ZArchiveEntryType.File &&
+                string.Equals(entry.Name, "eboot.bin", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(static entry => entry.FullName.Count(character => character == '/'))
+            .ThenBy(static entry => entry.FullName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return candidates.FirstOrDefault()
+            ?? throw new InvalidDataException("The ZArchive does not contain an eboot.bin file.");
+    }
+
+    private static string? ReadTextEntry(ZArchiveReader archive, string entryPath)
+    {
+        var entry = archive.GetEntry(entryPath);
+        if (entry is null || entry.EntryType != ZArchiveEntryType.File)
+        {
+            return null;
+        }
+
+        using var input = entry.Open();
+        using var reader = new StreamReader(
+            input,
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true,
+            bufferSize: 4096,
+            leaveOpen: false);
+        return reader.ReadToEnd();
+    }
+
+    private static string? FindFirstFile(
+        ZArchiveReader archive,
+        string gameDirectory,
+        params string[] relativePaths)
+    {
+        foreach (var relativePath in relativePaths)
+        {
+            var entry = archive.GetEntry(ArchiveCombine(gameDirectory, relativePath));
+            if (entry is not null && entry.EntryType == ZArchiveEntryType.File)
+            {
+                return entry.FullName;
+            }
+        }
+
+        return null;
+    }
+
+    private static string ArchiveDirectoryName(string path)
+    {
+        var separator = path.LastIndexOf('/');
+        return separator < 0 ? string.Empty : path[..separator];
+    }
+
+    private static string ArchiveCombine(string directory, string relativePath) =>
+        string.IsNullOrEmpty(directory) ? relativePath : $"{directory}/{relativePath}";
+
+    private static string GetSafeDestination(string root, string archivePath)
+    {
+        var fullRoot = Path.GetFullPath(root);
+        var relativePath = archivePath.Replace('/', Path.DirectorySeparatorChar);
+        var destination = Path.GetFullPath(Path.Combine(fullRoot, relativePath));
+        var rootPrefix = Path.TrimEndingDirectorySeparator(fullRoot) + Path.DirectorySeparatorChar;
+        if (!destination.StartsWith(rootPrefix, PathComparison))
+        {
+            throw new InvalidDataException($"Archive entry escapes the extraction root: {archivePath}");
+        }
+
+        return destination;
+    }
+
+    private static bool TryGetCachedEboot(
+        string extractionRoot,
+        string statePath,
+        long archiveLength,
+        long archiveWriteTicks,
+        out string ebootPath)
+    {
+        ebootPath = string.Empty;
+        if (!Directory.Exists(extractionRoot) || !File.Exists(statePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var state = JsonSerializer.Deserialize<CacheState>(File.ReadAllText(statePath));
+            if (state is null ||
+                state.FormatVersion != CacheFormatVersion ||
+                state.ArchiveLength != archiveLength ||
+                state.ArchiveWriteTimeUtcTicks != archiveWriteTicks ||
+                string.IsNullOrEmpty(state.EbootEntryPath))
+            {
+                return false;
+            }
+
+            ebootPath = GetSafeDestination(extractionRoot, state.EbootEntryPath);
+            return File.Exists(ebootPath);
+        }
+        catch (Exception exception) when (
+            exception is IOException or UnauthorizedAccessException or JsonException or InvalidDataException)
+        {
+            ebootPath = string.Empty;
+            return false;
+        }
+    }
+
+    private static FileStream AcquireExtractionLock(string lockPath)
+    {
+        var deadline = DateTime.UtcNow.AddMinutes(10);
+        while (true)
+        {
+            try
+            {
+                return new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch (IOException) when (DateTime.UtcNow < deadline)
+            {
+                Thread.Sleep(100);
+            }
+        }
+    }
+
+    private static string GetDefaultCacheRoot()
+    {
+        var localData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(localData))
+        {
+            localData = Path.GetTempPath();
+        }
+
+        return Path.Combine(localData, "SharpEmu", "cache", CacheDirectoryName);
+    }
+
+    private static StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    private sealed record CacheState(
+        int FormatVersion,
+        long ArchiveLength,
+        long ArchiveWriteTimeUtcTicks,
+        string EbootEntryPath);
+}

--- a/src/SharpEmu.GUI/GameEntry.cs
+++ b/src/SharpEmu.GUI/GameEntry.cs
@@ -30,7 +30,8 @@ public sealed class GameEntry : INotifyPropertyChanged
 
     public GameEntry(
         string name, string? titleId, string? version, string path, long sizeBytes,
-        string? coverPath, string? backgroundPath)
+        string? coverPath, string? backgroundPath,
+        string? coverArchiveEntryPath = null, string? backgroundArchiveEntryPath = null)
     {
         Name = name;
         TitleId = titleId;
@@ -39,6 +40,8 @@ public sealed class GameEntry : INotifyPropertyChanged
         _sizeBytes = sizeBytes;
         CoverPath = coverPath;
         BackgroundPath = backgroundPath;
+        CoverArchiveEntryPath = coverArchiveEntryPath;
+        BackgroundArchiveEntryPath = backgroundArchiveEntryPath;
         Initials = ComputeInitials(name);
     }
 
@@ -79,6 +82,16 @@ public sealed class GameEntry : INotifyPropertyChanged
 
     /// <summary>Path to the key art (pic0/pic1) shipped with the game, if found.</summary>
     public string? BackgroundPath { get; }
+
+    /// <summary>Cover-art entry inside <see cref="Path"/> when the game is a ZArchive.</summary>
+    public string? CoverArchiveEntryPath { get; }
+
+    /// <summary>Backdrop entry inside <see cref="Path"/> when the game is a ZArchive.</summary>
+    public string? BackgroundArchiveEntryPath { get; }
+
+    public bool HasCoverSource => CoverPath is not null || CoverArchiveEntryPath is not null;
+
+    public bool HasBackgroundSource => BackgroundPath is not null || BackgroundArchiveEntryPath is not null;
 
     /// <summary>
     /// Decoded key art used as the window backdrop while this game is

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -12,6 +12,7 @@ using Avalonia.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using SharpEmu.Core;
 using SharpEmu.Core.Cpu;
 using SharpEmu.Core.Runtime;
 using SharpEmu.HLE.Host;
@@ -1151,14 +1152,17 @@ public partial class MainWindow : Window
                     return;
                 }
 
-                if (game.CoverPath is null)
+                if (!game.HasCoverSource)
                 {
                     continue;
                 }
 
                 try
                 {
-                    using var stream = File.OpenRead(game.CoverPath);
+                    using var stream = OpenGameImage(
+                        game,
+                        game.CoverPath,
+                        game.CoverArchiveEntryPath);
                     var bitmap = Bitmap.DecodeToWidth(stream, 312);
                     Dispatcher.UIThread.Post(() =>
                     {
@@ -1197,11 +1201,23 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Totals the size of the game's install folder (the directory holding
-    /// the eboot), which is far more accurate than the eboot alone.
+    /// Totals the size of the game's install folder, or returns the compressed
+    /// size when the library entry is a ZArchive.
     /// </summary>
     private static long ComputeInstallSize(string ebootPath)
     {
+        if (ZArchiveGame.IsArchivePath(ebootPath))
+        {
+            try
+            {
+                return new FileInfo(ebootPath).Length;
+            }
+            catch (Exception)
+            {
+                return 0;
+            }
+        }
+
         var directory = Path.GetDirectoryName(ebootPath);
         if (directory is null)
         {
@@ -1249,8 +1265,15 @@ public partial class MainWindow : Window
 
             try
             {
-                foreach (var file in Directory.EnumerateFiles(folder, "eboot.bin", enumeration))
+                foreach (var file in Directory.EnumerateFiles(folder, "*", enumeration))
                 {
+                    var isArchive = ZArchiveGame.IsArchivePath(file);
+                    if (!isArchive &&
+                        !string.Equals(Path.GetFileName(file), "eboot.bin", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
                     var fullPath = Path.GetFullPath(file);
                     if (!seen.Add(fullPath) || excludedPaths.Contains(fullPath))
                     {
@@ -1266,10 +1289,36 @@ public partial class MainWindow : Window
                     {
                     }
 
-                    var (title, titleId, version) = TryReadParamJson(fullPath);
+                    (string? Title, string? TitleId, string? Version) metadata;
+                    ZArchiveGameInfo? archiveInfo = null;
+                    if (isArchive)
+                    {
+                        try
+                        {
+                            archiveInfo = ZArchiveGame.Inspect(fullPath);
+                            metadata = TryParseParamJson(archiveInfo.ParamJson);
+                        }
+                        catch (Exception)
+                        {
+                            // Invalid archives are not launchable, so leave them out of the library.
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        metadata = TryReadParamJson(fullPath);
+                    }
+
                     games.Add(new GameEntry(
-                        title ?? GameNameFor(fullPath), titleId, version, fullPath, size,
-                        FindCoverFor(fullPath), FindBackgroundFor(fullPath)));
+                        metadata.Title ?? GameNameFor(fullPath),
+                        metadata.TitleId,
+                        metadata.Version,
+                        fullPath,
+                        size,
+                        isArchive ? null : FindCoverFor(fullPath),
+                        isArchive ? null : FindBackgroundFor(fullPath),
+                        archiveInfo?.CoverEntryPath,
+                        archiveInfo?.BackgroundEntryPath));
                 }
             }
             catch (Exception)
@@ -1302,9 +1351,25 @@ public partial class MainWindow : Window
                 return (null, null, null);
             }
 
-            // ReadAllText handles a UTF-8 BOM, which JsonDocument rejects in
-            // raw bytes.
-            using var document = JsonDocument.Parse(File.ReadAllText(paramPath));
+            // ReadAllText handles a UTF-8 BOM, which JsonDocument rejects in raw bytes.
+            return TryParseParamJson(File.ReadAllText(paramPath));
+        }
+        catch (Exception)
+        {
+            return (null, null, null);
+        }
+    }
+
+    private static (string? Title, string? TitleId, string? Version) TryParseParamJson(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return (null, null, null);
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
             var root = document.RootElement;
 
             string? titleId = null;
@@ -1418,6 +1483,11 @@ public partial class MainWindow : Window
 
     private static string GameNameFor(string ebootPath)
     {
+        if (ZArchiveGame.IsArchivePath(ebootPath))
+        {
+            return Path.GetFileNameWithoutExtension(ebootPath);
+        }
+
         var directory = Path.GetDirectoryName(ebootPath);
         var name = directory is not null ? Path.GetFileName(directory) : null;
         return string.IsNullOrEmpty(name) ? Path.GetFileName(ebootPath) : name;
@@ -1706,7 +1776,7 @@ public partial class MainWindow : Window
             }
         }
 
-        if (game?.BackgroundPath is null)
+        if (game is null || !game.HasBackgroundSource)
         {
             ShowDefaultBackdrop();
             return;
@@ -1716,10 +1786,12 @@ public partial class MainWindow : Window
         {
             try
             {
-                var path = game.BackgroundPath;
                 game.Background = await Task.Run(() =>
                 {
-                    using var stream = File.OpenRead(path);
+                    using var stream = OpenGameImage(
+                        game,
+                        game.BackgroundPath,
+                        game.BackgroundArchiveEntryPath);
                     return Bitmap.DecodeToWidth(stream, 1600);
                 });
             }
@@ -1737,6 +1809,25 @@ public partial class MainWindow : Window
         }
     }
 
+    private static Stream OpenGameImage(
+        GameEntry game,
+        string? physicalPath,
+        string? archiveEntryPath)
+    {
+        if (physicalPath is not null)
+        {
+            return File.OpenRead(physicalPath);
+        }
+        if (archiveEntryPath is not null && ZArchiveGame.IsArchivePath(game.Path))
+        {
+            return new MemoryStream(
+                ZArchiveGame.ReadEntryBytes(game.Path, archiveEntryPath),
+                writable: false);
+        }
+
+        throw new FileNotFoundException("The game image was not found.");
+    }
+
     // ---- Launching ----
 
     private async Task OpenFileAsync()
@@ -1748,7 +1839,7 @@ public partial class MainWindow : Window
             FileTypeFilter = new[]
             {
                 new FilePickerFileType(Localization.Instance.Get("Dialog.PsExecutables"))
-                    { Patterns = new[] { "eboot.bin", "*.bin", "*.self", "*.elf" } },
+                    { Patterns = new[] { "eboot.bin", "*.bin", "*.self", "*.elf", "*.zar" } },
                 FilePickerFileTypes.All,
             },
         });

--- a/tests/SharpEmu.Libs.Tests/Loader/ZArchiveGameTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Loader/ZArchiveGameTests.cs
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text;
+using SharpEmu.Core;
+using Xunit;
+using ZarSharp;
+
+namespace SharpEmu.Libs.Tests.Loader;
+
+public sealed class ZArchiveGameTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        $"sharpemu-zar-tests-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void Inspect_FindsNestedEbootAndReadsParamJson()
+    {
+        var archivePath = Path.Combine(_root, "nested.zar");
+        const string paramJson = """
+            { "titleId": "PPSA12345", "contentVersion": "01.002.000" }
+            """;
+        CreateArchive(
+            archivePath,
+            ("Game/eboot.bin", [0x7f, (byte)'E', (byte)'L', (byte)'F']),
+            ("Game/sce_sys/param.json", Encoding.UTF8.GetBytes(paramJson)),
+            ("Game/sce_sys/icon0.png", [4, 5]),
+            ("Game/sce_sys/pic0.png", [6]),
+            ("Game/data/file.bin", [1, 2, 3]));
+
+        var info = ZArchiveGame.Inspect(archivePath);
+
+        Assert.Equal("Game/eboot.bin", info.EbootEntryPath);
+        Assert.Contains("PPSA12345", info.ParamJson);
+        Assert.Equal("Game/sce_sys/icon0.png", info.CoverEntryPath);
+        Assert.Equal("Game/sce_sys/pic0.png", info.BackgroundEntryPath);
+        Assert.Equal([4, 5], ZArchiveGame.ReadEntryBytes(archivePath, info.CoverEntryPath!));
+        Assert.Equal(4 + Encoding.UTF8.GetByteCount(paramJson) + 2 + 1 + 3, info.UncompressedSize);
+    }
+
+    [Fact]
+    public void ExtractToCache_MaterializesTheWholeGameAndReusesTheCache()
+    {
+        var archivePath = Path.Combine(_root, "game.zar");
+        var cacheRoot = Path.Combine(_root, "cache");
+        CreateArchive(
+            archivePath,
+            ("eboot.bin", [10, 20, 30]),
+            ("sce_sys/param.json", Encoding.UTF8.GetBytes("{\"titleId\":\"PPSA00001\"}")),
+            ("data/asset.bin", [40, 50]));
+
+        var ebootPath = ZArchiveGame.ExtractToCache(archivePath, cacheRoot);
+        var cachedEbootPath = ZArchiveGame.ExtractToCache(archivePath, cacheRoot);
+
+        Assert.Equal(ebootPath, cachedEbootPath);
+        Assert.Equal([10, 20, 30], File.ReadAllBytes(ebootPath));
+        Assert.Equal(
+            [40, 50],
+            File.ReadAllBytes(Path.Combine(Path.GetDirectoryName(ebootPath)!, "data", "asset.bin")));
+    }
+
+    [Fact]
+    public void Inspect_RejectsArchiveWithoutEboot()
+    {
+        var archivePath = Path.Combine(_root, "missing-eboot.zar");
+        CreateArchive(archivePath, ("data/asset.bin", [1, 2, 3]));
+
+        var exception = Assert.Throws<InvalidDataException>(() => ZArchiveGame.Inspect(archivePath));
+
+        Assert.Contains("eboot.bin", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private static void CreateArchive(string archivePath, params (string Path, byte[] Data)[] entries)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(archivePath)!);
+        using var writer = ZArchiveWriter.Create(archivePath);
+        foreach (var entry in entries)
+        {
+            using var source = new MemoryStream(entry.Data, writable: false);
+            writer.WriteEntry(entry.Path, source);
+        }
+
+        writer.Complete();
+    }
+}


### PR DESCRIPTION
## What this does

This adds support for loading compressed .zar games using the Zarchive implementation [ZarSharp](https://www.nuget.org/packages/ZarSharp/)

## Testing

- Dreaming Sarah – The game properly loads, and its artwork shows in the launcher.

## Why this is needed

PS5 games are large folders that can have hundreds to thousands of files, and moving/copying them around can take ages. This allows them to be stored as a single file (so transfers are much faster), with the benefit of some compression (exact ratio depends on how compressed the game assets already are)

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).