### PR TITLE
[Performance] Reduce runtime hot-path overhead

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -340,6 +340,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private bool _logStackCheck;
 
+	private bool _logFocusedContinuation;
+
 	private string? _probeImportReturn;
 
 	private ulong _probeImportReturnAddress;
@@ -355,6 +357,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	private readonly HashSet<ulong> _patchedResolverReturnSites = new HashSet<ulong>();
 
 	private readonly HashSet<ulong> _patchedTlsImmediateThunkTargets = new HashSet<ulong>();
+
+	private readonly HashSet<(ulong Address, ulong Size)> _scannedTlsRegions = new();
 
 	private readonly HashSet<ulong> _contextualUnresolvedReturnSites = new HashSet<ulong>();
 
@@ -492,6 +496,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		public GuestContinuationRunner? ContinuationRunner { get; set; }
 
 		public GuestExecutionRunner? ExecutionRunner { get; set; }
+
+		public Action? ExecutionWork { get; set; }
+
+		public string? ExecutionReason { get; set; }
 	}
 
 	private sealed class ExternalGuestThreadState
@@ -1135,6 +1143,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		_logImportFrames = string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_IMPORT_FRAMES"), "1", StringComparison.Ordinal);
 		_logImportRecent = string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_IMPORT_RECENT"), "1", StringComparison.Ordinal);
 		_logStackCheck = string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_STACK_CHK"), "1", StringComparison.Ordinal);
+		_logFocusedContinuation = string.Equals(
+			Environment.GetEnvironmentVariable("SHARPEMU_TRACE_FOCUSED_CONTINUATION"),
+			"1",
+			StringComparison.Ordinal);
 		_probeImportReturn = Environment.GetEnvironmentVariable("SHARPEMU_PROBE_IMPORT_RET");
 		_probeImportReturnAddress = ParseOptionalHexAddress(
 			Environment.GetEnvironmentVariable("SHARPEMU_PROBE_IMPORT_RET_ADDRESS"));
@@ -2560,6 +2572,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		int num4 = 0;
 		int num9 = 0;
 		int sse4aPatchCount = 0;
+		int cachedRegionCount = 0;
 		while (num < num2)
 		{
 			if (VirtualQuery((void*)num, out var lpBuffer, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) == 0 || lpBuffer.RegionSize == 0)
@@ -2576,7 +2589,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			uint num7 = lpBuffer.Protect & 0xFF;
 			bool flag = lpBuffer.State == 4096 && (lpBuffer.Protect & PAGE_GUARD) == 0 && num7 != PAGE_NOACCESS;
 			bool flag2 = num7 == PAGE_EXECUTE || num7 == 32 || num7 == 64 || num7 == PAGE_EXECUTE_WRITECOPY;
-			if (flag && flag2 && num6 > num5 + MinTlsPatchInstructionBytes)
+			if (flag && flag2 && num6 > num5 + MinTlsPatchInstructionBytes &&
+				_scannedTlsRegions.Add((num5, num6 - num5)))
 			{
 				byte* ptr = (byte*)num5;
 				int scanBytes = (int)(num6 - num5);
@@ -2602,9 +2616,13 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					}
 				}
 			}
+			else if (flag && flag2 && num6 > num5 + MinTlsPatchInstructionBytes)
+			{
+				cachedRegionCount++;
+			}
 			num = num6 > num ? num6 : num + 4096uL;
 		}
-		Console.Error.WriteLine($"[LOADER][INFO] Patched {num3} TLS loads, {num9} TLS stores, {num4} stack-canary accesses, {sse4aPatchCount} SSE4a EXTRQ blends");
+		Console.Error.WriteLine($"[LOADER][INFO] Patched {num3} TLS loads, {num9} TLS stores, {num4} stack-canary accesses, {sse4aPatchCount} SSE4a EXTRQ blends (cached regions: {cachedRegionCount})");
 	}
 
 	private unsafe bool TryPatchSse4aExtrqBlend(nint address, byte* source)
@@ -4933,16 +4951,13 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			out reason);
 	}
 
-	private static void TraceFocusedContinuation(
+	private void TraceFocusedContinuation(
 		string operation,
 		ulong threadHandle,
 		GuestCpuContinuation continuation,
 		string detail)
 	{
-		if (!string.Equals(
-				Environment.GetEnvironmentVariable("SHARPEMU_TRACE_FOCUSED_CONTINUATION"),
-				"1",
-				StringComparison.Ordinal) ||
+		if (!_logFocusedContinuation ||
 			continuation.Rsp < 0x00006FFFAC000000UL ||
 			continuation.Rsp >= 0x00006FFFAC200000UL)
 		{
@@ -6013,12 +6028,19 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		GuestExecutionRunner runner;
 		lock (_guestThreadGate)
 		{
-			runner = thread.ExecutionRunner ??= new GuestExecutionRunner(
-				thread.ThreadHandle,
-				thread.Name,
-				MapGuestThreadPriority(thread.Priority));
+			if (thread.ExecutionRunner is null)
+			{
+				thread.ExecutionRunner = new GuestExecutionRunner(
+					thread.ThreadHandle,
+					thread.Name,
+					MapGuestThreadPriority(thread.Priority));
+				thread.ExecutionWork = () => RunGuestThread(thread, thread.ExecutionReason!);
+			}
+
+			thread.ExecutionReason = reason;
+			runner = thread.ExecutionRunner;
 		}
-		runner.Schedule(() => RunGuestThread(thread, reason));
+		runner.Schedule(thread.ExecutionWork!);
 	}
 
 	// Caller must hold _guestThreadGate. A guest wait can be satisfied before

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -125,6 +125,14 @@ public static partial class KernelMemoryCompatExports
         OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
     private static readonly HashSet<string> _negativeStatCache = new(HostFsPathComparer);
     private static readonly ConcurrentDictionary<string, ulong> _aprFileSizeCache = new(HostFsPathComparer);
+    private static readonly bool _logWidePrintfArgs =
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_WIDE_PRINTF_ARGS"), "1", StringComparison.Ordinal);
+    private static readonly string? _widePrintfFilter =
+        Environment.GetEnvironmentVariable("SHARPEMU_LOG_WIDE_PRINTF_FILTER");
+    private static readonly bool _logIo =
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_IO"), "1", StringComparison.Ordinal);
+    private static readonly string? _ioTraceFilter =
+        Environment.GetEnvironmentVariable("SHARPEMU_LOG_IO_FILTER");
     private static long _nextFileDescriptor = 2;
 
     internal static int AllocateGuestFileDescriptor()
@@ -1692,6 +1700,7 @@ public static partial class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
+        var verifiedPathComponents = new HashSet<string>(HostFsPathComparer);
         for (ulong i = 0; i < count; i++)
         {
             if (idsAddress != 0 &&
@@ -1707,7 +1716,7 @@ public static partial class KernelMemoryCompatExports
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
             }
 
-            var hostPath = ResolveGuestPath(guestPath);
+            var hostPath = ResolveGuestPath(guestPath, verifiedPathComponents);
             if (!TryGetAprFileSize(hostPath, out var fileSize))
             {
                 // Stop at the first miss and report its index.
@@ -1775,6 +1784,7 @@ public static partial class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
+        var verifiedPathComponents = new HashSet<string>(HostFsPathComparer);
         for (ulong i = 0; i < count; i++)
         {
             if (!TryWriteUInt32Compat(ctx, idsAddress + (i * sizeof(uint)), uint.MaxValue))
@@ -1789,7 +1799,7 @@ public static partial class KernelMemoryCompatExports
                 return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
             }
 
-            var hostPath = ResolveGuestPath(guestPath);
+            var hostPath = ResolveGuestPath(guestPath, verifiedPathComponents);
             if (!TryGetAprFileSize(hostPath, out _))
             {
                 LogIoTrace("apr_resolve_ids", guestPath, $"host='{hostPath}' index={i} count={count} result=not_found");
@@ -3928,13 +3938,12 @@ public static partial class KernelMemoryCompatExports
 
     private static bool ShouldTraceWidePrintfArgs(string format)
     {
-        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_WIDE_PRINTF_ARGS"), "1", StringComparison.Ordinal))
+        if (!_logWidePrintfArgs)
         {
             return false;
         }
 
-        var filter = Environment.GetEnvironmentVariable("SHARPEMU_LOG_WIDE_PRINTF_FILTER");
-        return string.IsNullOrEmpty(filter) || format.Contains(filter, StringComparison.Ordinal);
+        return string.IsNullOrEmpty(_widePrintfFilter) || format.Contains(_widePrintfFilter, StringComparison.Ordinal);
     }
 
     private static void TracePrintfStringArgument(CpuContext ctx, string lengthMod, ulong address)
@@ -4798,14 +4807,23 @@ public static partial class KernelMemoryCompatExports
         return FileMode.Open;
     }
 
-    public static string ResolveGuestPath(string guestPath)
+    public static string ResolveGuestPath(string guestPath) =>
+        ResolveGuestPath(guestPath, verifiedPathComponents: null);
+
+    private static string ResolveGuestPath(
+        string guestPath,
+        HashSet<string>? verifiedPathComponents)
     {
         if (string.IsNullOrWhiteSpace(guestPath))
         {
             return guestPath;
         }
 
-        if (TryResolveRegisteredGuestMount(guestPath, out var mountedPath, out var mountPrefixMatched))
+        if (TryResolveRegisteredGuestMount(
+                guestPath,
+                verifiedPathComponents,
+                out var mountedPath,
+                out var mountPrefixMatched))
         {
             return mountedPath;
         }
@@ -4824,13 +4842,13 @@ public static partial class KernelMemoryCompatExports
         if (guestPath.StartsWith("/devlog/app/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["/devlog/app/".Length..]);
-            return CombineWithinMount(ResolveDevlogAppRoot(), relative);
+            return CombineWithinMount(ResolveDevlogAppRoot(), relative, verifiedPathComponents);
         }
 
         if (guestPath.StartsWith("devlog/app/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["devlog/app/".Length..]);
-            return CombineWithinMount(ResolveDevlogAppRoot(), relative);
+            return CombineWithinMount(ResolveDevlogAppRoot(), relative, verifiedPathComponents);
         }
 
         if (string.Equals(guestPath, "/devlog/app", StringComparison.OrdinalIgnoreCase) ||
@@ -4842,7 +4860,7 @@ public static partial class KernelMemoryCompatExports
         if (guestPath.StartsWith("/temp0/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["/temp0/".Length..]);
-            return CombineWithinMount(ResolveTemp0Root(), relative);
+            return CombineWithinMount(ResolveTemp0Root(), relative, verifiedPathComponents);
         }
 
         if (string.Equals(guestPath, "/temp0", StringComparison.OrdinalIgnoreCase))
@@ -4853,13 +4871,13 @@ public static partial class KernelMemoryCompatExports
         if (guestPath.StartsWith("/download0/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["/download0/".Length..]);
-            return CombineWithinMount(ResolveDownload0Root(), relative);
+            return CombineWithinMount(ResolveDownload0Root(), relative, verifiedPathComponents);
         }
 
         if (guestPath.StartsWith("download0/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["download0/".Length..]);
-            return CombineWithinMount(ResolveDownload0Root(), relative);
+            return CombineWithinMount(ResolveDownload0Root(), relative, verifiedPathComponents);
         }
 
         if (string.Equals(guestPath, "/download0", StringComparison.OrdinalIgnoreCase) ||
@@ -4871,13 +4889,13 @@ public static partial class KernelMemoryCompatExports
         if (guestPath.StartsWith("/hostapp/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["/hostapp/".Length..]);
-            return CombineWithinMount(ResolveHostappRoot(), relative);
+            return CombineWithinMount(ResolveHostappRoot(), relative, verifiedPathComponents);
         }
 
         if (guestPath.StartsWith("hostapp/", StringComparison.OrdinalIgnoreCase))
         {
             var relative = NormalizeMountRelativePath(guestPath["hostapp/".Length..]);
-            return CombineWithinMount(ResolveHostappRoot(), relative);
+            return CombineWithinMount(ResolveHostappRoot(), relative, verifiedPathComponents);
         }
 
         if (string.Equals(guestPath, "/hostapp", StringComparison.OrdinalIgnoreCase) ||
@@ -4900,7 +4918,7 @@ public static partial class KernelMemoryCompatExports
                 guestPath.StartsWith("$\\", StringComparison.Ordinal))
             {
                 var relative = NormalizeMountRelativePath(guestPath[2..]);
-                return CombineWithinMount(app0Root, relative);
+                return CombineWithinMount(app0Root, relative, verifiedPathComponents);
             }
 
             if (string.Equals(guestPath, "/app0", StringComparison.OrdinalIgnoreCase) ||
@@ -4912,13 +4930,13 @@ public static partial class KernelMemoryCompatExports
             if (guestPath.StartsWith("/app0/", StringComparison.OrdinalIgnoreCase))
             {
                 var relative = NormalizeMountRelativePath(guestPath["/app0/".Length..]);
-                return CombineWithinMount(app0Root, relative);
+                return CombineWithinMount(app0Root, relative, verifiedPathComponents);
             }
 
             if (guestPath.StartsWith("app0/", StringComparison.OrdinalIgnoreCase))
             {
                 var relative = NormalizeMountRelativePath(guestPath["app0/".Length..]);
-                return CombineWithinMount(app0Root, relative);
+                return CombineWithinMount(app0Root, relative, verifiedPathComponents);
             }
 
             if (!Path.IsPathFullyQualified(guestPath) &&
@@ -4926,7 +4944,7 @@ public static partial class KernelMemoryCompatExports
                 !guestPath.StartsWith("\\", StringComparison.Ordinal))
             {
                 var relative = NormalizeMountRelativePath(guestPath);
-                return CombineWithinMount(app0Root, relative);
+                return CombineWithinMount(app0Root, relative, verifiedPathComponents);
             }
         }
 
@@ -4941,6 +4959,7 @@ public static partial class KernelMemoryCompatExports
 
     private static bool TryResolveRegisteredGuestMount(
         string guestPath,
+        HashSet<string>? verifiedPathComponents,
         out string hostPath,
         out bool mountPrefixMatched)
     {
@@ -5011,7 +5030,10 @@ public static partial class KernelMemoryCompatExports
         // Textual containment does not follow symlinks/junctions; refuse a
         // reparse point planted inside the mount that would redirect onto the
         // host filesystem. See EscapesMountViaReparsePoint.
-        if (EscapesMountViaReparsePoint(Path.GetFullPath(matchedHostRoot), candidate))
+        if (EscapesMountViaReparsePoint(
+                Path.GetFullPath(matchedHostRoot),
+                candidate,
+                verifiedPathComponents))
         {
             return false;
         }
@@ -5083,7 +5105,10 @@ public static partial class KernelMemoryCompatExports
     // checking containment (the same guard TryResolveRegisteredGuestMount uses)
     // rejects that escape. Returns string.Empty on denial, which callers treat
     // as an unresolved path.
-    private static string CombineWithinMount(string mountRoot, string relative)
+    private static string CombineWithinMount(
+        string mountRoot,
+        string relative,
+        HashSet<string>? verifiedPathComponents)
     {
         string fullRoot;
         string candidate;
@@ -5110,7 +5135,7 @@ public static partial class KernelMemoryCompatExports
             return string.Empty;
         }
 
-        if (EscapesMountViaReparsePoint(fullRoot, candidate))
+        if (EscapesMountViaReparsePoint(fullRoot, candidate, verifiedPathComponents))
         {
             return string.Empty;
         }
@@ -5128,7 +5153,10 @@ public static partial class KernelMemoryCompatExports
     // that do not yet exist (e.g. an O_CREAT target and its parents) carry no
     // link to follow and are simply skipped. Mirrors the reparse rejection in
     // AvPlayerExports.TryResolveSandboxedFile.
-    private static bool EscapesMountViaReparsePoint(string mountRoot, string candidate)
+    private static bool EscapesMountViaReparsePoint(
+        string mountRoot,
+        string candidate,
+        HashSet<string>? verifiedPathComponents)
     {
         var rootTrimmed = Path.TrimEndingDirectorySeparator(mountRoot);
         if (string.Equals(candidate, rootTrimmed, HostFsPathComparison))
@@ -5156,12 +5184,19 @@ public static partial class KernelMemoryCompatExports
                      StringSplitOptions.RemoveEmptyEntries))
         {
             current = Path.Combine(current, segment);
+            if (verifiedPathComponents?.Contains(current) == true)
+            {
+                continue;
+            }
+
             try
             {
                 if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
                 {
                     return true;
                 }
+
+                verifiedPathComponents?.Add(current);
             }
             catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
             {
@@ -7219,14 +7254,13 @@ public static partial class KernelMemoryCompatExports
 
     private static void LogIoTrace(string operation, string path, string detail)
     {
-        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_IO"), "1", StringComparison.Ordinal))
+        if (!_logIo)
         {
             return;
         }
 
-        var filter = Environment.GetEnvironmentVariable("SHARPEMU_LOG_IO_FILTER");
-        if (!string.IsNullOrWhiteSpace(filter) &&
-            path.IndexOf(filter, StringComparison.OrdinalIgnoreCase) < 0)
+        if (!string.IsNullOrWhiteSpace(_ioTraceFilter) &&
+            path.IndexOf(_ioTraceFilter, StringComparison.OrdinalIgnoreCase) < 0)
         {
             return;
         }
@@ -7236,7 +7270,7 @@ public static partial class KernelMemoryCompatExports
 
     private static void LogUniqueStatTrace(string guestPath, string hostPath, bool found)
     {
-        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_IO"), "1", StringComparison.Ordinal))
+        if (!_logIo)
         {
             return;
         }

--- a/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
+++ b/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
@@ -496,6 +496,7 @@ public static class Ngs2Exports
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
+        Span<byte> renderBufferInfo = stackalloc byte[RenderBufferInfoSize];
         for (uint i = 0; i < bufferInfoCount; i++)
         {
             var entryAddress = bufferInfoAddress + (i * RenderBufferInfoSize);
@@ -527,10 +528,9 @@ public static class Ngs2Exports
 
                 if (ShouldTrace() && Interlocked.Increment(ref _renderInfoDumps) <= 4)
                 {
-                    Span<byte> rbi = stackalloc byte[RenderBufferInfoSize];
-                    ctx.Memory.TryRead(entryAddress, rbi);
+                    ctx.Memory.TryRead(entryAddress, renderBufferInfo);
                     Console.Error.WriteLine(
-                        $"[LOADER][TRACE] ngs2.renderbufinfo addr=0x{bufferAddress:X} size={bufferSize} ch={channels} raw={Convert.ToHexString(rbi)}");
+                        $"[LOADER][TRACE] ngs2.renderbufinfo addr=0x{bufferAddress:X} size={bufferSize} ch={channels} raw={Convert.ToHexString(renderBufferInfo)}");
                 }
             }
         }

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -6021,9 +6021,7 @@ internal static unsafe class VulkanVideoPresenter
             }
             if (forceRasterState)
             {
-                resources.Blends = Enumerable.Repeat(
-                    GuestBlendState.Default,
-                    renderTargetFormats.Count).ToArray();
+                Array.Fill(resources.Blends, GuestBlendState.Default);
                 resources.Scissor = null;
                 resources.Viewport = null;
                 resources.Raster = GuestRasterState.Default;
@@ -6031,9 +6029,7 @@ internal static unsafe class VulkanVideoPresenter
             }
             if (isTitleDraw && _forceTitleDefaultBlend)
             {
-                resources.Blends = Enumerable.Repeat(
-                    GuestBlendState.Default,
-                    renderTargetFormats.Count).ToArray();
+                Array.Fill(resources.Blends, GuestBlendState.Default);
             }
             if (isTitleDraw && _forceTitleDefaultViewportScissor)
             {


### PR DESCRIPTION
## Summary

Reduce CPU and allocation overhead in runtime paths identified by static review and profiling the Demon's Souls intro.

- Cache diagnostic environment settings instead of querying them from hot paths.
- Reuse the guest-thread execution callback across resumes.
- Skip executable regions already covered by TLS pattern scanning.
- Reuse verified mount components within one APR filepath batch while preserving the existing reparse-point checks between calls.
- Fill existing Vulkan blend-state arrays instead of allocating replacements.
- Move the NGS2 render-info stack allocation outside the buffer loop.

The changes are intentionally local and preserve the existing architecture and compatibility behavior.

## Profiling

Two 20-second sampled CPU sessions were captured during the Demon's Souls intro. File.GetAttributes dropped from 1.23% exclusive CPU and Environment.GetEnvironmentVariableCore from 0.8% to outside the optimized trace's top 30. A separate pair of 20-second runtime-counter sessions measured managed allocation throughput decreasing from 147.9 MB/s to 106.9 MB/s and average GC pause time from 81.3 ms/s to 24.9 ms/s. These short runs are workload-sensitive, but the allocation trace also directly identified the per-resume guest-thread closure removed here.

## Testing

- dotnet build src/SharpEmu.Cli/SharpEmu.Cli.csproj -c Debug --no-restore
- dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Debug --no-restore --filter FullyQualifiedName~KernelSandboxEscapeTests|FullyQualifiedName~KernelPathCaseSensitivityTests|FullyQualifiedName~AprStreamingContractTests (24 passed)
- Demon's Souls (PPSA01342) — boots to the intro and remains responsive with the Vulkan presenter on an NVIDIA GeForce GTX 1080 Ti.
- Captured sampled CPU, GC allocation, and System.Runtime counter sessions during the intro.

## Checklist

- [x] I have read and followed CONTRIBUTING.md.
- [x] I tested my changes or marked the testing section as N/A.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as N/A).