### PR TITLE
[Ampr] Implement the FW 4.00 write-address command exports

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -1404,11 +1404,13 @@ public sealed partial class DirectExecutionBackend
 			"vWU-odnS+fU" or // sceAmprMeasureCommandSizeReadFile
 			"sSAUCCU1dv4" or // sceAmprMeasureCommandSizeWriteKernelEventQueue_04_00
 			"C+IEj+BsAFM" or // sceAmprMeasureCommandSizeWriteAddressOnCompletion
+            "4fgtGfXDrFc" or // sceAmprMeasureCommandSizeWriteAddress_04_00
 			"tZDDEo2tE5k" or // sceAmprCommandBufferGetSize
 			"GnxKOHEawhk" or // sceAmprCommandBufferGetCurrentOffset
 			"gzndltBEzWc" or // sceAmprCommandBufferGetNumCommands
 			"H896Pt-yB4I" or // sceAmprCommandBufferWriteKernelEventQueue_04_00
 			"sJXyWHjP-F8" or // sceAmprCommandBufferWriteAddressOnCompletion
+            "j0+3uJMxYJY" or // sceAmprCommandBufferWriteAddress_04_00
 			"mPpPxv5CZt4" or // sceSystemServiceGetHdrToneMapLuminance
 			"1FZBKy8HeNU" or // sceVideoOutGetVblankStatus
 			"ASoW5WE-UPo" or // sceKernelAprSubmitCommandBufferAndGetResult
@@ -1554,11 +1556,13 @@ public sealed partial class DirectExecutionBackend
 			"vWU-odnS+fU" or
 			"sSAUCCU1dv4" or
 			"C+IEj+BsAFM" or
+            "4fgtGfXDrFc" or
 			"tZDDEo2tE5k" or
 			"GnxKOHEawhk" or
 			"gzndltBEzWc" or
 			"H896Pt-yB4I" or
 			"sJXyWHjP-F8" or
+            "j0+3uJMxYJY" or
 			"mPpPxv5CZt4" or
 			"1FZBKy8HeNU" or
 			"ASoW5WE-UPo" or

--- a/src/SharpEmu.Libs/Ampr/AmprExports.cs
+++ b/src/SharpEmu.Libs/Ampr/AmprExports.cs
@@ -341,6 +341,18 @@ public static class AmprExports
     }
 
     [SysAbiExport(
+        Nid = "4fgtGfXDrFc",
+        ExportName = "sceAmprMeasureCommandSizeWriteAddress_04_00",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAmpr")]
+    public static int MeasureCommandSizeWriteAddress0400(CpuContext ctx)
+    {
+        TraceAmpr(ctx, "measure_write_address", 0, WriteAddressRecordSize, 0);
+        ctx[CpuRegister.Rax] = WriteAddressRecordSize;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
         Nid = "tZDDEo2tE5k",
         ExportName = "sceAmprCommandBufferGetSize",
         Target = Generation.Gen5,
@@ -505,6 +517,32 @@ public static class AmprExports
         }
 
         TraceAmpr(ctx, "write_address_complete", commandBuffer, address, value);
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "j0+3uJMxYJY",
+        ExportName = "sceAmprCommandBufferWriteAddress_04_00",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAmpr")]
+    public static int CommandBufferWriteAddress0400(CpuContext ctx)
+    {
+        var commandBuffer = ctx[CpuRegister.Rdi];
+        var address = ctx[CpuRegister.Rsi];
+        var value = ctx[CpuRegister.Rdx];
+
+        if (commandBuffer == 0 || address == 0)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (!AppendWriteAddressRecord(ctx, commandBuffer, address, value))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        TraceAmpr(ctx, "write_address", commandBuffer, address, value);
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }

--- a/tests/SharpEmu.Libs.Tests/Ampr/AmprWriteAddressTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ampr/AmprWriteAddressTests.cs
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Ampr;
+using System.Buffers.Binary;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Ampr;
+
+public sealed class AmprWriteAddressTests
+{
+    [Fact]
+    public void MeasureCommandSizeWriteAddress0400_MatchesOnCompletionVariant()
+    {
+        const string nid = "4fgtGfXDrFc";
+        const ulong memoryBase = 0x1_0000_0000;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        var manager = CreateManagerWithExport(
+            nid,
+            "sceAmprMeasureCommandSizeWriteAddress_04_00");
+
+        Assert.Equal(OrbisGen2Result.ORBIS_GEN2_OK, manager.Dispatch(nid, context));
+        var measured = context[CpuRegister.Rax];
+
+        Assert.Equal(0, AmprExports.MeasureCommandSizeWriteAddressOnCompletion(context));
+        Assert.Equal(context[CpuRegister.Rax], measured);
+    }
+
+    [Fact]
+    public void CommandBufferWriteAddress0400_WritesValueOnCompletion()
+    {
+        const string nid = "j0+3uJMxYJY";
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong commandBufferAddress = memoryBase + 0x100;
+        const ulong recordBufferAddress = memoryBase + 0x200;
+        const ulong watcherAddress = memoryBase + 0x800;
+        const ulong watcherValue = 1;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        var manager = CreateManagerWithExport(
+            nid,
+            "sceAmprCommandBufferWriteAddress_04_00");
+
+        context[CpuRegister.Rdi] = commandBufferAddress;
+        context[CpuRegister.Rsi] = recordBufferAddress;
+        context[CpuRegister.Rdx] = 0x100;
+
+        Assert.Equal(0, AmprExports.CommandBufferConstructor(context));
+
+        context[CpuRegister.Rdi] = commandBufferAddress;
+        context[CpuRegister.Rsi] = watcherAddress;
+        context[CpuRegister.Rdx] = watcherValue;
+
+        Assert.Equal(OrbisGen2Result.ORBIS_GEN2_OK, manager.Dispatch(nid, context));
+
+        Span<byte> watcher = stackalloc byte[sizeof(ulong)];
+        Assert.True(memory.TryRead(watcherAddress, watcher));
+        Assert.Equal(0UL, BinaryPrimitives.ReadUInt64LittleEndian(watcher));
+
+        Assert.Equal(0, AmprExports.CompleteCommandBuffer(context, commandBufferAddress));
+
+        Assert.True(memory.TryRead(watcherAddress, watcher));
+        Assert.Equal(watcherValue, BinaryPrimitives.ReadUInt64LittleEndian(watcher));
+    }
+
+    private static ModuleManager CreateManagerWithExport(string nid, string exportName)
+    {
+        var manager = new ModuleManager();
+        manager.RegisterExports(
+            SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen5));
+
+        Assert.True(manager.TryGetExport(nid, out var export), $"NID {nid} did not register.");
+        Assert.Equal(exportName, export.Name);
+        Assert.Equal("libSceAmpr", export.LibraryName);
+        Assert.Equal(Generation.Gen5, export.Target);
+        return manager;
+    }
+}


### PR DESCRIPTION
## What this does
Implements the two firmware 4.00 write-address exports in `libSceAmpr`:

- `sceAmprCommandBufferWriteAddress_04_00` (NID `j0+3uJMxYJY`)
- `sceAmprMeasureCommandSizeWriteAddress_04_00` (NID `4fgtGfXDrFc`)

`sceAmprCommandBufferWriteAddress_04_00` appends the same write-address completion record as the existing `sceAmprCommandBufferWriteAddressOnCompletion` export, while the measure export returns the same shared record size. The two NIDs are also classified as leaf/no-block imports (`IsLeafImport` / `IsNoBlockLeafImport`), alongside their existing `OnCompletion` counterparts.

## Why it's needed
Demon's Souls patch v01.005.000 imports the two `_04_00` NIDs and neither `OnCompletion` NID (`sJXyWHjP-F8`, `C+IEj+BsAFM`). During early boot, its file system layer posts a completion marker through the command export; with the import unresolved, the result check fails and the title asserts about 0.08s in:

```text
FileSystem FAILURE: pOpData->mCmdBuffer.writeAddressOnCompletion(&pOpData->mDoneWatcher, 1)
File: d:\dev\CP11_packaging\Main\Code\BPE\Source\Core\System\PS5File.cpp (380)
Message: RESULT FAIL: ... => 0x80020002
```

The failing expression is `writeAddressOnCompletion(&watcher, 1)`, with the same (command buffer, address, value) shape as the existing `OnCompletion` variant, which is why the `_04_00` exports map to the completion behavior.

## How it was verified
  - Two unit tests added in `AmprWriteAddressTests`. Both resolve the new NID through the generated Gen5 export registry, verify its export name, library, and target generation, and dispatch it by NID:
    - `MeasureCommandSizeWriteAddress0400_MatchesOnCompletionVariant`: pins the measured record size to the existing `OnCompletion` variant's so the two cannot drift apart.
    - `CommandBufferWriteAddress0400_WritesValueOnCompletion`: constructs a command buffer, dispatches the new export, verifies that the target is initially unchanged, and confirms that completion writes the requested value.
  - Full `SharpEmu.Libs.Tests` suite passes: 519/519.


## Testing

- Demon's Souls (PPSA01342 v01.005.000), Linux, RX 9070 XT (RADV): boots past the previous PS5File.cpp(380) FileSystem assert, with the completion marker written through the new export and the file system layer proceeding into engine worker-thread startup.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
