### PR TITLE
shader: allow larger bounded Gen5 programs

### DIFF
--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
@@ -80,7 +80,7 @@ public static class Gen5ShaderTranslator
     public static bool IsScalarConsumed(ulong[] mask, uint register) =>
         register < 256 && (mask[register >> 6] & (1UL << (int)(register & 63))) != 0;
 
-    private const int MaxInstructions = 4096;
+    private const int MaxInstructions = 16384;
     private const uint PsUserDataRegister = 0x0C;
     private const uint VsUserDataRegister = 0x4C;
     private const uint GsUserDataRegister = 0x8C;

--- a/tests/SharpEmu.Libs.Tests/Agc/Gen5ShaderDecoderBoundaryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/Gen5ShaderDecoderBoundaryTests.cs
@@ -13,7 +13,8 @@ public sealed class Gen5ShaderDecoderBoundaryTests
     private const ulong ShaderAddress = 0x1_0000_0000;
     private const uint Export = 0xF8000000;
     private const uint Nop = 0xBF800000;
-    private const int MaximumInstructionCount = 4096;
+    private const uint EndPgm = 0xBF810000;
+    private const int MaximumInstructionCount = 16384;
 
     [Fact]
     public void MissingAddress_IsRejectedWithoutReadingGuestMemory()
@@ -97,6 +98,23 @@ public sealed class Gen5ShaderDecoderBoundaryTests
                 sizeof(uint),
                 true),
             memory.Reads[^1]);
+    }
+
+    [Fact]
+    public void ProgramMayEndAfterPreviousDecoderLimit()
+    {
+        const int previousDecoderLimit = 4096;
+        var words = new uint[previousDecoderLimit + 1];
+        Array.Fill(words, Nop);
+        words[^1] = EndPgm;
+        var memory = RecordingCpuMemory.FromWords(ShaderAddress, words);
+
+        var decoded = Decode(memory, ShaderAddress, out var program, out var error);
+
+        Assert.True(decoded, error);
+        Assert.Equal(words.Length, program.Instructions.Count);
+        Assert.Equal("SEndpgm", program.Instructions[^1].Opcode);
+        Assert.Equal(words.Length, memory.Reads.Count);
     }
 
     private static bool Decode(


### PR DESCRIPTION
## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

---

Currently, the Gen5 shader decoder gives up after 4096 instructions. While I was testing Super Bomberman R 2, I found a shader whose 's_endpgm' appears after that cutoff, so the decoder incorrectly reports it as unterminated. This change raises that limit, to 16384. 

The focused decoder tests and complete project suite pass.

Tested with Super Bomberman R 2, also tested Dreaming Sarah and Demon's Souls for regressions to be sure. 