### PR TITLE
UPDATE: Added layout validation and complete ELF64 types

### DIFF
--- a/src/SharpEmu.Core/Loader/ProgramHeader.cs
+++ b/src/SharpEmu.Core/Loader/ProgramHeader.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
-
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace SharpEmu.Core.Loader;
@@ -8,6 +8,9 @@ namespace SharpEmu.Core.Loader;
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
 public readonly struct ProgramHeader
 {
+
+    public const int ExpectedSize = 56;
+
     private readonly uint _type;
     private readonly uint _flags;
     private readonly ulong _offset;
@@ -16,6 +19,20 @@ public readonly struct ProgramHeader
     private readonly ulong _fileSize;
     private readonly ulong _memorySize;
     private readonly ulong _alignment;
+
+    static ProgramHeader()
+    {
+        
+        int actualSize = Unsafe.SizeOf<ProgramHeader>();
+        if (actualSize != ExpectedSize)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(ProgramHeader)} layout drift detected: expected " +
+                $"{ExpectedSize} bytes (ELF64_Phdr), but got {actualSize}. " +
+                "This struct is read directly from raw ELF bytes; its " +
+                "field order and size must exactly match the ELF64 spec.");
+        }
+    }
 
     public uint Type => _type;
 
@@ -41,21 +58,17 @@ public readonly struct ProgramHeader
 public enum ProgramHeaderType : uint
 {
     Null = 0,
-
     Load = 1,
-
     Dynamic = 2,
-
+    Interp = 3,
+    Note = 4,
+    ShLib = 5,
+    Phdr = 6,
     Tls = 7,
-
     GnuEhFrame = 0x6474E550,
-
     SceRela = 0x60000000,
-
     SceProcParam = 0x61000001,
-
     SceDynLibData = 0x61000000,
-
     SceRelro = 0x61000010,
 }
 
@@ -63,10 +76,7 @@ public enum ProgramHeaderType : uint
 public enum ProgramHeaderFlags : uint
 {
     None = 0,
-
     Execute = 0x1,
-
     Write = 0x2,
-
     Read = 0x4,
 }


### PR DESCRIPTION
Static constructor verifies struct size matches ELF64 spec (56 bytes) and added missing standard ELF64 p_type values