### PR TITLE
kernel: return -1/errno from extended POSIX file calls

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
@@ -46,7 +46,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ezv-RSBNKqI", ExportName = "pread",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixPread(CpuContext ctx) => KernelPreadCore(ctx);
+    public static int PosixPread(CpuContext ctx)
+    {
+        var result = KernelPreadCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "+r3rMFwItV4", ExportName = "sceKernelPread",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -97,7 +103,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "C2kJ-byS5rM", ExportName = "pwrite",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixPwrite(CpuContext ctx) => KernelPwriteCore(ctx);
+    public static int PosixPwrite(CpuContext ctx)
+    {
+        var result = KernelPwriteCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "nKWi-N2HBV4", ExportName = "sceKernelPwrite",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -149,7 +161,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "juWbTNM+8hw", ExportName = "fsync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFsync(CpuContext ctx) => KernelFsyncCore(ctx);
+    public static int PosixFsync(CpuContext ctx)
+    {
+        var result = KernelFsyncCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "fTx66l5iWIA", ExportName = "sceKernelFsync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -157,7 +175,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "KIbJFQ0I1Cg", ExportName = "fdatasync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFdatasync(CpuContext ctx) => KernelFsyncCore(ctx);
+    public static int PosixFdatasync(CpuContext ctx)
+    {
+        var result = KernelFsyncCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "30Rh4ixbKy4", ExportName = "sceKernelFdatasync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -210,7 +234,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ih4CD9-gghM", ExportName = "ftruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFtruncate(CpuContext ctx) => KernelFtruncateCore(ctx);
+    public static int PosixFtruncate(CpuContext ctx)
+    {
+        var result = KernelFtruncateCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "VW3TVZiM4-E", ExportName = "sceKernelFtruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -246,7 +276,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ayrtszI7GBg", ExportName = "truncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixTruncate(CpuContext ctx) => KernelTruncateCore(ctx);
+    public static int PosixTruncate(CpuContext ctx)
+    {
+        var result = KernelTruncateCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result);
+    }
 
     [SysAbiExport(Nid = "WlyEA-sLDf0", ExportName = "sceKernelTruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -294,7 +330,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "NN01qLRhiqU", ExportName = "rename",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixRename(CpuContext ctx) => KernelRenameCore(ctx);
+    public static int PosixRename(CpuContext ctx)
+    {
+        var result = KernelRenameCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result);
+    }
 
     [SysAbiExport(Nid = "52NcYU9+lEo", ExportName = "sceKernelRename",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -363,7 +405,10 @@ public static partial class KernelMemoryCompatExports
         {
             if (!_openFiles.TryGetValue(fd, out var stream))
             {
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                return PosixFailure(
+                    ctx,
+                    (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND,
+                    notFoundErrno: Ebadf);
             }
 
             // POSIX dup shares the open file description (and offset), which is
@@ -386,7 +431,10 @@ public static partial class KernelMemoryCompatExports
         {
             if (!_openFiles.TryGetValue(oldFd, out var stream))
             {
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                return PosixFailure(
+                    ctx,
+                    (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND,
+                    notFoundErrno: Ebadf);
             }
 
             if (oldFd == newFd)
@@ -412,7 +460,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "8nY19bKoiZk", ExportName = "fcntl",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFcntl(CpuContext ctx) => KernelFcntlCore(ctx);
+    public static int PosixFcntl(CpuContext ctx)
+    {
+        var result = KernelFcntlCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "SoZkxZkCHaw", ExportName = "sceKernelFcntl",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelMemoryCompatExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelMemoryCompatExportsTests.cs
@@ -126,6 +126,110 @@ public sealed class KernelMemoryCompatExportsTests
     }
 
     [Fact]
+    public void PosixPread_BadDescriptorReturnsMinusOne()
+    {
+        AssertBadDescriptorReturnsMinusOne(KernelMemoryCompatExports.PosixPread);
+    }
+
+    [Fact]
+    public void PosixPwrite_BadDescriptorReturnsMinusOne()
+    {
+        AssertBadDescriptorReturnsMinusOne(KernelMemoryCompatExports.PosixPwrite);
+    }
+
+    [Fact]
+    public void PosixFsync_BadDescriptorReturnsMinusOne()
+    {
+        AssertBadDescriptorReturnsMinusOne(KernelMemoryCompatExports.PosixFsync);
+    }
+
+    [Fact]
+    public void PosixFdatasync_BadDescriptorReturnsMinusOne()
+    {
+        AssertBadDescriptorReturnsMinusOne(KernelMemoryCompatExports.PosixFdatasync);
+    }
+
+    [Fact]
+    public void PosixFtruncate_BadDescriptorReturnsMinusOne()
+    {
+        AssertBadDescriptorReturnsMinusOne(KernelMemoryCompatExports.PosixFtruncate);
+    }
+
+    [Fact]
+    public void PosixDup_BadDescriptorReturnsMinusOne()
+    {
+        AssertBadDescriptorReturnsMinusOne(KernelMemoryCompatExports.PosixDup);
+    }
+
+    [Fact]
+    public void PosixDup2_BadDescriptorReturnsMinusOne()
+    {
+        AssertBadDescriptorReturnsMinusOne(KernelMemoryCompatExports.PosixDup2);
+    }
+
+    [Fact]
+    public void PosixFcntl_BadDescriptorReturnsMinusOne()
+    {
+        AssertBadDescriptorReturnsMinusOne(KernelMemoryCompatExports.PosixFcntl);
+    }
+
+    [Fact]
+    public void PosixTruncate_MissingFileReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong pathAddress = memoryBase + 0x100;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context.FsBase = memoryBase + 0x800;
+        memory.WriteCString(pathAddress, "/__sharpemu_test_missing__/truncate.bin");
+        context[CpuRegister.Rdi] = pathAddress;
+        context[CpuRegister.Rsi] = 0;
+
+        var result = KernelMemoryCompatExports.PosixTruncate(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+        Assert.True(context.TryReadUInt32(context.FsBase + 0x40, out var errno));
+        Assert.Equal(2u, errno);
+    }
+
+    [Fact]
+    public void PosixRename_MissingFileReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong sourceAddress = memoryBase + 0x100;
+        const ulong destinationAddress = memoryBase + 0x200;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context.FsBase = memoryBase + 0x800;
+        memory.WriteCString(sourceAddress, "/__sharpemu_test_missing__/source.bin");
+        memory.WriteCString(destinationAddress, "/__sharpemu_test_missing__/destination.bin");
+        context[CpuRegister.Rdi] = sourceAddress;
+        context[CpuRegister.Rsi] = destinationAddress;
+
+        var result = KernelMemoryCompatExports.PosixRename(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+        Assert.True(context.TryReadUInt32(context.FsBase + 0x40, out var errno));
+        Assert.Equal(2u, errno);
+    }
+
+    private static void AssertBadDescriptorReturnsMinusOne(Func<CpuContext, int> export)
+    {
+        var context = new CpuContext(new FakeCpuMemory(GuestMemoryBase, 0x1000), Generation.Gen5);
+        context.FsBase = GuestMemoryBase + 0x800;
+        context[CpuRegister.Rdi] = 0x80020002;
+
+        var result = export(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+        Assert.True(context.TryReadUInt32(context.FsBase + 0x40, out var errno));
+        Assert.Equal(9u, errno);
+    }
+
+    [Fact]
     public void Sprintf_ReadsVariadicDoubleFromXmmRegister()
     {
         const ulong memoryBase = 0x1_0000_0000;


### PR DESCRIPTION
## Summary

Fixes for #491.

The extended POSIX file exports were returning raw Orbis error results when their underlying operations failed. POSIX callers expect these functions to return `-1` and set `errno`.

Route failures from `pread`, `pwrite`, `fsync`, `fdatasync`, `ftruncate`, `truncate`, `rename`, and `fcntl` through the existing POSIX error conversion helper. Invalid descriptor failures from `dup` and `dup2` now use the same conversion.

Descriptor failures use `EBADF`, while missing path failures use `ENOENT`. Invalid arguments, memory faults, and permission failures retain their existing `EINVAL`, `EFAULT`, and `EACCES` mappings.

The raw `sceKernel*` exports remain unchanged and continue returning Orbis result codes.

## Testing

Added unit tests for invalid descriptors across the affected descriptor functions and missing paths for `truncate` and `rename`.

The tests verify that failures return `-1`, place `0xffffffffffffffff` in the guest `RAX` register, and set `errno` to either `EBADF` or `ENOENT`.

Game testing was not performed because these failure paths can be exercised directly through the kernel export unit tests.

- `dotnet build SharpEmu.slnx -c Release --no-restore`
- `dotnet test SharpEmu.slnx -c Release --no-build --verbosity quiet`
- `python -m reuse lint`

All 591 tests pass.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste explanations I do not understand.
- [x] I listed the game(s) I tested or explained why game testing was not required.