### PR TITLE
fix: accept AJM codec types 23 and 24

### DIFF
--- a/src/SharpEmu.Libs/Audio/AjmExports.cs
+++ b/src/SharpEmu.Libs/Audio/AjmExports.cs
@@ -17,7 +17,7 @@ public static class AjmExports
     private const int OrbisAjmErrorCodecAlreadyRegistered = unchecked((int)0x80930009);
     private const int OrbisAjmErrorCodecNotRegistered = unchecked((int)0x8093000A);
     private const int OrbisAjmErrorWrongRevisionFlag = unchecked((int)0x8093000B);
-    private const uint MaxCodecType = 23;
+    private const uint MaxCodecType = 25;
     private const int MaxInstanceIndex = 0x2FFF;
     private static readonly ConcurrentDictionary<uint, AjmContextState> Contexts = new();
     private static int _nextContextId;

--- a/tests/SharpEmu.Libs.Tests/Audio/AjmExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Audio/AjmExportsTests.cs
@@ -80,6 +80,19 @@ public sealed class AjmExportsTests : IDisposable
         Assert.Equal(InvalidContext, RegisterCodec(contextId + 1, 1));
     }
 
+    [Theory]
+    [InlineData(23u)]
+    [InlineData(24u)]
+    public void Gen5CodecTypesCanRegisterAndCreateInstances(uint codecType)
+    {
+        var contextId = Initialize();
+
+        Assert.Equal(0, RegisterCodec(contextId, codecType));
+        Assert.Equal(
+            0,
+            CreateInstance(contextId, codecType, 0x401, InstanceAddress));
+    }
+
     [Fact]
     public void InstanceDestroy_RejectsUnknownContextAndSlot()
     {


### PR DESCRIPTION
## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

---

Currently, SharpEmu accepts AJM codec IDs 0 through 22. While testing Super Bomberman R 2, I found that it registers codec 24, which is currently rejected.

The complete project test suite passes.

Tested with Super Bomberman R 2, also tested Dreaming Sarah and Demon's Souls for regressions to be sure.
