### PR TITLE
HLE: Add stubs for sceUserServiceInitialize2, sceUserServiceGetUserNumber, sceLoginDialogInitialize, sceKernelCheckReachability, sceSaveDataDirNameSearch2, sceAjmMemoryRegister, sceAudioOut2ContextSetAttributes, sceNpTrophy2GetTrophyInfoArray

### DIFF
--- a/src/SharpEmu.Libs/Audio/AjmExports.cs
+++ b/src/SharpEmu.Libs/Audio/AjmExports.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -225,6 +226,17 @@ public static class AjmExports
         // value or an additional output object here.
         ctx[CpuRegister.Rax] = 0;
         return 0;
+    }
+
+    [SysAbiExport(
+        Nid = "bkRHEYG6lEM",
+        ExportName = "sceAjmMemoryRegister",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAjm")]
+    public static int AjmMemoryRegister(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
     internal static void ResetForTests()

--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -347,6 +347,13 @@ public static class AudioOut2Exports
     public static int AudioOut2UserDestroy(CpuContext ctx) => SetReturn(ctx, 0);
 
     [SysAbiExport(
+        Nid = "4dq2rblWlg0",
+        ExportName = "sceAudioOut2ContextSetAttributes",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2ContextSetAttributes(CpuContext ctx) => SetReturn(ctx, 0);
+
+    [SysAbiExport(
         Nid = "xywYcRB7nbQ",
         ExportName = "sceAudioOut2UserCreate",
         Target = Generation.Gen5,

--- a/src/SharpEmu.Libs/CommonDialog/LoginDialogExports.cs
+++ b/src/SharpEmu.Libs/CommonDialog/LoginDialogExports.cs
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+
+namespace SharpEmu.Libs.CommonDialog;
+
+public static class LoginDialogExports
+{
+    [SysAbiExport(
+        Nid = "qP-EvQRl2Hc",
+        ExportName = "sceLoginDialogInitialize",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceLoginDialog")]
+    public static int LoginDialogInitialize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+}

--- a/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
@@ -2170,4 +2170,15 @@ public static class KernelRuntimeCompatExports
         ctx[CpuRegister.Rax] = unchecked((uint)processId);
         return processId;
     }
+
+    [SysAbiExport(
+        Nid = "uWyW3v98sU4",
+        ExportName = "sceKernelCheckReachability",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelCheckReachability(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
 }

--- a/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
@@ -11,6 +11,18 @@ namespace SharpEmu.Libs.SaveData;
 
 public static class SaveDataExports
 {
+    [SysAbiExport(
+        Nid = "PHnuI4LhuRk",
+        ExportName = "sceSaveDataDirNameSearch2",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceSaveData")]
+    public static int DirNameSearch2(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+
     private const int OrbisSaveDataErrorParameter = unchecked((int)0x809F0000);
     private const int OrbisSaveDataErrorExists = unchecked((int)0x809F0007);
     private const int OrbisSaveDataErrorNotFound = unchecked((int)0x809F0008);

--- a/src/SharpEmu.Libs/Stubs/GameServiceStubs.cs
+++ b/src/SharpEmu.Libs/Stubs/GameServiceStubs.cs
@@ -59,4 +59,9 @@ public static class GameServiceStubs
     public static int NpUniversalDataSystemCreateEvent(CpuContext ctx) => OkWithHandle(ctx, CpuRegister.Rdi);
     public static int NpUniversalDataSystemPostEvent(CpuContext ctx) => Ok(ctx);
     public static int NpUniversalDataSystemDestroyEvent(CpuContext ctx) => Ok(ctx);
+
+    // ---- NpTrophy2: trophy info array lookup ----
+    [SysAbiExport(Nid = "y3zHpdZO6ME", ExportName = "sceNpTrophy2GetTrophyInfoArray",
+        Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libSceNpTrophy2")]
+    public static int NpTrophy2GetTrophyInfoArray(CpuContext ctx) => Ok(ctx);
 }

--- a/src/SharpEmu.Libs/UserService/UserServiceExports.cs
+++ b/src/SharpEmu.Libs/UserService/UserServiceExports.cs
@@ -35,6 +35,38 @@ public static class UserServiceExports
     }
 
     [SysAbiExport(
+        Nid = "az-0R6eviZ0",
+        ExportName = "sceUserServiceInitialize2",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceUserService")]
+    public static int UserServiceInitialize2(CpuContext ctx)
+    {
+        Trace("initialize2");
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "qbwy0Ub8b3M",
+        ExportName = "sceUserServiceGetUserNumber",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceUserService")]
+    public static int UserServiceGetUserNumber(CpuContext ctx)
+    {
+        var userId = unchecked((int)ctx[CpuRegister.Rdi]);
+        var outNumberAddress = ctx[CpuRegister.Rsi];
+        if (outNumberAddress == 0)
+        {
+            return SetReturn(ctx, OrbisUserServiceErrorInvalidArgument);
+        }
+
+        // The primary user is always user number 0.
+        return TryWriteInt32(ctx, outNumberAddress, 0)
+            ? SetReturnWithTrace(ctx, 0, $"get_user_number user={userId} number=0 out=0x{outNumberAddress:X16}")
+            : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+    }
+
+    [SysAbiExport(
         Nid = "CdWp0oHWGr0",
         ExportName = "sceUserServiceGetInitialUser",
         Target = Generation.Gen4 | Generation.Gen5,


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Testing

- Story of Seasons: A Wonderful Life (PPSA11541) previously crashed on missing imports, now boots further to Vulkan rendering.
- Light testing only, game still crashes later due to unrelated memory fault.

## Checklist

By submitting this pull request, you confirm that:

- [X] I have read and followed `CONTRIBUTING.md`.
- [X] I tested my changes or marked the testing section as `N/A`.
- [X] I wrote this pull request description myself and did not paste AI-generated explanations.
- [X] I listed the game(s) I tested (or marked the testing section as `N/A`).