### PR TITLE
fix(agc): add missing Cb/Dcb GetSize stubs for packet sizing probes

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -962,6 +962,20 @@ public static partial class AgcExports
         return ReturnPointer(ctx, commandAddress);
     }
 
+    // RenderThread/Subrender probe this before writing a NOP. Unresolved
+    // GetSize returns NOT_FOUND and leaves command-buffer sizing broken.
+    // CbNop rejects dwordCount < 2, so report that floor.
+    [SysAbiExport(
+        Nid = "t7PlZ9nt5Lc",
+        ExportName = "sceAgcCbNopGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int CbNopGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 2u * sizeof(uint);
+        return (int)ctx[CpuRegister.Rax];
+    }
+
     [SysAbiExport(
         Nid = "k3GhuSNmBLU",
         ExportName = "sceAgcCbDispatch",
@@ -1157,6 +1171,18 @@ public static partial class AgcExports
         }
 
         return ReturnPointer(ctx, commandAddress);
+    }
+
+    // Matches the fixed 8-dword ACQUIRE_MEM packet AcbAcquireMem writes above.
+    [SysAbiExport(
+        Nid = "ewobAQeMo5k",
+        ExportName = "sceAgcAcbAcquireMemGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int AcbAcquireMemGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 8u * sizeof(uint);
+        return (int)ctx[CpuRegister.Rax];
     }
 
     [SysAbiExport(
@@ -1731,6 +1757,18 @@ public static partial class AgcExports
             $"agc.dcb_acquire_mem buf=0x{commandBufferAddress:X16} cmd=0x{commandAddress:X16} " +
             $"engine={engine} cbdb=0x{cbDbOp:X8} gcr=0x{gcrControl:X8} base=0x{baseAddress:X16} size=0x{sizeBytes:X16}");
         return ReturnPointer(ctx, commandAddress);
+    }
+
+    // Matches the fixed 8-dword ACQUIRE_MEM packet DcbAcquireMem writes above.
+    [SysAbiExport(
+        Nid = "-vnlTPPXPrw",
+        ExportName = "sceAgcDcbAcquireMemGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbAcquireMemGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 8u * sizeof(uint);
+        return (int)ctx[CpuRegister.Rax];
     }
 
     [SysAbiExport(
@@ -2394,6 +2432,20 @@ public static partial class AgcExports
                              (op == ItNop && register is RWaitMem32 or RWaitMem64)
                 ? OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT
                 : OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+    }
+
+    // PatchAddress/PatchData touch UInt64 fields at +12/+20 of an RReleaseMem
+    // packet, so the packet is at least 7 dwords; use the 8-dword RELEASE_MEM
+    // family size already used elsewhere in this file.
+    [SysAbiExport(
+        Nid = "hL7C0IRpWZI",
+        ExportName = "sceAgcCbQueueEndOfPipeActionGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int CbQueueEndOfPipeActionGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 8u * sizeof(uint);
+        return (int)ctx[CpuRegister.Rax];
     }
 
     [SysAbiExport(
@@ -11327,6 +11379,34 @@ public static partial class AgcExports
 
         Console.Error.WriteLine(
             $"[LOADER][TRACE] agc.create_shader dst=0x{destinationAddress:X16} header=0x{headerAddress:X16} code=0x{codeAddress:X16} {detail}");
+    }
+
+    // Hardware REWIND is a fixed 2-dword header + valid-bit packet (same floor
+    // as CbNopGetSize). No Rewind writer is implemented yet; size-only is enough
+    // for callers that allocate the packet before filling it.
+    [SysAbiExport(
+        Nid = "QIXCsbipds0",
+        ExportName = "sceAgcDcbRewindGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbRewindGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 2u * sizeof(uint);
+        return (int)ctx[CpuRegister.Rax];
+    }
+
+    // Matches the 4-dword INDIRECT_BUFFER packet DcbJump writes below.
+    // Returning NOT_FOUND here left callers with a null packet pointer and an
+    // immediate write AV on RenderThread.
+    [SysAbiExport(
+        Nid = "VEGu4dixjUg",
+        ExportName = "sceAgcDcbJumpGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbJumpGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 4u * sizeof(uint);
+        return (int)ctx[CpuRegister.Rax];
     }
 
     [SysAbiExport(


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Adds HLE for AGC `*GetSize` NIDs that were unresolved during RenderThread / Subrender command-buffer setup.

**What changed** (`AgcExports.cs` only) — each returns a fixed packet byte size in `rax`, **no guest memory writes**:

| NID | Export | Size |
|-----|--------|------|
| `t7PlZ9nt5Lc` | `sceAgcCbNopGetSize` | 2 dwords |
| `ewobAQeMo5k` | `sceAgcAcbAcquireMemGetSize` | 8 dwords |
| `-vnlTPPXPrw` | `sceAgcDcbAcquireMemGetSize` | 8 dwords |
| `hL7C0IRpWZI` | `sceAgcCbQueueEndOfPipeActionGetSize` | 8 dwords |
| `QIXCsbipds0` | `sceAgcDcbRewindGetSize` | 2 dwords |
| `VEGu4dixjUg` | `sceAgcDcbJumpGetSize` | 4 dwords |

Sizes match the packet footprints already written by existing siblings where those exist (`CbNop`, `Acb/DcbAcquireMem`, `DcbJump`), or the known REWIND / RELEASE_MEM family floors.

**Why**
Callers probe `GetSize` before allocating/filling PM4 packets. Unresolved stubs returned `ORBIS_GEN2_ERROR_NOT_FOUND` (`0x80020002`). On PPSA04264, RenderThread then wrote through a null pointer (`r12=0`) immediately after `sceAgcDcbJumpGetSize`. This is generic sizing ABI, not a title hack, and deliberately does not invent packet writers for unknown NIDs.

**AI-assisted**
Research and implementation were AI-assisted. I reviewed each size against the existing writer / packet family in-tree and confirmed these exports perform no guest writes.

## Testing

- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) — local stack also includes AudioOut2 canary (#532) + APR WithPrefix (#534), which are separate PRs required to reach this path on this title:
  - Before: unresolved `VEGu4dixjUg` / `QIXCsbipds0` / `hL7C0IRpWZI` (and related GetSize NIDs); RenderThread AV write to `0x0` with `last_import=VEGu4dixjUg`, `rax=0x80020002`; no guest frame
  - After: **zero** unresolved WARNs for all six NIDs above; first hosted frame + guest VideoOut frame presented (`3840x2160`); RenderThread GetSize null-write AV gone
  - Remaining (out of scope): later Main Thread AV around `memcpy` (`Q3VBxCXhUHs`) — separate follow-up
- Build: `.\build.ps1` (Release `win-x64`) succeeded

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).