### PR TITLE
fix(remoteplay): stub Initialize and GetConnectionStatus as disconnected

### DIFF
--- a/src/SharpEmu.Libs/Remoteplay/RemoteplayExports.cs
+++ b/src/SharpEmu.Libs/Remoteplay/RemoteplayExports.cs
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+
+namespace SharpEmu.Libs.Remoteplay;
+
+// SharpEmu does not implement PS5 Remote Play. Titles still probe this API
+// during startup (initialize + connection-status checks while bringing up
+// pad/network subsystems). Without a handler they get ORBIS_GEN2_ERROR_NOT_FOUND
+// instead of a real status code. Reporting a clean "initialized, not connected"
+// state lets callers take their normal no-remote-play path.
+public static class RemoteplayExports
+{
+    private const int StatusDisconnected = 0;
+
+    [SysAbiExport(
+        Nid = "k1SwgkMSOM8",
+        ExportName = "sceRemoteplayInitialize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceRemoteplay")]
+    public static int RemoteplayInitialize(CpuContext ctx) => SetReturn(ctx, 0);
+
+    [SysAbiExport(
+        Nid = "g3PNjYKWqnQ",
+        ExportName = "sceRemoteplayGetConnectionStatus",
+        Target = Generation.Gen5,
+        LibraryName = "libSceRemoteplay")]
+    public static int RemoteplayGetConnectionStatus(CpuContext ctx)
+    {
+        var statusAddress = ctx[CpuRegister.Rsi];
+        if (statusAddress != 0)
+        {
+            Span<byte> status = stackalloc byte[0x10];
+            status.Clear();
+            status[0] = StatusDisconnected;
+            if (!ctx.Memory.TryWrite(statusAddress, status))
+            {
+                return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+        }
+
+        return SetReturn(ctx, 0);
+    }
+
+    private static int SetReturn(CpuContext ctx, int result)
+    {
+        ctx[CpuRegister.Rax] = unchecked((ulong)result);
+        return result;
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Remoteplay/RemoteplayExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Remoteplay/RemoteplayExportsTests.cs
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Remoteplay;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Remoteplay;
+
+public sealed class RemoteplayExportsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong StatusAddress = MemoryBase + 0x100;
+
+    private static CpuContext CreateContext(out FakeCpuMemory memory)
+    {
+        memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        return new CpuContext(memory, Generation.Gen5);
+    }
+
+    [Fact]
+    public void Initialize_Succeeds()
+    {
+        var ctx = CreateContext(out _);
+
+        var result = RemoteplayExports.RemoteplayInitialize(ctx);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void GetConnectionStatus_WritesDisconnectedStatus()
+    {
+        var ctx = CreateContext(out var memory);
+        ctx[CpuRegister.Rdi] = 0x1000_0000;
+        ctx[CpuRegister.Rsi] = StatusAddress;
+        memory.TryWrite(StatusAddress, stackalloc byte[] { 0xFF, 0xFF, 0xFF, 0xFF });
+
+        var result = RemoteplayExports.RemoteplayGetConnectionStatus(ctx);
+
+        Assert.Equal(0, result);
+        var status = new byte[4];
+        Assert.True(ctx.Memory.TryRead(StatusAddress, status));
+        Assert.Equal(0, status[0]);
+    }
+
+    [Fact]
+    public void GetConnectionStatus_NullOutPointerStillSucceeds()
+    {
+        var ctx = CreateContext(out _);
+        ctx[CpuRegister.Rdi] = 0x1000_0000;
+        ctx[CpuRegister.Rsi] = 0;
+
+        var result = RemoteplayExports.RemoteplayGetConnectionStatus(ctx);
+
+        Assert.Equal(0, result);
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Adds minimal HLE for `libSceRemoteplay` startup probes.

**What changed**
- New `RemoteplayExports.cs`:
  - `sceRemoteplayInitialize` (`k1SwgkMSOM8`) → success
  - `sceRemoteplayGetConnectionStatus` (`g3PNjYKWqnQ`) → success and writes a disconnected status byte to the caller out-buffer when present
- Unit tests for initialize, disconnected status write, and null out-pointer

**Why**
SharpEmu does not implement PS5 Remote Play, but titles still call initialize + connection-status during pad/network bring-up. Unresolved imports returned `ORBIS_GEN2_ERROR_NOT_FOUND` (`0x80020002`) instead of a real status. Reporting initialized + disconnected lets callers take their normal no-remote-play path.

**AI-assisted**
Research and implementation were AI-assisted. I reviewed the stub behavior (success / disconnected, no host Remote Play) and the unit tests, and I can explain / maintain the change.

## Testing

- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) — local stack also includes earlier AudioOut2 / APR / AGC GetSize fixes submitted separately (#532, #534, #535):
  - Before: unresolved `g3PNjYKWqnQ` ~719 times (+ `k1SwgkMSOM8`)
  - After: **zero** unresolved WARNs for both Remoteplay NIDs; unresolved import flood dropped from ~734 to 14
  - Remaining (out of scope): Main Thread null-deref AV and unresolved `w4-d0n60hdo` (`sceAgcDcbSetUcRegisterDirect`) — separate follow-up
- Unit tests: `FullyQualifiedName~Remoteplay` — 3 passed
- Build: `.\build.ps1` (Release `win-x64`) succeeded on the verify stack used for title testing

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).