### PR TITLE
[CPU] Preserve guest return values across TLS lookup

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -2444,9 +2444,16 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 		byte* code = (byte*)ptr;
 		int offset = 0;
-		EmitByte(code, ref offset, 0x48); // sub rsp, 0x20
+		// TlsGetValue returns its TLS pointer in RAX. Preserve the guest return value
+		// above the 32-byte Windows shadow space while keeping the call site aligned.
+		EmitByte(code, ref offset, 0x48); // sub rsp, 0x30
 		EmitByte(code, ref offset, 0x83);
 		EmitByte(code, ref offset, 0xEC);
+		EmitByte(code, ref offset, 0x30);
+		EmitByte(code, ref offset, 0x48); // mov [rsp+0x20], rax
+		EmitByte(code, ref offset, 0x89);
+		EmitByte(code, ref offset, 0x44);
+		EmitByte(code, ref offset, 0x24);
 		EmitByte(code, ref offset, 0x20);
 		EmitByte(code, ref offset, 0xB9); // mov ecx, tlsIndex
 		EmitUInt32(code, ref offset, _hostRspSlotTlsIndex);
@@ -2456,13 +2463,21 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		offset += sizeof(ulong);
 		EmitByte(code, ref offset, 0xFF); // call rax
 		EmitByte(code, ref offset, 0xD0);
-		EmitByte(code, ref offset, 0x48); // add rsp, 0x20
+		EmitByte(code, ref offset, 0x49); // mov r11, rax
+		EmitByte(code, ref offset, 0x89);
+		EmitByte(code, ref offset, 0xC3);
+		EmitByte(code, ref offset, 0x48); // mov rax, [rsp+0x20]
+		EmitByte(code, ref offset, 0x8B);
+		EmitByte(code, ref offset, 0x44);
+		EmitByte(code, ref offset, 0x24);
+		EmitByte(code, ref offset, 0x20);
+		EmitByte(code, ref offset, 0x48); // add rsp, 0x30
 		EmitByte(code, ref offset, 0x83);
 		EmitByte(code, ref offset, 0xC4);
-		EmitByte(code, ref offset, 0x20);
-		EmitByte(code, ref offset, 0x48); // mov rsp, [rax]
+		EmitByte(code, ref offset, 0x30);
+		EmitByte(code, ref offset, 0x49); // mov rsp, [r11]
 		EmitByte(code, ref offset, 0x8B);
-		EmitByte(code, ref offset, 0x20);
+		EmitByte(code, ref offset, 0x23);
 		EmitHostNonvolatileXmmRestore(code, ref offset);
 		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5F);
 		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5E);

--- a/tests/SharpEmu.Libs.Tests/Cpu/ImportTrampolineAbiTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/ImportTrampolineAbiTests.cs
@@ -60,6 +60,39 @@ public sealed class ImportTrampolineAbiTests
         }
     }
 
+    [Fact]
+    public unsafe void GeneratedGuestReturnStub_PreservesGuestRaxAcrossTlsLookup()
+    {
+        if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            return;
+        }
+
+        var backend = (DirectExecutionBackend)RuntimeHelpers.GetUninitializedObject(
+            typeof(DirectExecutionBackend));
+        var createStub = typeof(DirectExecutionBackend).GetMethod(
+            "CreateGuestReturnStub",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(createStub);
+        var stub = (nint)createStub.Invoke(backend, null)!;
+        Assert.NotEqual(0, stub);
+
+        try
+        {
+            var code = new ReadOnlySpan<byte>((void*)stub, 256);
+            AssertContains(code, [0x48, 0x83, 0xEC, 0x30]);       // sub rsp,0x30
+            AssertContains(code, [0x48, 0x89, 0x44, 0x24, 0x20]); // mov [rsp+0x20],rax
+            AssertContains(code, [0x49, 0x89, 0xC3]);             // mov r11,rax
+            AssertContains(code, [0x48, 0x8B, 0x44, 0x24, 0x20]); // mov rax,[rsp+0x20]
+            AssertContains(code, [0x48, 0x83, 0xC4, 0x30]);       // add rsp,0x30
+            AssertContains(code, [0x49, 0x8B, 0x23]);             // mov rsp,[r11]
+        }
+        finally
+        {
+            Assert.True(HostMemory.Free((void*)stub, 0, HostMemory.MEM_RELEASE));
+        }
+    }
+
     private static unsafe byte[] CreateTrampolineBytes()
     {
         var backend = (DirectExecutionBackend)RuntimeHelpers.GetUninitializedObject(


### PR DESCRIPTION
## What changed

- Preserve the guest's `RAX` value while the return stub calls `TlsGetValue`.
- Keep the TLS slot pointer in `R11` while restoring the original guest result.
- Add an ABI regression test for the emitted return-stub instructions.

## Why

`CreateGuestReturnStub` receives the guest function result in `RAX`, then calls
`TlsGetValue` to recover the host stack. That host call also returns in `RAX`, so
the guest result was replaced by the TLS slot pointer before control returned to
the caller.

This preservation previously existed in #104, but was lost when the CPU backend
was rewritten by #216. The change restores only that ABI guarantee while keeping
the current XMM restoration and allocation-failure cleanup intact.

## Impact

Guest entry points that return an integer or pointer now deliver that value to
their caller instead of leaking an internal host TLS address. The fix changes
only the one generated return stub; it adds no work to normal import dispatch.

## Testing

- No commercial game dump was available for runtime testing.
- `dotnet build SharpEmu.slnx -c Release --no-restore`
- `dotnet test SharpEmu.slnx -c Release --no-build --verbosity normal`
  - SharpEmu.Libs.Tests: 542 passed
  - SharpEmu.SourceGenerators.Tests: 33 passed
  - SharpEmu.ShaderCompiler.Metal.Tests: 27 passed

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or clearly stated that game testing was unavailable).