### PR TITLE
fix(cmake): invalidate stale FFmpeg library cache

### DIFF
--- a/native/bink2-bridge/CMakeLists.txt
+++ b/native/bink2-bridge/CMakeLists.txt
@@ -81,6 +81,9 @@ target_include_directories(sharpemu_bink2_bridge PRIVATE
     "${SHARPEMU_FFMPEG_SOURCE_DIR}/include")
 
 function(sharpemu_link_ffmpeg_library target library_name)
+    # find_library caches absolute paths; discard paths from an older FFmpeg
+    # tag when a build directory is reused after a package update.
+    unset(SHARPEMU_${library_name}_LIBRARY CACHE)
     find_library(SHARPEMU_${library_name}_LIBRARY
         NAMES "${library_name}" "lib${library_name}"
         PATHS "${SHARPEMU_FFMPEG_LIB_DIR}"


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Testing

- Reproduced the Linux Bink2 bridge failure with a reused CMake build directory containing the older FFmpeg library paths.
- Verified that CMake now selects the current `ffmpeg-core-6a6861e` libraries and links `libsharpemu_bink2_bridge.so` successfully.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
