### PR TITLE
fix(kernel): reject getdents on file fds and emit . / .. for empty dirs

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -7182,28 +7182,41 @@ public static partial class KernelMemoryCompatExports
     {
         if (fd < 0 || bufferAddress == 0 || requested < 512)
         {
+            ctx[CpuRegister.Rax] = unchecked((ulong)(int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
         OpenDirectory? directory;
+        bool isOpenFile;
         lock (_fdGate)
         {
             _openDirectories.TryGetValue(fd, out directory);
+            isOpenFile = directory is null && _openFiles.ContainsKey(fd);
         }
 
         if (directory is null)
         {
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            // A regular file fd used with getdents must not look like EOF (rax=0);
+            // that path has caused GTA's fiWriteAsyncDataWorker to treat the fd
+            // integer as a pointer and AV at address 0xB1.
+            var error = isOpenFile
+                ? OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT
+                : OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            LogIoTrace("getdents", $"fd:{fd}", $"result={(isOpenFile ? "not_directory" : "badfd")}");
+            ctx[CpuRegister.Rax] = unchecked((ulong)(int)error);
+            return (int)error;
         }
 
         var currentIndex = directory.NextIndex;
         if (basePointerAddress != 0 && !TryWriteUInt64Compat(ctx, basePointerAddress, (ulong)currentIndex))
         {
+            ctx[CpuRegister.Rax] = unchecked((ulong)(int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
         if (currentIndex >= directory.Entries.Length)
         {
+            LogIoTrace("getdents", directory.Path, $"fd={fd} result=eof entries={directory.Entries.Length}");
             ctx[CpuRegister.Rax] = 0;
             return (int)OrbisGen2Result.ORBIS_GEN2_OK;
         }
@@ -7234,11 +7247,16 @@ public static partial class KernelMemoryCompatExports
 
     private static string[] EnumerateDirectoryEntries(string hostPath)
     {
-        return Directory.EnumerateFileSystemEntries(hostPath)
+        // Real getdents always yields "." / ".." before other names. An empty
+        // host dir previously returned EOF on the first call (rax=0), which
+        // sent GTA's fiWriteAsyncDataWorker down a path that treated the fd as
+        // a pointer (AV at 0xB1 on /download0/cloudcache/).
+        var children = Directory.EnumerateFileSystemEntries(hostPath)
             .Select(Path.GetFileName)
             .Where(static name => !string.IsNullOrEmpty(name))
-            .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
-            .ToArray()!;
+            .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase);
+
+        return new[] { ".", ".." }.Concat(children).ToArray()!;
     }
 
     private static uint ComputeDirectoryEntryHash(ReadOnlySpan<byte> utf8Name)


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Hardens `sceKernelGetdents` / getdirentries so non-directory and empty-directory cases cannot look like EOF (`rax=0`) to callers.

**What changed** (`KernelMemoryCompatExports.cs` only)
- `KernelGetdirentriesCore`: if the fd is an open **file** (in `_openFiles`) but not an open directory, return `INVALID_ARGUMENT` and set `rax` to that error; unknown fds still return `NOT_FOUND` with the error in `rax` — never success/`rax=0`
- `EnumerateDirectoryEntries`: always prepend `.` and `..` before children so an empty host directory yields real entries on the first call instead of immediate EOF

**Why**
Callers that treat `rax=0` as end-of-directory can then misuse the raw fd integer as a pointer. On PPSA04264, `getdents(fd=0xB1)` returning success/`rax=0` led `fiWriteAsyncDataWorker` to AV reading address `0xB1`. Matching POSIX-ish getdents behavior (error on non-dirs; `.`/`..` before children) is generic kernel HLE, not a title hack.

**AI-assisted**
Research and implementation were AI-assisted. I reviewed the file-vs-directory fd check, the explicit `rax` error writes, and the `.`/`..` enumeration change, and I can explain / maintain them.

## Testing

- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) — local verify stack also includes earlier AudioOut2 / APR / AGC / Remoteplay / CreateShader fixes submitted separately (needed to reach this path on this title):
  - Before: `fiWriteAsyncDataWorker` AV read `0xB1` with `last_import=j2AIqSqJP0w` (`sceKernelGetdents`), `rax=0`, `rdi=0xB1`; exit `-1073741819`
  - After: no AV at `0xB1`; `fiWriteAsyncDataWorker` stays alive; session ran until user close; VideoOut presented hosted + guest frames (`3840x2160`)
  - Remaining (out of scope): blank/black presentation; unresolved binder NIDs `dolOmWH+huQ` / `fd5Bp5tGTgo` — separate follow-ups
- Build: `.\build.ps1` (Release `win-x64`) succeeded on the verify stack used for title testing

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).