### PR TITLE
fix(agc): nop PrepareShaderWorkDescriptor and BindShaderWorkInstance

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -273,6 +273,8 @@ public static partial class AgcExports
     private static int _tracedVertexRangeCount;
     private static long _dcbWaitRegMemTraceCount;
     private static long _createShaderTraceCount;
+    private static long _prepareShaderWorkTraceCount;
+    private static long _bindShaderWorkTraceCount;
     private static long _packetPayloadTraceCount;
     private static bool _tracedMissingPixelShaderBindings;
     private static long _unsatisfiedWaitTraceCount;
@@ -737,6 +739,54 @@ public static partial class AgcExports
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
+
+    // NID captured from shipped titles (not in the public catalog). Always
+    // paired with fd5Bp5tGTgo on the same CreateShader header.
+    //
+    // IMPORTANT: these must remain side-effect-free success stubs. Speculative
+    // guest writes through *[rdi] have smashed allocator / vtable state and
+    // triggered guest int 0x41. Unresolved imports previously returned rax=0
+    // with no writes and boot got further — match that until the real AGC ABI
+    // is known.
+    #pragma warning disable SHEM004, SHEM006
+    [SysAbiExport(
+        Nid = "dolOmWH+huQ",
+        ExportName = "sceAgcPrepareShaderWorkDescriptor",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int PrepareShaderWorkDescriptor(CpuContext ctx)
+    {
+        if (_traceAgc && ShouldTraceHotPath(ref _prepareShaderWorkTraceCount))
+        {
+            TraceAgc(
+                $"agc.prepare_shader_work.nop rdi=0x{ctx[CpuRegister.Rdi]:X16} " +
+                $"shader=0x{ctx[CpuRegister.Rsi]:X16} r8=0x{ctx[CpuRegister.R8]:X} r9=0x{ctx[CpuRegister.R9]:X}");
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+    #pragma warning restore SHEM004, SHEM006
+
+    #pragma warning disable SHEM004, SHEM006
+    [SysAbiExport(
+        Nid = "fd5Bp5tGTgo",
+        ExportName = "sceAgcBindShaderWorkInstance",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int BindShaderWorkInstance(CpuContext ctx)
+    {
+        if (_traceAgc && ShouldTraceHotPath(ref _bindShaderWorkTraceCount))
+        {
+            TraceAgc(
+                $"agc.bind_shader_work.nop inst=0x{ctx[CpuRegister.Rdi]:X16} " +
+                $"shader=0x{ctx[CpuRegister.Rsi]:X16} gpu=0x{ctx[CpuRegister.Rcx]:X16}");
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+    #pragma warning restore SHEM004, SHEM006
 
     [SysAbiExport(
         Nid = "vcmNN+AAXnY",


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Adds intentional nop-success HLE for two unknown Gen5 AGC shader-work NIDs seen after CreateShader.

**What changed** (`AgcExports.cs` only)
- `dolOmWH+huQ` → `sceAgcPrepareShaderWorkDescriptor` — `rax=0`, **no guest writes**
- `fd5Bp5tGTgo` → `sceAgcBindShaderWorkInstance` — same
- Optional `SHARPEMU_LOG_AGC=1` hot-path traces (`agc.prepare_shader_work.nop` / `agc.bind_shader_work.nop`)

**Why**
These NIDs are not in the public catalog. Speculative implementations that wrote through `*[rdi]` smashed guest allocator / vtable state and triggered `int 0x41`. Leaving them unresolved already returned `rax=0` with no writes and boot got further — this PR makes that behavior explicit until the real ABI is RE’d. **Do not “improve” with guest memory writes.**

**AI-assisted**
Research and implementation were AI-assisted. I reviewed that both exports are side-effect-free success stubs and can explain why speculative writes are unsafe here.

## Testing

- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) — local verify stack also includes earlier fixes submitted separately:
  - Before: unresolved `dolOmWH+huQ` / `fd5Bp5tGTgo` ×720 each
  - After: **zero** unresolved WARNs for both NIDs; no new AV / `int 0x41` from this path; session ran until user close
  - Remaining (out of scope): blank screen — these nops are not expected to fix presentation
- Build: `.\build.ps1` (Release `win-x64`) succeeded on the verify stack used for title testing

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).