### PR TITLE
fix(systemservice): stub notice-screen skip flag setters

### DIFF
--- a/src/SharpEmu.Libs/SystemService/SystemServiceExports.cs
+++ b/src/SharpEmu.Libs/SystemService/SystemServiceExports.cs
@@ -46,6 +46,25 @@ public static class SystemServiceExports
     }
 
     [SysAbiExport(
+        Nid = "8Lo6Zv94aho",
+        ExportName = "sceSystemServiceDisableNoticeScreenSkipFlagAutoSet",
+        Target = Generation.Gen5,
+        LibraryName = "libSceSystemService")]
+    public static int SystemServiceDisableNoticeScreenSkipFlagAutoSet(CpuContext ctx) =>
+        ctx.SetReturn(0);
+
+    // Settings entry calls this immediately before spawning SaveModTime/Load
+    // threads. An unresolved stub returns NOT_FOUND and the title can stall in
+    // that path; accept the write and report success.
+    [SysAbiExport(
+        Nid = "Q3utJvma4Mo",
+        ExportName = "sceSystemServiceSetNoticeScreenSkipFlag",
+        Target = Generation.Gen5,
+        LibraryName = "libSceSystemService")]
+    public static int SystemServiceSetNoticeScreenSkipFlag(CpuContext ctx) =>
+        ctx.SetReturn(0);
+
+    [SysAbiExport(
         Nid = "4veE0XiIugA",
         ExportName = "sceSystemServiceGetMainAppTitleId",
         Target = Generation.Gen5,


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Stubs the SystemService notice-screen skip flag setters that Settings / boot probes call.

**What changed** (`SystemServiceExports.cs` only)
- `sceSystemServiceDisableNoticeScreenSkipFlagAutoSet` (`8Lo6Zv94aho`) → success
- `sceSystemServiceSetNoticeScreenSkipFlag` (`Q3utJvma4Mo`) → success

**Why**
Unresolved stubs returned `ORBIS_GEN2_ERROR_NOT_FOUND` (`0x80020002`). On this title, Settings entry has been observed to call `Q3utJvma4Mo` immediately before SaveModTime/Load threads; accepting the calls lets that path proceed. No notice UI exists in the emulator — success is enough.

**AI-assisted**
Research and implementation were AI-assisted. I reviewed both stubs as side-effect-free success returns next to the existing GetNoticeScreenSkipFlag helper.

## Testing

- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) — local verify stack also includes earlier fixes submitted separately:
  - Before: unresolved `8Lo6Zv94aho` / `Q3utJvma4Mo` ×1 each during boot
  - After: **zero** unresolved WARNs for both NIDs; session ran until user close
  - Remaining (out of scope): full Settings soft-lock / SaveData profile path if it reappears — separate follow-up
- Build: `.\build.ps1` (Release `win-x64`) succeeded on the verify stack used for title testing

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).