### PR TITLE
fix(agc): map PS interpolants via SPI_PS_INPUT_CNTL semantics

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -215,7 +215,7 @@ public static partial class AgcExports
     private static readonly ConcurrentDictionary<
         (ulong Es, ulong EsState, ulong Ps, ulong PsState, ulong OutputLayout,
          uint OutputCount, uint Attributes, uint PsInputEna, uint PsInputAddr,
-         ulong AliasAlignment),
+         ulong PsInputCntl, ulong AliasAlignment),
         (IGuestCompiledShader Vertex, IGuestCompiledShader Pixel)> _graphicsShaderCache = new();
     private static readonly ConcurrentDictionary<
         (ulong Cs, ulong State, uint LocalX, uint LocalY, uint LocalZ,
@@ -846,53 +846,228 @@ public static partial class AgcExports
         var geometryShaderAddress = ctx[CpuRegister.Rsi];
         var pixelShaderAddress = ctx[CpuRegister.Rdx];
 
-        if (registersAddress == 0 || geometryShaderAddress == 0)
+        if (registersAddress == 0)
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryReadUInt64(ctx, geometryShaderAddress + ShaderOutputSemanticsOffset, out var outputSemanticsAddress) ||
-            !TryReadUInt32(ctx, geometryShaderAddress + ShaderNumOutputSemanticsOffset, out var outputSemanticsCount))
-        {
-            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
-        }
-
+        // SPI_PS_INPUT_CNTL maps each PS VINTRP ATTR slot to a VS/GS param export.
+        // Walk PS input semantics, find the GS output with the same semantic id,
+        // and pack the hardware CNTL word (location in bits [4:0], Flat at 0x400).
+        uint inputSemanticsCount = 0;
         ulong inputSemanticsAddress = 0;
-        if (pixelShaderAddress != 0 &&
-            (!TryReadUInt64(ctx, pixelShaderAddress + ShaderInputSemanticsOffset, out inputSemanticsAddress) ||
-             !TryReadUInt32(ctx, pixelShaderAddress + ShaderNumInputSemanticsOffset, out _)))
+        if (pixelShaderAddress != 0)
         {
-            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
-        }
-
-        for (uint i = 0; i < 32; i++)
-        {
-            uint value = 0;
-            if (i < outputSemanticsCount && outputSemanticsAddress != 0)
-            {
-                var flat = false;
-                if (pixelShaderAddress != 0 && inputSemanticsAddress != 0 &&
-                    TryReadUInt32(ctx, inputSemanticsAddress + (i * sizeof(uint)), out var inputSemantic))
-                {
-                    flat = ((inputSemantic >> 22) & 0x1) != 0;
-                }
-
-                value = i | (flat ? 0x400u : 0u);
-            }
-
-            var destination = registersAddress + (i * 8);
-            if (!TryWriteUInt32(ctx, destination, SpiPsInputCntl0 + i) ||
-                !TryWriteUInt32(ctx, destination + sizeof(uint), value))
+            if (!TryReadUInt64(ctx, pixelShaderAddress + ShaderInputSemanticsOffset, out inputSemanticsAddress) ||
+                !TryReadUInt32(ctx, pixelShaderAddress + ShaderNumInputSemanticsOffset, out inputSemanticsCount))
             {
                 return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             }
         }
 
-        TraceAgc($"agc.create_interpolant_mapping regs=0x{registersAddress:X16} gs=0x{geometryShaderAddress:X16} ps=0x{pixelShaderAddress:X16}");
+        if (inputSemanticsCount == 0 || inputSemanticsAddress == 0)
+        {
+            if (!TryWriteIdentityInterpolantRegisters(ctx, registersAddress, 0))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+
+            TraceAgc(
+                $"agc.create_interpolant_mapping regs=0x{registersAddress:X16} " +
+                $"gs=0x{geometryShaderAddress:X16} ps=0x{pixelShaderAddress:X16} inputs=0");
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        if (geometryShaderAddress == 0)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        // NumOutputSemantics is a u16 at header +0x56.
+        if (!TryReadUInt64(ctx, geometryShaderAddress + ShaderOutputSemanticsOffset, out var outputSemanticsAddress) ||
+            !TryReadUInt16(ctx, geometryShaderAddress + ShaderNumOutputSemanticsOffset, out var outputSemanticsCount))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        inputSemanticsCount = Math.Min(inputSemanticsCount, 32u);
+        for (uint psIndex = 0; psIndex < inputSemanticsCount; psIndex++)
+        {
+            if (!TryReadUInt32(
+                    ctx,
+                    inputSemanticsAddress + (psIndex * sizeof(uint)),
+                    out var psWord))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+
+            var psSemantic = psWord & 0xFFu;
+            uint? gsWord = null;
+            if (outputSemanticsAddress != 0)
+            {
+                for (uint gsIndex = 0; gsIndex < outputSemanticsCount; gsIndex++)
+                {
+                    if (!TryReadUInt32(
+                            ctx,
+                            outputSemanticsAddress + (gsIndex * sizeof(uint)),
+                            out var candidate))
+                    {
+                        return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+                    }
+
+                    if ((candidate & 0xFFu) == psSemantic)
+                    {
+                        gsWord = candidate;
+                        break;
+                    }
+                }
+            }
+
+            var value = (psWord & 0x0030_0000u) != 0
+                ? CreateInterpolantF16Value(psWord, gsWord)
+                : CreateInterpolantNonF16Value(psWord, gsWord.HasValue);
+            value = gsWord is { } matched
+                ? CreateInterpolantMappingValue(value, psWord, matched)
+                : CreateInterpolantDefaultParamValue(value, psWord);
+
+            if (!TryWriteInterpolantRegister(ctx, registersAddress, psIndex, value))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+        }
+
+        if (!TryWriteIdentityInterpolantRegisters(ctx, registersAddress, inputSemanticsCount))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAgc(
+            $"agc.create_interpolant_mapping regs=0x{registersAddress:X16} " +
+            $"gs=0x{geometryShaderAddress:X16} ps=0x{pixelShaderAddress:X16} " +
+            $"inputs={inputSemanticsCount} outputs={outputSemanticsCount}");
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
     #pragma warning restore SHEM004
+
+    private static uint ApplyInterpolantDefaultValue(uint value, uint psWord)
+    {
+        value &= ~0x0000_0300u;
+        value |= ((psWord >> 28) & 0x3u) << 8;
+        return value;
+    }
+
+    private static uint ApplyInterpolantDefaultValueHi(uint value, uint psWord)
+    {
+        value &= ~0x0060_0000u;
+        value |= ((psWord >> 30) & 0x3u) << 21;
+        return value;
+    }
+
+    private static uint CreateInterpolantMappingValue(uint value, uint psWord, uint gsWord)
+    {
+        var flatShade =
+            (psWord & 0x0040_0000u) != 0 || (psWord & 0x0100_0000u) != 0
+                ? 0x0000_0400u
+                : 0u;
+        value &= ~0x0000_001Fu;
+        value |= (gsWord >> 8) & 0x1Fu;
+        value &= ~0x0000_0400u;
+        value |= flatShade;
+        return ApplyInterpolantDefaultValue(value, psWord);
+    }
+
+    private static uint CreateInterpolantDefaultParamValue(uint value, uint psWord)
+    {
+        value &= ~0x0000_001Fu;
+        value &= ~0x0000_0400u;
+        return ApplyInterpolantDefaultValue(value, psWord);
+    }
+
+    private static uint CreateInterpolantF16Value(uint psWord, uint? gsWord)
+    {
+        var value = (psWord << 4) & 0x0300_0000u;
+        if (gsWord is null)
+        {
+            value |= 0x0018_0020u;
+        }
+        else
+        {
+            var commonWord = psWord & gsWord.Value;
+            value &= 0xFFF7_FFDFu;
+            value |= (commonWord >> 15) & 0x20u;
+            value ^= 0x0008_0020u;
+            value &= ~0x0010_0000u;
+            value |= (~commonWord >> 1) & 0x0010_0000u;
+        }
+
+        return ApplyInterpolantDefaultValueHi(value, psWord);
+    }
+
+    private static uint CreateInterpolantNonF16Value(uint psWord, bool hasGsSemantic)
+    {
+        uint value = 0;
+        if ((psWord & 0x0100_0000u) != 0 || !hasGsSemantic)
+        {
+            value |= 0x20u;
+        }
+
+        return value;
+    }
+
+    private static bool TryWriteInterpolantRegister(
+        CpuContext ctx,
+        ulong registersAddress,
+        uint index,
+        uint value)
+    {
+        var destination = registersAddress + (index * 8);
+        return TryWriteUInt32(ctx, destination, SpiPsInputCntl0 + index) &&
+               TryWriteUInt32(ctx, destination + sizeof(uint), value);
+    }
+
+    private static bool TryWriteIdentityInterpolantRegisters(
+        CpuContext ctx,
+        ulong registersAddress,
+        uint firstIndex)
+    {
+        for (uint i = firstIndex; i < 32u; i++)
+        {
+            if (!TryWriteInterpolantRegister(ctx, registersAddress, i, i))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static uint[] ReadPsInputCntlRegisters(IReadOnlyDictionary<uint, uint> cxRegisters)
+    {
+        var cntl = new uint[32];
+        for (uint i = 0; i < 32u; i++)
+        {
+            // Unprogrammed slots default to identity (ATTR i → param i).
+            cntl[i] = cxRegisters.TryGetValue(SpiPsInputCntl0 + i, out var value)
+                ? value
+                : i;
+        }
+
+        return cntl;
+    }
+
+    private static ulong ComputePsInputCntlFingerprint(ReadOnlySpan<uint> cntl)
+    {
+        const ulong prime = 1099511628211UL;
+        var hash = 14695981039346656037UL;
+        foreach (var value in cntl)
+        {
+            hash = (hash ^ value) * prime;
+        }
+
+        return hash;
+    }
 
     // NID captured from shipped titles; the friendly name collides with a real catalog symbol of a different NID. Rename pending AGC API confirmation.
     #pragma warning disable SHEM004
@@ -6503,6 +6678,8 @@ public static partial class AgcExports
         var pixelStateFingerprint = _bakeScalars
             ? ComputeShaderStateFingerprint(pixelEvaluation)
             : ComputeShaderStructuralFingerprint(pixelEvaluation);
+        var psInputCntl = ReadPsInputCntlRegisters(state.CxRegisters);
+        var psInputCntlFingerprint = ComputePsInputCntlFingerprint(psInputCntl);
         var shaderKey = (
             exportShaderAddress,
             exportStateFingerprint,
@@ -6513,6 +6690,7 @@ public static partial class AgcExports
             attributeCount,
             psInputEna,
             psInputAddr,
+            psInputCntlFingerprint,
             _storageBufferOffsetAlignment);
 
         var guestGlobalBuffers =
@@ -6586,6 +6764,7 @@ public static partial class AgcExports
                         scalarRegisterBufferIndex: _bakeScalars ? -1 : guestGlobalBuffers,
                         pixelInputEnable: psInputEna,
                         pixelInputAddress: psInputAddr,
+                        pixelInputCntl: psInputCntl,
                         storageBufferOffsetAlignment:
                             _storageBufferOffsetAlignment) ||
                     !GuestGpu.Current.TryCompileVertexShader(
@@ -10504,6 +10683,7 @@ public static partial class AgcExports
                                  out var compileError,
                                  pixelInputEnable: psInputEna,
                                  pixelInputAddress: psInputAddr,
+                                 pixelInputCntl: ReadPsInputCntlRegisters(state.CxRegisters),
                                  storageBufferOffsetAlignment:
                                      _storageBufferOffsetAlignment))
                         {
@@ -11507,6 +11687,28 @@ public static partial class AgcExports
             _dcbWindowBuffer = null;
             _dcbWindowByteLength = 0;
         }
+    }
+
+    private static bool TryReadUInt16(CpuContext ctx, ulong address, out ushort value)
+    {
+        if (_dcbWindowBuffer is { } window &&
+            address >= _dcbWindowStart &&
+            address - _dcbWindowStart + sizeof(ushort) <= (ulong)_dcbWindowByteLength)
+        {
+            value = BinaryPrimitives.ReadUInt16LittleEndian(
+                window.AsSpan((int)(address - _dcbWindowStart)));
+            return true;
+        }
+
+        Span<byte> buffer = stackalloc byte[sizeof(ushort)];
+        if (!ctx.Memory.TryRead(address, buffer))
+        {
+            value = 0;
+            return false;
+        }
+
+        value = BinaryPrimitives.ReadUInt16LittleEndian(buffer);
+        return true;
     }
 
     private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)

--- a/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
@@ -54,6 +54,7 @@ internal interface IGuestGpuBackend
         int scalarRegisterBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1);
 
     bool TryCompileComputeShader(

--- a/src/SharpEmu.Libs/Gpu/Metal/MetalGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Metal/MetalGuestGpuBackend.cs
@@ -70,6 +70,7 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
         int scalarRegisterBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1)
     {
         shader = null;
@@ -85,6 +86,7 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
                 scalarRegisterBufferIndex,
                 pixelInputEnable,
                 pixelInputAddress,
+                pixelInputCntl,
                 storageBufferOffsetAlignment))
         {
             return false;

--- a/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
@@ -64,6 +64,7 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         int scalarRegisterBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1)
     {
         shader = null;
@@ -79,6 +80,7 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
                 scalarRegisterBufferIndex,
                 pixelInputEnable,
                 pixelInputAddress,
+                pixelInputCntl,
                 storageBufferOffsetAlignment))
         {
             return false;

--- a/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.cs
@@ -74,6 +74,7 @@ public static partial class Gen5MslTranslator
         int pixelRenderTargetSlot = 0,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1) =>
         TryCompilePixelShader(
             state,
@@ -87,6 +88,7 @@ public static partial class Gen5MslTranslator
             initialScalarBufferIndex,
             pixelInputEnable,
             pixelInputAddress,
+            pixelInputCntl,
             storageBufferOffsetAlignment);
 
     public static bool TryCompilePixelShader(
@@ -101,6 +103,7 @@ public static partial class Gen5MslTranslator
         int initialScalarBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1)
     {
         shader = default!;
@@ -161,7 +164,8 @@ public static partial class Gen5MslTranslator
             pixelOutputBindings: outputs,
             imageBindingBase: imageBindingBase,
             pixelInputEnable: pixelInputEnable,
-            pixelInputAddress: pixelInputAddress);
+            pixelInputAddress: pixelInputAddress,
+            pixelInputCntl: pixelInputCntl);
         return context.TryCompile(out shader, out error);
     }
 
@@ -254,6 +258,7 @@ public static partial class Gen5MslTranslator
         private readonly int _imageBindingBase;
         private readonly uint _pixelInputEnable;
         private readonly uint _pixelInputAddress;
+        private readonly uint[] _pixelInputCntl;
         private readonly Dictionary<uint, int> _imageBindingByPc = [];
         private readonly Dictionary<uint, int> _bufferBindingByPc = [];
         private readonly List<(bool IsStorage, string ComponentKind)> _imageKinds = [];
@@ -294,12 +299,20 @@ public static partial class Gen5MslTranslator
             int imageBindingBase = 0,
             uint pixelInputEnable = 0,
             uint pixelInputAddress = 0,
+            IReadOnlyList<uint>? pixelInputCntl = null,
             int requiredVertexOutputCount = 0)
         {
             _pixelOutputBindings = pixelOutputBindings ?? [];
             _imageBindingBase = imageBindingBase;
             _pixelInputEnable = pixelInputEnable;
             _pixelInputAddress = pixelInputAddress;
+            _pixelInputCntl = new uint[32];
+            for (uint i = 0; i < 32u; i++)
+            {
+                _pixelInputCntl[i] = pixelInputCntl is not null && i < (uint)pixelInputCntl.Count
+                    ? pixelInputCntl[(int)i]
+                    : i;
+            }
             _requiredVertexOutputCount = requiredVertexOutputCount;
             _stage = stage;
             _state = state;
@@ -592,7 +605,13 @@ public static partial class Gen5MslTranslator
                 source.AppendLine("    float4 sharpemu_frag_coord [[position]];");
                 foreach (var attribute in _pixelAttributes)
                 {
-                    source.AppendLine($"    float4 attr{attribute} [[user(locn{attribute})]];");
+                    var cntl = attribute < (uint)_pixelInputCntl.Length
+                        ? _pixelInputCntl[attribute]
+                        : attribute;
+                    var location = cntl & 0x1Fu;
+                    var flat = (cntl & 0x400u) != 0 ? ", flat" : string.Empty;
+                    source.AppendLine(
+                        $"    float4 attr{attribute} [[user(locn{location}){flat}]];");
                 }
 
                 source.AppendLine("};");

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -31,6 +31,7 @@ public static partial class Gen5SpirvTranslator
         int pixelRenderTargetSlot = 0,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1) =>
         TryCompilePixelShader(
             state,
@@ -44,6 +45,7 @@ public static partial class Gen5SpirvTranslator
             initialScalarBufferIndex,
             pixelInputEnable,
             pixelInputAddress,
+            pixelInputCntl,
             storageBufferOffsetAlignment);
 
     public static bool TryCompilePixelShader(
@@ -58,6 +60,7 @@ public static partial class Gen5SpirvTranslator
         int initialScalarBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1)
     {
         if (outputs.Count > 8 || outputs.Any(output => output.GuestSlot > 7))
@@ -99,6 +102,7 @@ public static partial class Gen5SpirvTranslator
             initialScalarBufferIndex,
             pixelInputEnable: pixelInputEnable,
             pixelInputAddress: pixelInputAddress,
+            pixelInputCntl: pixelInputCntl,
             storageBufferOffsetAlignment: storageBufferOffsetAlignment);
         return context.TryCompile(out shader, out error);
     }
@@ -231,6 +235,7 @@ public static partial class Gen5SpirvTranslator
         private readonly int _initialScalarBufferIndex;
         private readonly uint _pixelInputEnable;
         private readonly uint _pixelInputAddress;
+        private readonly uint[] _pixelInputCntl;
         private readonly ulong _storageBufferOffsetAlignment;
         private readonly List<uint> _interfaces = [];
         private readonly Dictionary<uint, uint> _pixelInputs = [];
@@ -342,6 +347,7 @@ public static partial class Gen5SpirvTranslator
             int initialScalarBufferIndex,
             uint pixelInputEnable = 0,
             uint pixelInputAddress = 0,
+            IReadOnlyList<uint>? pixelInputCntl = null,
             int requiredVertexOutputCount = 0,
             uint waveLaneCount = 32,
             ulong storageBufferOffsetAlignment = 1)
@@ -367,6 +373,13 @@ public static partial class Gen5SpirvTranslator
             _initialScalarBufferIndex = initialScalarBufferIndex;
             _pixelInputEnable = pixelInputEnable;
             _pixelInputAddress = pixelInputAddress;
+            _pixelInputCntl = new uint[32];
+            for (uint i = 0; i < 32u; i++)
+            {
+                _pixelInputCntl[i] = pixelInputCntl is not null && i < (uint)pixelInputCntl.Count
+                    ? pixelInputCntl[(int)i]
+                    : i;
+            }
             if (storageBufferOffsetAlignment == 0 ||
                 (storageBufferOffsetAlignment & (storageBufferOffsetAlignment - 1)) != 0 ||
                 storageBufferOffsetAlignment > uint.MaxValue)
@@ -1236,7 +1249,18 @@ public static partial class Gen5SpirvTranslator
                     var variable = _module.AddGlobalVariable(
                         inputVec4Pointer,
                         SpirvStorageClass.Input);
-                    _module.AddDecoration(variable, SpirvDecoration.Location, attribute);
+                    // VINTRP ATTR selects the PS input slot. SPI_PS_INPUT_CNTL
+                    // maps that slot to a VS parameter export location.
+                    var cntl = attribute < (uint)_pixelInputCntl.Length
+                        ? _pixelInputCntl[attribute]
+                        : attribute;
+                    var location = cntl & 0x1Fu;
+                    _module.AddDecoration(variable, SpirvDecoration.Location, location);
+                    if ((cntl & 0x400u) != 0)
+                    {
+                        _module.AddDecoration(variable, SpirvDecoration.Flat);
+                    }
+
                     _pixelInputs.Add(attribute, variable);
                     _interfaces.Add(variable);
                 }


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Implements real `SPI_PS_INPUT_CNTL` remapping for Gen5 pixel interpolants instead of identity ATTR→param wiring.

**What changed**
- `sceAgcCreateInterpolantMapping` (`HV4j+E0MBHE`) matches PS input semantics to GS/VS outputs and packs CNTL words (param OFFSET in bits `[4:0]`, Flat at `0x400`; output-semantic count read as u16 at header `+0x56`)
- Draw compile path reads CX `SPI_PS_INPUT_CNTL_*`, fingerprints them into the graphics shader cache key, and passes them into pixel-shader compile
- Vulkan SPIR-V / Metal MSL: fragment `Location = cntl & 0x1F`; Flat when `cntl & 0x400`

**Why**
AMD/AGC maps each PS VINTRP ATTR slot through `SPI_PS_INPUT_CNTL`, not 1:1 ATTR index. Identity mapping produced wrong interpolants (clear-heavy / incoherent UI). This is generic semantic→OFFSET plumbing (same idea as desktop drivers), not a title-specific hack. Host still only consumes OFFSET + Flat from the packed word; deeper DEFAULT/F16 host modelling is follow-up, not required for this fix.

**AI-assisted**
Research and implementation were AI-assisted. I reviewed the semantic match + CNTL packing, cache fingerprint, and Vulkan/Metal Location/Flat wiring, and I can explain / maintain them.

## Testing

- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) on a local verify stack that also includes other open fixes needed to boot (AudioOut2, APR, Remoteplay, CreateShader HS, getdents, GuestImageWriteTracker):
  - Before F11 (same stack minus interpolants): intro could run, but post-intro UI stayed clear-only / missing logo art
  - After F11: **GTA logo appears**; **loading circles on the copyright screen appear**
  - Remaining (out of scope): Scaleform / menu text still not readable — handoff points at ForceUnormCoords / later UI path work, not this PR
- Build: `.\build.ps1` (Release `win-x64`) succeeded on the verify stack

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).