### PR TITLE
fix(agc): skip CB metadata draws for EliminateFastClear/Fmask/DCC

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -273,6 +273,7 @@ public static partial class AgcExports
     private static int _tracedVertexRangeCount;
     private static long _dcbWaitRegMemTraceCount;
     private static long _createShaderTraceCount;
+    private static long _cbMetadataSkipTraceCount;
     private static long _packetPayloadTraceCount;
     private static bool _tracedMissingPixelShaderBindings;
     private static long _unsatisfiedWaitTraceCount;
@@ -5619,6 +5620,25 @@ public static partial class AgcExports
         }
         state.TranslatedDraw = null;
         state.GuestDrawKind = GuestDrawKind.None;
+
+        // CB modes EliminateFastClear / FmaskDecompress / DccDecompress run
+        // colour-buffer metadata ops. The bound shader is only a vehicle and
+        // must not be applied as a normal colour draw.
+        if (TryGetCbColorControlMode(state.CxRegisters, out var cbMode) &&
+            IsCbMetadataColorMode(cbMode))
+        {
+            if (_traceAgcShader || ShouldTraceHotPath(ref _cbMetadataSkipTraceCount))
+            {
+                TraceAgcShader(
+                    $"agc.cb_metadata_skip seq={drawSequence} mode={cbMode} " +
+                    $"es=0x{(hasExportShader ? exportShaderAddress : 0):X16} " +
+                    $"ps=0x{(hasPixelShader ? pixelShaderAddress : 0):X16} " +
+                    $"vertices={vertexCount}");
+            }
+
+            return;
+        }
+
         foreach (var target in renderTargets)
         {
             state.KnownRenderTargets[target.Address] = target;
@@ -6953,6 +6973,35 @@ public static partial class AgcExports
         return hash;
     }
 
+    private enum CbColorMode : byte
+    {
+        Disable = 0,
+        Normal = 1,
+        EliminateFastClear = 2,
+        Resolve = 3,
+        FmaskDecompress = 5,
+        DccDecompress = 6,
+    }
+
+    private static bool TryGetCbColorControlMode(
+        IReadOnlyDictionary<uint, uint> registers,
+        out uint mode)
+    {
+        mode = 0;
+        if (!registers.TryGetValue(CbColorControl, out var colorControl))
+        {
+            return false;
+        }
+
+        mode = (colorControl >> 4) & 0x7u;
+        return true;
+    }
+
+    private static bool IsCbMetadataColorMode(uint mode) =>
+        mode is (uint)CbColorMode.EliminateFastClear or
+            (uint)CbColorMode.FmaskDecompress or
+            (uint)CbColorMode.DccDecompress;
+
     private static bool TryGetHardwareColorResolveTargets(
         IReadOnlyDictionary<uint, uint> registers,
         out RenderTargetDescriptor source,
@@ -6960,8 +7009,8 @@ public static partial class AgcExports
     {
         source = default;
         destination = default;
-        if (!registers.TryGetValue(CbColorControl, out var colorControl) ||
-            ((colorControl >> 4) & 0x7u) != 3u)
+        if (!TryGetCbColorControlMode(registers, out var mode) ||
+            mode != (uint)CbColorMode.Resolve)
         {
             return false;
         }


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Stop treating colour-buffer **metadata** operations as normal colour draws.

On AMD/AGC, `CB_COLOR_CONTROL.MODE` distinguishes normal shading from CB maintenance:

| Mode | Meaning |
|------|--------|
| 1 | Normal colour draw |
| 2 | EliminateFastClear |
| 3 | Resolve (MSAA → single-sample) — already special-cased |
| 5 | FmaskDecompress |
| 6 | DccDecompress |

Modes **2 / 5 / 6** update compressed CB metadata (DCC, Fmask, fast-clear). The bound VS/PS is often only a vehicle; the real work is in the CB. SharpEmu was still translating those submits as ordinary “shade these verts into the RT” draws, which can trash the surface the next real composite needs.

**What changed** (`AgcExports.cs` only)
- Early-out in `TryTranslateGuestDraw` when MODE is 2 / 5 / 6 (`(CB_COLOR_CONTROL >> 4) & 7`)
- Shared `CbColorMode` / `TryGetCbColorControlMode` helpers; Resolve (mode 3) uses the same decoder
- Optional `agc.cb_metadata_skip` when `SHARPEMU_LOG_AGC_SHADER=1` (or hot-path sample)

**Why this is the right first step**
- Not running them as colour draws is the correct generic behaviour. Faking a normal colour pass for those modes is actively wrong.
- Long-term, a full emulator may emulate the metadata op (or its effect). Until then, **skip > wrong draw** — same idea as not inventing guest writes for unknown AGC NIDs.
- Not a title hack: any game using DCC/Fmask/fast-clear hits this path. Mode decode is standard `CB_COLOR_CONTROL` layout.

**What this does not do**
- Does not implement real DCC/Fmask/EliminateFastClear
- Does not fix Scaleform / menu text
- If a title truly depends on metadata being updated, skip alone can still be incomplete — still better than painting garbage with a dummy colour shader

**AI-assisted**
Research and implementation were AI-assisted. I reviewed the MODE decode, early-out placement (before RT writer / colour translate), and Resolve helper reuse, and I can explain / maintain them.

## Testing

- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) on a local verify stack that also includes other open fixes needed to boot (AudioOut2, APR, Remoteplay, CreateShader HS, getdents, GuestImageWriteTracker, F11 interpolants):
  - Intro, GTA logo, and copyright loading circles still work (no regress vs F11 stack)
  - No new crash / black regression after logo
- Optional: `SHARPEMU_LOG_AGC_SHADER=1` → look for `agc.cb_metadata_skip` with `mode=2` / `5` / `6`
- Build: `.\build.ps1` (Release `win-x64`) succeeded on the verify stack

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).