### PR TITLE
fix(agc): rect-list/NGG strips, Index8 expand, and GE_INDX_OFFSET

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -99,6 +99,10 @@ public static partial class AgcExports
     private const uint ComputeNumThreadZ = 0x209;
     private const uint SpiPsInputCntl0 = 0x191;
     private const uint VgtPrimitiveType = 0x242;
+    private const uint VgtIndexType = 0x243;
+    // GE_INDX_OFFSET — base vertex for DrawIndexed / firstVertex for
+    // DrawIndexAuto. Glyph meshes and UI icon batches rely on this.
+    private const uint GeIndxOffset = 0x24A;
     private const uint PaScScreenScissorTl = 0x0C;
     private const uint PaScScreenScissorBr = 0x0D;
     private const uint CbTargetMask = 0x8E;
@@ -428,6 +432,7 @@ public static partial class AgcExports
         uint AttributeCount,
         uint VertexCount,
         uint InstanceCount,
+        int BaseVertex,
         GuestIndexBuffer? IndexBuffer,
         IReadOnlyList<TranslatedImageBinding> Textures,
         IReadOnlyList<Gen5GlobalMemoryBinding> GlobalMemoryBindings,
@@ -3505,7 +3510,8 @@ public static partial class AgcExports
                         vertexBuffers,
                         pendingComposite.RenderState,
                         pendingComposite.DepthTarget,
-                        pendingComposite.PixelShaderAddress);
+                        pendingComposite.PixelShaderAddress,
+                        pendingComposite.BaseVertex);
                     TraceAgcShader(
                         $"agc.deferred_composite ps=0x{pendingComposite.PixelShaderAddress:X16} " +
                         $"src=0x{pendingComposite.Textures.FirstOrDefault()?.Descriptor.Address ?? 0:X16} " +
@@ -5528,6 +5534,10 @@ public static partial class AgcExports
                 }
 
                 directDestination[startRegister + index] = value;
+                if (op == ItSetUconfigReg)
+                {
+                    ApplyUcIndexTypeIfNeeded(state, startRegister + index, value);
+                }
             }
 
             return;
@@ -5562,6 +5572,25 @@ public static partial class AgcExports
             // Dropping it leaves stale depth/render-control state active in
             // later passes.
             destination[registerOffset] = value;
+            if (register == RUcRegsIndirect)
+            {
+                ApplyUcIndexTypeIfNeeded(state, registerOffset, value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// GraphicsDcbSetIndexSize writes VGT_INDEX_TYPE via SET_UCONFIG_REG.
+    /// Mirror that into <see cref="SubmittedDcbState.IndexSize"/>.
+    /// </summary>
+    private static void ApplyUcIndexTypeIfNeeded(
+        SubmittedDcbState state,
+        uint registerOffset,
+        uint value)
+    {
+        if (registerOffset == VgtIndexType)
+        {
+            state.IndexSize = value & 0x3;
         }
     }
 
@@ -5739,7 +5768,8 @@ public static partial class AgcExports
                 depthOnlyDraw.IndexBuffer,
                 vertexBuffers,
                 renderState,
-                depthOnlyDraw.PixelShaderAddress);
+                depthOnlyDraw.PixelShaderAddress,
+                depthOnlyDraw.BaseVertex);
 
             if (_traceAgcShader)
             {
@@ -5896,7 +5926,8 @@ public static partial class AgcExports
                         sharedVertexBuffers,
                         translatedDraw.RenderState,
                         translatedDraw.DepthTarget,
-                        translatedDraw.PixelShaderAddress);
+                        translatedDraw.PixelShaderAddress,
+                        translatedDraw.BaseVertex);
                 }
             }
             else
@@ -5938,7 +5969,8 @@ public static partial class AgcExports
                         translatedDraw.IndexBuffer,
                         vertexBuffers,
                         renderState,
-                        translatedDraw.PixelShaderAddress);
+                        translatedDraw.PixelShaderAddress,
+                        translatedDraw.BaseVertex);
                 }
                 else
                 {
@@ -6241,6 +6273,7 @@ public static partial class AgcExports
             AttributeCount: 0,
             vertexCount,
             state.InstanceCount,
+            GetBaseVertex(state),
             indexed ? CreateGuestIndexBuffer(ctx, state, vertexCount) : null,
             textures,
             exportEvaluation.GlobalMemoryBindings,
@@ -6429,6 +6462,22 @@ public static partial class AgcExports
             Environment.GetEnvironmentVariable("SHARPEMU_TRACE_TITLE_GLOBALS_LIVE") == "1")
         {
             TraceAstroTitlePixelGlobalProbe(pixelEvaluation);
+        }
+
+        state.UcRegisters.TryGetValue(VgtPrimitiveType, out var earlyPrimitiveType);
+        if (IsRectListPrimitive(earlyPrimitiveType) &&
+            (exportEvaluation.VertexInputs is null || exportEvaluation.VertexInputs.Count == 0) &&
+            !VertexProgramExportsParameters(exportState.Program) &&
+            GetInterpolatedAttributeCount(pixelState) != 0)
+        {
+            ReturnPooledEvaluationArrays(exportEvaluation);
+            ReturnPooledEvaluationArrays(pixelEvaluation);
+            error =
+                $"rect-list-no-param-exports ps_inputs={GetInterpolatedAttributeCount(pixelState)}";
+            TraceAgcShader(
+                $"agc.rect_list_skip es=0x{exportShaderAddress:X16} " +
+                $"ps=0x{pixelShaderAddress:X16} {error}");
+            return false;
         }
 
         // Every bound color target the shader exports to. Deferred renderers
@@ -6716,6 +6765,7 @@ public static partial class AgcExports
             GetInterpolatedAttributeCount(pixelState),
             vertexCount,
             state.InstanceCount,
+            GetBaseVertex(state),
             indexed ? CreateGuestIndexBuffer(ctx, state, vertexCount) : null,
             textures,
             globalMemoryBindings,
@@ -7027,6 +7077,22 @@ public static partial class AgcExports
             ColorFunc: 0,
         };
 
+    private static AgcIndexHelpers.ProsperoIndexType GetProsperoIndexType(SubmittedDcbState state) =>
+        // IndexSize is latched from ItIndexType and from UC VGT_INDEX_TYPE
+        // writes. Do not fall back to a stale UC value when IndexSize is 0 —
+        // that mis-classified 16-bit draws as index8 and blanked meshes.
+        AgcIndexHelpers.Decode(state.IndexSize);
+
+    /// <summary>
+    /// ResolveVertexOffset for the common UC path: GE_INDX_OFFSET is the
+    /// DrawIndexed vertexOffset / DrawAuto firstVertex. Embedded-fetch SGPR
+    /// fallback is not required when the game latches this register (GTA UI).
+    /// </summary>
+    private static int GetBaseVertex(SubmittedDcbState state) =>
+        state.UcRegisters.TryGetValue(GeIndxOffset, out var indexOffset)
+            ? unchecked((int)indexOffset)
+            : 0;
+
     private static GuestIndexBuffer? CreateGuestIndexBuffer(
         CpuContext ctx,
         SubmittedDcbState state,
@@ -7037,17 +7103,40 @@ public static partial class AgcExports
             return null;
         }
 
-        var is32Bit = state.IndexSize != 0;
-        var bytesPerIndex = is32Bit ? sizeof(uint) : sizeof(ushort);
-        var byteOffset = checked((ulong)state.DrawIndexOffset * (uint)bytesPerIndex);
-        var byteCount = checked((int)(indexCount * (uint)bytesPerIndex));
-        var data = GuestDataPool.Shared.Rent(byteCount);
-        var span = data.AsSpan(0, byteCount);
+        var indexType = GetProsperoIndexType(state);
+        var guestBytesPerIndex = AgcIndexHelpers.GetGuestStrideBytes(indexType);
+        var byteOffset = checked((ulong)state.DrawIndexOffset * (uint)guestBytesPerIndex);
+        var guestByteCount = checked((int)(indexCount * (uint)guestBytesPerIndex));
         var address = state.IndexBufferAddress + byteOffset;
+
+        // Host backends only bind u16/u32. Expand kIndex8 -> u16.
+        if (indexType == AgcIndexHelpers.ProsperoIndexType.Index8)
+        {
+            var guestData = GuestDataPool.Shared.Rent(guestByteCount);
+            var guestSpan = guestData.AsSpan(0, guestByteCount);
+            if (!ctx.Memory.TryRead(address, guestSpan) &&
+                !KernelMemoryCompatExports.TryReadTrackedLibcHeap(address, guestSpan))
+            {
+                GuestDataPool.Shared.Return(guestData);
+                return null;
+            }
+
+            var hostByteCount = checked((int)(indexCount * sizeof(ushort)));
+            var hostData = GuestDataPool.Shared.Rent(hostByteCount);
+            AgcIndexHelpers.ExpandIndex8ToU16(
+                guestSpan,
+                hostData.AsSpan(0, hostByteCount));
+            GuestDataPool.Shared.Return(guestData);
+            return new GuestIndexBuffer(hostData, hostByteCount, Is32Bit: false, Pooled: true);
+        }
+
+        var is32Bit = indexType == AgcIndexHelpers.ProsperoIndexType.Index32;
+        var data = GuestDataPool.Shared.Rent(guestByteCount);
+        var span = data.AsSpan(0, guestByteCount);
         if (ctx.Memory.TryRead(address, span) ||
             KernelMemoryCompatExports.TryReadTrackedLibcHeap(address, span))
         {
-            return new GuestIndexBuffer(data, byteCount, is32Bit, Pooled: true);
+            return new GuestIndexBuffer(data, guestByteCount, is32Bit, Pooled: true);
         }
 
         GuestDataPool.Shared.Return(data);
@@ -7061,7 +7150,10 @@ public static partial class AgcExports
         bool indexed,
         out uint recordCount)
     {
-        recordCount = Math.Max(drawCount, Math.Max(state.InstanceCount, 1u));
+        var baseVertex = (uint)Math.Max(GetBaseVertex(state), 0);
+        recordCount = Math.Max(
+            baseVertex + drawCount,
+            Math.Max(state.InstanceCount, 1u));
         if (!indexed)
         {
             return true;
@@ -7072,8 +7164,8 @@ public static partial class AgcExports
             return false;
         }
 
-        var is32Bit = state.IndexSize != 0;
-        var bytesPerIndex = is32Bit ? sizeof(uint) : sizeof(ushort);
+        var indexType = GetProsperoIndexType(state);
+        var bytesPerIndex = AgcIndexHelpers.GetGuestStrideBytes(indexType);
         var byteOffset = checked((ulong)state.DrawIndexOffset * (uint)bytesPerIndex);
         var address = state.IndexBufferAddress + byteOffset;
         const int chunkBytes = 64 * 1024;
@@ -7098,12 +7190,22 @@ public static partial class AgcExports
 
                 for (var index = 0; index < chunkIndices; index++)
                 {
-                    var value = is32Bit
-                        ? BinaryPrimitives.ReadUInt32LittleEndian(
-                            span.Slice(index * sizeof(uint), sizeof(uint)))
-                        : BinaryPrimitives.ReadUInt16LittleEndian(
-                            span.Slice(index * sizeof(ushort), sizeof(ushort)));
-                    if (value == (is32Bit ? uint.MaxValue : ushort.MaxValue))
+                    uint value = indexType switch
+                    {
+                        AgcIndexHelpers.ProsperoIndexType.Index32 =>
+                            BinaryPrimitives.ReadUInt32LittleEndian(
+                                span.Slice(index * sizeof(uint), sizeof(uint))),
+                        AgcIndexHelpers.ProsperoIndexType.Index8 => span[index],
+                        _ => BinaryPrimitives.ReadUInt16LittleEndian(
+                            span.Slice(index * sizeof(ushort), sizeof(ushort))),
+                    };
+                    var restart = indexType switch
+                    {
+                        AgcIndexHelpers.ProsperoIndexType.Index32 => uint.MaxValue,
+                        AgcIndexHelpers.ProsperoIndexType.Index8 => 0xFFu,
+                        _ => ushort.MaxValue,
+                    };
+                    if (value == restart)
                     {
                         // Primitive-restart markers do not address vertex data.
                         continue;
@@ -7123,17 +7225,24 @@ public static partial class AgcExports
         }
 
         var indexedRecords = sawIndex && maxIndex != uint.MaxValue
-            ? maxIndex + 1
-            : 1u;
+            ? baseVertex + maxIndex + 1
+            : Math.Max(baseVertex + 1, 1u);
         recordCount = Math.Max(indexedRecords, Math.Max(state.InstanceCount, 1u));
         if (_traceVertexRanges &&
             Interlocked.Increment(ref _tracedVertexRangeCount) <= 512)
         {
+            var indexBits = indexType switch
+            {
+                AgcIndexHelpers.ProsperoIndexType.Index32 => 32,
+                AgcIndexHelpers.ProsperoIndexType.Index8 => 8,
+                _ => 16,
+            };
             Console.Error.WriteLine(
                 $"[LOADER][TRACE] agc.vertex_range indexed=1 draw_count={drawCount} " +
-                $"max_index={(sawIndex ? maxIndex : 0)} records={recordCount} " +
-                $"instances={state.InstanceCount} index_size={(is32Bit ? 32 : 16)} " +
-                $"index_addr=0x{state.IndexBufferAddress:X16} offset={state.DrawIndexOffset}");
+                $"max_index={(sawIndex ? maxIndex : 0)} base_vertex={baseVertex} " +
+                $"records={recordCount} instances={state.InstanceCount} " +
+                $"index_size={indexBits} index_addr=0x{state.IndexBufferAddress:X16} " +
+                $"offset={state.DrawIndexOffset}");
         }
         return true;
     }
@@ -7142,6 +7251,20 @@ public static partial class AgcExports
         target < ColorTargetCount
             ? (packedMasks >> (int)(target * 4)) & 0xFu
             : 0;
+
+    private static bool VertexProgramExportsParameters(Gen5ShaderProgram program)
+    {
+        foreach (var instruction in program.Instructions)
+        {
+            if (instruction.Control is Gen5ExportControl export &&
+                export.Target is >= 32 and < 64)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private static uint GetInterpolatedAttributeCount(Gen5ShaderState state)
     {
@@ -7847,10 +7970,15 @@ public static partial class AgcExports
                     ? $"{entry.Name}=0x{value:X8}"
                     : $"{entry.Name}=missing"));
         var blend = draw.RenderState.Blend;
+        var rectExpanded = AgcPrimitiveHelpers.GetRectListDrawVertexCount(
+            draw.PrimitiveType,
+            draw.VertexCount,
+            indexed: draw.IndexBuffer is not null,
+            hasVertexBuffers: draw.VertexInputs.Count > 0);
         TraceAgcShader(
             $"agc.shader_draw es=0x{draw.ExportShaderAddress:X16} " +
             $"ps=0x{draw.PixelShaderAddress:X16} spirv={draw.PixelShader.Payload.Length} " +
-            $"primitive=0x{draw.PrimitiveType:X} " +
+            $"primitive=0x{draw.PrimitiveType:X} verts={draw.VertexCount}->{rectExpanded} " +
             $"blend={(blend.Enable ? 1 : 0)}:{blend.ColorSrcFactor}/{blend.ColorDstFactor}/{blend.ColorFunc} " +
             $"write_mask=0x{blend.WriteMask:X} scissor={scissor} viewport={viewport} " +
             $"raster=[{raster}] " +
@@ -8919,36 +9047,51 @@ public static partial class AgcExports
         TranslatedGuestDraw draw,
         IReadOnlyList<GuestVertexBuffer> vertexBuffers)
     {
-        if (draw.PrimitiveType != 0x11 ||
-            draw.IndexBuffer is not null ||
-            vertexBuffers.Count == 0 ||
-            _rectListTraceCount >= 8 ||
-            Interlocked.Increment(ref _rectListTraceCount) > 8)
+        if (!AgcPrimitiveHelpers.IsRectListPrimitive(draw.PrimitiveType) ||
+            _rectListTraceCount >= 16 ||
+            Interlocked.Increment(ref _rectListTraceCount) > 16)
         {
             return;
         }
 
-        var buffer = vertexBuffers[0];
-        var stride = Math.Max(buffer.Stride, 4u);
+        var expanded = AgcPrimitiveHelpers.GetRectListDrawVertexCount(
+            draw.PrimitiveType,
+            draw.VertexCount,
+            indexed: draw.IndexBuffer is not null,
+            hasVertexBuffers: vertexBuffers.Count > 0);
         var text = new System.Text.StringBuilder();
-        for (var vertex = 0; vertex < 3; vertex++)
-        {
-            var baseOffset = (int)(buffer.OffsetBytes + vertex * stride);
-            if (baseOffset + 16 > buffer.Length)
-            {
-                break;
-            }
+        text.Append(
+            $"agc.rectlist prim=0x{draw.PrimitiveType:X} verts={draw.VertexCount}->{expanded} " +
+            $"indexed={(draw.IndexBuffer is not null ? 1 : 0)} vb={vertexBuffers.Count}");
 
-            var x = BitConverter.ToSingle(buffer.Data, baseOffset);
-            var y = BitConverter.ToSingle(buffer.Data, baseOffset + 4);
-            var z = BitConverter.ToSingle(buffer.Data, baseOffset + 8);
-            var w = BitConverter.ToSingle(buffer.Data, baseOffset + 12);
-            text.Append($" v{vertex}=({x:0.###},{y:0.###},{z:0.###},{w:0.###})");
+        if (vertexBuffers.Count > 0)
+        {
+            var buffer = vertexBuffers[0];
+            var stride = Math.Max(buffer.Stride, 4u);
+            text.Append(
+                $" stride={buffer.Stride} " +
+                $"fmt={buffer.DataFormat}/{buffer.NumberFormat}x{buffer.ComponentCount}");
+            for (var vertex = 0; vertex < 3; vertex++)
+            {
+                var baseOffset = (int)(buffer.OffsetBytes + vertex * stride);
+                if (baseOffset + 16 > buffer.Length)
+                {
+                    break;
+                }
+
+                var x = BitConverter.ToSingle(buffer.Data, baseOffset);
+                var y = BitConverter.ToSingle(buffer.Data, baseOffset + 4);
+                var z = BitConverter.ToSingle(buffer.Data, baseOffset + 8);
+                var w = BitConverter.ToSingle(buffer.Data, baseOffset + 12);
+                text.Append($" v{vertex}=({x:0.###},{y:0.###},{z:0.###},{w:0.###})");
+            }
+        }
+        else
+        {
+            text.Append(" procedural=1");
         }
 
-        TraceAgcShader(
-            $"agc.rectlist verts={draw.VertexCount} stride={buffer.Stride} " +
-            $"fmt={buffer.DataFormat}/{buffer.NumberFormat}x{buffer.ComponentCount}{text}");
+        TraceAgcShader(text.ToString());
     }
 
     private static int _textureDumpCount;
@@ -11026,6 +11169,9 @@ public static partial class AgcExports
 
     private static bool IsEsGeometryShaderType(byte shaderType) =>
         shaderType is 2 or 6;
+
+    private static bool IsRectListPrimitive(uint primitiveType) =>
+        AgcPrimitiveHelpers.IsRectListPrimitive(primitiveType);
 
     private static int SetIndirectPatchAddress(CpuContext ctx, string registerSpace)
     {

--- a/src/SharpEmu.Libs/Agc/AgcIndexHelpers.cs
+++ b/src/SharpEmu.Libs/Agc/AgcIndexHelpers.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+
+namespace SharpEmu.Libs.Agc;
+
+/// <summary>Prospero/AGC IndexType helpers (gpu_defs / renderDraw index8 expand).</summary>
+internal static class AgcIndexHelpers
+{
+    internal enum ProsperoIndexType : uint
+    {
+        Index16 = 0,
+        Index32 = 1,
+        Index8 = 2,
+    }
+
+    internal static ProsperoIndexType Decode(uint raw) =>
+        (raw & 0x3u) switch
+        {
+            1 => ProsperoIndexType.Index32,
+            2 => ProsperoIndexType.Index8,
+            _ => ProsperoIndexType.Index16,
+        };
+
+    internal static int GetGuestStrideBytes(ProsperoIndexType indexType) =>
+        indexType switch
+        {
+            ProsperoIndexType.Index32 => sizeof(uint),
+            ProsperoIndexType.Index8 => sizeof(byte),
+            _ => sizeof(ushort),
+        };
+
+    /// <summary>Expand guest u8 indices to host u16 (Vulkan/Metal bindable).</summary>
+    internal static void ExpandIndex8ToU16(ReadOnlySpan<byte> source, Span<byte> destination)
+    {
+        if (destination.Length < source.Length * sizeof(ushort))
+        {
+            throw new ArgumentException("destination too small for u8->u16 expansion.");
+        }
+
+        for (var index = 0; index < source.Length; index++)
+        {
+            BinaryPrimitives.WriteUInt16LittleEndian(
+                destination.Slice(index * sizeof(ushort), sizeof(ushort)),
+                source[index]);
+        }
+    }
+}

--- a/src/SharpEmu.Libs/Agc/AgcPrimitiveHelpers.cs
+++ b/src/SharpEmu.Libs/Agc/AgcPrimitiveHelpers.cs
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Libs.Agc;
+
+/// <summary>
+/// Shared Prospero/AGC primitive-type helpers (renderDraw / gpu_defs).
+/// </summary>
+internal static class AgcPrimitiveHelpers
+{
+    internal const uint PrimitiveRectList = 7;
+    internal const uint PrimitiveRectListLegacy = 0x11;
+
+    internal enum GsOutputPrimitiveType : uint
+    {
+        Points = 0,
+        Lines = 1,
+        Triangles = 2,
+        Rectangle2D = 3,
+        RectList = 4,
+    }
+
+    internal static bool IsRectListPrimitive(uint primitiveType) =>
+        primitiveType is PrimitiveRectList or PrimitiveRectListLegacy;
+
+    /// <summary>
+    /// Maps draw prim type to VGT_GS_OUT_PRIM_TYPE when NGG is not enabled
+    /// on the GS (GraphicsPrimitiveTypeToGsOut).
+    /// </summary>
+    internal static uint PrimitiveTypeToGsOut(uint primitiveType) =>
+        primitiveType switch
+        {
+            1 => (uint)GsOutputPrimitiveType.Points, // PointList
+            2 or 3 or 10 or 11 or 18 => (uint)GsOutputPrimitiveType.Lines,
+            PrimitiveRectList => (uint)GsOutputPrimitiveType.Rectangle2D,
+            PrimitiveRectListLegacy => (uint)GsOutputPrimitiveType.RectList,
+            _ => (uint)GsOutputPrimitiveType.Triangles,
+        };
+
+    /// <summary>
+    /// Rect-list auto-draw topology selection.
+    /// NGG single-rect UI quads (DualSense prompts) submit count 1/3/4 and
+    /// must become a 4-vert triangle strip — even when the VS has embedded
+    /// vertex-buffer fetches (those still show up as host VBs). Indexed and
+    /// larger auto counts stay triangle list so the loading video is safe.
+    /// </summary>
+    internal static bool ShouldDrawRectListAsTriangleStrip(
+        uint primitiveType,
+        bool indexed,
+        uint vertexCount,
+        bool hasVertexBuffers = false)
+    {
+        _ = hasVertexBuffers;
+        if (indexed || !IsRectListPrimitive(primitiveType))
+        {
+            return false;
+        }
+
+        if (primitiveType == PrimitiveRectListLegacy)
+        {
+            return true;
+        }
+
+        // NGG kRectList: strip for auto + ngg_rectlist_draw.
+        // Restrict to the single-rect counts GTA UI actually submits.
+        return vertexCount is 1 or 3 or 4;
+    }
+
+    /// <summary>
+    /// Host vertex count for auto rect-list draws that expand to a strip.
+    /// NGG single-rect: always 4. Legacy 0x11: 3 -> 4.
+    /// </summary>
+    internal static uint GetRectListDrawVertexCount(
+        uint primitiveType,
+        uint vertexCount,
+        bool indexed,
+        bool hasVertexBuffers = false)
+    {
+        if (!ShouldDrawRectListAsTriangleStrip(
+                primitiveType,
+                indexed,
+                vertexCount,
+                hasVertexBuffers))
+        {
+            return vertexCount;
+        }
+
+        if (primitiveType == PrimitiveRectList)
+        {
+            return 4;
+        }
+
+        if (primitiveType == PrimitiveRectListLegacy && vertexCount == 3)
+        {
+            return 4;
+        }
+
+        return vertexCount;
+    }
+
+    /// <summary>
+    /// Legacy helper — prefer
+    /// <see cref="ShouldDrawRectListAsTriangleStrip"/>.
+    /// </summary>
+    internal static bool IsRectListTriangleStrip(uint primitiveType) =>
+        IsRectListPrimitive(primitiveType);
+}

--- a/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
@@ -108,7 +108,8 @@ internal interface IGuestGpuBackend
         GuestIndexBuffer? indexBuffer = null,
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
-        ulong shaderAddress = 0);
+        ulong shaderAddress = 0,
+        int baseVertex = 0);
 
     void SubmitOffscreenTranslatedDraw(
         IGuestCompiledShader pixelShader,
@@ -124,7 +125,8 @@ internal interface IGuestGpuBackend
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
         GuestDepthTarget? depthTarget = null,
-        ulong shaderAddress = 0);
+        ulong shaderAddress = 0,
+        int baseVertex = 0);
 
     void SubmitStorageTranslatedDraw(
         IGuestCompiledShader pixelShader,

--- a/src/SharpEmu.Libs/Gpu/Metal/MetalGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Metal/MetalGuestGpuBackend.cs
@@ -251,7 +251,8 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
         GuestIndexBuffer? indexBuffer = null,
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
-        ulong shaderAddress = 0) =>
+        ulong shaderAddress = 0,
+        int baseVertex = 0) =>
         MetalVideoPresenter.SubmitDepthOnlyTranslatedDraw(
             Msl(pixelShader),
             textures,
@@ -265,7 +266,8 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
             indexBuffer,
             vertexBuffers,
             renderState,
-            shaderAddress);
+            shaderAddress,
+            baseVertex);
 
     public void SubmitOffscreenTranslatedDraw(
         IGuestCompiledShader pixelShader,
@@ -281,7 +283,8 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
         GuestDepthTarget? depthTarget = null,
-        ulong shaderAddress = 0) =>
+        ulong shaderAddress = 0,
+        int baseVertex = 0) =>
         MetalVideoPresenter.SubmitOffscreenTranslatedDraw(
             Msl(pixelShader),
             textures,
@@ -296,7 +299,8 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
             vertexBuffers,
             renderState,
             depthTarget,
-            shaderAddress);
+            shaderAddress,
+            baseVertex);
 
     public void SubmitStorageTranslatedDraw(
         IGuestCompiledShader pixelShader,

--- a/src/SharpEmu.Libs/Gpu/Metal/MetalVideoPresenter.Draws.cs
+++ b/src/SharpEmu.Libs/Gpu/Metal/MetalVideoPresenter.Draws.cs
@@ -1,6 +1,8 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Buffers.Binary;
+using SharpEmu.Libs.Agc;
 using SharpEmu.ShaderCompiler;
 using SharpEmu.ShaderCompiler.Metal;
 
@@ -86,7 +88,8 @@ internal static partial class MetalVideoPresenter
         uint InstanceCount,
         uint PrimitiveType,
         GuestIndexBuffer? IndexBuffer,
-        GuestRenderState RenderState);
+        GuestRenderState RenderState,
+        int BaseVertex = 0);
 
     private sealed record OffscreenGuestDraw(
         TranslatedGuestDraw Draw,
@@ -244,7 +247,8 @@ internal static partial class MetalVideoPresenter
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers,
         GuestRenderState? renderState,
         GuestDepthTarget? depthTarget,
-        ulong shaderAddress)
+        ulong shaderAddress,
+        int baseVertex = 0)
     {
         if (targets.Count == 0)
         {
@@ -292,7 +296,8 @@ internal static partial class MetalVideoPresenter
                         instanceCount,
                         primitiveType,
                         indexBuffer,
-                        effectiveRenderState),
+                        effectiveRenderState,
+                        baseVertex),
                     ToArray(targets),
                     depthTarget,
                     PublishTarget: true,
@@ -320,7 +325,8 @@ internal static partial class MetalVideoPresenter
         GuestIndexBuffer? indexBuffer,
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers,
         GuestRenderState? renderState,
-        ulong shaderAddress)
+        ulong shaderAddress,
+        int baseVertex = 0)
     {
         if (depthTarget.Address == 0 || depthTarget.Width == 0 || depthTarget.Height == 0)
         {
@@ -347,7 +353,8 @@ internal static partial class MetalVideoPresenter
                         instanceCount,
                         primitiveType,
                         indexBuffer,
-                        renderState ?? GuestRenderState.Default),
+                        renderState ?? GuestRenderState.Default,
+                        baseVertex),
                     [new GuestRenderTarget(Address: 0, depthTarget.Width, depthTarget.Height, Format: 10, NumberType: 0)],
                     depthTarget,
                     PublishTarget: false,
@@ -980,17 +987,38 @@ internal static partial class MetalVideoPresenter
 
     private static void EncodeDrawCall(nint encoder, TranslatedGuestDraw draw)
     {
-        var primitive = GetPrimitiveType(draw.PrimitiveType);
-        var vertexCount = draw.PrimitiveType == 0x11 && draw.IndexBuffer is null
-            ? 4u
-            : draw.VertexCount;
+        var indexed = draw.IndexBuffer is not null;
+        var hasVertexBuffers = draw.VertexBuffers.Length > 0;
+        var primitive = GetPrimitiveType(
+            draw.PrimitiveType,
+            indexed,
+            draw.VertexCount,
+            hasVertexBuffers);
+        var vertexCount = AgcPrimitiveHelpers.GetRectListDrawVertexCount(
+            draw.PrimitiveType,
+            draw.VertexCount,
+            indexed,
+            hasVertexBuffers);
+        var baseVertex = (nuint)Math.Max(draw.BaseVertex, 0);
         if (draw.IndexBuffer is { } indexBuffer)
         {
             var device = MetalNative.Send(encoder, MetalNative.Selector("device"));
             var slice = AllocateUpload(
                 device, Math.Max(indexBuffer.Length, 1), out var buffer, out var offset);
-            indexBuffer.Data.AsSpan(0, Math.Min(indexBuffer.Length, indexBuffer.Data.Length))
-                .CopyTo(slice);
+            var source = indexBuffer.Data.AsSpan(
+                0,
+                Math.Min(indexBuffer.Length, indexBuffer.Data.Length));
+            // Metal drawIndexed without baseVertex: bake GE_INDX_OFFSET into
+            // the uploaded indices so glyph batches still hit the right verts.
+            if (draw.BaseVertex != 0)
+            {
+                BakeBaseVertexIntoIndices(source, slice, indexBuffer.Is32Bit, draw.BaseVertex);
+            }
+            else
+            {
+                source.CopyTo(slice);
+            }
+
             MetalNative.SendDrawIndexedPrimitives(
                 encoder,
                 MetalNative.Selector("drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:"),
@@ -1011,9 +1039,43 @@ internal static partial class MetalVideoPresenter
                 encoder,
                 MetalNative.Selector("drawPrimitives:vertexStart:vertexCount:instanceCount:"),
                 primitive,
-                0,
+                baseVertex,
                 vertexCount,
                 Math.Max(draw.InstanceCount, 1));
+        }
+    }
+
+    private static void BakeBaseVertexIntoIndices(
+        ReadOnlySpan<byte> source,
+        Span<byte> destination,
+        bool is32Bit,
+        int baseVertex)
+    {
+        if (is32Bit)
+        {
+            var count = source.Length / sizeof(uint);
+            for (var index = 0; index < count; index++)
+            {
+                var value = BinaryPrimitives.ReadUInt32LittleEndian(
+                    source.Slice(index * sizeof(uint), sizeof(uint)));
+                var adjusted = unchecked((uint)(value + baseVertex));
+                BinaryPrimitives.WriteUInt32LittleEndian(
+                    destination.Slice(index * sizeof(uint), sizeof(uint)),
+                    adjusted);
+            }
+
+            return;
+        }
+
+        var shortCount = source.Length / sizeof(ushort);
+        for (var index = 0; index < shortCount; index++)
+        {
+            var value = BinaryPrimitives.ReadUInt16LittleEndian(
+                source.Slice(index * sizeof(ushort), sizeof(ushort)));
+            var adjusted = unchecked((ushort)(value + baseVertex));
+            BinaryPrimitives.WriteUInt16LittleEndian(
+                destination.Slice(index * sizeof(ushort), sizeof(ushort)),
+                adjusted);
         }
     }
 
@@ -2019,11 +2081,28 @@ internal static partial class MetalVideoPresenter
 
                 return 3;
             case 6:
-            case 0x11:
                 return 4;
             default:
                 return 3;
         }
+    }
+
+    private static nuint GetPrimitiveType(
+        uint guestPrimitiveType,
+        bool indexed,
+        uint vertexCount,
+        bool hasVertexBuffers)
+    {
+        if (AgcPrimitiveHelpers.ShouldDrawRectListAsTriangleStrip(
+                guestPrimitiveType,
+                indexed,
+                vertexCount,
+                hasVertexBuffers))
+        {
+            return 4; // MTLPrimitiveTypeTriangleStrip
+        }
+
+        return GetPrimitiveType(guestPrimitiveType);
     }
 
     private static bool IsIntegerFormat(Gen5PixelOutputKind kind) =>

--- a/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
@@ -179,7 +179,8 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         GuestIndexBuffer? indexBuffer = null,
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
-        ulong shaderAddress = 0) =>
+        ulong shaderAddress = 0,
+        int baseVertex = 0) =>
         VulkanVideoPresenter.SubmitDepthOnlyTranslatedDraw(
             Spirv(pixelShader),
             textures,
@@ -193,7 +194,8 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
             indexBuffer,
             vertexBuffers,
             renderState,
-            shaderAddress);
+            shaderAddress,
+            baseVertex);
 
     public void SubmitOffscreenTranslatedDraw(
         IGuestCompiledShader pixelShader,
@@ -209,7 +211,8 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
         GuestDepthTarget? depthTarget = null,
-        ulong shaderAddress = 0) =>
+        ulong shaderAddress = 0,
+        int baseVertex = 0) =>
         VulkanVideoPresenter.SubmitOffscreenTranslatedDraw(
             Spirv(pixelShader),
             textures,
@@ -224,7 +227,8 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
             vertexBuffers,
             renderState,
             depthTarget,
-            shaderAddress);
+            shaderAddress,
+            baseVertex);
 
     public void SubmitStorageTranslatedDraw(
         IGuestCompiledShader pixelShader,

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -45,7 +45,8 @@ internal sealed record VulkanTranslatedGuestDraw(
     uint InstanceCount,
     uint PrimitiveType,
     GuestIndexBuffer? IndexBuffer,
-    GuestRenderState RenderState);
+    GuestRenderState RenderState,
+    int BaseVertex = 0);
 
 internal sealed record VulkanOffscreenGuestDraw(
     VulkanTranslatedGuestDraw Draw,
@@ -449,7 +450,8 @@ internal static unsafe class VulkanVideoPresenter
         uint.TryParse(Environment.GetEnvironmentVariable("SHARPEMU_SKIP_TALL_COMPUTE_Z"), out var z)
             ? z
             : 0;
-    private const uint GuestPrimitiveRectList = 0x11;
+    private const uint GuestPrimitiveRectList = AgcPrimitiveHelpers.PrimitiveRectListLegacy;
+    private const uint GuestPrimitiveRectListNgg = AgcPrimitiveHelpers.PrimitiveRectList;
 
     private static readonly object _gate = new();
     private readonly record struct PendingGuestWork(
@@ -1009,7 +1011,8 @@ internal static unsafe class VulkanVideoPresenter
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
         GuestDepthTarget? depthTarget = null,
-        ulong shaderAddress = 0)
+        ulong shaderAddress = 0,
+        int baseVertex = 0)
     {
         SubmitOffscreenTranslatedDraw(
             pixelSpirv,
@@ -1025,7 +1028,8 @@ internal static unsafe class VulkanVideoPresenter
             vertexBuffers,
             renderState,
             depthTarget,
-            shaderAddress);
+            shaderAddress,
+            baseVertex);
     }
 
     // Manual scans (targets are <= 8) so the per-draw validation does not
@@ -1078,7 +1082,8 @@ internal static unsafe class VulkanVideoPresenter
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
         GuestDepthTarget? depthTarget = null,
-        ulong shaderAddress = 0)
+        ulong shaderAddress = 0,
+        int baseVertex = 0)
     {
         if (pixelSpirv.Length == 0 ||
             targets.Count == 0 ||
@@ -1145,7 +1150,8 @@ internal static unsafe class VulkanVideoPresenter
                         instanceCount,
                         primitiveType,
                         indexBuffer,
-                        effectiveRenderState),
+                        effectiveRenderState,
+                        baseVertex),
                     targets.ToArray(),
                     depthTarget,
                     PublishTarget: true,
@@ -1170,7 +1176,8 @@ internal static unsafe class VulkanVideoPresenter
         GuestIndexBuffer? indexBuffer = null,
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
-        ulong shaderAddress = 0)
+        ulong shaderAddress = 0,
+        int baseVertex = 0)
     {
         if (pixelSpirv.Length == 0 ||
             depthTarget.Address == 0 ||
@@ -1200,7 +1207,8 @@ internal static unsafe class VulkanVideoPresenter
                         instanceCount,
                         primitiveType,
                         indexBuffer,
-                        renderState ?? GuestRenderState.Default),
+                        renderState ?? GuestRenderState.Default,
+                        baseVertex),
                     [new GuestRenderTarget(
                         Address: 0,
                         depthTarget.Width,
@@ -3079,6 +3087,7 @@ internal static unsafe class VulkanVideoPresenter
             public bool Index32Bit;
             public uint VertexCount = 3;
             public uint InstanceCount = 1;
+            public int BaseVertex;
             public PrimitiveTopology Topology = PrimitiveTopology.TriangleList;
             public GuestBlendState[] Blends = [GuestBlendState.Default];
             public GuestBlendConstant BlendConstant;
@@ -6112,9 +6121,18 @@ internal static unsafe class VulkanVideoPresenter
                 GlobalMemoryBuffers =
                     new GlobalBufferResource[draw.GlobalMemoryBuffers.Count],
                 VertexBuffers = new VertexBufferResource[draw.VertexBuffers.Count],
-                VertexCount = GetDrawVertexCount(draw.PrimitiveType, draw.VertexCount, draw.IndexBuffer),
+                VertexCount = GetDrawVertexCount(
+                    draw.PrimitiveType,
+                    draw.VertexCount,
+                    draw.IndexBuffer,
+                    draw.VertexBuffers.Count > 0),
                 InstanceCount = Math.Max(draw.InstanceCount, 1),
-                Topology = GetPrimitiveTopology(draw.PrimitiveType),
+                BaseVertex = draw.BaseVertex,
+                Topology = GetPrimitiveTopology(
+                    draw.PrimitiveType,
+                    indexed: draw.IndexBuffer is not null,
+                    vertexCount: draw.VertexCount,
+                    hasVertexBuffers: draw.VertexBuffers.Count > 0),
                 Blends = draw.RenderState.Blends.ToArray(),
                 BlendConstant = draw.RenderState.BlendConstant,
                 Scissor = draw.RenderState.Scissor,
@@ -9376,7 +9394,11 @@ internal static unsafe class VulkanVideoPresenter
             _vk.FreeMemory(_device, allocation.Memory, null);
         }
 
-        private static PrimitiveTopology GetPrimitiveTopology(uint primitiveType) =>
+        private static PrimitiveTopology GetPrimitiveTopology(
+            uint primitiveType,
+            bool indexed,
+            uint vertexCount,
+            bool hasVertexBuffers) =>
             primitiveType switch
             {
                 1 => PrimitiveTopology.PointList,
@@ -9384,7 +9406,12 @@ internal static unsafe class VulkanVideoPresenter
                 3 => PrimitiveTopology.LineStrip,
                 5 => PrimitiveTopology.TriangleFan,
                 6 => PrimitiveTopology.TriangleStrip,
-                GuestPrimitiveRectList => PrimitiveTopology.TriangleStrip,
+                GuestPrimitiveRectListNgg or GuestPrimitiveRectList
+                    when AgcPrimitiveHelpers.ShouldDrawRectListAsTriangleStrip(
+                        primitiveType,
+                        indexed,
+                        vertexCount,
+                        hasVertexBuffers) => PrimitiveTopology.TriangleStrip,
                 _ => PrimitiveTopology.TriangleList,
             };
 
@@ -9500,15 +9527,13 @@ internal static unsafe class VulkanVideoPresenter
         private static uint GetDrawVertexCount(
             uint primitiveType,
             uint vertexCount,
-            GuestIndexBuffer? indexBuffer)
-        {
-            if (primitiveType == GuestPrimitiveRectList && indexBuffer is null)
-            {
-                return 4;
-            }
-
-            return vertexCount;
-        }
+            GuestIndexBuffer? indexBuffer,
+            bool hasVertexBuffers) =>
+            AgcPrimitiveHelpers.GetRectListDrawVertexCount(
+                primitiveType,
+                vertexCount,
+                indexed: indexBuffer is not null,
+                hasVertexBuffers);
 
         private static BlendFactor ToVkBlendFactor(uint factor) =>
             factor switch
@@ -15316,12 +15341,14 @@ internal static unsafe class VulkanVideoPresenter
                         resources.IndexBuffer,
                         0,
                         resources.Index32Bit ? IndexType.Uint32 : IndexType.Uint16);
+                    // vertexOffset = ResolveVertexOffset(GE_INDX_OFFSET).
+                    // GTA UI glyphs use relative indices + a nonzero base vertex.
                     _vk.CmdDrawIndexed(
                         _commandBuffer,
                         resources.VertexCount,
                         resources.InstanceCount,
                         0,
-                        0,
+                        resources.BaseVertex,
                         0);
                 }
                 else
@@ -15330,7 +15357,7 @@ internal static unsafe class VulkanVideoPresenter
                         _commandBuffer,
                         resources.VertexCount,
                         resources.InstanceCount,
-                        0,
+                        (uint)Math.Max(resources.BaseVertex, 0),
                         0);
                 }
 

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcRectListIndexHelpersTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcRectListIndexHelpersTests.cs
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+/// <summary>
+/// Regression coverage for the AGC UI path: index8 expansion and rect-list
+/// vertex counts / topology selection.
+/// </summary>
+public sealed class AgcRectListIndexHelpersTests
+{
+    [Theory]
+    [InlineData(0u, 0u, 2)] // Index16
+    [InlineData(1u, 1u, 4)] // Index32
+    [InlineData(2u, 2u, 1)] // Index8
+    [InlineData(0x402u, 2u, 1)] // UC 0x400|size -> Index8
+    public void IndexType_DecodeAndStride_MatchProspero(uint raw, uint expected, int stride)
+    {
+        var decoded = AgcIndexHelpers.Decode(raw);
+        Assert.Equal((AgcIndexHelpers.ProsperoIndexType)expected, decoded);
+        Assert.Equal(stride, AgcIndexHelpers.GetGuestStrideBytes(decoded));
+    }
+
+    [Fact]
+    public void ExpandIndex8ToU16_PreservesValues()
+    {
+        ReadOnlySpan<byte> source = [0x00, 0x01, 0xFF, 0x7F];
+        Span<byte> destination = stackalloc byte[8];
+        AgcIndexHelpers.ExpandIndex8ToU16(source, destination);
+        Assert.Equal(0, BinaryPrimitives.ReadUInt16LittleEndian(destination[..2]));
+        Assert.Equal(1, BinaryPrimitives.ReadUInt16LittleEndian(destination.Slice(2, 2)));
+        Assert.Equal(255, BinaryPrimitives.ReadUInt16LittleEndian(destination.Slice(4, 2)));
+        Assert.Equal(127, BinaryPrimitives.ReadUInt16LittleEndian(destination.Slice(6, 2)));
+    }
+
+    [Theory]
+    // NGG single-rect UI (DualSense): expand even when VBs are present
+    [InlineData(7u, 3u, false, true, 4u)]
+    [InlineData(7u, 1u, false, false, 4u)]
+    [InlineData(7u, 4u, false, true, 4u)]
+    // Indexed / multi-vert auto: keep guest count (loading video)
+    [InlineData(7u, 3u, true, false, 3u)]
+    [InlineData(7u, 6u, false, true, 6u)]
+    [InlineData(7u, 4u, true, true, 4u)]
+    [InlineData(0x11u, 3u, false, false, 4u)]
+    [InlineData(0x11u, 6u, false, false, 6u)]
+    [InlineData(4u, 3u, false, false, 3u)]
+    public void RectListDrawVertexCount_MatchesExpansion(
+        uint primitiveType,
+        uint vertexCount,
+        bool indexed,
+        bool hasVertexBuffers,
+        uint expected)
+    {
+        Assert.Equal(
+            expected,
+            AgcPrimitiveHelpers.GetRectListDrawVertexCount(
+                primitiveType,
+                vertexCount,
+                indexed,
+                hasVertexBuffers));
+    }
+
+    [Theory]
+    [InlineData(7u, false, 3u, true, true)]
+    [InlineData(7u, false, 6u, true, false)]
+    [InlineData(7u, true, 3u, false, false)]
+    [InlineData(0x11u, false, 3u, true, true)]
+    [InlineData(0x11u, true, 3u, false, false)]
+    public void RectListTriangleStrip_MatchesGuards(
+        uint primitiveType,
+        bool indexed,
+        uint vertexCount,
+        bool hasVertexBuffers,
+        bool expected) =>
+        Assert.Equal(
+            expected,
+            AgcPrimitiveHelpers.ShouldDrawRectListAsTriangleStrip(
+                primitiveType,
+                indexed,
+                vertexCount,
+                hasVertexBuffers));
+
+    [Theory]
+    [InlineData(7u, (uint)AgcPrimitiveHelpers.GsOutputPrimitiveType.Rectangle2D)]
+    [InlineData(0x11u, (uint)AgcPrimitiveHelpers.GsOutputPrimitiveType.RectList)]
+    [InlineData(4u, (uint)AgcPrimitiveHelpers.GsOutputPrimitiveType.Triangles)]
+    [InlineData(1u, (uint)AgcPrimitiveHelpers.GsOutputPrimitiveType.Points)]
+    public void PrimitiveTypeToGsOut_MatchesProspero(uint primitiveType, uint expected) =>
+        Assert.Equal(expected, AgcPrimitiveHelpers.PrimitiveTypeToGsOut(primitiveType));
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Implements Prospero rect-list / NGG UI draw expansion, Index8 host expand, and `GE_INDX_OFFSET` base vertex for indexed batches.

**What changed**
- New `AgcPrimitiveHelpers` — prim `7` / legacy `0x11`; triangle-strip for auto counts **1/3/4** (NGG single-rect UI); draw vertex count expand to 4 when needed
- New `AgcIndexHelpers` — decode Prospero Index16/32/8; expand Index8 → host u16 (no `IndexSize=0` → Index8 fallback)
- `AgcExports` — latch UC `VGT_INDEX_TYPE` (`0x243`), read base vertex from `GE_INDX_OFFSET` (`0x24A`), pass `BaseVertex` into translated draws / presenters; skip param-less rect-lists (`agc.rect_list_skip`)
- Vulkan / Metal presenters — topology + count via helpers; `CmdDrawIndexed` / `CmdDraw` (and Metal index bake) honour base vertex
- Unit tests for index decode/expand, rect-list strip guards, and GsOut mapping

**Why**
NGG single-rect UI submits need a 4-vert strip on the host; Prospero Index8 is not Index16/32; glyph batches need the hardware index offset as base vertex. Param-less rect-lists are not normal colour draws. This is generic AGC draw/index plumbing, not a title-specific hack. Keep loading-video indexed / large auto rect-lists on triangle list (helpers only strip for the NGG auto 1/3/4 cases).

**AI-assisted**
Research and implementation were AI-assisted. I reviewed the strip guards, Index8 expand, `GE_INDX_OFFSET` wiring, and presenter base-vertex paths, and I can explain / maintain them.

## Testing

- Unit: `FullyQualifiedName~AgcRectListIndexHelpersTests` — **23 passed**
- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) on a local verify stack that also includes other open fixes needed to boot (AudioOut2, APR, Remoteplay, CreateShader HS, getdents, GuestImageWriteTracker, F11–F13):
  - Intro / logo / copyright path still boots on the stacked build used for title testing
  - Focus of this change: UI quads / prompts and indexed glyph batches; Scaleform text may still be wrong (later ForceUnorm / atlas work)
- Build: `.\build.ps1` (Release `win-x64`) succeeded on the verify stack

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).