### PR TITLE
fix(agc): implement sceAgcDcbSetUcRegisterDirect

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -1432,6 +1432,26 @@ public static partial class AgcExports
         DcbSetRegistersIndirect(ctx, RUcRegsIndirect, "uc");
 
     [SysAbiExport(
+        Nid = "w4-d0n60hdo",
+        ExportName = "sceAgcDcbSetUcRegisterDirect",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbSetUcRegisterDirect(CpuContext ctx) =>
+        DcbSetRegisterDirect(ctx, ItSetUconfigReg, "uc");
+
+    [SysAbiExport(
+        Nid = "aP1Ki9G3++4",
+        ExportName = "sceAgcDcbSetUcRegisterDirectGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbSetUcRegisterDirectGetSize(CpuContext ctx)
+    {
+        // SET_UCONFIG_REG header + offset + value.
+        ctx[CpuRegister.Rax] = 3u * sizeof(uint);
+        return (int)ctx[CpuRegister.Rax];
+    }
+
+    [SysAbiExport(
         Nid = "GIIW2J37e70",
         ExportName = "sceAgcDcbSetIndexSize",
         Target = Generation.Gen5,
@@ -10811,6 +10831,33 @@ public static partial class AgcExports
         }
 
         TraceAgc($"agc.dcb_set_{registerSpace}_indirect buf=0x{commandBufferAddress:X16} cmd=0x{commandAddress:X16} regs=0x{registersAddress:X16} count={registerCount}");
+        return ReturnPointer(ctx, commandAddress);
+    }
+
+    private static int DcbSetRegisterDirect(CpuContext ctx, uint op, string registerSpace)
+    {
+        var commandBufferAddress = ctx[CpuRegister.Rdi];
+        // Uc/Cx/Sh register is passed by value as {u32 offset, u32 value} in RSI.
+        var packedRegister = ctx[CpuRegister.Rsi];
+        var registerOffset = (uint)(packedRegister & 0xFFFF_FFFFUL);
+        var registerValue = (uint)(packedRegister >> 32);
+        if (commandBufferAddress == 0)
+        {
+            return ReturnPointer(ctx, 0);
+        }
+
+        const uint packetDwords = 3;
+        if (!TryAllocateCommandDwords(ctx, commandBufferAddress, packetDwords, out var commandAddress) ||
+            !TryWriteUInt32(ctx, commandAddress, Pm4(packetDwords, op, 0)) ||
+            !TryWriteUInt32(ctx, commandAddress + 4, registerOffset & 0xFFFFu) ||
+            !TryWriteUInt32(ctx, commandAddress + 8, registerValue))
+        {
+            return ReturnPointer(ctx, 0);
+        }
+
+        TraceAgc(
+            $"agc.dcb_set_{registerSpace}_direct buf=0x{commandBufferAddress:X16} " +
+            $"cmd=0x{commandAddress:X16} offset=0x{registerOffset:X4} value=0x{registerValue:X8}");
         return ReturnPointer(ctx, commandAddress);
     }
 


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Implements HLE for `sceAgcDcbSetUcRegisterDirect` (`w4-d0n60hdo`) and its `GetSize` sibling.

**What changed**
- Emit the 3-dword `SET_UCONFIG_REG` packet from the packed `{u32 offset, u32 value}` in RSI into the DCB
- `sceAgcDcbSetUcRegisterDirectGetSize` returns 12 bytes (header + offset + value)
- Shared helper next to the existing indirect UC setter path

**Why**
Unresolved calls left GPU uconfig registers unset. Titles use this to write registers such as `GE_INDX_OFFSET` (`0x24A`); without it, indexed UI draws keep base vertex 0 and collapse (e.g. DualSense prompt icons as a single triangle). This is generic AGC DCB packet emission, not a title-specific hack. Works with the separate base-vertex / Index8 draw path that *reads* `GE_INDX_OFFSET`.

**AI-assisted**
Research and implementation were AI-assisted. I reviewed the packed RSI layout, PM4 opcode path, and GetSize width, and I can explain / maintain them.

## Testing

- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) on a local verify stack that also includes other open fixes needed to boot / draw UI (AudioOut2, APR, Remoteplay, CreateShader HS, getdents, GuestImageWriteTracker, interpolants, CB metadata skip, vertex metadata, rect-list/Index8/base vertex):
  - Before: `w4-d0n60hdo` unresolved × many; RSI targets included `0x24A` (`GE_INDX_OFFSET`); DualSense icon drew as one triangle
  - After: NID resolved; DualSense icons render as expected when stacked with the Index8 / base-vertex draw path
- Build: `.\build.ps1` (Release `win-x64`) succeeded on the verify stack

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).