### PR TITLE
fix(hle): GameService Ok stubs plus NetInetPton and Json terminate

### DIFF
--- a/src/SharpEmu.Libs/Json/JsonExports.cs
+++ b/src/SharpEmu.Libs/Json/JsonExports.cs
@@ -81,6 +81,18 @@ public static class JsonExports
     }
 
     [SysAbiExport(
+        Nid = "PR5k1penBLM",
+        ExportName = "_ZN3sce4Json11Initializer9terminateEv",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceJson")]
+    public static int InitializerTerminate(CpuContext ctx)
+    {
+        TraceJson("Initializer.terminate", ctx[CpuRegister.Rdi], 0);
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
         Nid = "Cxwy7wHq4J0",
         ExportName = "_ZN3sce4Json11Initializer10initializeEPKNS0_13InitParameterE",
         Target = Generation.Gen4 | Generation.Gen5,

--- a/src/SharpEmu.Libs/Network/NetExports.cs
+++ b/src/SharpEmu.Libs/Network/NetExports.cs
@@ -755,6 +755,52 @@ public static class NetExports
         return true;
     }
 
+    [SysAbiExport(
+        Nid = "8Kcp5d-q1Uo",
+        ExportName = "sceNetInetPton",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceNet")]
+    public static int NetInetPton(CpuContext ctx)
+    {
+        var addressFamily = unchecked((int)ctx[CpuRegister.Rdi]);
+        var sourceAddress = ctx[CpuRegister.Rsi];
+        var destinationAddress = ctx[CpuRegister.Rdx];
+        if (sourceAddress == 0 || destinationAddress == 0)
+        {
+            return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
+        }
+
+        if (!TryReadUtf8Z(ctx, sourceAddress, MaxNameLength, out var source))
+        {
+            return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
+        }
+
+        var family = addressFamily switch
+        {
+            2 => AddressFamily.InterNetwork,      // AF_INET
+            28 => AddressFamily.InterNetworkV6,   // AF_INET6
+            _ => AddressFamily.Unknown,
+        };
+        if (family == AddressFamily.Unknown ||
+            !IPAddress.TryParse(source, out var parsed) ||
+            parsed.AddressFamily != family)
+        {
+            // Match BSD inet_pton: return 0 for a parseable-family miss.
+            ctx[CpuRegister.Rax] = 0;
+            return 0;
+        }
+
+        var bytes = parsed.GetAddressBytes();
+        if (!ctx.Memory.TryWrite(destinationAddress, bytes))
+        {
+            return SetNetError(ctx, NetErrorInvalidArgument, NetErrnoInvalidArgument);
+        }
+
+        TraceNet("inet_pton", addressFamily, sourceAddress, destinationAddress, (ulong)bytes.Length);
+        ctx[CpuRegister.Rax] = 1;
+        return 1;
+    }
+
     private static void TraceNet(string operation, int id, ulong arg0, ulong arg1, ulong arg2)
     {
         if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_NET"), "1", StringComparison.Ordinal))

--- a/src/SharpEmu.Libs/Stubs/GameServiceStubs.cs
+++ b/src/SharpEmu.Libs/Stubs/GameServiceStubs.cs
@@ -59,4 +59,65 @@ public static class GameServiceStubs
     public static int NpUniversalDataSystemCreateEvent(CpuContext ctx) => OkWithHandle(ctx, CpuRegister.Rdi);
     public static int NpUniversalDataSystemPostEvent(CpuContext ctx) => Ok(ctx);
     public static int NpUniversalDataSystemDestroyEvent(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "47UAEuQl+iI", ExportName = "sceNpUniversalDataSystemTerminate",
+        Target = Generation.Gen5, LibraryName = "libSceNpUniversalDataSystem")]
+    public static int NpUniversalDataSystemTerminate(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "0HBYxYAjmf0", ExportName = "sceNpGameIntentTerminate",
+        Target = Generation.Gen5, LibraryName = "libSceNpGameIntent")]
+    public static int NpGameIntentTerminate(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "jqb7HntFQFc", ExportName = "sceWebBrowserDialogInitialize",
+        Target = Generation.Gen5, LibraryName = "libSceWebBrowserDialog")]
+    public static int WebBrowserDialogInitialize(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "ocHtyBwHfys", ExportName = "sceWebBrowserDialogTerminate",
+        Target = Generation.Gen5, LibraryName = "libSceWebBrowserDialog")]
+    public static int WebBrowserDialogTerminate(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "kvYEw2lBndk", ExportName = "sceGameLiveStreamingInitialize",
+        Target = Generation.Gen5, LibraryName = "libSceGameLiveStreaming")]
+    public static int GameLiveStreamingInitialize(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "isruqthpYcw", ExportName = "sceSharePlayInitialize",
+        Target = Generation.Gen5, LibraryName = "libSceSharePlay")]
+    public static int SharePlayInitialize(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "0IL1keINExQ", ExportName = "sceShareTerminate",
+        Target = Generation.Gen5, LibraryName = "libSceShareUtility")]
+    public static int ShareTerminate(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "YBiIdcDPrxs", ExportName = "sceShareFeaturePermit",
+        Target = Generation.Gen5, LibraryName = "libSceShareUtility")]
+    public static int ShareFeaturePermit(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "9TrhuGzberQ", ExportName = "sceVoiceInit",
+        Target = Generation.Gen5, LibraryName = "libSceVoice")]
+    public static int VoiceInit(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "clyKUyi3RYU", ExportName = "sceVoiceSetThreadsParams",
+        Target = Generation.Gen5, LibraryName = "libSceVoice")]
+    public static int VoiceSetThreadsParams(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "dPj4ZtRcIWk", ExportName = "sceContentSearchInit",
+        Target = Generation.Gen5, LibraryName = "libSceContentSearch")]
+    public static int ContentSearchInit(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "zoxb0wEChEM", ExportName = "sceContentDeleteInitialize",
+        Target = Generation.Gen5, LibraryName = "libSceContentDelete")]
+    public static int ContentDeleteInitialize(CpuContext ctx) => Ok(ctx);
+
+    [SysAbiExport(Nid = "Fc8qxlKINYQ", ExportName = "sceVideoRecordingSetInfo",
+        Target = Generation.Gen5, LibraryName = "libSceVideoRecording")]
+    public static int VideoRecordingSetInfo(CpuContext ctx) => Ok(ctx);
+
+    // Captured from GTA V Enhanced (PPSA04264); not in the public NID catalog.
+    // Side-effect-free success — same as unresolved stub behavior that kept boot
+    // moving; reverse the ABI before writing guest memory.
+    #pragma warning disable SHEM006
+    [SysAbiExport(Nid = "Ikfdt-rIqCE", ExportName = "sceUnknownIkfdt",
+        Target = Generation.Gen5, LibraryName = "libKernel")]
+    public static int UnknownIkfdt(CpuContext ctx) => Ok(ctx);
+    #pragma warning restore SHEM006
 }


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Resolves a cluster of unresolved startup NIDs that can gate logo/accept progress on GTA V Enhanced.

**What changed**
- `GameServiceStubs`: Ok success stubs for share/voice/telemetry/content/web-browser/live-streaming/video-recording terminate/init probes, plus `Ikfdt-rIqCE` (uncatalogued NID seen on PPSA04264; success only, no guest writes)
- `NetExports`: real `sceNetInetPton` (`8Kcp5d-q1Uo`) — parse AF_INET/AF_INET6 text and write binary address bytes
- `JsonExports`: `sce::Json::Initializer::terminate` (`PR5k1penBLM`) success path matching existing ctor/dtor/initialize style

**Why**
On clean PPSA04264 these NIDs stay `NOT_FOUND`. Titles that treat that as hard failure can stick on the logo Cross / accept prompt even when pad input is wired. NetInetPton is a real ABI (not a silent Ok). GameService entries are side-effect-free success for optional social/telemetry init that the title already tolerates when unresolved elsewhere — here we return success so init continues. No Pad changes; no binder guest writes.

**AI-assisted**
Research and port from an experimental tree were AI-assisted. I reviewed the NID list, InetPton family/parse path, and Json terminate placement, and I can explain / maintain them.

## Testing

- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) on a local verify stack that also includes open AGC/boot fixes needed to reach the logo
- Verify log no longer lists the NIDs above as unresolved; retest logo accept with DualSense Cross and/or keyboard Enter/Z
- Optional: `SHARPEMU_AUTO_CROSS=50,60,70` and leave 90s+
- Build: `.\build.ps1` (Release `win-x64`) succeeded

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).