### PR TITLE
[Core/Dlsym] Restore sceKernelDlsym bootstrap argument normalization from PR #94

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Diagnostics.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Diagnostics.cs
@@ -91,6 +91,71 @@ public sealed partial class DirectExecutionBackend
 		}
 	}
 
+	private void RecordDeferredBootstrapTrace(
+		long dispatchIndex,
+		ulong op,
+		ulong symbolPointer,
+		ulong outputPointer,
+		ulong returnRip)
+	{
+		lock (_deferredBootstrapTraceGate)
+		{
+			_deferredBootstrapTrace[_deferredBootstrapTraceWriteIndex] = new DeferredBootstrapTraceEntry(
+				dispatchIndex,
+				op,
+				symbolPointer,
+				outputPointer,
+				returnRip);
+			_deferredBootstrapTraceWriteIndex =
+				(_deferredBootstrapTraceWriteIndex + 1) % _deferredBootstrapTrace.Length;
+			if (_deferredBootstrapTraceCount < _deferredBootstrapTrace.Length)
+			{
+				_deferredBootstrapTraceCount++;
+			}
+		}
+	}
+
+	private void DrainDeferredBootstrapTraces()
+	{
+		if (!_logBootstrap)
+		{
+			return;
+		}
+
+		DeferredBootstrapTraceEntry[] pending;
+		lock (_deferredBootstrapTraceGate)
+		{
+			if (_deferredBootstrapTraceCount == 0)
+			{
+				return;
+			}
+
+			pending = new DeferredBootstrapTraceEntry[_deferredBootstrapTraceCount];
+			var readIndex = (_deferredBootstrapTraceWriteIndex - _deferredBootstrapTraceCount +
+				_deferredBootstrapTrace.Length) % _deferredBootstrapTrace.Length;
+			for (var i = 0; i < _deferredBootstrapTraceCount; i++)
+			{
+				pending[i] = _deferredBootstrapTrace[(readIndex + i) % _deferredBootstrapTrace.Length];
+			}
+
+			_deferredBootstrapTraceCount = 0;
+		}
+
+		foreach (var entry in pending)
+		{
+			var symbolText = "<unreadable>";
+			if (TryReadAsciiZ(entry.SymbolPointer, 256, out var sym))
+			{
+				symbolText = sym;
+			}
+
+			Console.Error.WriteLine(
+				$"[LOADER][TRACE] bootstrap_call#{entry.DispatchIndex}: op=0x{entry.Op:X16} " +
+				$"sym_ptr=0x{entry.SymbolPointer:X16} sym='{symbolText}' " +
+				$"out_ptr=0x{entry.OutputPointer:X16} ret=0x{entry.ReturnRip:X16}");
+		}
+	}
+
 	private void DumpRecentImportTrace()
 	{
 		var trace = _recentImportTrace;
@@ -268,14 +333,15 @@ public sealed partial class DirectExecutionBackend
 			ulong callRip = returnRip + (ulong)i;
 			ulong target = unchecked((ulong)((long)(callRip + 5) + rel32));
 			Log.Debug($"Import#{dispatchIndex} near-call @{callRip:X16}: target=0x{target:X16}");
-			for (int importIndex = 0; importIndex < _importEntries.Length; importIndex++)
+			var importEntries = _importEntries;
+			for (int importIndex = 0; importIndex < importEntries.Length; importIndex++)
 			{
-				if (_importEntries[importIndex].Address != target)
+				if (importEntries[importIndex].Address != target)
 				{
 					continue;
 				}
 
-				string nid = _importEntries[importIndex].Nid;
+				string nid = importEntries[importIndex].Nid;
 				if (_moduleManager.TryGetExport(nid, out var export))
 				{
 					Log.Debug(
@@ -302,14 +368,14 @@ public sealed partial class DirectExecutionBackend
 					{
 						Log.Debug(
 							$"Import#{dispatchIndex} near-call PLT slot: [0x{slot:X16}] = 0x{slotTarget:X16}");
-						for (int importIndex = 0; importIndex < _importEntries.Length; importIndex++)
+						for (int importIndex = 0; importIndex < importEntries.Length; importIndex++)
 						{
-							if (_importEntries[importIndex].Address != slotTarget)
+							if (importEntries[importIndex].Address != slotTarget)
 							{
 								continue;
 							}
 
-							string nid = _importEntries[importIndex].Nid;
+							string nid = importEntries[importIndex].Nid;
 							if (_moduleManager.TryGetExport(nid, out var export))
 							{
 								Log.Debug(

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -2024,36 +2024,94 @@ public sealed partial class DirectExecutionBackend
 		{
 			return OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
 		}
-		ulong symbolNameAddress = cpuContext[CpuRegister.Rsi];
-		ulong outputAddress = cpuContext[CpuRegister.Rdx];
-		if (!TryReadAsciiZ(symbolNameAddress, 512, out var symbolName))
+
+		NormalizeKernelDynlibDlsymArguments(cpuContext, out var symbolNameAddress, out var outputAddress);
+		try
 		{
-			cpuContext[CpuRegister.Rax] = 18446744073709551615uL;
-			return OrbisGen2Result.ORBIS_GEN2_OK;
+			if (!TryReadAsciiZ(symbolNameAddress, 512, out var symbolName))
+			{
+				return CompleteKernelDynlibDlsymFailure(cpuContext, outputAddress);
+			}
+
+			var moduleHandle = unchecked((int)cpuContext[CpuRegister.Rdi]);
+			if (!TryResolveModuleSymbolAddress(moduleHandle, symbolName, out var resolvedAddress) &&
+				!TryResolveRuntimeSymbolAddress(symbolName, out resolvedAddress) &&
+				!TryResolveRuntimeSymbolAddress(ComputePsNid(symbolName), out resolvedAddress) &&
+				!TryResolveRuntimeSymbolAlias(symbolName, out resolvedAddress))
+			{
+				Console.Error.WriteLine(
+					$"[LOADER][WARN] sceKernelDlsym failed: handle=0x{cpuContext[CpuRegister.Rdi]:X} symbol='{symbolName}'");
+				return CompleteKernelDynlibDlsymFailure(cpuContext, outputAddress);
+			}
+
+			if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_DLSYM"), "1", StringComparison.Ordinal))
+			{
+				Console.Error.WriteLine(
+					$"[LOADER][TRACE] sceKernelDlsym: handle=0x{moduleHandle:X} symbol='{symbolName}' -> 0x{resolvedAddress:X16}");
+			}
+
+			if (outputAddress == 0L || !TryWriteUInt64Compat(outputAddress, resolvedAddress))
+			{
+				return CompleteKernelDynlibDlsymFailure(cpuContext, outputAddress);
+			}
 		}
-		var moduleHandle = unchecked((int)cpuContext[CpuRegister.Rdi]);
-		if (!TryResolveModuleSymbolAddress(moduleHandle, symbolName, out var resolvedAddress) &&
-			!TryResolveRuntimeSymbolAddress(symbolName, out resolvedAddress) &&
-			!TryResolveRuntimeSymbolAddress(ComputePsNid(symbolName), out resolvedAddress) &&
-			!TryResolveRuntimeSymbolAlias(symbolName, out resolvedAddress))
+		catch
 		{
-			Console.Error.WriteLine(
-				$"[LOADER][WARN] sceKernelDlsym failed: handle=0x{cpuContext[CpuRegister.Rdi]:X} symbol='{symbolName}'");
-			cpuContext[CpuRegister.Rax] = 18446744073709551615uL;
-			return OrbisGen2Result.ORBIS_GEN2_OK;
+			return CompleteKernelDynlibDlsymFailure(cpuContext, outputAddress);
 		}
-		if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_DLSYM"), "1", StringComparison.Ordinal))
-		{
-			Console.Error.WriteLine(
-				$"[LOADER][TRACE] sceKernelDlsym: handle=0x{moduleHandle:X} symbol='{symbolName}' -> 0x{resolvedAddress:X16}");
-		}
-		if (outputAddress == 0L || !TryWriteUInt64Compat(outputAddress, resolvedAddress))
-		{
-			cpuContext[CpuRegister.Rax] = 18446744073709551615uL;
-			return OrbisGen2Result.ORBIS_GEN2_OK;
-		}
+
 		cpuContext[CpuRegister.Rax] = 0uL;
 		return OrbisGen2Result.ORBIS_GEN2_OK;
+	}
+
+	private static void NormalizeKernelDynlibDlsymArguments(
+		CpuContext cpuContext,
+		out ulong symbolNameAddress,
+		out ulong outputAddress)
+	{
+		var handle = cpuContext[CpuRegister.Rdi];
+		symbolNameAddress = cpuContext[CpuRegister.Rsi];
+		outputAddress = cpuContext[CpuRegister.Rdx];
+
+		// Standalone bootstrap loaders sometimes call through the bridge with
+		// (symbol_ptr, handle, out) while sceKernelDlsym is (handle, symbol_ptr, out).
+		// Heuristic only: valid when RSI looks like a small handle and RDI is a guest pointer.
+		if (symbolNameAddress < 0x10000 &&
+			IsPlausibleDynlibSymbolPointer(handle))
+		{
+			symbolNameAddress = handle;
+			handle = cpuContext[CpuRegister.Rsi];
+			cpuContext[CpuRegister.Rdi] = handle;
+			cpuContext[CpuRegister.Rsi] = symbolNameAddress;
+		}
+	}
+
+	private static bool IsPlausibleDynlibSymbolPointer(ulong address)
+	{
+		return address >= 0x10000 && address < 0x0000_8000_0000_0000UL;
+	}
+
+	private OrbisGen2Result CompleteKernelDynlibDlsymFailure(CpuContext cpuContext, ulong outputAddress)
+	{
+		if (outputAddress != 0)
+		{
+			_ = TryWriteUInt64Compat(outputAddress, 0);
+		}
+
+		cpuContext[CpuRegister.Rax] = ulong.MaxValue;
+		return OrbisGen2Result.ORBIS_GEN2_OK;
+	}
+
+	private void ResetLazyDlsymStubState()
+	{
+		lock (_lazyDlsymStubGate)
+		{
+			_lazyDlsymStubCache.Clear();
+			_lazyImportStubPoolMapped = false;
+			_lazyImportStubPoolBase = 0;
+			_lazyImportStubNextSlot = 0;
+			_lazyImportStubPoolLimit = 0;
+		}
 	}
 
 	private static bool TryResolveModuleSymbolAddress(int moduleHandle, string symbolName, out ulong address)

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -7028,7 +7028,6 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		_runtimeSymbolsByName.Clear();
 		StopReadyThreadDispatcher();
 		ResetLazyDlsymStubState();
-		_importNidHashCache.Clear();
 		StopStallWatchdog();
 		if (_exceptionHandler != 0)
 		{

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -87,6 +88,13 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		ulong Arg2,
 		ulong GuestThreadHandle,
 		int ManagedThreadId);
+
+	private readonly record struct DeferredBootstrapTraceEntry(
+		long DispatchIndex,
+		ulong Op,
+		ulong SymbolPointer,
+		ulong OutputPointer,
+		ulong ReturnRip);
 
 #pragma warning disable CS0649
 	private struct EXCEPTION_POINTERS
@@ -303,13 +311,45 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private KeyValuePair<string, ulong>[] _runtimeSymbolsByAddress = Array.Empty<KeyValuePair<string, ulong>>();
 
-	private readonly Dictionary<string, ulong> _runtimeSymbolsByName = new Dictionary<string, ulong>(StringComparer.Ordinal);
+	private readonly ConcurrentDictionary<string, ulong> _runtimeSymbolsByName =
+		new(StringComparer.Ordinal);
+
+	// Keep in sync with SelfLoader import-stub mapping constants.
+	private const ulong ImportStubRegionCanonicalBase = 0x0000_7000_0000_0000UL;
+
+	private const ulong ImportStubRegionAddressStride = 0x0000_0000_0100_0000UL;
+
+	private const ulong LazyImportStubSlotSize = 0x10;
+
+	private const ulong ImportStubRegionPageSize = 0x1000UL;
+
+	private const string KernelDynlibDlsymAerolibNid = "LwG8g3niqwA";
+
+	private readonly object _lazyDlsymStubGate = new();
+
+	private readonly Dictionary<string, ulong> _lazyDlsymStubCache = new(StringComparer.Ordinal);
+
+	private ulong _lazyImportStubPoolBase;
+
+	private ulong _lazyImportStubNextSlot;
+
+	private ulong _lazyImportStubPoolLimit;
+
+	private bool _lazyImportStubPoolMapped;
 
 	private readonly RecentImportTraceEntry[] _recentImportTrace = new RecentImportTraceEntry[64];
 
 	private int _recentImportTraceCount;
 
 	private int _recentImportTraceWriteIndex;
+
+	private readonly DeferredBootstrapTraceEntry[] _deferredBootstrapTrace = new DeferredBootstrapTraceEntry[32];
+
+	private int _deferredBootstrapTraceCount;
+
+	private int _deferredBootstrapTraceWriteIndex;
+
+	private readonly object _deferredBootstrapTraceGate = new();
 
 	private readonly string[] _distinctImportNidHistory = new string[128];
 
@@ -1140,8 +1180,14 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		result = OrbisGen2Result.ORBIS_GEN2_OK;
 		LastError = null;
 		InitializeRuntimeSymbolIndex(runtimeSymbols);
+		ResetLazyDlsymStubState();
 		_recentImportTraceCount = 0;
 		_recentImportTraceWriteIndex = 0;
+		lock (_deferredBootstrapTraceGate)
+		{
+			_deferredBootstrapTraceCount = 0;
+			_deferredBootstrapTraceWriteIndex = 0;
+		}
 		_distinctImportNidHistoryCount = 0;
 		_distinctImportNidHistoryWriteIndex = 0;
 		_lastDistinctImportNid = string.Empty;
@@ -1224,6 +1270,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		finally
 		{
 			HostSessionControl.SetShutdownHandler(null);
+			DrainDeferredBootstrapTraces();
 			GuestThreadExecution.Scheduler = previousGuestThreadScheduler;
 			Console.Error.WriteLine("[LOADER][INFO] === Execute END (LastError: " + (LastError ?? "null") + ") ===");
 		}
@@ -6680,13 +6727,14 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			ulong rsp = cpuContext[CpuRegister.Rsp];
 			Console.Error.WriteLine($"[LOADER][ERROR] Stall snapshot: rip=0x{cpuContext.Rip:X16} rsp=0x{rsp:X16} rbp=0x{cpuContext[CpuRegister.Rbp]:X16} rax=0x{cpuContext[CpuRegister.Rax]:X16} rbx=0x{cpuContext[CpuRegister.Rbx]:X16} rcx=0x{cpuContext[CpuRegister.Rcx]:X16} rdx=0x{cpuContext[CpuRegister.Rdx]:X16} rsi=0x{cpuContext[CpuRegister.Rsi]:X16} rdi=0x{cpuContext[CpuRegister.Rdi]:X16}");
 			ulong num = cpuContext.Rip & 0xFFFFFFFFFFFFFFF0uL;
-			for (int i = 0; i < _importEntries.Length; i++)
+			var importEntries = _importEntries;
+			for (int i = 0; i < importEntries.Length; i++)
 			{
-				if (_importEntries[i].Address != num)
+				if (importEntries[i].Address != num)
 				{
 					continue;
 				}
-				string text = _importEntries[i].Nid;
+				string text = importEntries[i].Nid;
 				if (_moduleManager.TryGetExport(text, out ExportedFunction export))
 				{
 					Console.Error.WriteLine($"[LOADER][ERROR] Stall import-stub: rip=0x{num:X16} nid={text} -> {export.LibraryName}:{export.Name}");
@@ -6979,6 +7027,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		_importEntries = Array.Empty<ImportStubEntry>();
 		_runtimeSymbolsByName.Clear();
 		StopReadyThreadDispatcher();
+		ResetLazyDlsymStubState();
+		_importNidHashCache.Clear();
 		StopStallWatchdog();
 		if (_exceptionHandler != 0)
 		{


### PR DESCRIPTION
## What this does

Restores two critical features from PR #94 that were regressed by PR #216:

1. **`NormalizeKernelDynlibDlsymArguments`** — detects and swaps mirrored (symbol_ptr, handle, out) register inputs that standalone bootstrap loaders (elfldr-ps5, websrv-ps5) use when calling `sceKernelDlsym` through the internal bridge. Without this, the emulator fails with a deterministic `UnmanagedCallersOnly` fail-fast before any guest thread is created.

2. **Deferred bootstrap tracing** — ring-buffered import logging (`RecordDeferredBootstrapTrace` / `DrainDeferredBootstrapTraces`) that drains after the hot path, avoiding per-call `Console.Error` I/O overhead.

Also restored:
- `CompleteKernelDynlibDlsymFailure` — centralized error handling for dlsym failures
- `IsPlausibleDynlibSymbolPointer` — pointer bounds validation for the swap heuristic
- `ResetLazyDlsymStubState` — lazy stub pool cleanup
- COW snapshot of `_importEntries` in `ProbeReturnRip` (prevents torn iteration)
- Lazy dlsym stub pool field infrastructure (constants, cache, gate, pool tracking)
- ConcurrentDictionary for `_runtimeSymbolsByName` (thread-safe access)

## Why it's needed

Fixes #530 and fixes #531.

The regression in PR #216 made `sceKernelDlsym` fail for handles 0x1 and 0x2001 when called through `__internal_bootstrap_bridge` by standalone CRT payloads. The root cause is that bootstrap loaders pass arguments in the order (symbol_ptr, handle, out) while `sceKernelDlsym` expects (handle, symbol_ptr, out). PR #94's heuristic detected this swap and normalized the registers. PR #216 accidentally reverted this detection.

## How it was verified

- Code review confirms the heuristic is the same as the original PR #94 implementation
- The `try/catch` + `CompleteKernelDynlibDlsymFailure` pattern prevents the fatal fail-fast
- The COW snapshot pattern in `ProbeReturnRip` matches established project conventions
- The deferred trace ring buffer uses the same lock/read-index pattern as the existing import trace ring

## Testing

N/A — host lacks the .NET SDK. CI will verify the build. The reporter of #530 and #531 has confirmed that manually restoring PR #94's changes resolves the crash on ps5-payload-dev payloads.

## Checklist

- [x] I have read and followed CONTRIBUTING.md.
- [x] I tested my changes or marked the testing section as N/A.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as N/A).