### PR TITLE
fix(metal): apply GuestBlendStateNormalizer for integer RTs

### DIFF
--- a/src/SharpEmu.Libs/Gpu/Metal/MetalVideoPresenter.Draws.cs
+++ b/src/SharpEmu.Libs/Gpu/Metal/MetalVideoPresenter.Draws.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using SharpEmu.Libs.VideoOut;
 using SharpEmu.ShaderCompiler;
 using SharpEmu.ShaderCompiler.Metal;
 
@@ -464,6 +465,20 @@ internal static partial class MetalVideoPresenter
         {
             ReturnPooledGuestData(draw);
             return;
+        }
+
+        // Integer RTs cannot blend; match Vulkan so pipeline keys and enable
+        // bits agree with the guest constraint
+        var normalizedBlends = GuestBlendStateNormalizer.NormalizeIntegerAttachments(
+            draw.RenderState.Blends,
+            targetFormats.Select(static format => IsIntegerFormat(format.OutputKind)).ToArray(),
+            out var normalizedBlendCount);
+        if (normalizedBlendCount != 0)
+        {
+            draw = draw with
+            {
+                RenderState = draw.RenderState with { Blends = normalizedBlends },
+            };
         }
 
         // Resolve color targets: published guest images by address, transient

--- a/tests/SharpEmu.Libs.Tests/VideoOut/GuestBlendStateNormalizerTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/GuestBlendStateNormalizerTests.cs
@@ -1,0 +1,119 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.Gpu;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class GuestBlendStateNormalizerTests
+{
+    private static GuestBlendState EnabledBlend => GuestBlendState.Default with { Enable = true };
+
+    [Fact]
+    public void NormalizeIntegerAttachments_DisablesBlendOnIntegerAttachments()
+    {
+        var blends = new[]
+        {
+            EnabledBlend,
+            EnabledBlend,
+            GuestBlendState.Default,
+        };
+        var integerAttachments = new[] { true, false, true };
+
+        var normalized = GuestBlendStateNormalizer.NormalizeIntegerAttachments(
+            blends,
+            integerAttachments,
+            out var normalizedCount);
+
+        Assert.Equal(1, normalizedCount);
+        Assert.False(normalized[0].Enable);
+        Assert.True(normalized[1].Enable);
+        Assert.False(normalized[2].Enable);
+    }
+
+    [Fact]
+    public void NormalizeIntegerAttachments_LeavesNonIntegerUnchanged()
+    {
+        var blends = new[] { EnabledBlend, EnabledBlend };
+        var integerAttachments = new[] { false, false };
+
+        var normalized = GuestBlendStateNormalizer.NormalizeIntegerAttachments(
+            blends,
+            integerAttachments,
+            out var normalizedCount);
+
+        Assert.Equal(0, normalizedCount);
+        Assert.True(normalized[0].Enable);
+        Assert.True(normalized[1].Enable);
+        Assert.Equal(blends[0], normalized[0]);
+        Assert.Equal(blends[1], normalized[1]);
+    }
+
+    [Fact]
+    public void NormalizeIntegerAttachments_DoesNotCountAlreadyDisabledIntegerBlends()
+    {
+        var blends = new[] { GuestBlendState.Default };
+        var integerAttachments = new[] { true };
+
+        var normalized = GuestBlendStateNormalizer.NormalizeIntegerAttachments(
+            blends,
+            integerAttachments,
+            out var normalizedCount);
+
+        Assert.Equal(0, normalizedCount);
+        Assert.False(normalized[0].Enable);
+    }
+
+    [Fact]
+    public void NormalizeIntegerAttachments_PreservesNonEnableFields()
+    {
+        var blend = GuestBlendState.Default with
+        {
+            Enable = true,
+            ColorSrcFactor = 4,
+            ColorDstFactor = 5,
+            ColorFunc = 1,
+            AlphaSrcFactor = 6,
+            AlphaDstFactor = 7,
+            AlphaFunc = 2,
+            SeparateAlphaBlend = true,
+            WriteMask = 0x7u,
+        };
+
+        var normalized = GuestBlendStateNormalizer.NormalizeIntegerAttachments(
+            [blend],
+            [true],
+            out var normalizedCount);
+
+        Assert.Equal(1, normalizedCount);
+        Assert.Equal(
+            blend with { Enable = false },
+            normalized[0]);
+    }
+
+    [Fact]
+    public void NormalizeIntegerAttachments_ThrowsOnCountMismatch()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            GuestBlendStateNormalizer.NormalizeIntegerAttachments(
+                [EnabledBlend],
+                [true, false],
+                out _));
+
+        Assert.Equal("integerAttachments", exception.ParamName);
+    }
+
+    [Fact]
+    public void NormalizeIntegerAttachments_HandlesEmptyLists()
+    {
+        var normalized = GuestBlendStateNormalizer.NormalizeIntegerAttachments(
+            Array.Empty<GuestBlendState>(),
+            Array.Empty<bool>(),
+            out var normalizedCount);
+
+        Assert.Equal(0, normalizedCount);
+        Assert.Empty(normalized);
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Vulkan already runs `GuestBlendStateNormalizer.NormalizeIntegerAttachments` before offscreen PSO setup. Metal did not, so pipeline keys and guest blend enable bits could disagree with the "integer targets cannot blend" rule.

**What changed**
- Metal offscreen draw path: normalize blends from target integer flags before texture resolve / pipeline create (same idea as Vulkan)
- Unit tests for `GuestBlendStateNormalizer` (integer disables blend, float left alone, empty lists, field preservation)

**Why**
Metal still has a late `blend.Enable && !IsIntegerFormat` guard when building the MTL blend descriptor. This is about matching Vulkan earlier (guest state + hash) so the two backends do not diverge. Generic GPU correctness, not a title hack.

Default host path remains Vulkan/MoltenVK. This mainly matters for `SHARPEMU_GPU_BACKEND=metal`, plus locking the shared helper with tests that both paths can rely on.

**AI-assisted**
Implementation and tests were AI-assisted. I compared the Vulkan call site, Metal format integer helper, and the normalizer API. I can explain and maintain this.

## Testing

- `dotnet test SharpEmu.slnx -c Release` on this branch: green (Libs.Tests 548, includes the new blend tests)
- Dead Cells (PPSA15552, `01.005.000`) macOS osx-x64 Release publish of this branch:
  - Default Vulkan/MoltenVK: title loads, VideoOut 3840x2160, guest frames present (~60s smoke, killed cleanly)
  - `SHARPEMU_GPU_BACKEND=metal`: GPU backend Metal log, Metal VideoOut presenter starts, presenting 3840x2160, AudioOut ports open, AGC imports keep running (~75s). Still slow on Air + Rosetta; that is host cost
- I am not claiming a visible color bug fixed in a specific title. This is parity + tests. Smoke is regression coverage that Metal and Vulkan still boot the same dump

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).