### PR TITLE
fix(audio): AudioOut2 host beds, deeper waveOut queue, AJM MP3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="NLayer" Version="1.14.0" />
     <PackageVersion Include="Silk.NET.Input" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.23.0" />

--- a/src/SharpEmu.HLE/Host/Windows/WindowsWaveOutAudio.cs
+++ b/src/SharpEmu.HLE/Host/Windows/WindowsWaveOutAudio.cs
@@ -17,7 +17,9 @@ internal sealed partial class WindowsWaveOutAudio : IHostAudioOutput
         private const uint CallbackEvent = 0x0005_0000;
         private const ushort WaveFormatPcm = 1;
         private const uint WaveHeaderDone = 0x0000_0001;
-        private const int MaximumQueuedPcmBytes = 32 * 1024;
+        // Deeper than the old 32KB (~170ms) queue: FMOD's bursty AudioOut2 Push
+        // pattern underran a shallow buffer and crackled even at stable FPS.
+        private const int MaximumQueuedPcmBytes = 128 * 1024;
 
         private readonly object _gate = new();
         private readonly AutoResetEvent _completion = new(false);

--- a/src/SharpEmu.Libs/Audio/AjmExports.cs
+++ b/src/SharpEmu.Libs/Audio/AjmExports.cs
@@ -23,13 +23,32 @@ public static class AjmExports
     private static int _nextContextId;
     private static int _nextBatchId;
 
+    private const uint AjmCodecMp3 = 0;
+
+    private sealed class AjmInstanceState
+    {
+        public required uint Codec { get; init; }
+        public required ulong Flags { get; init; }
+        public AjmMp3Decoder? Mp3 { get; init; }
+
+        public bool PreferPcm16
+        {
+            get
+            {
+                // AjmInstanceFlags: version:3, channels:4, format:3
+                var encoding = (Flags >> 7) & 0x7;
+                return encoding is 0 or 1; // S16 / S32 — we emit S16 for both
+            }
+        }
+    }
+
     private sealed class AjmContextState
     {
         public object Gate { get; } = new();
 
         public HashSet<uint> RegisteredCodecs { get; } = new();
 
-        public Dictionary<uint, uint> InstancesBySlot { get; } = new();
+        public Dictionary<uint, AjmInstanceState> InstancesBySlot { get; } = new();
 
         public int NextInstanceIndex { get; set; }
     }
@@ -169,7 +188,14 @@ public static class AjmExports
             }
 
             state.NextInstanceIndex = nextInstanceIndex;
-            state.InstancesBySlot.Add(instanceSlot, instanceId);
+            state.InstancesBySlot.Add(
+                instanceSlot,
+                new AjmInstanceState
+                {
+                    Codec = codecType,
+                    Flags = flags,
+                    Mp3 = codecType == AjmCodecMp3 ? new AjmMp3Decoder() : null,
+                });
         }
 
         Trace($"instance_create context={contextId} codec={codecType} flags=0x{flags:X} instance=0x{instanceId:X8}");
@@ -229,11 +255,9 @@ public static class AjmExports
     }
 
     /// <summary>
-    /// Enqueues a decode job on a batch. Titles call this on the Bink/AJM hot
-    /// path; leaving it unresolved floods Import WARN spam. This is a silence
-    /// stub, not a codec: advance the batch cursor and report the input as
-    /// consumed with silence produced so the title does not spin on the same
-    /// packet.
+    /// Enqueues a decode job on a batch. GTA V Enhanced streams menu music
+    /// through AJM MP3 (codec 0); we decode eagerly here so BatchStart/Wait
+    /// stay synchronous no-ops.
     /// </summary>
     [SysAbiExport(
         Nid = "39WxhR-ePew",
@@ -255,37 +279,120 @@ public static class AjmExports
             return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
         }
 
-        // Best-effort: bump the batch cursor when the guest filled AjmBatchInfo.
-        // Still succeed without it — the unresolved stub returned 0 and titles
-        // keep calling; failing here would reintroduce hot-path spam via retries.
         _ = TryAppendBatchJob(ctx, infoAddress, AjmJobRunSize);
 
-        // Silence: clear PCM out and claim full input consumed so the guest
-        // advances its bitstream cursor instead of re-submitting forever.
-        if (outputAddress != 0 && outputSize != 0 && outputSize <= MaxSilentPcmBytes)
+        var inputConsumed = 0;
+        var outputWritten = 0;
+        ulong totalSamples = 0;
+        var frames = 0u;
+        var decoded = false;
+
+        if (TryGetInstance(instanceId, out var instance) &&
+            instance.Mp3 is not null &&
+            inputAddress != 0 &&
+            inputSize is > 0 and <= MaxSilentPcmBytes &&
+            outputAddress != 0 &&
+            outputSize is > 0 and <= MaxSilentPcmBytes)
         {
-            ClearGuestMemory(ctx, outputAddress, outputSize);
+            var input = new byte[inputSize];
+            var output = new byte[outputSize];
+            if (ctx.Memory.TryRead(inputAddress, input))
+            {
+                var result = instance.Mp3.Decode(input, output, pcm16: instance.PreferPcm16);
+                if (result.OutputWritten > 0)
+                {
+                    if (!ctx.Memory.TryWrite(outputAddress, output.AsSpan(0, result.OutputWritten)))
+                    {
+                        return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
+                    }
+
+                    // Zero any remainder so stale PCM does not leak into FMOD.
+                    if ((ulong)result.OutputWritten < outputSize)
+                    {
+                        ClearGuestMemory(
+                            ctx,
+                            outputAddress + (ulong)result.OutputWritten,
+                            outputSize - (ulong)result.OutputWritten);
+                    }
+
+                    decoded = true;
+                    inputConsumed = result.InputConsumed;
+                    outputWritten = result.OutputWritten;
+                    frames = result.Frames;
+                    totalSamples = instance.Mp3.TotalDecodedSamples;
+                }
+                else
+                {
+                    inputConsumed = result.InputConsumed;
+                    totalSamples = instance.Mp3.TotalDecodedSamples;
+                }
+            }
+        }
+
+        if (!decoded)
+        {
+            // Fallback: silence + consume input so the guest does not spin.
+            if (outputAddress != 0 && outputSize != 0 && outputSize <= MaxSilentPcmBytes)
+            {
+                ClearGuestMemory(ctx, outputAddress, outputSize);
+            }
+
+            if (inputConsumed == 0)
+            {
+                inputConsumed = inputSize > int.MaxValue ? int.MaxValue : (int)inputSize;
+            }
+
+            if (frames == 0 && (inputSize != 0 || outputSize != 0))
+            {
+                frames = 1;
+            }
         }
 
         WriteDecodeStreamResult(
             ctx,
             resultAddress,
-            inputConsumed: inputSize > int.MaxValue ? int.MaxValue : (int)inputSize,
-            outputWritten: 0,
-            totalDecodedSamples: 0,
-            frames: inputSize != 0 || outputSize != 0 ? 1u : 0u);
+            inputConsumed,
+            outputWritten,
+            totalSamples,
+            frames);
 
         Trace(
             $"batch_job_decode info=0x{infoAddress:X16} instance=0x{instanceId:X8} " +
             $"in=0x{inputAddress:X16}+0x{inputSize:X} out=0x{outputAddress:X16}+0x{outputSize:X} " +
-            $"result=0x{resultAddress:X16}");
+            $"written={outputWritten} frames={frames} result=0x{resultAddress:X16}");
         return ctx.SetReturn(0);
     }
 
+    private static bool TryGetInstance(uint instanceId, out AjmInstanceState instance)
+    {
+        instance = null!;
+        var codec = instanceId >> 14;
+        var slot = instanceId & 0x3FFF;
+        if (slot == 0)
+        {
+            return false;
+        }
+
+        foreach (var context in Contexts.Values)
+        {
+            lock (context.Gate)
+            {
+                if (context.InstancesBySlot.TryGetValue(slot, out var found) &&
+                    found.Codec == codec)
+                {
+                    instance = found;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>
-    /// Submits a built batch. Instant-complete silence stub: publish a batch id
-    /// and clear any error out. Decode sidebands were already filled at
-    /// job-enqueue time.
+    /// Submits a built batch. Hot path after BatchJobDecode; unresolved WARNs
+    /// dominate the log. Instant-complete: publish a batch id and clear any
+    /// error out. Decode sidebands were already filled at job-enqueue time.
     /// </summary>
     [SysAbiExport(
         Nid = "5tOfnaClcqM",
@@ -363,6 +470,7 @@ public static class AjmExports
     private const ulong AjmBatchInfoSizeField = 16;
     private const ulong AjmBatchInfoLastGoodJobField = 24;
     private const ulong AjmJobRunSize = 64;
+    private const int OrbisAjmErrorJobCreation = unchecked((int)0x80930012);
     private const ulong MaxSilentPcmBytes = 1 << 20;
     // AjmSidebandResult (8) + AjmSidebandStream (16) + AjmSidebandMFrame (8).
     private const int DecodeSidebandBytes = 32;

--- a/src/SharpEmu.Libs/Audio/AjmMp3Decoder.cs
+++ b/src/SharpEmu.Libs/Audio/AjmMp3Decoder.cs
@@ -1,0 +1,231 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using NLayer;
+using System.Buffers.Binary;
+using System.Reflection;
+
+namespace SharpEmu.Libs.Audio;
+
+/// <summary>
+/// Stateful AJM MP3 (codec 0) decoder. GTA menu music arrives as ~960-byte
+/// packets that NLayer must decode with a persistent bit-reservoir.
+/// </summary>
+internal sealed class AjmMp3Decoder
+{
+    private static readonly Type? MpegStreamReaderType =
+        typeof(MpegFrameDecoder).Assembly.GetType("NLayer.Decoder.MpegStreamReader");
+
+    private static readonly MethodInfo? NextFrameMethod =
+        MpegStreamReaderType?.GetMethod(
+            "NextFrame",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+    private static readonly MethodInfo? ClearBufferMethod =
+        typeof(MpegFrameDecoder).Assembly.GetType("NLayer.Decoder.FrameBase")
+            ?.GetMethod("ClearBuffer", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+    private readonly MpegFrameDecoder _decoder = new();
+    private readonly object _gate = new();
+    private byte[] _pending = Array.Empty<byte>();
+    private readonly float[] _floatScratch = new float[1152 * 2];
+
+    public ulong TotalDecodedSamples { get; private set; }
+
+    public void Reset()
+    {
+        lock (_gate)
+        {
+            _decoder.Reset();
+            _pending = Array.Empty<byte>();
+            TotalDecodedSamples = 0;
+        }
+    }
+
+    public DecodeResult Decode(ReadOnlySpan<byte> input, Span<byte> output, bool pcm16)
+    {
+        lock (_gate)
+        {
+            if (MpegStreamReaderType is null || NextFrameMethod is null)
+            {
+                return DecodeResult.Failed;
+            }
+
+            var merged = new byte[_pending.Length + input.Length];
+            if (_pending.Length != 0)
+            {
+                _pending.CopyTo(merged, 0);
+            }
+
+            input.CopyTo(merged.AsSpan(_pending.Length));
+
+            using var stream = new MemoryStream(merged, writable: false);
+            object? reader;
+            try
+            {
+                reader = Activator.CreateInstance(
+                    MpegStreamReaderType,
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    binder: null,
+                    args: [stream],
+                    culture: null);
+            }
+            catch
+            {
+                return DecodeResult.Failed;
+            }
+
+            if (reader is null)
+            {
+                return DecodeResult.Failed;
+            }
+
+            var outputOffset = 0;
+            var inputConsumed = 0;
+            var frames = 0u;
+            var samplesThisCall = 0u;
+
+            while (outputOffset < output.Length)
+            {
+                object? frameObj;
+                try
+                {
+                    frameObj = NextFrameMethod.Invoke(reader, null);
+                }
+                catch
+                {
+                    break;
+                }
+
+                if (frameObj is not IMpegFrame frame)
+                {
+                    break;
+                }
+
+                try
+                {
+                    var frameOffset = GetFrameOffset(frameObj);
+                    var frameLength = frame.FrameLength;
+                    if (frameLength <= 0 || frameOffset + frameLength > merged.Length)
+                    {
+                        break;
+                    }
+
+                    int sampleCount;
+                    try
+                    {
+                        sampleCount = _decoder.DecodeFrame(frame, _floatScratch, 0);
+                    }
+                    catch
+                    {
+                        _decoder.Reset();
+                        inputConsumed = frameOffset + frameLength;
+                        continue;
+                    }
+
+                    if (sampleCount <= 0)
+                    {
+                        inputConsumed = frameOffset + frameLength;
+                        continue;
+                    }
+
+                    var channels = frame.ChannelMode == MpegChannelMode.Mono ? 1 : 2;
+                    var bytesPerSample = pcm16 ? 2 : 4;
+                    var byteCount = sampleCount * bytesPerSample;
+                    if (outputOffset + byteCount > output.Length)
+                    {
+                        // Not enough room for this frame — leave it for next job.
+                        break;
+                    }
+
+                    if (pcm16)
+                    {
+                        WritePcm16(_floatScratch.AsSpan(0, sampleCount), output[outputOffset..]);
+                    }
+                    else
+                    {
+                        WriteFloat(_floatScratch.AsSpan(0, sampleCount), output[outputOffset..]);
+                    }
+
+                    outputOffset += byteCount;
+                    inputConsumed = frameOffset + frameLength;
+                    frames++;
+                    samplesThisCall += (uint)(sampleCount / Math.Max(channels, 1));
+                    TotalDecodedSamples += (ulong)(sampleCount / Math.Max(channels, 1));
+                }
+                finally
+                {
+                    try
+                    {
+                        ClearBufferMethod?.Invoke(frameObj, null);
+                    }
+                    catch
+                    {
+                        // best-effort
+                    }
+                }
+            }
+
+            _pending = inputConsumed < merged.Length
+                ? merged[inputConsumed..]
+                : Array.Empty<byte>();
+
+            // Consume the portion of *this* input that left the pending window.
+            var pendingBefore = merged.Length - input.Length;
+            var consumedFromInput = Math.Clamp(inputConsumed - pendingBefore, 0, input.Length);
+
+            return new DecodeResult(
+                Success: frames > 0 || consumedFromInput > 0,
+                InputConsumed: consumedFromInput,
+                OutputWritten: outputOffset,
+                Frames: frames,
+                SamplesThisCall: samplesThisCall);
+        }
+    }
+
+    private static int GetFrameOffset(object frameObj)
+    {
+        for (var type = frameObj.GetType(); type is not null; type = type.BaseType)
+        {
+            var prop = type.GetProperty(
+                "Offset",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            if (prop?.GetValue(frameObj) is long offset)
+            {
+                return checked((int)offset);
+            }
+        }
+
+        return 0;
+    }
+
+    private static void WritePcm16(ReadOnlySpan<float> samples, Span<byte> destination)
+    {
+        for (var i = 0; i < samples.Length; i++)
+        {
+            var sample = samples[i];
+            var scaled = sample < 0f ? sample * 32768f : sample * 32767f;
+            var value = (short)Math.Clamp(MathF.Round(scaled), short.MinValue, short.MaxValue);
+            BinaryPrimitives.WriteInt16LittleEndian(destination[(i * 2)..], value);
+        }
+    }
+
+    private static void WriteFloat(ReadOnlySpan<float> samples, Span<byte> destination)
+    {
+        for (var i = 0; i < samples.Length; i++)
+        {
+            var bits = BitConverter.SingleToInt32Bits(samples[i]);
+            BinaryPrimitives.WriteInt32LittleEndian(destination[(i * 4)..], bits);
+        }
+    }
+
+    internal readonly record struct DecodeResult(
+        bool Success,
+        int InputConsumed,
+        int OutputWritten,
+        uint Frames,
+        uint SamplesThisCall)
+    {
+        public static DecodeResult Failed { get; } = new(false, 0, 0, 0, 0);
+    }
+}

--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
+using SharpEmu.HLE.Host;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -15,36 +17,66 @@ public static class AudioOut2Exports
     // Clearing 0x80 bytes here overwrote the caller's stack canary immediately
     // following the 0x40-byte parameter block.
     private const int AudioOut2ContextParamSize = 0x40;
-    private const int AudioOut2ContextMemorySize = 0x10000;
-    private const int AudioOut2ContextMemoryAlignment = 0x10000;
+    // Keep these modest. GTA V Enhanced stack-allocates QueryMemory results next
+    // to the frame canary: a 16-byte {size,align} write to [rbp-0x38] plants
+    // align at [rbp-0x30] (observed canary=0x100). Size-only (8 bytes) on stack.
+    private const int AudioOut2ContextMemorySize = 0x4000;
+    private const int AudioOut2ContextMemoryAlignment = 0x100;
+    // Exact object body size. Do not page-align to 64K — the RAGE Main Thread
+    // stack-allocates this and a 64K VLA is what planted 0x10000 on the canary.
+    private const int SpeakerArrayHeaderSize = 0x40;
+    private const int SpeakerArrayEntrySize = 0x100;
+    // Extra scratch the title writes after the per-channel entries (coefficients).
+    private const int SpeakerArrayScratchBytes = 0x400;
+    private const uint SpeakerArrayDefaultChannels = 8;
+    private const uint SpeakerArrayMaxChannels = 32;
+    // Field read by GTA at object+0x34 (see AV at eboot+0xB07D: mov eax,[rbx+0x34]).
+    private const int SpeakerArrayDivisorFieldOffset = 0x34;
+    private const int SpeakerArrayResultFieldOffset = 0x3C;
+    private const uint SpeakerArrayDefaultDivisor = 1;
+    private const int SpeakerArrayCoefficientBytes = 0x400;
+    // OrbisAudioOutPortState is 0x20 bytes. Never grow this from r8/r9 — those
+    // regs arrive polluted with GetSize leftovers (0x840/0x10C/0x180) and caused
+    // PortGetState/GetSpeakerInfo to overwrite the speaker-array param block
+    // (param+0x18 == first PortGetState out) and smash the Main Thread canary
+    // with ContextMemoryAlignment (0x100).
+    private const int PortStateSize = 0x20;
+    private const int SpeakerInfoSize = 0x20;
+    private const int PortParamSize = 0x40;
+    private const int AttributeEntrySize = 0x18;
+    private const uint PortAttributeIdPcm = 0;
+    private const ushort PortStateOutputConnectedPrimary = 0x01;
     private static long _nextContextHandle = 1;
     private static long _nextUserHandle = 1;
     private static int _nextPortId;
     private static long _pushTraceCount;
+    private static long _submitTraceCount;
+    private static long _attributePcmTraceCount;
 
-    // Per-context audio parameters captured at ContextCreate so ContextAdvance
-    // can pace to the real playback cadence (grain samples at the sample rate).
+    private static readonly ConcurrentDictionary<ulong, byte> SpeakerArrays = new();
     private static readonly ConcurrentDictionary<ulong, ContextState> Contexts = new();
+    private static readonly ConcurrentDictionary<ulong, PortState> Ports = new();
 
     private sealed class ContextState
     {
         private readonly object _paceGate = new();
         private long _nextAdvanceTimestamp;
 
-        public ContextState(uint frequency, uint channels, uint grainSamples)
+        public ContextState(ulong handle, uint frequency, uint grainSamples, uint queueDepth, IHostAudioStream? backend)
         {
+            Handle = handle;
             Frequency = frequency == 0 ? 48000 : frequency;
-            Channels = channels == 0 ? 2 : channels;
             GrainSamples = grainSamples == 0 ? 256 : grainSamples;
+            QueueDepth = queueDepth == 0 ? 4 : queueDepth;
+            Backend = backend;
         }
 
+        public ulong Handle { get; }
         public uint Frequency { get; }
-        public uint Channels { get; }
         public uint GrainSamples { get; }
+        public uint QueueDepth { get; }
+        public IHostAudioStream? Backend { get; }
 
-        // Blocks the advancing thread until one grain worth of wall-clock time
-        // has elapsed since the previous advance, matching hardware timing so
-        // audio-gated titles neither spin nor drift ahead.
         public void PaceAdvance()
         {
             long delay;
@@ -67,6 +99,45 @@ public static class AudioOut2Exports
             }
         }
     }
+
+    private sealed class PortState
+    {
+        public PortState(
+            ulong handle,
+            ulong contextHandle,
+            ushort portType,
+            uint dataFormat,
+            uint samplingFrequency,
+            uint grainSamples)
+        {
+            Handle = handle;
+            ContextHandle = contextHandle;
+            PortType = portType;
+            DataFormat = dataFormat;
+            SamplingFrequency = samplingFrequency == 0 ? 48000 : samplingFrequency;
+            GrainSamples = grainSamples == 0 ? 256 : grainSamples;
+        }
+
+        public ulong Handle { get; }
+        public ulong ContextHandle { get; }
+        /// <summary>Full Prospero port type (low byte = MAIN/BGM/…, 0x0100 = object).</summary>
+        public ushort PortType { get; }
+        public uint DataFormat { get; }
+        public uint SamplingFrequency { get; }
+        public uint GrainSamples { get; }
+        public ulong PcmAddress;
+    }
+
+    // Two host streams: primary FMOD context (menus) and everything else
+    // (Bink/intro). Mixing those into one waveOut re-crunched audio; the OS
+    // mixer keeps separate devices clean.
+    private static readonly object HostBackendGate = new();
+    private static IHostAudioStream? PrimaryBackend;
+    private static IHostAudioStream? SecondaryBackend;
+    private static string PrimaryBackendName = "none";
+    private static string SecondaryBackendName = "none";
+    private static ulong PrimaryContextHandle;
+    private static readonly object HostSubmitGate = new();
 
     [SysAbiExport(
         Nid = "g2tViFIohHE",
@@ -92,12 +163,17 @@ public static class AudioOut2Exports
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
+        // Layout matches libSceAudioOut2 SceAudioOut2ContextParam (no size prefix):
+        // max_ports, max_object_ports, guarantee_object_ports, queue_depth,
+        // num_grains, flags, reserved...
         Span<byte> param = stackalloc byte[AudioOut2ContextParamSize];
         param.Clear();
-        BinaryPrimitives.WriteUInt32LittleEndian(param[0x00..], AudioOut2ContextParamSize);
-        BinaryPrimitives.WriteUInt32LittleEndian(param[0x04..], 2);
-        BinaryPrimitives.WriteUInt32LittleEndian(param[0x08..], 48000);
-        BinaryPrimitives.WriteUInt32LittleEndian(param[0x0C..], 0x400);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x00..], 256);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x04..], 256);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x08..], 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x0C..], 4);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x10..], 512);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x14..], 1);
 
         return ctx.Memory.TryWrite(paramAddress, param)
             ? SetReturn(ctx, 0)
@@ -112,19 +188,36 @@ public static class AudioOut2Exports
     public static int AudioOut2ContextQueryMemory(CpuContext ctx)
     {
         var paramAddress = ctx[CpuRegister.Rdi];
-        var memoryInfoAddress = ctx[CpuRegister.Rsi];
+        var memoryInfoAddress = ResolveGuestOutBuffer(ctx[CpuRegister.Rsi], ctx[CpuRegister.Rdx]);
         if (paramAddress == 0 || memoryInfoAddress == 0)
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        Span<byte> memoryInfo = stackalloc byte[0x20];
+        // Heap: {size, alignment} (16 bytes), matching sceAudioPropagationSystemQueryMemory.
+        // Stack: SIZE ONLY as a full ulong (8 bytes). Writing alignment at +8 is how
+        // [rbp-0x30] became 0x100 on GTA V Enhanced. Do NOT shrink this to uint32 —
+        // Main reads the out as a 64-bit size; a 4-byte write leaves a garbage high
+        // dword (observed 0x7<<32|0x4000) and the allocator aborts with int 0x41.
+        if (IsGuestStackAddress(memoryInfoAddress))
+        {
+            Span<byte> sizeOnly = stackalloc byte[sizeof(ulong)];
+            BinaryPrimitives.WriteUInt64LittleEndian(sizeOnly, AudioOut2ContextMemorySize);
+            Console.Error.WriteLine(
+                $"[LOADER][TRACE] audio_out2.context-query-memory stack-size-only " +
+                $"out=0x{memoryInfoAddress:X} size=0x{AudioOut2ContextMemorySize:X}");
+            return ctx.Memory.TryWrite(memoryInfoAddress, sizeOnly)
+                ? SetReturn(ctx, 0)
+                : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        Span<byte> memoryInfo = stackalloc byte[0x10];
         memoryInfo.Clear();
         BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x00..], AudioOut2ContextMemorySize);
         BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x08..], AudioOut2ContextMemoryAlignment);
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x10..], AudioOut2ContextMemorySize);
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x18..], AudioOut2ContextMemoryAlignment);
-
+        Console.Error.WriteLine(
+            $"[LOADER][TRACE] audio_out2.context-query-memory out=0x{memoryInfoAddress:X} " +
+            $"size=0x{AudioOut2ContextMemorySize:X} align=0x{AudioOut2ContextMemoryAlignment:X}");
         return ctx.Memory.TryWrite(memoryInfoAddress, memoryInfo)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
@@ -146,28 +239,27 @@ public static class AudioOut2Exports
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        // Read channels/frequency/grain from the reset-param blob so the
-        // context can pace advances to the real audio cadence.
-        uint channels = 2;
+        // Prospero AudioOut2 context params are port/queue config, not an AudioOut
+        // open-style frequency/channel block. Sample rate is fixed at 48 kHz.
         uint frequency = 48000;
         uint grain = 256;
+        uint queueDepth = 4;
         Span<byte> param = stackalloc byte[AudioOut2ContextParamSize];
         if (ctx.Memory.TryRead(paramAddress, param))
         {
-            var pc = BinaryPrimitives.ReadUInt32LittleEndian(param[0x04..]);
-            var pf = BinaryPrimitives.ReadUInt32LittleEndian(param[0x08..]);
-            var pg = BinaryPrimitives.ReadUInt32LittleEndian(param[0x0C..]);
-            if (pc is > 0 and <= 8) channels = pc;
-            if (pf is >= 8000 and <= 192000) frequency = pf;
-            // Values below one cache line are flags/counts in observed PS5
-            // callers, not audio grains. Keep the hardware-sized default.
-            if (pg is >= 64 and <= 0x4000) grain = pg;
+            var qd = BinaryPrimitives.ReadUInt32LittleEndian(param[0x0C..]);
+            var ng = BinaryPrimitives.ReadUInt32LittleEndian(param[0x10..]);
+            if (qd is >= 1 and <= 32) queueDepth = qd;
+            if (ng is >= 64 and <= 0x4000) grain = ng;
             TraceAudioOut2($"context-param address=0x{paramAddress:X} bytes={Convert.ToHexString(param)}");
         }
 
         var handle = (ulong)Interlocked.Increment(ref _nextContextHandle);
-        Contexts[handle] = new ContextState(frequency, channels, grain);
-        TraceAudioOut2($"context-create handle=0x{handle:X} frequency={frequency} channels={channels} grain={grain} memory=0x{memoryAddress:X} size=0x{memorySize:X}");
+        // Backend is bound lazily on first real Push (primary vs secondary device).
+        Contexts[handle] = new ContextState(handle, frequency, grain, queueDepth, backend: null);
+        TraceAudioOut2(
+            $"context-create handle=0x{handle:X} frequency={frequency} grain={grain} " +
+            $"queue={queueDepth} memory=0x{memoryAddress:X} size=0x{memorySize:X} backend=pending");
         return TryWriteUInt64(ctx, outContextAddress, handle)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
@@ -180,6 +272,7 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2ContextDestroy(CpuContext ctx)
     {
+        // Shared backend lifetime is process-wide; just drop the context entry.
         Contexts.TryRemove(ctx[CpuRegister.Rdi], out _);
         return SetReturn(ctx, 0);
     }
@@ -198,18 +291,25 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2ContextPush(CpuContext ctx)
     {
+        // ABI: sceAudioOut2ContextPush(ctx, blocking). RSI is a blocking flag
+        // (observed 1), not a PCM pointer. PCM is attached earlier via
+        // PortSetAttributes(attribute_id=PCM) and flushed here.
         var handle = ctx[CpuRegister.Rdi];
-        var traceCount = Interlocked.Increment(ref _pushTraceCount);
-        if (traceCount <= 16)
+        var blocking = unchecked((uint)ctx[CpuRegister.Rsi]);
+        if (Interlocked.Increment(ref _pushTraceCount) <= 8)
         {
-            TraceAudioOut2($"context-push count={traceCount} rdi=0x{handle:X} rsi=0x{ctx[CpuRegister.Rsi]:X} rdx=0x{ctx[CpuRegister.Rdx]:X} rcx=0x{ctx[CpuRegister.Rcx]:X}");
+            TraceAudioOut2($"context-push handle=0x{handle:X} blocking={blocking}");
         }
 
-        if (Contexts.TryGetValue(handle, out var context))
+        if (!Contexts.TryGetValue(handle, out var context))
         {
-            // FMOD's PS5 output path uses ContextPush as the submission clock
-            // and does not call ContextAdvance. Pace pushes to one hardware
-            // grain so the feeder cannot outrun playback and starve the game.
+            return SetReturn(ctx, 0);
+        }
+
+        // Host Submit already blocks on the waveOut queue; only fall back to
+        // software pacing when nothing was queued (silence / non-primary ctx).
+        if (!TrySubmitContextAudio(ctx, context))
+        {
             context.PaceAdvance();
         }
 
@@ -223,11 +323,9 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2ContextAdvance(CpuContext ctx)
     {
-        // Advancing renders one grain of audio on hardware; pace it to the same
-        // wall-clock cadence so the guest audio thread runs at the right speed.
-        if (Contexts.TryGetValue(ctx[CpuRegister.Rdi], out var context))
+        if (Contexts.TryGetValue(ctx[CpuRegister.Rdi], out var state))
         {
-            context.PaceAdvance();
+            state.PaceAdvance();
         }
 
         return SetReturn(ctx, 0);
@@ -240,11 +338,93 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2ContextGetQueueLevel(CpuContext ctx)
     {
-        // The advance path paces synchronously, so the queue is always drained.
-        var levelAddress = ctx[CpuRegister.Rsi];
-        if (levelAddress != 0)
+        // ABI out is a 32-bit queue depth (GTA compares dword [out] to 4). A
+        // uint64 write into a stack slot at [rbp-0x14] next to the canary at
+        // [rbp-0x10] zeroed the canary low half and killed Bink Snd @ eboot+0xAE36.
+        var outLevelAddress = ctx[CpuRegister.Rsi];
+        if (outLevelAddress == 0)
         {
-            _ = TryWriteUInt64(ctx, levelAddress, 0);
+            outLevelAddress = ctx[CpuRegister.Rdx];
+        }
+
+        if (outLevelAddress != 0)
+        {
+            Span<byte> level = stackalloc byte[sizeof(uint)];
+            BinaryPrimitives.WriteUInt32LittleEndian(level, 0);
+            if (!ctx.Memory.TryWrite(outLevelAddress, level))
+            {
+                return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+        }
+
+        return SetReturn(ctx, 0);
+    }
+
+    [SysAbiExport(
+        Nid = "Q8DZkKQ-SYc",
+        ExportName = "sceAudioOut2LoContextGetQueueLevel",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2LoContextGetQueueLevel(CpuContext ctx) =>
+        AudioOut2ContextGetQueueLevel(ctx);
+
+    [SysAbiExport(
+        Nid = "8XTArSPyWHk",
+        ExportName = "sceAudioOut2PortSetAttributes",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2PortSetAttributes(CpuContext ctx)
+    {
+        // sceAudioOut2PortSetAttributes(port, attributes*, num).
+        // Attribute id 0 = PCM; value points at { const void* data }.
+        var portHandle = ctx[CpuRegister.Rdi];
+        var attributesAddress = ctx[CpuRegister.Rsi];
+        var attributeCount = unchecked((uint)ctx[CpuRegister.Rdx]);
+        if (!Ports.TryGetValue(portHandle, out var port))
+        {
+            return SetReturn(ctx, 0);
+        }
+
+        if (attributeCount == 0 || attributesAddress == 0)
+        {
+            return SetReturn(ctx, 0);
+        }
+
+        if (attributeCount > 32)
+        {
+            attributeCount = 32;
+        }
+
+        Span<byte> entry = stackalloc byte[AttributeEntrySize];
+        Span<byte> pcm = stackalloc byte[8];
+        for (uint i = 0; i < attributeCount; i++)
+        {
+            if (!ctx.Memory.TryRead(attributesAddress + (i * AttributeEntrySize), entry))
+            {
+                break;
+            }
+
+            var attributeId = BinaryPrimitives.ReadUInt32LittleEndian(entry);
+            var valueAddress = BinaryPrimitives.ReadUInt64LittleEndian(entry[0x08..]);
+            var valueSize = BinaryPrimitives.ReadUInt64LittleEndian(entry[0x10..]);
+            if (attributeId != PortAttributeIdPcm || valueAddress == 0 || valueSize < 8)
+            {
+                continue;
+            }
+
+            if (!ctx.Memory.TryRead(valueAddress, pcm))
+            {
+                continue;
+            }
+
+            port.PcmAddress = BinaryPrimitives.ReadUInt64LittleEndian(pcm);
+            var n = Interlocked.Increment(ref _attributePcmTraceCount);
+            if (n <= 8 || n % 500 == 0)
+            {
+                TraceAudioOut2(
+                    $"port-set-pcm#{n} port=0x{portHandle:X} pcm=0x{port.PcmAddress:X} " +
+                    $"format=0x{port.DataFormat:X} grains={port.GrainSamples}");
+            }
         }
 
         return SetReturn(ctx, 0);
@@ -257,29 +437,63 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2PortCreate(CpuContext ctx)
     {
-        var type = unchecked((int)ctx[CpuRegister.Rdi]);
+        // sceAudioOut2PortCreate(ctx, PortParam*, outPort*).
+        var contextHandle = ctx[CpuRegister.Rdi];
         var paramAddress = ctx[CpuRegister.Rsi];
-        var outPortAddress = ctx[CpuRegister.Rdx];
-        var contextAddress = ctx[CpuRegister.Rcx];
-        if (type < 0 || type > 255 || paramAddress == 0 || outPortAddress == 0 || contextAddress == 0)
+        var outPortAddress = ResolveGuestOutBuffer(ctx[CpuRegister.Rdx], ctx[CpuRegister.Rcx]);
+        if (outPortAddress == 0)
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        var portId = unchecked((uint)Interlocked.Increment(ref _nextPortId)) & 0xFF;
-        var handle = 0x2000_0000UL | ((ulong)(uint)type << 16) | portId;
-        return TryWriteUInt64(ctx, outPortAddress, handle)
-            ? SetReturn(ctx, 0)
-            : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        ushort portType = 0;
+        uint dataFormat = 0x0000_0200; // float stereo default
+        uint samplingFrequency = 48000;
+        uint grainSamples = 256;
+        if (Contexts.TryGetValue(contextHandle, out var context))
+        {
+            grainSamples = context.GrainSamples;
+            samplingFrequency = context.Frequency;
+        }
+
+        if (paramAddress != 0 && IsPlausibleGuestObjectPointer(paramAddress))
+        {
+            Span<byte> param = stackalloc byte[PortParamSize];
+            if (ctx.Memory.TryRead(paramAddress, param))
+            {
+                portType = BinaryPrimitives.ReadUInt16LittleEndian(param);
+                dataFormat = BinaryPrimitives.ReadUInt32LittleEndian(param[0x04..]);
+                var freq = BinaryPrimitives.ReadUInt32LittleEndian(param[0x08..]);
+                if (freq is >= 8000 and <= 192000)
+                {
+                    samplingFrequency = freq;
+                }
+            }
+        }
+
+        var portId = (uint)Interlocked.Increment(ref _nextPortId);
+        // Handle encodes only the low type byte; PortState keeps the full type
+        // so object ports (0x01xx) can still be filtered at submit time.
+        var handle = 0x2000_0000UL | ((ulong)(portType & 0xFF) << 16) | portId;
+        Ports[handle] = new PortState(
+            handle,
+            contextHandle,
+            portType,
+            dataFormat,
+            samplingFrequency,
+            grainSamples);
+        if (!TryWriteUInt64(ctx, outPortAddress, handle))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAudioOut2(
+            $"port-create handle=0x{handle:X} ctx=0x{contextHandle:X} type=0x{portType:X} " +
+            $"format=0x{dataFormat:X} freq={samplingFrequency} out=0x{outPortAddress:X}");
+        return SetReturn(ctx, 0);
     }
 
-    [SysAbiExport(
-        Nid = "8XTArSPyWHk",
-        ExportName = "sceAudioOut2PortSetAttributes",
-        Target = Generation.Gen5,
-        LibraryName = "libSceAudioOut2")]
-    public static int AudioOut2PortSetAttributes(CpuContext ctx) => SetReturn(ctx, 0);
-
+    // Fixed-size connected stereo state. Do not trust r8/r9 for byte counts.
     [SysAbiExport(
         Nid = "gatEUKG+Ea4",
         ExportName = "sceAudioOut2PortGetState",
@@ -287,27 +501,51 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2PortGetState(CpuContext ctx)
     {
-        var handle = ctx[CpuRegister.Rdi];
-        var stateAddress = ctx[CpuRegister.Rsi];
-        if (handle == 0 || stateAddress == 0)
+        var portHandle = ctx[CpuRegister.Rdi];
+        var stateAddress = ResolveGuestOutBuffer(ctx[CpuRegister.Rsi], ctx[CpuRegister.Rdx]);
+        if (stateAddress == 0)
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        var type = (int)((handle >> 16) & 0xFF);
-        Span<byte> state = stackalloc byte[0x20];
+        // Stack out-buffers with garbage handles were writing 0x20 bytes over
+        // caller frames / canaries (state=0x7FFFDE1FF688 right before fail).
+        // Heap outs still get a real state blob even when the handle wasn't
+        // minted by PortCreate — this title synthesizes port ids itself.
+        if (IsGuestStackAddress(stateAddress))
+        {
+            TraceAudioOut2(
+                $"port-get-state skip-stack handle=0x{portHandle:X} state=0x{stateAddress:X}");
+            return SetReturn(ctx, 0);
+        }
+
+        Span<byte> state = stackalloc byte[PortStateSize];
         state.Clear();
-        var output = type == 2 ? 0x40 : 0x01;
-        var channels = type == 2 ? 1 : 2;
-        BinaryPrimitives.WriteUInt16LittleEndian(state[0x00..], unchecked((ushort)output));
-        state[0x02] = unchecked((byte)channels);
+        //   +0x00 u16 output   = CONNECTED_PRIMARY (1)
+        //   +0x02 u8  channels = from port format when known, else 2
+        //   +0x04 s16 volume   = -1 (N/A for main)
+        byte channels = 2;
+        if (Ports.TryGetValue(portHandle, out var port) &&
+            TryDecodeDataFormat(port.DataFormat, out var decodedChannels, out _, out _))
+        {
+            channels = (byte)Math.Clamp(decodedChannels, 1, 16);
+        }
+
+        BinaryPrimitives.WriteUInt16LittleEndian(state[0x00..], PortStateOutputConnectedPrimary);
+        state[0x02] = channels;
         BinaryPrimitives.WriteInt16LittleEndian(state[0x04..], -1);
 
-        return ctx.Memory.TryWrite(stateAddress, state)
-            ? SetReturn(ctx, 0)
-            : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        if (!ctx.Memory.TryWrite(stateAddress, state))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAudioOut2(
+            $"port-get-state handle=0x{portHandle:X} state=0x{stateAddress:X} bytes=0x{PortStateSize:X}");
+        return SetReturn(ctx, 0);
     }
 
+    // rdi=out buffer, rsi=type/flag (not a pointer). Fixed-size write only.
     [SysAbiExport(
         Nid = "DImz2Ft9E2g",
         ExportName = "sceAudioOut2GetSpeakerInfo",
@@ -315,21 +553,134 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2GetSpeakerInfo(CpuContext ctx)
     {
-        var infoAddress = ctx[CpuRegister.Rdi];
+        var infoAddress = ResolveGuestOutBuffer(ctx[CpuRegister.Rdi], ctx[CpuRegister.Rdx]);
         if (infoAddress == 0)
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        Span<byte> info = stackalloc byte[0x40];
-        info.Clear();
-        BinaryPrimitives.WriteUInt32LittleEndian(info[0x00..], 1);
-        BinaryPrimitives.WriteUInt32LittleEndian(info[0x04..], 2);
-        BinaryPrimitives.WriteUInt32LittleEndian(info[0x08..], 48000);
+        // Same rule as PortGetState — never bulk-write speaker info onto the stack.
+        if (IsGuestStackAddress(infoAddress))
+        {
+            TraceAudioOut2($"get-speaker-info skip-stack out=0x{infoAddress:X}");
+            return SetReturn(ctx, 0);
+        }
 
-        return ctx.Memory.TryWrite(infoAddress, info)
-            ? SetReturn(ctx, 0)
-            : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        Span<byte> info = stackalloc byte[SpeakerInfoSize];
+        info.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(info[0x00..], 2);
+        BinaryPrimitives.WriteUInt32LittleEndian(info[0x04..], 48000);
+        BinaryPrimitives.WriteUInt16LittleEndian(info[0x08..], PortStateOutputConnectedPrimary);
+
+        if (!ctx.Memory.TryWrite(infoAddress, info))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAudioOut2(
+            $"get-speaker-info out=0x{infoAddress:X} type=0x{ctx[CpuRegister.Rsi]:X} bytes=0x{SpeakerInfoSize:X}");
+        return SetReturn(ctx, 0);
+    }
+
+    // Matches sceAudio3dGetSpeakerArrayMemorySize(uiNumSpeakers, bIs3d): size is
+    // returned directly in rax. Exact channel-scaled body — never a 64K slab.
+    [SysAbiExport(
+        Nid = "G1YOKDJYX2Y",
+        ExportName = "sceAudioOut2GetSpeakerArrayMemorySize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2GetSpeakerArrayMemorySize(CpuContext ctx)
+    {
+        var numChannels = (uint)ctx[CpuRegister.Rdi];
+        if (numChannels == 0 || numChannels > SpeakerArrayMaxChannels)
+        {
+            numChannels = SpeakerArrayDefaultChannels;
+        }
+
+        var size = ComputeSpeakerArrayBytes(numChannels);
+        Console.Error.WriteLine(
+            $"[LOADER][TRACE] audio_out2.speaker-array-get-size rdi=0x{ctx[CpuRegister.Rdi]:X} " +
+            $"rsi=0x{ctx[CpuRegister.Rsi]:X} rdx=0x{ctx[CpuRegister.Rdx]:X} -> 0x{size:X}");
+        ctx[CpuRegister.Rax] = unchecked((ulong)size);
+        return size;
+    }
+
+    [SysAbiExport(
+        Nid = "4BlZurolOAo",
+        ExportName = "sceAudioOut2GetSpeakerArrayCoefficients",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2GetSpeakerArrayCoefficients(CpuContext ctx) =>
+        WriteZeroSpeakerArrayCoefficients(ctx, "coefficients");
+
+    [SysAbiExport(
+        Nid = "28QqMnuuJ9Y",
+        ExportName = "sceAudioOut2GetSpeakerArrayAmbisonicsCoefficients",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2GetSpeakerArrayAmbisonicsCoefficients(CpuContext ctx) =>
+        WriteZeroSpeakerArrayCoefficients(ctx, "ambisonics-coefficients");
+
+    // rdi = param (may share a heap slab with PortGetState/GetSpeakerInfo outs —
+    // do NOT read buffer*/size* from it). rsi = &outHandle, rdx = reserved/size
+    // slot (leave alone), rcx = channels. Always heap-allocate a fresh object.
+    [SysAbiExport(
+        Nid = "+k91hoTuoA8",
+        ExportName = "sceAudioOut2SpeakerArrayCreate",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2SpeakerArrayCreate(CpuContext ctx)
+    {
+        var param = ctx[CpuRegister.Rdi];
+        var outHandleAddress = ctx[CpuRegister.Rsi];
+        var outReservedAddress = ctx[CpuRegister.Rdx];
+        var channels = (uint)ctx[CpuRegister.Rcx];
+        if (channels == 0 || channels > SpeakerArrayMaxChannels)
+        {
+            channels = SpeakerArrayDefaultChannels;
+        }
+
+        if (outHandleAddress == 0)
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        var bytes = ComputeSpeakerArrayBytes(channels);
+        if (!TryAllocateSpeakerArrayMemory(ctx, (ulong)bytes, out var memory) ||
+            !InitializeSpeakerArrayObject(ctx, memory, channels))
+        {
+            Console.Error.WriteLine(
+                $"[LOADER][ERROR] audio_out2.speaker-array-create alloc-failed bytes=0x{bytes:X} " +
+                $"channels={channels}");
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        SpeakerArrays[memory] = 0;
+        // Publish ONLY the out-handle slot. rdx is an adjacent size/reserved
+        // local on GTA's stack — writing it previously fed canary corruption.
+        if (!TryWriteUInt64(ctx, outHandleAddress, memory))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        Console.Error.WriteLine(
+            $"[LOADER][TRACE] audio_out2.speaker-array-create object=0x{memory:X} bytes=0x{bytes:X} " +
+            $"channels={channels} param=0x{param:X} out=0x{outHandleAddress:X} " +
+            $"reserved=0x{outReservedAddress:X} (untouched)");
+
+        ctx[CpuRegister.Rax] = memory;
+        return 0;
+    }
+
+    [SysAbiExport(
+        Nid = "erCWQR5eKiQ",
+        ExportName = "sceAudioOut2SpeakerArrayDestroy",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2SpeakerArrayDestroy(CpuContext ctx)
+    {
+        SpeakerArrays.TryRemove(ctx[CpuRegister.Rdi], out _);
+        return SetReturn(ctx, 0);
     }
 
     [SysAbiExport(
@@ -337,7 +688,11 @@ public static class AudioOut2Exports
         ExportName = "sceAudioOut2PortDestroy",
         Target = Generation.Gen5,
         LibraryName = "libSceAudioOut2")]
-    public static int AudioOut2PortDestroy(CpuContext ctx) => SetReturn(ctx, 0);
+    public static int AudioOut2PortDestroy(CpuContext ctx)
+    {
+        Ports.TryRemove(ctx[CpuRegister.Rdi], out _);
+        return SetReturn(ctx, 0);
+    }
 
     [SysAbiExport(
         Nid = "IaZXJ9M79uo",
@@ -365,6 +720,494 @@ public static class AudioOut2Exports
         return TryWriteUInt64(ctx, outUserAddress, handle)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+    }
+
+    private static IHostAudioStream? ResolveContextBackend(ContextState context, out string backendName)
+    {
+        lock (HostBackendGate)
+        {
+            if (PrimaryContextHandle == 0)
+            {
+                PrimaryContextHandle = context.Handle;
+            }
+
+            if (context.Handle == PrimaryContextHandle)
+            {
+                if (PrimaryBackend is null)
+                {
+                    try
+                    {
+                        var audio = HostPlatform.Current.Audio;
+                        PrimaryBackend = audio.OpenStereoPcm16Stream(context.Frequency);
+                        PrimaryBackendName = audio.BackendName + "-primary";
+                    }
+                    catch (Exception exception)
+                    {
+                        PrimaryBackendName = "silent";
+                        Console.Error.WriteLine(
+                            $"[LOADER][WARN] AudioOut2 primary backend unavailable: {exception.Message}");
+                    }
+                }
+
+                backendName = PrimaryBackendName;
+                return PrimaryBackend;
+            }
+
+            if (SecondaryBackend is null)
+            {
+                try
+                {
+                    var audio = HostPlatform.Current.Audio;
+                    SecondaryBackend = audio.OpenStereoPcm16Stream(context.Frequency);
+                    SecondaryBackendName = audio.BackendName + "-secondary";
+                }
+                catch (Exception exception)
+                {
+                    SecondaryBackendName = "silent";
+                    Console.Error.WriteLine(
+                        $"[LOADER][WARN] AudioOut2 secondary backend unavailable: {exception.Message}");
+                }
+            }
+
+            backendName = SecondaryBackendName;
+            return SecondaryBackend;
+        }
+    }
+
+    private static bool TrySubmitContextAudio(CpuContext ctx, ContextState context)
+    {
+        var frames = checked((int)context.GrainSamples);
+        if (frames <= 0)
+        {
+            return false;
+        }
+
+        // Serialize submits per process so ArrayPool buffers stay private; primary
+        // and secondary devices still receive independent PCM (no digital sum).
+        lock (HostSubmitGate)
+        {
+            if (!TryPickMainBed(context.Handle, out var mainPort))
+            {
+                mainPort = null;
+            }
+
+            if (!TryPickAuxBed(context.Handle, out var auxPort))
+            {
+                auxPort = null;
+            }
+
+            if (mainPort is null && auxPort is null)
+            {
+                return false;
+            }
+
+            var mix = ArrayPool<float>.Shared.Rent(frames * 2);
+            var source = ArrayPool<byte>.Shared.Rent(frames * 16 * sizeof(float));
+            var output = ArrayPool<byte>.Shared.Rent(frames * AudioPcmConversion.OutputFrameSize);
+            try
+            {
+                mix.AsSpan(0, frames * 2).Clear();
+                var mixedPorts = 0;
+                ulong lastPort = 0;
+                uint lastFormat = 0;
+                var lastChannels = 0;
+
+                // At most one MAIN/BGM + one AUX on this context. Menus stay on
+                // MAIN; intro/Bink rides AUX without stacking every bed.
+                for (var bed = 0; bed < 2; bed++)
+                {
+                    var port = bed == 0 ? mainPort : auxPort;
+                    if (port is null ||
+                        !TryDecodeDataFormat(port.DataFormat, out var ch, out var bps, out var isFloat))
+                    {
+                        continue;
+                    }
+
+                    var byteLength = checked(frames * ch * bps);
+                    if (byteLength <= 0 || byteLength > source.Length)
+                    {
+                        continue;
+                    }
+
+                    var sourceSpan = source.AsSpan(0, byteLength);
+                    if (!ctx.Memory.TryRead(port.PcmAddress, sourceSpan))
+                    {
+                        continue;
+                    }
+
+                    MixPortIntoStereo(
+                        sourceSpan,
+                        mix.AsSpan(0, frames * 2),
+                        frames,
+                        ch,
+                        bps,
+                        isFloat,
+                        additive: mixedPorts > 0);
+                    mixedPorts++;
+                    lastPort = port.Handle;
+                    lastFormat = port.DataFormat;
+                    lastChannels = ch;
+                }
+
+                if (mixedPorts == 0)
+                {
+                    return false;
+                }
+
+                var outputSpan = output.AsSpan(0, frames * AudioPcmConversion.OutputFrameSize);
+                var peak = 0f;
+                var any = false;
+                for (var frame = 0; frame < frames; frame++)
+                {
+                    var left = Math.Clamp(mix[frame * 2], -1f, 1f);
+                    var right = Math.Clamp(mix[(frame * 2) + 1], -1f, 1f);
+                    var framePeak = Math.Max(Math.Abs(left), Math.Abs(right));
+                    if (framePeak > peak)
+                    {
+                        peak = framePeak;
+                    }
+
+                    if (framePeak > 1e-7f)
+                    {
+                        any = true;
+                    }
+
+                    BinaryPrimitives.WriteInt16LittleEndian(
+                        outputSpan[(frame * AudioPcmConversion.OutputFrameSize)..],
+                        FloatToPcm16(left));
+                    BinaryPrimitives.WriteInt16LittleEndian(
+                        outputSpan[((frame * AudioPcmConversion.OutputFrameSize) + 2)..],
+                        FloatToPcm16(right));
+                }
+
+                if (!any)
+                {
+                    return false;
+                }
+
+                // Bind primary only after a real grain so silent early contexts
+                // do not steal the menu device.
+                var backend = ResolveContextBackend(context, out var backendName);
+                if (backend is null)
+                {
+                    return false;
+                }
+
+                var n = Interlocked.Increment(ref _submitTraceCount);
+                if (n <= 8 || n % 200 == 0)
+                {
+                    TraceAudioOut2(
+                        $"context-submit#{n} handle=0x{context.Handle:X} frames={frames} " +
+                        $"ports={mixedPorts} lastPort=0x{lastPort:X} format=0x{lastFormat:X} " +
+                        $"ch={lastChannels} peak={peak:F4} backend={backendName}");
+                }
+
+                return backend.Submit(outputSpan);
+            }
+            finally
+            {
+                ArrayPool<float>.Shared.Return(mix);
+                ArrayPool<byte>.Shared.Return(source);
+                ArrayPool<byte>.Shared.Return(output);
+            }
+        }
+    }
+
+    private static bool TryPickMainBed(ulong contextHandle, out PortState? chosen)
+    {
+        chosen = null;
+        var chosenScore = int.MinValue;
+        foreach (var port in Ports.Values)
+        {
+            if (port.ContextHandle != contextHandle ||
+                port.PcmAddress == 0 ||
+                IsObjectPort(port.PortType) ||
+                !IsMainOrBgmPort(port.PortType) ||
+                !TryDecodeDataFormat(port.DataFormat, out var channels, out _, out _))
+            {
+                continue;
+            }
+
+            var score = channels switch
+            {
+                2 => 300,
+                1 => 200,
+                8 => 100,
+                _ => 50,
+            };
+            if ((port.PortType & 0xFF) == 0)
+            {
+                score += 20; // MAIN over BGM
+            }
+
+            if (score > chosenScore)
+            {
+                chosenScore = score;
+                chosen = port;
+            }
+        }
+
+        return chosen is not null;
+    }
+
+    private static bool TryPickAuxBed(ulong contextHandle, out PortState? chosen)
+    {
+        chosen = null;
+        var chosenScore = int.MinValue;
+        foreach (var port in Ports.Values)
+        {
+            if (port.ContextHandle != contextHandle ||
+                port.PcmAddress == 0 ||
+                IsObjectPort(port.PortType) ||
+                (port.PortType & 0xFF) != 6 ||
+                !TryDecodeDataFormat(port.DataFormat, out var channels, out _, out _))
+            {
+                continue;
+            }
+
+            var score = channels switch
+            {
+                2 => 300,
+                1 => 200,
+                8 => 100,
+                _ => 50,
+            };
+            if (score > chosenScore)
+            {
+                chosenScore = score;
+                chosen = port;
+            }
+        }
+
+        return chosen is not null;
+    }
+
+    private static bool IsMainOrBgmPort(ushort portType)
+    {
+        var kind = portType & 0xFF;
+        return kind is 0 or 1;
+    }
+
+    private static void MixPortIntoStereo(
+        ReadOnlySpan<byte> source,
+        Span<float> mix,
+        int frames,
+        int channels,
+        int bytesPerSample,
+        bool isFloat,
+        bool additive)
+    {
+        var frameSize = channels * bytesPerSample;
+        for (var frame = 0; frame < frames; frame++)
+        {
+            var frameBytes = source.Slice(frame * frameSize, frameSize);
+            float left;
+            float right;
+            if (channels >= 8)
+            {
+                var fl = ReadNormalizedSample(frameBytes, 0, bytesPerSample, isFloat);
+                var fr = ReadNormalizedSample(frameBytes, 1, bytesPerSample, isFloat);
+                var c = ReadNormalizedSample(frameBytes, 2, bytesPerSample, isFloat);
+                var bl = ReadNormalizedSample(frameBytes, 4, bytesPerSample, isFloat);
+                var br = ReadNormalizedSample(frameBytes, 5, bytesPerSample, isFloat);
+                var sl = ReadNormalizedSample(frameBytes, 6, bytesPerSample, isFloat);
+                var sr = ReadNormalizedSample(frameBytes, 7, bytesPerSample, isFloat);
+                const float side = 0.70710678f;
+                left = fl + (c * side) + (bl * side) + (sl * side);
+                right = fr + (c * side) + (br * side) + (sr * side);
+            }
+            else
+            {
+                left = ReadNormalizedSample(frameBytes, 0, bytesPerSample, isFloat);
+                right = channels == 1
+                    ? left
+                    : ReadNormalizedSample(frameBytes, 1, bytesPerSample, isFloat);
+            }
+
+            if (additive)
+            {
+                mix[frame * 2] += left;
+                mix[(frame * 2) + 1] += right;
+            }
+            else
+            {
+                mix[frame * 2] = left;
+                mix[(frame * 2) + 1] = right;
+            }
+        }
+    }
+
+    private static float ReadNormalizedSample(
+        ReadOnlySpan<byte> frame,
+        int channel,
+        int bytesPerSample,
+        bool isFloat)
+    {
+        var sample = frame.Slice(channel * bytesPerSample, bytesPerSample);
+        if (isFloat)
+        {
+            var bits = BinaryPrimitives.ReadInt32LittleEndian(sample);
+            var value = BitConverter.Int32BitsToSingle(bits);
+            return float.IsFinite(value) ? value : 0f;
+        }
+
+        return BinaryPrimitives.ReadInt16LittleEndian(sample) / 32768f;
+    }
+
+    private static short FloatToPcm16(float value)
+    {
+        var scale = value < 0f ? 32768f : short.MaxValue;
+        return (short)Math.Clamp(MathF.Round(value * scale), short.MinValue, short.MaxValue);
+    }
+
+    private static bool IsObjectPort(ushort portType) => (portType & 0xFF00) == 0x0100;
+
+    private static bool TryDecodeDataFormat(
+        uint dataFormat,
+        out int channels,
+        out int bytesPerSample,
+        out bool isFloat)
+    {
+        channels = (int)((dataFormat >> 8) & 0xFF);
+        if (channels == 0)
+        {
+            channels = 2;
+        }
+
+        if (channels is < 1 or > 16)
+        {
+            bytesPerSample = 0;
+            isFloat = false;
+            return false;
+        }
+
+        var dataType = dataFormat & 0x7Fu;
+        isFloat = dataType == 0;
+        bytesPerSample = isFloat ? 4 : dataType == 1 ? 2 : 0;
+        return bytesPerSample != 0;
+    }
+
+    private static int ComputeSpeakerArrayBytes(uint channels) =>
+        SpeakerArrayHeaderSize + (int)(channels * SpeakerArrayEntrySize) + SpeakerArrayScratchBytes;
+
+    private static bool InitializeSpeakerArrayObject(CpuContext ctx, ulong memory, uint channels)
+    {
+        // Header only — never wipe the full GetSize slab (and never touch stack).
+        Span<byte> body = stackalloc byte[SpeakerArrayHeaderSize];
+        body.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(body[0x00..], (uint)SpeakerArrayHeaderSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(body[0x04..], channels);
+        BinaryPrimitives.WriteUInt32LittleEndian(body[SpeakerArrayDivisorFieldOffset..], SpeakerArrayDefaultDivisor);
+        BinaryPrimitives.WriteUInt32LittleEndian(body[SpeakerArrayResultFieldOffset..], 0);
+        return ctx.Memory.TryWrite(memory, body);
+    }
+
+    // Prefer the high guest arena (0x6000_xxxx). TryAllocateHleData advances
+    // _nextVirtualAddress into the title's direct-memory window (~0x1559_xxxx);
+    // publishing an object there made sceKernelBatchMap(fixed, 0x1559C80000,
+    // 0x20000) return NOT_FOUND and abort RenderThread with int 0x41.
+    // Never mint the old 0x1559C0xxxx "cookie" pointers — they are unmapped and
+    // collide with dmem VAs.
+    private static bool TryAllocateSpeakerArrayMemory(CpuContext ctx, ulong bytes, out ulong memory)
+    {
+        memory = 0;
+        var length = Math.Max(bytes, 0x1000UL);
+
+        if (TryAllocateViaGuestAllocator(ctx, length, 0x1000, out memory) &&
+            IsSafeSpeakerArrayAddress(memory))
+        {
+            return true;
+        }
+
+        if (Kernel.KernelMemoryCompatExports.TryAllocateHleData(ctx, length, 0x1000, out memory) &&
+            IsSafeSpeakerArrayAddress(memory))
+        {
+            return true;
+        }
+
+        memory = 0;
+        return false;
+    }
+
+    private static bool TryAllocateViaGuestAllocator(CpuContext ctx, ulong length, ulong alignment, out ulong memory)
+    {
+        memory = 0;
+        var allocator = ctx.Memory as IGuestMemoryAllocator;
+        if (allocator is null && ctx.Memory is ICpuMemoryWrapper { Inner: IGuestMemoryAllocator inner })
+        {
+            allocator = inner;
+        }
+
+        return allocator is not null && allocator.TryAllocateGuestMemory(length, alignment, out memory);
+    }
+
+    private static bool IsSafeSpeakerArrayAddress(ulong value) =>
+        IsPlausibleGuestObjectPointer(value) &&
+        !IsGuestStackAddress(value) &&
+        !IsDirectMemoryWindowAddress(value);
+
+    // GTA V Enhanced BatchMap fixed dmem VAs observed around 0x1559_xxxx_xxxx.
+    // Keep HLE speaker-array objects out of that window.
+    private static bool IsDirectMemoryWindowAddress(ulong value) =>
+        value >= 0x0000_1400_0000_0000UL && value < 0x0000_1800_0000_0000UL;
+
+    private static bool IsPlausibleGuestObjectPointer(ulong value) =>
+        value >= 0x1000_0000UL &&
+        value != 0x10000UL &&
+        value < 0x0000_8000_0000_0000UL;
+
+    // Windows user stacks sit in 0x00007FFFxxxxxxxx. Never treat those as
+    // heap objects we can bulk-initialize.
+    private static bool IsGuestStackAddress(ulong value) =>
+        value >= 0x0000_7FF0_0000_0000UL && value <= 0x0000_7FFF_FFFF_FFFFUL;
+
+    private static ulong ResolveGuestOutBuffer(ulong primary, ulong secondary)
+    {
+        // Accept heap or stack out-buffers (PortGetState legitimately uses both),
+        // but never small integers / size constants.
+        if (IsWritableOutBuffer(primary))
+        {
+            return primary;
+        }
+
+        if (IsWritableOutBuffer(secondary))
+        {
+            return secondary;
+        }
+
+        return 0;
+    }
+
+    private static bool IsWritableOutBuffer(ulong value) =>
+        value != 0 &&
+        value != 0x10000UL &&
+        value >= 0x1000UL &&
+        (IsPlausibleGuestObjectPointer(value) || IsGuestStackAddress(value));
+
+    private static int WriteZeroSpeakerArrayCoefficients(CpuContext ctx, string label)
+    {
+        var destination = ctx[CpuRegister.Rsi];
+        if (destination == 0)
+        {
+            destination = ctx[CpuRegister.Rdx];
+        }
+
+        // Coefficients are large — only wipe real heap objects, never stack.
+        if (destination != 0 &&
+            IsPlausibleGuestObjectPointer(destination) &&
+            !IsGuestStackAddress(destination))
+        {
+            Span<byte> zeros = stackalloc byte[SpeakerArrayCoefficientBytes];
+            zeros.Clear();
+            if (!ctx.Memory.TryWrite(destination, zeros))
+            {
+                TraceAudioOut2($"{label} write-failed dest=0x{destination:X}");
+                return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+        }
+
+        TraceAudioOut2($"{label} ok dest=0x{destination:X}");
+        return SetReturn(ctx, 0);
     }
 
     private static bool TryWriteUInt64(CpuContext ctx, ulong address, ulong value)

--- a/src/SharpEmu.Libs/SharpEmu.Libs.csproj
+++ b/src/SharpEmu.Libs/SharpEmu.Libs.csproj
@@ -26,6 +26,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
   <ItemGroup>
     <PackageReference Include="FFmpeg.AutoGen" />
+    <PackageReference Include="NLayer" />
     <PackageReference Include="Silk.NET.Input" />
     <PackageReference Include="Silk.NET.Vulkan" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" />


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Turns AudioOut2 + AJM MP3 into a real host playback path so titles that use `libSceAudioOut2` (and FMOD→AJM→AudioOut2 for music) are not silent.

**What this actually does**
- **AudioOut2**
  - `PortCreate` reads PortParam (type / format / rate) and keeps full port state linked to a context
  - `PortSetAttributes` attribute id `0` stores the guest PCM pointer for that grain
  - `ContextPush`: RSI is a **blocking flag**, not a PCM pointer. On Push we read each port’s latest PCM, convert, and submit to the host
  - Two process-wide stereo S16 host streams (primary / secondary); first context that produces non-silent audio owns primary, others use secondary; OS mixer combines them
  - Per Push we only mix **at most one MAIN/BGM bed** (type low-byte 0/1) **plus at most one type-6 AUX bed** (intro/Bink-style). Object ports (`portType & 0xFF00 == 0x0100`) are skipped
  - Keeps the canary-safe out-buffer rules (stack size-only QueryMemory, no bulk PortGetState onto guest stack, etc.)
- **Windows waveOut**: queued PCM capacity raised from 32 KiB → **128 KiB** so FMOD’s bursty Push pattern does not underrun as easily
- **AJM codec 0 (MP3)**: stateful NLayer decoder per instance; `BatchJobDecode` writes real PCM + sideband counts instead of zeroing the output buffer. Non-MP3 codecs stay on the silence path

**Honesty / limitations (please read)**
- This is **not** a complete AudioOut2 Accel / object-audio implementation. We deliberately do **not** digitally sum every bed or open one waveOut per context — those strategies sounded crushed on GTA. The MAIN+AUX / dual-stream model is a pragmatic subset that fixed intro + menu SFX + menu music there; other titles with different bed layouts may still be wrong or quiet.
- Posix backends were **not** deepened to 128 KiB (WinMM only).
- AJM only gains real decode for **codec 0**. Other codecs still silence.
- `AjmMp3Decoder` reaches into NLayer internals via reflection for the bit-reservoir across ~960-byte packets. That works today but is a maintenance risk if NLayer internals move.
- New NuGet: **NLayer 1.14.0**.
- No soft-recover of `__stack_chk_fail`.
- Rebased onto current `main` after the large “restore state before huge regression” revert, so the AudioOut2 diff looks big relative to the thinned post-revert tree.

**Why this is still generic**
AudioOut2 + AJM MP3 are system ABIs, not title-specific NIDs. The host path and MP3 decode are the correct direction for any title on that stack; the bed-selection heuristics are the part that may need iteration.

**AI-assisted**
Research / port from an experimental tree were AI-assisted. I reviewed the Push ABI, bed rules, dual-stream choice, waveOut depth, and AJM sideband writes, and I can explain / maintain them.

## Testing

- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) on a local verify stack:
  - **Before:** silent intro/menus (AudioOut2 had no host path; AJM MP3 zeroed output)
  - **After:** intro audible, menu clicks + menu music audible, playback not crunchy
- Unit: existing AJM / AudioPcm tests passed after rebase (note: some AudioOut2 unit tests were removed from `main` by the recent revert, so this PR does not re-add them)
- Build: `.\build.ps1` succeeded

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).