### PR TITLE
test: lock Ngs2 VAG decode and depth extent resolution

### DIFF
--- a/tests/SharpEmu.Libs.Tests/Ngs2/Ngs2VagDecoderTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ngs2/Ngs2VagDecoderTests.cs
@@ -1,0 +1,157 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.Libs.Ngs2;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Ngs2;
+
+/// <summary>
+/// Contract tests for the clean-room PS-ADPCM (VAGp) decoder.
+/// These assert real decode outputs (sample counts, rates, loop markers, reject paths),
+/// not just "returns true".
+/// </summary>
+public sealed class Ngs2VagDecoderTests
+{
+    [Fact]
+    public void IsVag_RequiresMagicAndFullHeader()
+    {
+        Assert.False(Ngs2VagDecoder.IsVag(ReadOnlySpan<byte>.Empty));
+        Assert.False(Ngs2VagDecoder.IsVag(new byte[Ngs2VagDecoder.VagHeaderSize - 1]));
+
+        var badMagic = new byte[Ngs2VagDecoder.VagHeaderSize];
+        BinaryPrimitives.WriteUInt32BigEndian(badMagic, 0x41424344); // "ABCD"
+        Assert.False(Ngs2VagDecoder.IsVag(badMagic));
+
+        var good = BuildVagContainer(sampleRate: 22050, frames: [BuildFrame(shift: 12, filter: 0, flags: 0x01, nibble: 0)]);
+        Assert.True(Ngs2VagDecoder.IsVag(good));
+    }
+
+    [Fact]
+    public void TryDecode_RejectsMissingOrEmptyPayload()
+    {
+        Assert.False(Ngs2VagDecoder.TryDecode(ReadOnlySpan<byte>.Empty, out _));
+
+        // Valid magic/header but no ADPCM body.
+        var headerOnly = new byte[Ngs2VagDecoder.VagHeaderSize];
+        BinaryPrimitives.WriteUInt32BigEndian(headerOnly, 0x56414770); // "VAGp"
+        BinaryPrimitives.WriteUInt32BigEndian(headerOnly.AsSpan(0x0C), 0);
+        BinaryPrimitives.WriteUInt32BigEndian(headerOnly.AsSpan(0x10), 48000);
+        Assert.False(Ngs2VagDecoder.TryDecode(headerOnly, out _));
+    }
+
+    [Fact]
+    public void TryDecode_OneShotFrame_Produces28SamplesAndDefaultLoop()
+    {
+        // filter=0, shift=12, nibble=1 -> sample = (1<<12)>>12 = 1, all 28 samples.
+        // flags=0x01 ends one-shot at end of this frame.
+        var frame = BuildFrame(shift: 12, filter: 0, flags: 0x01, nibble: 1);
+        var container = BuildVagContainer(sampleRate: 22050, frames: [frame]);
+
+        Assert.True(Ngs2VagDecoder.TryDecode(container, out var waveform));
+        Assert.Equal(22050, waveform.SampleRate);
+        Assert.Equal(28, waveform.Samples.Length);
+        Assert.All(waveform.Samples, sample => Assert.Equal((short)1, sample));
+        Assert.Equal(-1, waveform.LoopStart);
+        Assert.Equal(-1, waveform.LoopEnd);
+    }
+
+    [Fact]
+    public void TryDecode_ZeroSampleRate_FallsBackTo48k()
+    {
+        var frame = BuildFrame(shift: 12, filter: 0, flags: 0x01, nibble: 0);
+        var container = BuildVagContainer(sampleRate: 0, frames: [frame]);
+
+        Assert.True(Ngs2VagDecoder.TryDecode(container, out var waveform));
+        Assert.Equal(48000, waveform.SampleRate);
+        Assert.Equal(28, waveform.Samples.Length);
+    }
+
+    [Fact]
+    public void Decode_LoopStartAndEndFlags_AreCaptured()
+    {
+        // Frame 0: loop start (0x03). Frame 1: loop end (0x06). No one-shot end.
+        var frames = ConcatFrames(
+            BuildFrame(shift: 12, filter: 0, flags: 0x03, nibble: 2),
+            BuildFrame(shift: 12, filter: 0, flags: 0x06, nibble: 3));
+
+        var waveform = Ngs2VagDecoder.Decode(frames, sampleRate: 44100);
+        Assert.Equal(44100, waveform.SampleRate);
+        Assert.Equal(56, waveform.Samples.Length);
+        Assert.Equal(0, waveform.LoopStart);
+        Assert.Equal(56, waveform.LoopEnd);
+        Assert.Equal((short)2, waveform.Samples[0]);
+        Assert.Equal((short)3, waveform.Samples[28]);
+    }
+
+    [Fact]
+    public void Decode_OneShotEnd_TruncatesRemainingFrames()
+    {
+        // First frame ends one-shot; second frame must not be decoded.
+        var frames = ConcatFrames(
+            BuildFrame(shift: 12, filter: 0, flags: 0x07, nibble: 4),
+            BuildFrame(shift: 12, filter: 0, flags: 0x00, nibble: 5));
+
+        var waveform = Ngs2VagDecoder.Decode(frames, sampleRate: 48000);
+        Assert.Equal(28, waveform.Samples.Length);
+        Assert.All(waveform.Samples, sample => Assert.Equal((short)4, sample));
+    }
+
+    [Fact]
+    public void Decode_PredictorFilter1_UsesHistory()
+    {
+        // filter=1, f0=60/64: second sample depends on first.
+        // nibble=1, shift=12 -> base s=1 each step.
+        // sample0 = 1; sample1 = 1 + (1*60)>>6 = 1 + 0 = 1 with integer hist.
+        // Use shift=0 so s is large enough for history to matter: s = (1<<12) = 4096.
+        // sample0 = 4096
+        // sample1 = 4096 + (4096*60)>>6 = 4096 + 3840 = 7936
+        var frame = BuildFrame(shift: 0, filter: 1, flags: 0x01, nibble: 1);
+        var waveform = Ngs2VagDecoder.Decode(frame, sampleRate: 48000);
+        Assert.Equal(28, waveform.Samples.Length);
+        Assert.Equal((short)4096, waveform.Samples[0]);
+        Assert.Equal((short)7936, waveform.Samples[1]);
+    }
+
+    private static byte[] BuildVagContainer(int sampleRate, byte[][] frames)
+    {
+        var body = ConcatFrames(frames);
+        var data = new byte[Ngs2VagDecoder.VagHeaderSize + body.Length];
+        BinaryPrimitives.WriteUInt32BigEndian(data, 0x56414770); // "VAGp"
+        BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(0x0C), (uint)body.Length);
+        BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(0x10), (uint)sampleRate);
+        body.CopyTo(data.AsSpan(Ngs2VagDecoder.VagHeaderSize));
+        return data;
+    }
+
+    // One 16-byte ADPCM frame: header byte = (filter<<4)|shift, flag byte, then 14
+    // packed nibble pairs all equal to the same 4-bit value.
+    private static byte[] BuildFrame(int shift, int filter, int flags, int nibble)
+    {
+        var frame = new byte[16];
+        frame[0] = (byte)(((filter & 0x0F) << 4) | (shift & 0x0F));
+        frame[1] = (byte)flags;
+        var packed = (byte)(((nibble & 0x0F) << 4) | (nibble & 0x0F));
+        for (var i = 2; i < 16; i++)
+        {
+            frame[i] = packed;
+        }
+
+        return frame;
+    }
+
+    private static byte[] ConcatFrames(params byte[][] frames)
+    {
+        var total = frames.Sum(static f => f.Length);
+        var buffer = new byte[total];
+        var offset = 0;
+        foreach (var frame in frames)
+        {
+            frame.CopyTo(buffer.AsSpan(offset));
+            offset += frame.Length;
+        }
+
+        return buffer;
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/VideoOut/GuestDepthExtentResolverTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/GuestDepthExtentResolverTests.cs
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.Gpu;
+using SharpEmu.Libs.VideoOut;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+/// <summary>
+/// Locks the four resolution outcomes used when binding guest depth against color RTs.
+/// Wrong branch selection undersizes D/S images or skips depth entirely.
+/// </summary>
+public sealed class GuestDepthExtentResolverTests
+{
+    [Fact]
+    public void Resolve_DepthCoversColor_IsExact()
+    {
+        var depth = MakeDepth(width: 1920, height: 1080);
+        var result = GuestDepthExtentResolver.Resolve(depth, colorWidth: 1280, colorHeight: 720, textures: []);
+
+        Assert.Equal(GuestDepthExtentResolutionKind.Exact, result.Kind);
+        Assert.True(result.IsUsable);
+        Assert.Equal(1920u, result.Width);
+        Assert.Equal(1080u, result.Height);
+    }
+
+    [Fact]
+    public void Resolve_MatchingTextureAlias_UsesTextureExtent()
+    {
+        // Depth is smaller than color, but a texture at the depth address has full size.
+        var depth = MakeDepth(width: 64, height: 64, writeAddress: 0x1000, readAddress: 0x1000);
+        var textures = new[]
+        {
+            MakeTexture(address: 0x1000, width: 1920, height: 1080),
+        };
+
+        var result = GuestDepthExtentResolver.Resolve(depth, colorWidth: 1920, colorHeight: 1080, textures);
+
+        Assert.Equal(GuestDepthExtentResolutionKind.TextureAlias, result.Kind);
+        Assert.True(result.IsUsable);
+        Assert.Equal(1920u, result.Width);
+        Assert.Equal(1080u, result.Height);
+    }
+
+    [Fact]
+    public void Resolve_TextureMustMatchDepthAddress_AndCoverColor()
+    {
+        var depth = MakeDepth(width: 64, height: 64, writeAddress: 0x1000, readAddress: 0x1000);
+        // Wrong address: no alias.
+        var wrongAddress = new[]
+        {
+            MakeTexture(address: 0x2000, width: 1920, height: 1080),
+        };
+        var mismatch = GuestDepthExtentResolver.Resolve(depth, 1920, 1080, wrongAddress);
+        Assert.Equal(GuestDepthExtentResolutionKind.Mismatch, mismatch.Kind);
+        Assert.False(mismatch.IsUsable);
+
+        // Right address but still smaller than color: no alias.
+        var tooSmall = new[]
+        {
+            MakeTexture(address: 0x1000, width: 640, height: 360),
+        };
+        var stillMismatch = GuestDepthExtentResolver.Resolve(depth, 1920, 1080, tooSmall);
+        Assert.Equal(GuestDepthExtentResolutionKind.Mismatch, stillMismatch.Kind);
+    }
+
+    [Fact]
+    public void Resolve_StaleOneByOneDepth_FallsBackToColorExtent()
+    {
+        var depth = MakeDepth(width: 1, height: 1);
+        var result = GuestDepthExtentResolver.Resolve(depth, colorWidth: 2560, colorHeight: 1440, textures: []);
+
+        Assert.Equal(GuestDepthExtentResolutionKind.StaleOneByOne, result.Kind);
+        Assert.True(result.IsUsable);
+        Assert.Equal(2560u, result.Width);
+        Assert.Equal(1440u, result.Height);
+    }
+
+    [Fact]
+    public void Resolve_UndersizedDepthWithoutAlias_IsMismatch()
+    {
+        var depth = MakeDepth(width: 640, height: 360);
+        var result = GuestDepthExtentResolver.Resolve(depth, colorWidth: 1920, colorHeight: 1080, textures: []);
+
+        Assert.Equal(GuestDepthExtentResolutionKind.Mismatch, result.Kind);
+        Assert.False(result.IsUsable);
+        Assert.Equal(640u, result.Width);
+        Assert.Equal(360u, result.Height);
+    }
+
+    [Fact]
+    public void Resolve_ReadAddressAlias_WhenWriteAddressIsZero()
+    {
+        // Address property prefers WriteAddress, else ReadAddress.
+        var depth = new GuestDepthTarget(
+            ReadAddress: 0xABCD,
+            WriteAddress: 0,
+            Width: 8,
+            Height: 8,
+            GuestFormat: 0,
+            SwizzleMode: 0,
+            ClearDepth: 1f,
+            ReadOnly: true);
+        var textures = new[]
+        {
+            MakeTexture(address: 0xABCD, width: 800, height: 600),
+        };
+
+        var result = GuestDepthExtentResolver.Resolve(depth, colorWidth: 800, colorHeight: 600, textures);
+        Assert.Equal(GuestDepthExtentResolutionKind.TextureAlias, result.Kind);
+        Assert.Equal(800u, result.Width);
+        Assert.Equal(600u, result.Height);
+    }
+
+    private static GuestDepthTarget MakeDepth(
+        uint width,
+        uint height,
+        ulong writeAddress = 0x1000,
+        ulong readAddress = 0x1000) =>
+        new(
+            ReadAddress: readAddress,
+            WriteAddress: writeAddress,
+            Width: width,
+            Height: height,
+            GuestFormat: 0,
+            SwizzleMode: 0,
+            ClearDepth: 1f,
+            ReadOnly: false);
+
+    private static GuestDrawTexture MakeTexture(ulong address, uint width, uint height) =>
+        new(
+            Address: address,
+            Width: width,
+            Height: height,
+            Format: 0,
+            NumberType: 0,
+            RgbaPixels: Array.Empty<byte>(),
+            IsFallback: false,
+            IsStorage: false);
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Two pure contract test suites for real production code that had zero coverage.

**Ngs2VagDecoder** (`Ngs2VagDecoderTests`)
- Rejects short buffers / wrong magic / empty body
- Decodes one VAGp frame to exactly 28 PCM16 samples with known nibble values
- Default sample rate 48k when header rate is 0
- Loop start/end from flag bytes `0x03` / `0x06`
- One-shot end (`0x07`) truncates remaining frames
- Filter=1 predictor path checks history (sample0=4096, sample1=7936 for shift 0 nibble 1)

These are not smoke asserts. They lock the PS-ADPCM math and container rules the NGS2 mixer relies on for VAGp voices.

**GuestDepthExtentResolver** (`GuestDepthExtentResolverTests`)
- Exact when depth covers color
- TextureAlias when an undersized depth has a matching full-size texture address
- Rejects wrong-address or still-too-small textures
- Stale 1x1 depth falls back to color extent
- Plain mismatch stays unusable

Vulkan (and any future Metal) depth bind path depends on this branch table. Wrong choice undersizes D/S or drops depth.

No production code changes.

**AI-assisted**
Tests were AI-assisted. I checked the decoder math and the four resolver outcomes against the source before landing them.

## Testing

- `dotnet test SharpEmu.slnx -c Release` on this branch: green
  - Libs.Tests: 555 passed (includes the 13 new cases)
  - Metal + SourceGenerators suites green
- No runtime behavior change, so game matrix is N/A for a delta. Locally I still use Dead Cells (PPSA15552) as a general smoke title on this fork; not required for this PR.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).