### PR TITLE
kernel: preserve pthread mutex identity across pointer slots

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -61,6 +61,11 @@ public static class KernelPthreadCompatExports
         public int QueuedWaiterCount => Volatile.Read(ref _queuedWaiterCount);
         public int Type { get; set; } = MutexTypeErrorCheck;
         public int Protocol { get; set; }
+
+        // Canonical identity: the guest address of the mutex object this state
+        // represents (the value stored in ScePthreadMutex pointer slots). Slot
+        // addresses are only revocable aliases of this key.
+        public ulong HandleAddress { get; set; }
         public LinkedList<PthreadMutexWaiter> Waiters { get; } = new();
 
         public bool TryAcquireUncontended(ulong threadId, bool allowWaiterBarge)
@@ -755,6 +760,7 @@ public static class KernelPthreadCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
         }
 
+        state.HandleAddress = handle;
         _mutexStates[mutexAddress] = state;
         _mutexStates[handle] = state;
 
@@ -1187,17 +1193,21 @@ public static class KernelPthreadCompatExports
             return 0;
         }
 
-        if (_mutexStates.ContainsKey(mutexAddress))
-        {
-            return mutexAddress;
-        }
-
+        // Prefer the stored object pointer for the same reason as
+        // TryResolveMutexState: slot-keyed entries can be stale aliases of a
+        // reused pointer variable, and destroy must target the mutex the slot
+        // points at now, not whichever one once lived behind that address.
         if (KernelMemoryCompatExports.TryReadUInt64Compat(ctx, mutexAddress, out var pointedHandle) && pointedHandle != 0)
         {
             if (_mutexStates.ContainsKey(pointedHandle))
             {
                 return pointedHandle;
             }
+        }
+
+        if (_mutexStates.ContainsKey(mutexAddress))
+        {
+            return mutexAddress;
         }
 
         return mutexAddress;
@@ -1212,13 +1222,36 @@ public static class KernelPthreadCompatExports
             return false;
         }
 
-        if (_mutexStates.TryGetValue(mutexAddress, out state))
+        var slotReadable = KernelMemoryCompatExports.TryReadUInt64Compat(ctx, mutexAddress, out var pointedHandle);
+        if (_mutexStates.TryGetValue(mutexAddress, out var direct))
         {
-            resolvedAddress = mutexAddress;
-            return true;
+            // A direct hit is valid when the caller passed the mutex object
+            // itself, or a pointer slot that still stores this state's object.
+            // Sony's ScePthreadMutex argument is the address of a pointer
+            // variable — often a stack temporary — so a reused slot may now
+            // hold a different mutex; trusting the stale alias would splinter
+            // or hijack identities. Revalidate against the stored pointer.
+            if (direct.HandleAddress == mutexAddress ||
+                !slotReadable ||
+                pointedHandle == direct.HandleAddress)
+            {
+                resolvedAddress = direct.HandleAddress == mutexAddress
+                    ? mutexAddress
+                    : direct.HandleAddress;
+                if (resolvedAddress == 0)
+                {
+                    // States created before HandleAddress tracking existed.
+                    resolvedAddress = mutexAddress;
+                }
+
+                state = direct;
+                return true;
+            }
+
+            _mutexStates.TryRemove(mutexAddress, out _);
         }
 
-        if (!KernelMemoryCompatExports.TryReadUInt64Compat(ctx, mutexAddress, out var pointedHandle))
+        if (!slotReadable)
         {
             return false;
         }
@@ -1237,8 +1270,7 @@ public static class KernelPthreadCompatExports
                 return true;
             }
 
-            resolvedAddress = pointedHandle;
-            return false;
+            return CreateForeignMutexState(mutexAddress, pointedHandle, out resolvedAddress, out state);
         }
 
         if (!createIfZero)
@@ -1248,6 +1280,37 @@ public static class KernelPthreadCompatExports
         }
 
         return CreateImplicitMutexState(ctx, mutexAddress, MutexTypeErrorCheck, out resolvedAddress, out state);
+    }
+
+    /// <summary>
+    /// Tracks a mutex object the guest runtime initialized without
+    /// scePthreadMutexInit (observed with SCREAM's global locks in Gen5
+    /// titles). The state is keyed by the pointed-to object so every slot
+    /// holding the same pointer resolves to one mutex; the guest's object
+    /// memory is never written. NORMAL type keeps the established
+    /// self-relock compatibility path instead of manufacturing EDEADLK
+    /// failures the real kernel object would not produce.
+    /// </summary>
+    private static bool CreateForeignMutexState(ulong mutexAddress, ulong objectAddress, out ulong resolvedAddress, [NotNullWhen(true)] out PthreadMutexState? state)
+    {
+        var createdState = new PthreadMutexState
+        {
+            Type = MutexTypeNormal,
+            HandleAddress = objectAddress,
+        };
+
+        lock (_stateGate)
+        {
+            if (!_mutexStates.TryGetValue(objectAddress, out state))
+            {
+                _mutexStates[objectAddress] = createdState;
+                state = createdState;
+            }
+        }
+
+        _mutexStates.TryAdd(mutexAddress, state);
+        resolvedAddress = objectAddress;
+        return true;
     }
 
     private static ulong ResolveMutexAttrHandle(CpuContext ctx, ulong attrAddress)
@@ -2090,6 +2153,7 @@ public static class KernelPthreadCompatExports
             return false;
         }
 
+        createdState.HandleAddress = handle;
         lock (_stateGate)
         {
             if (_mutexStates.TryGetValue(mutexAddress, out state))

--- a/tests/SharpEmu.Libs.Tests/Pthread/PthreadMutexSemanticsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Pthread/PthreadMutexSemanticsTests.cs
@@ -77,6 +77,104 @@ public sealed class PthreadMutexSemanticsTests
     }
 
     [Fact]
+    public void Mutex_SharedObjectPointerAcrossDifferentSlotsIsOneMutex()
+    {
+        const ulong memoryBase = 0x1_0010_0000;
+        const ulong slotA = memoryBase + 0x200;
+        const ulong slotB = memoryBase + 0x300;
+        var memory = new AllocatingCpuMemory(memoryBase, 0x4000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        context[CpuRegister.Rdi] = slotA;
+        context[CpuRegister.Rsi] = 0;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexInit(context));
+
+        // The guest copies the ScePthreadMutex pointer value into another
+        // variable; both slots must resolve to the same mutex.
+        Assert.True(context.TryReadUInt64(slotA, out var objectPointer));
+        Assert.True(context.TryWriteUInt64(slotB, objectPointer));
+
+        context[CpuRegister.Rdi] = slotA;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexLock(context));
+
+        // Held through A: a trylock through B must see the same held mutex.
+        context[CpuRegister.Rdi] = slotB;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY,
+            KernelPthreadCompatExports.PthreadMutexTrylock(context));
+
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexUnlock(context));
+        context[CpuRegister.Rdi] = slotA;
+        Assert.NotEqual(0, KernelPthreadCompatExports.PthreadMutexUnlock(context));
+    }
+
+    [Fact]
+    public void Mutex_ReusedSlotHoldingDifferentMutexPointerIsRevalidated()
+    {
+        const ulong memoryBase = 0x1_0011_0000;
+        const ulong slotS = memoryBase + 0x200;
+        const ulong slotT = memoryBase + 0x300;
+        var memory = new AllocatingCpuMemory(memoryBase, 0x4000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        context[CpuRegister.Rdi] = slotS;
+        context[CpuRegister.Rsi] = 0;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexInit(context));
+        context[CpuRegister.Rdi] = slotT;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexInit(context));
+
+        // Prime the slot-keyed alias for S, as any lock/unlock does.
+        context[CpuRegister.Rdi] = slotS;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexLock(context));
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexUnlock(context));
+
+        // The guest reuses S (a stack temporary) for the mutex that lives in T.
+        Assert.True(context.TryReadUInt64(slotT, out var mutexYPointer));
+        Assert.True(context.TryWriteUInt64(slotS, mutexYPointer));
+
+        context[CpuRegister.Rdi] = slotS;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexLock(context));
+
+        // Y must now be held: a trylock through its home slot reports BUSY.
+        context[CpuRegister.Rdi] = slotT;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY,
+            KernelPthreadCompatExports.PthreadMutexTrylock(context));
+
+        context[CpuRegister.Rdi] = slotS;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexUnlock(context));
+    }
+
+    [Fact]
+    public void Mutex_ForeignObjectPointerSharesStateAcrossSlots()
+    {
+        const ulong memoryBase = 0x1_0012_0000;
+        const ulong slotA = memoryBase + 0x200;
+        const ulong slotB = memoryBase + 0x300;
+        const ulong foreignObject = memoryBase + 0x800;
+        var memory = new AllocatingCpuMemory(memoryBase, 0x4000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        // A mutex object initialized by guest runtime code SharpEmu never saw:
+        // both slots store the same object pointer.
+        Assert.True(context.TryWriteUInt64(slotA, foreignObject));
+        Assert.True(context.TryWriteUInt64(slotB, foreignObject));
+
+        context[CpuRegister.Rdi] = slotA;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexLock(context));
+
+        context[CpuRegister.Rdi] = slotB;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY,
+            KernelPthreadCompatExports.PthreadMutexTrylock(context));
+
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexUnlock(context));
+
+        context[CpuRegister.Rdi] = slotA;
+        Assert.NotEqual(0, KernelPthreadCompatExports.PthreadMutexUnlock(context));
+    }
+
+    [Fact]
     public async Task ContendedMutex_HandsOffOneHostWaiterAtATime()
     {
         const ulong memoryBase = 0x2_0000_0000;


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Fixes `ScePthreadMutex` identity when guest pointer slots are copied or reused.

### Pthread mutex state

- Uses the pointed-to mutex object as the canonical identity
- Treats guest pointer-slot addresses as revocable aliases
- Revalidates a cached slot alias against the pointer currently stored in that slot
- Removes stale aliases when a stack or temporary slot is reused for another mutex
- Resolves destroy operations through the current pointed-to object first
- Creates one shared state for foreign mutex objects initialized by guest runtime code outside `scePthreadMutexInit`

The old lookup could key state by the address of a pointer variable. Two slots containing the same mutex pointer could then behave as different locks, while a reused slot could still resolve to the mutex it previously referenced.

### Tests

- Two pointer slots holding one mutex object share lock state
- A reused slot is revalidated and resolves to its new mutex
- A foreign mutex object shared by two slots receives one state
- Existing recursive and contended mutex behavior remains covered

This models object identity rather than special-casing a title or guest address.

## AI-assisted

The investigation, implementation, and tests were AI-assisted. I checked the pointer-slot ABI, state lookup order, stale-alias removal, destroy path, and foreign-object behavior against the source and the observed guest usage, and I can maintain the change.

## Testing

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release`: green
- `dotnet build src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r linux-x64 -v:minimal`: green
- Ghost of Yōtei (`PPSA26344`, `01.008.000`): used as the Gen5 runtime case that exposed copied and reused mutex pointer slots

No logging or title-specific compatibility branch is added.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
