### PR TITLE
audio: implement AudioOut2 queue-level semantics

### DIFF
--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -21,6 +21,28 @@ public static class AudioOut2Exports
     private static long _nextUserHandle = 1;
     private static int _nextPortId;
     private static long _pushTraceCount;
+    private static long _queueCallerTraceCount;
+
+    // Ghost of Yōtei's NCA pump gates all audio production on the second
+    // GetQueueLevel output ("free grain slots"): its submit routine clamps the
+    // grain count to that value and never calls ContextPush when it is zero.
+    // With the synchronous paced Push below, the host queue is drained by
+    // construction, so level=0/available=depth is the true queue state rather
+    // than a fabricated success value. Opt-in until validated on more titles.
+    private static int _queueDepth = ParseQueueDepth(
+        Environment.GetEnvironmentVariable("SHARPEMU_AUDIO_QUEUE_DEPTH"));
+
+    private static int ParseQueueDepth(string? raw)
+    {
+        // Depth is grains of readahead the guest may queue; keep it small so a
+        // misconfigured value cannot let the producer run far ahead of pacing.
+        const int maxDepth = 64;
+        return int.TryParse(raw, out var depth) && depth is > 0 and <= maxDepth
+            ? depth
+            : 0;
+    }
+
+    internal static void SetQueueDepthForTests(int depth) => _queueDepth = depth;
 
     // Per-context audio parameters captured at ContextCreate so ContextAdvance
     // can pace to the real playback cadence (grain samples at the sample rate).
@@ -41,6 +63,41 @@ public static class AudioOut2Exports
         public uint Frequency { get; }
         public uint Channels { get; }
         public uint GrainSamples { get; }
+
+        private int _queuedGrains;
+
+        public int QueuedGrains => Volatile.Read(ref _queuedGrains);
+
+        // The queued count is transient: a grain is "queued" only while its
+        // paced Push is in flight, so pollers on other threads observe a
+        // momentarily busy queue instead of one that can never fill or drain.
+        public void BeginQueuedGrain(int depth)
+        {
+            int observed;
+            do
+            {
+                observed = Volatile.Read(ref _queuedGrains);
+                if (observed >= depth)
+                {
+                    return;
+                }
+            }
+            while (Interlocked.CompareExchange(ref _queuedGrains, observed + 1, observed) != observed);
+        }
+
+        public void EndQueuedGrain()
+        {
+            int observed;
+            do
+            {
+                observed = Volatile.Read(ref _queuedGrains);
+                if (observed <= 0)
+                {
+                    return;
+                }
+            }
+            while (Interlocked.CompareExchange(ref _queuedGrains, observed - 1, observed) != observed);
+        }
 
         // Blocks the advancing thread until one grain worth of wall-clock time
         // has elapsed since the previous advance, matching hardware timing so
@@ -77,6 +134,30 @@ public static class AudioOut2Exports
     {
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "XHl38ZNknbs",
+        ExportName = "sceAudioOut2MasteringInit",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2MasteringInit(CpuContext ctx)
+    {
+        // Mastering is host-owned here. The guest only needs the service
+        // initialization call to complete before constructing its audio graph.
+        return SetReturn(ctx, 0);
+    }
+
+    [SysAbiExport(
+        Nid = "TViD1EZXkNI",
+        ExportName = "sceAudioOut2Set3DLatency",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2Set3DLatency(CpuContext ctx)
+    {
+        // The software path is paced by ContextPush/ContextAdvance, so no
+        // separate host latency profile is needed.
+        return SetReturn(ctx, 0);
     }
 
     [SysAbiExport(
@@ -210,7 +291,17 @@ public static class AudioOut2Exports
             // FMOD's PS5 output path uses ContextPush as the submission clock
             // and does not call ContextAdvance. Pace pushes to one hardware
             // grain so the feeder cannot outrun playback and starve the game.
+            var depth = _queueDepth;
+            if (depth > 0)
+            {
+                context.BeginQueuedGrain(depth);
+            }
+
             context.PaceAdvance();
+            if (depth > 0)
+            {
+                context.EndQueuedGrain();
+            }
         }
 
         return SetReturn(ctx, 0);
@@ -234,6 +325,13 @@ public static class AudioOut2Exports
     }
 
     [SysAbiExport(
+        Nid = "4dq2rblWlg0",
+        ExportName = "sceAudioOut2ContextSetAttributes",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2ContextSetAttributes(CpuContext ctx) => SetReturn(ctx, 0);
+
+    [SysAbiExport(
         Nid = "R7d0F1g2qsU",
         ExportName = "sceAudioOut2ContextGetQueueLevel",
         Target = Generation.Gen5,
@@ -241,13 +339,42 @@ public static class AudioOut2Exports
     public static int AudioOut2ContextGetQueueLevel(CpuContext ctx)
     {
         // The advance path paces synchronously, so the queue is always drained.
+        // Both ABI outputs are 32-bit values. A previous 64-bit write at the
+        // first pointer overwrote the adjacent guest stack field/canary.
         var levelAddress = ctx[CpuRegister.Rsi];
-        if (levelAddress != 0)
+        var availableAddress = ctx[CpuRegister.Rdx];
+        if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_TRACE_AUDIO_QUEUE_CALLER"), "1", StringComparison.Ordinal) &&
+            Interlocked.Increment(ref _queueCallerTraceCount) <= 128)
         {
-            _ = TryWriteUInt64(ctx, levelAddress, 0);
+            var rbp = ctx[CpuRegister.Rbp];
+            ulong callerRip = 0;
+            var callerKnown = rbp <= ulong.MaxValue - sizeof(ulong) &&
+                ctx.TryReadUInt64(rbp + sizeof(ulong), out callerRip);
+            Console.Error.WriteLine(
+                $"[LOADER][TRACE] audio_out2.queue-caller#{_queueCallerTraceCount} " +
+                $"rbp=0x{rbp:X16} caller={(callerKnown ? $"0x{callerRip:X16}" : "?")} " +
+                $"rsp=0x{ctx[CpuRegister.Rsp]:X16} rdi=0x{ctx[CpuRegister.Rdi]:X16} " +
+                $"rsi=0x{levelAddress:X16} rdx=0x{availableAddress:X16}");
+        }
+        if (levelAddress == 0 || availableAddress == 0)
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        return SetReturn(ctx, 0);
+        uint level = 0;
+        uint available = 0;
+        var depth = _queueDepth;
+        if (depth > 0 && Contexts.TryGetValue(ctx[CpuRegister.Rdi], out var context))
+        {
+            var queued = Math.Clamp(context.QueuedGrains, 0, depth);
+            level = (uint)queued;
+            available = (uint)(depth - queued);
+        }
+
+        return ctx.TryWriteUInt32(levelAddress, level) &&
+               ctx.TryWriteUInt32(availableAddress, available)
+            ? SetReturn(ctx, 0)
+            : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
     }
 
     [SysAbiExport(
@@ -257,17 +384,28 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2PortCreate(CpuContext ctx)
     {
-        var type = unchecked((int)ctx[CpuRegister.Rdi]);
+        var contextHandle = ctx[CpuRegister.Rdi];
         var paramAddress = ctx[CpuRegister.Rsi];
         var outPortAddress = ctx[CpuRegister.Rdx];
-        var contextAddress = ctx[CpuRegister.Rcx];
-        if (type < 0 || type > 255 || paramAddress == 0 || outPortAddress == 0 || contextAddress == 0)
+        if (!Contexts.ContainsKey(contextHandle) || paramAddress == 0 || outPortAddress == 0)
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
+        Span<byte> param = stackalloc byte[0x20];
+        if (!ctx.Memory.TryRead(paramAddress, param))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        var type = BinaryPrimitives.ReadUInt32LittleEndian(param);
+        if (type > byte.MaxValue)
+        {
+            type = 0;
+        }
+
         var portId = unchecked((uint)Interlocked.Increment(ref _nextPortId)) & 0xFF;
-        var handle = 0x2000_0000UL | ((ulong)(uint)type << 16) | portId;
+        var handle = 0x2000_0000UL | ((ulong)type << 16) | portId;
         return TryWriteUInt64(ctx, outPortAddress, handle)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);

--- a/tests/SharpEmu.Libs.Tests/Audio/AudioOut2ExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Audio/AudioOut2ExportsTests.cs
@@ -1,0 +1,244 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Audio;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Audio;
+
+public sealed class AudioOut2ExportsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong ContextParamAddress = MemoryBase + 0x100;
+    private const ulong ContextMemoryAddress = MemoryBase + 0x800;
+    private const ulong ContextOutputAddress = MemoryBase + 0x200;
+    private const ulong PortParamAddress = MemoryBase + 0x300;
+    private const ulong PortOutputAddress = MemoryBase + 0x400;
+
+    [Fact]
+    public void ContextGetQueueLevel_WritesTwo32BitOutputsWithoutClobberingAdjacentField()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5)
+        {
+            [CpuRegister.Rsi] = MemoryBase + 0x100,
+            [CpuRegister.Rdx] = MemoryBase + 0x108,
+        };
+
+        WriteUInt32(memory, MemoryBase + 0x100, 0x11111111);
+        WriteUInt32(memory, MemoryBase + 0x104, 0xA5A5A5A5);
+        WriteUInt32(memory, MemoryBase + 0x108, 0x22222222);
+
+        Assert.Equal(0, AudioOut2Exports.AudioOut2ContextGetQueueLevel(context));
+        Assert.Equal(0u, ReadUInt32(memory, MemoryBase + 0x100));
+        Assert.Equal(0xA5A5A5A5u, ReadUInt32(memory, MemoryBase + 0x104));
+        Assert.Equal(0u, ReadUInt32(memory, MemoryBase + 0x108));
+    }
+
+    [Fact]
+    public void ContextGetQueueLevel_RejectsMissingSecondOutput()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5)
+        {
+            [CpuRegister.Rsi] = MemoryBase + 0x100,
+            [CpuRegister.Rdx] = 0,
+        };
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            AudioOut2Exports.AudioOut2ContextGetQueueLevel(context));
+    }
+
+    [Fact]
+    public void ContextGetQueueLevel_ReportsConfiguredDepthForKnownContext()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5)
+        {
+            [CpuRegister.Rdi] = ContextParamAddress,
+            [CpuRegister.Rsi] = ContextMemoryAddress,
+            [CpuRegister.Rdx] = 0x10000,
+            [CpuRegister.Rcx] = ContextOutputAddress,
+        };
+
+        AudioOut2Exports.SetQueueDepthForTests(2);
+        try
+        {
+            Assert.Equal(0, AudioOut2Exports.AudioOut2ContextCreate(context));
+            var contextHandle = ReadUInt64(memory, ContextOutputAddress);
+
+            context[CpuRegister.Rdi] = contextHandle;
+            context[CpuRegister.Rsi] = MemoryBase + 0x100;
+            context[CpuRegister.Rdx] = MemoryBase + 0x108;
+            Assert.Equal(0, AudioOut2Exports.AudioOut2ContextGetQueueLevel(context));
+            Assert.Equal(0u, ReadUInt32(memory, MemoryBase + 0x100));
+            Assert.Equal(2u, ReadUInt32(memory, MemoryBase + 0x108));
+
+            context[CpuRegister.Rdi] = contextHandle;
+            Assert.Equal(0, AudioOut2Exports.AudioOut2ContextDestroy(context));
+        }
+        finally
+        {
+            AudioOut2Exports.SetQueueDepthForTests(0);
+        }
+    }
+
+    [Fact]
+    public void ContextGetQueueLevel_KeepsLegacyZeroOutputsForUnknownContextInDepthMode()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5)
+        {
+            [CpuRegister.Rdi] = 0xDEAD,
+            [CpuRegister.Rsi] = MemoryBase + 0x100,
+            [CpuRegister.Rdx] = MemoryBase + 0x108,
+        };
+
+        WriteUInt32(memory, MemoryBase + 0x100, 0x11111111);
+        WriteUInt32(memory, MemoryBase + 0x108, 0x22222222);
+
+        AudioOut2Exports.SetQueueDepthForTests(2);
+        try
+        {
+            Assert.Equal(0, AudioOut2Exports.AudioOut2ContextGetQueueLevel(context));
+            Assert.Equal(0u, ReadUInt32(memory, MemoryBase + 0x100));
+            Assert.Equal(0u, ReadUInt32(memory, MemoryBase + 0x108));
+        }
+        finally
+        {
+            AudioOut2Exports.SetQueueDepthForTests(0);
+        }
+    }
+
+    [Fact]
+    public void ContextPush_LeavesQueueDrainedInDepthMode()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5)
+        {
+            [CpuRegister.Rdi] = ContextParamAddress,
+            [CpuRegister.Rsi] = ContextMemoryAddress,
+            [CpuRegister.Rdx] = 0x10000,
+            [CpuRegister.Rcx] = ContextOutputAddress,
+        };
+
+        AudioOut2Exports.SetQueueDepthForTests(1);
+        try
+        {
+            Assert.Equal(0, AudioOut2Exports.AudioOut2ContextCreate(context));
+            var contextHandle = ReadUInt64(memory, ContextOutputAddress);
+
+            context[CpuRegister.Rdi] = contextHandle;
+            Assert.Equal(0, AudioOut2Exports.AudioOut2ContextPush(context));
+
+            context[CpuRegister.Rdi] = contextHandle;
+            context[CpuRegister.Rsi] = MemoryBase + 0x100;
+            context[CpuRegister.Rdx] = MemoryBase + 0x108;
+            Assert.Equal(0, AudioOut2Exports.AudioOut2ContextGetQueueLevel(context));
+            Assert.Equal(0u, ReadUInt32(memory, MemoryBase + 0x100));
+            Assert.Equal(1u, ReadUInt32(memory, MemoryBase + 0x108));
+
+            context[CpuRegister.Rdi] = contextHandle;
+            Assert.Equal(0, AudioOut2Exports.AudioOut2ContextDestroy(context));
+        }
+        finally
+        {
+            AudioOut2Exports.SetQueueDepthForTests(0);
+        }
+    }
+
+    [Fact]
+    public void PortCreate_UsesContextHandleAndReadsPortTypeFromParameterBlock()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        context[CpuRegister.Rdi] = ContextParamAddress;
+        context[CpuRegister.Rsi] = ContextMemoryAddress;
+        context[CpuRegister.Rdx] = 0x10000;
+        context[CpuRegister.Rcx] = ContextOutputAddress;
+        Assert.Equal(0, AudioOut2Exports.AudioOut2ContextCreate(context));
+        var contextHandle = ReadUInt64(memory, ContextOutputAddress);
+        Assert.NotEqual(0UL, contextHandle);
+
+        Span<byte> portParam = stackalloc byte[0x20];
+        BinaryPrimitives.WriteUInt32LittleEndian(portParam, 2);
+        Assert.True(memory.TryWrite(PortParamAddress, portParam));
+
+        context[CpuRegister.Rdi] = contextHandle;
+        context[CpuRegister.Rsi] = PortParamAddress;
+        context[CpuRegister.Rdx] = PortOutputAddress;
+        // RCX is intentionally unrelated to the ABI now; the context handle is
+        // in RDI and the output port pointer is in RDX.
+        context[CpuRegister.Rcx] = MemoryBase + 0x500;
+
+        Assert.Equal(0, AudioOut2Exports.AudioOut2PortCreate(context));
+        var portHandle = ReadUInt64(memory, PortOutputAddress);
+        Assert.Equal(0x2002u, (uint)(portHandle >> 16));
+        Assert.NotEqual(0u, (uint)portHandle & 0xFFu);
+
+        context[CpuRegister.Rdi] = contextHandle;
+        Assert.Equal(0, AudioOut2Exports.AudioOut2ContextDestroy(context));
+    }
+
+    [Fact]
+    public void PortCreate_RejectsUnknownContextHandle()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5)
+        {
+            [CpuRegister.Rdi] = 0xDEAD,
+            [CpuRegister.Rsi] = PortParamAddress,
+            [CpuRegister.Rdx] = PortOutputAddress,
+        };
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            AudioOut2Exports.AudioOut2PortCreate(context));
+    }
+
+    [Fact]
+    public void GhostAudioOut2Exports_RegisterForGen5()
+    {
+        var manager = new ModuleManager();
+        manager.RegisterExports(SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen5));
+
+        AssertExport(manager, "XHl38ZNknbs", "sceAudioOut2MasteringInit");
+        AssertExport(manager, "TViD1EZXkNI", "sceAudioOut2Set3DLatency");
+        AssertExport(manager, "4dq2rblWlg0", "sceAudioOut2ContextSetAttributes");
+        AssertExport(manager, "R7d0F1g2qsU", "sceAudioOut2ContextGetQueueLevel");
+        AssertExport(manager, "JK2wamZPzwM", "sceAudioOut2PortCreate");
+    }
+
+    private static void AssertExport(ModuleManager manager, string nid, string name)
+    {
+        Assert.True(manager.TryGetExport(nid, out var export), $"NID {nid} did not register.");
+        Assert.Equal(name, export.Name);
+        Assert.Equal("libSceAudioOut2", export.LibraryName);
+        Assert.Equal(Generation.Gen5, export.Target);
+    }
+
+    private static ulong ReadUInt64(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> value = stackalloc byte[sizeof(ulong)];
+        Assert.True(memory.TryRead(address, value));
+        return BinaryPrimitives.ReadUInt64LittleEndian(value);
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> value = stackalloc byte[sizeof(uint)];
+        Assert.True(memory.TryRead(address, value));
+        return BinaryPrimitives.ReadUInt32LittleEndian(value);
+    }
+
+    private static void WriteUInt32(FakeCpuMemory memory, ulong address, uint value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Implements the two-output `sceAudioOut2ContextGetQueueLevel` contract and per-context queue accounting for the synchronous AudioOut2 path.

### Queue reporting

- Writes `level` and `available` as two separate 32-bit outputs
- Rejects a missing output pointer
- Returns a memory fault when either output cannot be written
- Avoids the previous 64-bit write that could clobber an adjacent guest field
- Tracks transient queued grains per context while a paced push is in flight
- Reports `level = queued` and `available = depth - queued`
- Keeps the legacy zero/zero report when queue-depth mode is disabled
- Makes queue depth opt-in through `SHARPEMU_AUDIO_QUEUE_DEPTH`
- Bounds the configured depth to a small valid range

The host submission path is synchronous and paced. Queue accounting therefore represents grains currently in the paced push, not a fabricated asynchronous device queue.

### Related AudioOut2 ABI fixes

- Reads `sceAudioOut2PortCreate` arguments using the context handle and parameter structure
- Validates the context and output pointers
- Adds the observed mastering-init, 3D-latency, and context-attribute entry points required by the same startup path

### Tests

- Two 32-bit queue outputs do not overwrite the adjacent field
- Missing second output is rejected
- A known context reports the configured available depth
- Unknown contexts preserve the disabled/empty behavior
- Queue writes and port creation validate guest memory and parameters
- Queue-depth test state is restored after each case

## AI-assisted

The ABI investigation, implementation, and tests were AI-assisted. I checked the output widths, argument registers, context ownership, queue-state transitions, pacing behavior, and failure returns against the source and observed caller behavior, and I can maintain the change.

## Testing

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release`: green
- `dotnet build src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r linux-x64 -v:minimal`: green
- Ghost of Yōtei (`PPSA26344`, `01.008.000`) with `SHARPEMU_AUDIO_QUEUE_DEPTH=2`: the NCA audio pump receives nonzero free-grain capacity instead of permanently gating production

Queue-depth mode remains opt-in until it is validated on more titles.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
