### PR TITLE
audio: implement ACM batch completion and AJM support calls

### DIFF
--- a/src/SharpEmu.Libs/Acm/AcmExports.cs
+++ b/src/SharpEmu.Libs/Acm/AcmExports.cs
@@ -2,13 +2,59 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using SharpEmu.HLE;
 
 namespace SharpEmu.Libs.Acm;
 
 public static class AcmExports
 {
-    private static int _nextContextHandle;
+    // Batch terminator command observed in Ghost of Yōtei's NCA audio engine:
+    // {opcode 0xB, pointer to the caller's status block}. The status block's
+    // +8 field is pre-filled with 0xFFFFFFFF_00000000 and converted to the
+    // audio clock (cvtsi2ss) once the batch completes, so completion must
+    // overwrite it or the guest computes a garbage timestamp.
+    private const ulong BatchTerminatorOpcode = 0xB;
+    private const int BatchCommandSize = 0x10;
+    private const int BatchDescriptorSize = 0x18;
+    private const ulong MaxBatchBufferBytes = 0x100000;
+    private static int _nextContextId;
+    private static readonly ConcurrentDictionary<uint, AcmContextState> Contexts = new();
+
+    private sealed class AcmContextState
+    {
+        public AcmContextState(ulong parameterAddress, ulong workMemoryAddress, ulong workMemorySize)
+        {
+            ParameterAddress = parameterAddress;
+            WorkMemoryAddress = workMemoryAddress;
+            WorkMemorySize = workMemorySize;
+        }
+
+        public ulong ParameterAddress { get; }
+        public ulong WorkMemoryAddress { get; }
+        public ulong WorkMemorySize { get; }
+
+        // In-flight batches by id; the value is the terminator's status-block
+        // address (0 when the submitted buffer had no readable terminator).
+        public ConcurrentDictionary<uint, ulong> Batches { get; } = new();
+
+        private int _nextBatchId;
+
+        public uint AllocateBatchId()
+        {
+            while (true)
+            {
+                var id = unchecked((uint)Interlocked.Increment(ref _nextBatchId));
+                // The guest stores the id in a u32 slot where 0xFFFFFFFF means
+                // "no batch in flight"; avoid it and 0 so a written id is
+                // always distinguishable from both sentinels.
+                if (id != 0 && id != uint.MaxValue)
+                {
+                    return id;
+                }
+            }
+        }
+    }
 
     [SysAbiExport(
         Nid = "ZIXln2K3XMk",
@@ -23,12 +69,19 @@ public static class AcmExports
             return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        var handle = (ulong)Interlocked.Increment(ref _nextContextHandle);
-        Span<byte> handleBytes = stackalloc byte[sizeof(ulong)];
-        BinaryPrimitives.WriteUInt64LittleEndian(handleBytes, handle);
-        return ctx.Memory.TryWrite(outContextAddress, handleBytes)
-            ? ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK)
-            : ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        var contextId = unchecked((uint)Interlocked.Increment(ref _nextContextId));
+        Span<byte> contextBytes = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(contextBytes, contextId);
+        if (!ctx.Memory.TryWrite(outContextAddress, contextBytes))
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        Contexts[contextId] = new AcmContextState(
+            parameterAddress: ctx[CpuRegister.Rsi],
+            workMemoryAddress: ctx[CpuRegister.Rcx],
+            workMemorySize: ctx[CpuRegister.R8]);
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
     }
 
     [SysAbiExport(
@@ -38,7 +91,129 @@ public static class AcmExports
         LibraryName = "libSceAcm")]
     public static int AcmContextDestroy(CpuContext ctx)
     {
-        _ = ctx;
+        Contexts.TryRemove(unchecked((uint)ctx[CpuRegister.Rdi]), out _);
         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    /// <summary>
+    /// Submits a built command buffer: (contextId, 0, descriptorList,
+    /// 0, out u32 batchId). The descriptor list points at descriptor structs of
+    /// {commandBase, usedBytes, capacity}. This host renders batches
+    /// synchronously, so submission only records the terminator's status block
+    /// and publishes a batch id for the matching sceAcmBatchWait.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "8fe55ktlNVo",
+        ExportName = "sceAcmBatchStartBuffers",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAcm")]
+    public static int AcmBatchStartBuffers(CpuContext ctx)
+    {
+        var contextId = unchecked((uint)ctx[CpuRegister.Rdi]);
+        var descriptorListAddress = ctx[CpuRegister.Rdx];
+        var outBatchIdAddress = ctx[CpuRegister.R8];
+        if (!Contexts.TryGetValue(contextId, out var context) ||
+            descriptorListAddress == 0 ||
+            outBatchIdAddress == 0)
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        var statusAddress = FindTerminatorStatusAddress(ctx, descriptorListAddress);
+        var batchId = context.AllocateBatchId();
+        context.Batches[batchId] = statusAddress;
+
+        Span<byte> batchIdBytes = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(batchIdBytes, batchId);
+        if (!ctx.Memory.TryWrite(outBatchIdAddress, batchIdBytes))
+        {
+            context.Batches.TryRemove(batchId, out _);
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAcm($"batch-start context={contextId} batch={batchId} descriptors=0x{descriptorListAddress:X} status=0x{statusAddress:X}");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    /// <summary>
+    /// Waits for batch completion: (contextId, batchId, pollArg) with 0 meaning
+    /// complete. All batches complete immediately in the synchronous host
+    /// model; completion overwrites the status block's sentinel timestamp so
+    /// the guest audio clock gets 0 instead of a converted sentinel.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "RLN3gRlXJLE",
+        ExportName = "sceAcmBatchWait",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAcm")]
+    public static int AcmBatchWait(CpuContext ctx)
+    {
+        var contextId = unchecked((uint)ctx[CpuRegister.Rdi]);
+        var batchId = unchecked((uint)ctx[CpuRegister.Rsi]);
+        if (!Contexts.TryGetValue(contextId, out var context))
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        if (context.Batches.TryRemove(batchId, out var statusAddress) && statusAddress != 0)
+        {
+            Span<byte> timestamp = stackalloc byte[sizeof(ulong)];
+            timestamp.Clear();
+            _ = ctx.Memory.TryWrite(statusAddress + 8, timestamp);
+        }
+
+        TraceAcm($"batch-wait context={contextId} batch={batchId} status=0x{statusAddress:X}");
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    private static ulong FindTerminatorStatusAddress(CpuContext ctx, ulong descriptorListAddress)
+    {
+        Span<byte> pointerBytes = stackalloc byte[sizeof(ulong)];
+        if (!ctx.Memory.TryRead(descriptorListAddress, pointerBytes))
+        {
+            return 0;
+        }
+
+        var descriptorAddress = BinaryPrimitives.ReadUInt64LittleEndian(pointerBytes);
+        Span<byte> descriptor = stackalloc byte[BatchDescriptorSize];
+        if (descriptorAddress == 0 || !ctx.Memory.TryRead(descriptorAddress, descriptor))
+        {
+            return 0;
+        }
+
+        var commandBase = BinaryPrimitives.ReadUInt64LittleEndian(descriptor);
+        var usedBytes = BinaryPrimitives.ReadUInt64LittleEndian(descriptor[8..]);
+        var capacity = BinaryPrimitives.ReadUInt64LittleEndian(descriptor[16..]);
+        if (commandBase == 0 ||
+            usedBytes < BatchCommandSize ||
+            usedBytes > capacity ||
+            capacity > MaxBatchBufferBytes)
+        {
+            return 0;
+        }
+
+        Span<byte> command = stackalloc byte[BatchCommandSize];
+        if (!ctx.Memory.TryRead(commandBase + usedBytes - BatchCommandSize, command))
+        {
+            return 0;
+        }
+
+        return BinaryPrimitives.ReadUInt64LittleEndian(command) == BatchTerminatorOpcode
+            ? BinaryPrimitives.ReadUInt64LittleEndian(command[8..])
+            : 0;
+    }
+
+    private static void TraceAcm(string message)
+    {
+        if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_ACM"), "1", StringComparison.Ordinal))
+        {
+            Console.Error.WriteLine($"[LOADER][TRACE] acm.{message}");
+        }
+    }
+
+    internal static void ResetForTests()
+    {
+        Contexts.Clear();
+        Interlocked.Exchange(ref _nextContextId, 0);
     }
 }

--- a/src/SharpEmu.Libs/Audio/AjmExports.cs
+++ b/src/SharpEmu.Libs/Audio/AjmExports.cs
@@ -204,6 +204,55 @@ public static class AjmExports
     }
 
     [SysAbiExport(
+        Nid = "bkRHEYG6lEM",
+        ExportName = "sceAjmMemoryRegister",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAjm")]
+    public static int AjmMemoryRegister(CpuContext ctx)
+    {
+        var contextId = unchecked((uint)ctx[CpuRegister.Rdi]);
+        var address = ctx[CpuRegister.Rsi];
+        var pageCount = ctx[CpuRegister.Rdx];
+        if (!Contexts.ContainsKey(contextId))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidContext);
+        }
+
+        if (address == 0 || pageCount == 0)
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
+        }
+
+        // Guest memory is already directly visible to the software AJM path;
+        // registration records no additional host mapping.
+        Trace($"memory_register context={contextId} address=0x{address:X} pages={pageCount}");
+        return ctx.SetReturn(0);
+    }
+
+    [SysAbiExport(
+        Nid = "pIpGiaYkHkM",
+        ExportName = "sceAjmMemoryUnregister",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAjm")]
+    public static int AjmMemoryUnregister(CpuContext ctx)
+    {
+        var contextId = unchecked((uint)ctx[CpuRegister.Rdi]);
+        var address = ctx[CpuRegister.Rsi];
+        if (!Contexts.ContainsKey(contextId))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidContext);
+        }
+
+        if (address == 0)
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
+        }
+
+        Trace($"memory_unregister context={contextId} address=0x{address:X}");
+        return ctx.SetReturn(0);
+    }
+
+    [SysAbiExport(
         Nid = "Wi7DtlLV+KI",
         ExportName = "sceAjmModuleUnregister",
         Target = Generation.Gen4 | Generation.Gen5,
@@ -335,6 +384,37 @@ public static class AjmExports
             $"batch_wait context={unchecked((uint)ctx[CpuRegister.Rdi])} " +
             $"batch={unchecked((uint)ctx[CpuRegister.Rsi])} " +
             $"timeout={unchecked((uint)ctx[CpuRegister.Rdx])}");
+        return ctx.SetReturn(0);
+    }
+
+    /// <summary>
+    /// Ghost of Yōtei's FMOD-side pump calls this with an output slot in RDI
+    /// and, ignoring the return register, submits a new AJM batch only when the
+    /// written value is nonzero. All host batches complete synchronously, so
+    /// zero ("no pending work") is the truthful report and quietly idles that
+    /// producer instead of feeding it stale statistics.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "3cAg7xN995U",
+        ExportName = "sceAjmBatchJobGetStatistics",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAjm")]
+    public static int AjmBatchJobGetStatistics(CpuContext ctx)
+    {
+        var outAddress = ctx[CpuRegister.Rdi];
+        if (outAddress == 0)
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
+        }
+
+        Span<byte> pending = stackalloc byte[sizeof(ulong)];
+        pending.Clear();
+        if (!ctx.Memory.TryWrite(outAddress, pending))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
+        }
+
+        Trace($"batch_job_get_statistics out=0x{outAddress:X16} job=0x{ctx[CpuRegister.Rsi]:X16}");
         return ctx.SetReturn(0);
     }
 

--- a/tests/SharpEmu.Libs.Tests/Acm/AcmExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Acm/AcmExportsTests.cs
@@ -1,0 +1,221 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Acm;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Acm;
+
+[CollectionDefinition("AcmState", DisableParallelization = true)]
+public sealed class AcmStateCollection
+{
+    public const string Name = "AcmState";
+}
+
+[Collection(AcmStateCollection.Name)]
+public sealed class AcmExportsTests : IDisposable
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong ContextOutputAddress = MemoryBase + 0x100;
+
+    private readonly FakeCpuMemory _memory = new(MemoryBase, 0x1000);
+    private readonly CpuContext _context;
+
+    public AcmExportsTests()
+    {
+        AcmExports.ResetForTests();
+        _context = new CpuContext(_memory, Generation.Gen5);
+    }
+
+    [Fact]
+    public void ContextCreate_Writes32BitIdWithoutClobberingAdjacentGuestField()
+    {
+        WriteUInt32(ContextOutputAddress + sizeof(uint), 0xA5A5A5A5);
+        _context[CpuRegister.Rdi] = ContextOutputAddress;
+        _context[CpuRegister.Rsi] = MemoryBase + 0x200;
+        _context[CpuRegister.Rcx] = MemoryBase + 0x400;
+        _context[CpuRegister.R8] = 0x2000;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AcmExports.AcmContextCreate(_context));
+        Assert.Equal(1u, ReadUInt32(ContextOutputAddress));
+        Assert.Equal(0xA5A5A5A5u, ReadUInt32(ContextOutputAddress + sizeof(uint)));
+
+        _context[CpuRegister.Rdi] = 1;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AcmExports.AcmContextDestroy(_context));
+    }
+
+    [Fact]
+    public void ContextCreate_ReturnsMemoryFaultForUnmappedOutput()
+    {
+        _context[CpuRegister.Rdi] = MemoryBase + 0x1000;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT,
+            AcmExports.AcmContextCreate(_context));
+    }
+
+    [Fact]
+    public void BatchStartBuffers_Writes32BitBatchIdWithoutClobberingAdjacentGuestField()
+    {
+        var contextId = CreateContext();
+        const ulong DescriptorListAddress = MemoryBase + 0x200;
+        const ulong DescriptorAddress = MemoryBase + 0x300;
+        const ulong CommandBufferAddress = MemoryBase + 0x400;
+        const ulong StatusAddress = MemoryBase + 0x500;
+        const ulong OutBatchIdAddress = MemoryBase + 0x600;
+
+        // Guest layout: descriptor list -> descriptor {base, used, capacity};
+        // the command buffer ends with the terminator {opcode 0xB, &status}.
+        WriteUInt64(DescriptorListAddress, DescriptorAddress);
+        WriteUInt64(DescriptorAddress, CommandBufferAddress);
+        WriteUInt64(DescriptorAddress + 8, 0x10);
+        WriteUInt64(DescriptorAddress + 16, 0x2000);
+        WriteUInt64(CommandBufferAddress, 0xB);
+        WriteUInt64(CommandBufferAddress + 8, StatusAddress);
+        WriteUInt32(OutBatchIdAddress + sizeof(uint), 0xA5A5A5A5);
+
+        _context[CpuRegister.Rdi] = contextId;
+        _context[CpuRegister.Rsi] = 0;
+        _context[CpuRegister.Rdx] = DescriptorListAddress;
+        _context[CpuRegister.Rcx] = 0;
+        _context[CpuRegister.R8] = OutBatchIdAddress;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AcmExports.AcmBatchStartBuffers(_context));
+
+        var batchId = ReadUInt32(OutBatchIdAddress);
+        Assert.NotEqual(0u, batchId);
+        Assert.NotEqual(uint.MaxValue, batchId);
+        Assert.Equal(0xA5A5A5A5u, ReadUInt32(OutBatchIdAddress + sizeof(uint)));
+    }
+
+    [Fact]
+    public void BatchStartBuffers_RejectsUnknownContext()
+    {
+        _context[CpuRegister.Rdi] = 0xDEAD;
+        _context[CpuRegister.Rdx] = MemoryBase + 0x200;
+        _context[CpuRegister.R8] = MemoryBase + 0x600;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            AcmExports.AcmBatchStartBuffers(_context));
+    }
+
+    [Fact]
+    public void BatchWait_CompletesBatchAndNeutralizesStatusTimestamp()
+    {
+        var contextId = CreateContext();
+        const ulong DescriptorListAddress = MemoryBase + 0x200;
+        const ulong DescriptorAddress = MemoryBase + 0x300;
+        const ulong CommandBufferAddress = MemoryBase + 0x400;
+        const ulong StatusAddress = MemoryBase + 0x500;
+        const ulong OutBatchIdAddress = MemoryBase + 0x600;
+
+        WriteUInt64(DescriptorListAddress, DescriptorAddress);
+        WriteUInt64(DescriptorAddress, CommandBufferAddress);
+        WriteUInt64(DescriptorAddress + 8, 0x10);
+        WriteUInt64(DescriptorAddress + 16, 0x2000);
+        WriteUInt64(CommandBufferAddress, 0xB);
+        WriteUInt64(CommandBufferAddress + 8, StatusAddress);
+
+        // Guest pre-fills the status block timestamp with a sentinel; ACM must
+        // replace it on completion or the guest converts the sentinel to a
+        // garbage audio-clock value.
+        WriteUInt64(StatusAddress + 8, 0xFFFFFFFF00000000);
+
+        _context[CpuRegister.Rdi] = contextId;
+        _context[CpuRegister.Rdx] = DescriptorListAddress;
+        _context[CpuRegister.R8] = OutBatchIdAddress;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AcmExports.AcmBatchStartBuffers(_context));
+        var batchId = ReadUInt32(OutBatchIdAddress);
+
+        _context[CpuRegister.Rdi] = contextId;
+        _context[CpuRegister.Rsi] = batchId;
+        _context[CpuRegister.Rdx] = 0;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AcmExports.AcmBatchWait(_context));
+        Assert.Equal(0UL, ReadUInt64(StatusAddress + 8));
+    }
+
+    [Fact]
+    public void BatchWait_RejectsUnknownContext()
+    {
+        _context[CpuRegister.Rdi] = 0xDEAD;
+        _context[CpuRegister.Rsi] = 1;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            AcmExports.AcmBatchWait(_context));
+    }
+
+    [Fact]
+    public void ContextExports_RegisterForBothGenerations()
+    {
+        foreach (var generation in new[] { Generation.Gen4, Generation.Gen5 })
+        {
+            var manager = new ModuleManager();
+            manager.RegisterExports(SharpEmu.Generated.SysAbiExportRegistry.CreateExports(generation));
+
+            Assert.True(manager.TryGetExport("ZIXln2K3XMk", out var create));
+            Assert.Equal("sceAcmContextCreate", create.Name);
+            Assert.True(manager.TryGetExport("jBgBjAj02R8", out var destroy));
+            Assert.Equal("sceAcmContextDestroy", destroy.Name);
+            Assert.True(manager.TryGetExport("8fe55ktlNVo", out var start));
+            Assert.Equal("sceAcmBatchStartBuffers", start.Name);
+            Assert.True(manager.TryGetExport("RLN3gRlXJLE", out var wait));
+            Assert.Equal("sceAcmBatchWait", wait.Name);
+        }
+    }
+
+    public void Dispose() => AcmExports.ResetForTests();
+
+    private ulong CreateContext()
+    {
+        _context[CpuRegister.Rdi] = ContextOutputAddress;
+        _context[CpuRegister.Rsi] = MemoryBase + 0x800;
+        _context[CpuRegister.Rcx] = MemoryBase + 0x900;
+        _context[CpuRegister.R8] = 0x2000;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AcmExports.AcmContextCreate(_context));
+        return ReadUInt32(ContextOutputAddress);
+    }
+
+    private ulong ReadUInt64(ulong address)
+    {
+        Span<byte> value = stackalloc byte[sizeof(ulong)];
+        Assert.True(_memory.TryRead(address, value));
+        return BinaryPrimitives.ReadUInt64LittleEndian(value);
+    }
+
+    private void WriteUInt64(ulong address, ulong value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+        Assert.True(_memory.TryWrite(address, bytes));
+    }
+
+    private uint ReadUInt32(ulong address)
+    {
+        Span<byte> value = stackalloc byte[sizeof(uint)];
+        Assert.True(_memory.TryRead(address, value));
+        return BinaryPrimitives.ReadUInt32LittleEndian(value);
+    }
+
+    private void WriteUInt32(ulong address, uint value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+        Assert.True(_memory.TryWrite(address, bytes));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Audio/AjmExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Audio/AjmExportsTests.cs
@@ -94,6 +94,45 @@ public sealed class AjmExportsTests : IDisposable
     }
 
     [Fact]
+    public void MemoryRegisterAndUnregister_AcceptLiveContextAndPageRange()
+    {
+        var contextId = Initialize();
+        const ulong address = MemoryBase + 0x400;
+
+        _ctx[CpuRegister.Rdi] = contextId;
+        _ctx[CpuRegister.Rsi] = address;
+        _ctx[CpuRegister.Rdx] = 5;
+        Assert.Equal(0, AjmExports.AjmMemoryRegister(_ctx));
+
+        _ctx[CpuRegister.Rdi] = contextId;
+        _ctx[CpuRegister.Rsi] = address;
+        Assert.Equal(0, AjmExports.AjmMemoryUnregister(_ctx));
+    }
+
+    [Fact]
+    public void MemoryRegisterAndUnregister_RejectInvalidContextOrRange()
+    {
+        _ctx[CpuRegister.Rdi] = uint.MaxValue;
+        _ctx[CpuRegister.Rsi] = MemoryBase + 0x400;
+        _ctx[CpuRegister.Rdx] = 1;
+        Assert.Equal(InvalidContext, AjmExports.AjmMemoryRegister(_ctx));
+        Assert.Equal(InvalidContext, AjmExports.AjmMemoryUnregister(_ctx));
+
+        var contextId = Initialize();
+        _ctx[CpuRegister.Rdi] = contextId;
+        _ctx[CpuRegister.Rsi] = 0;
+        _ctx[CpuRegister.Rdx] = 1;
+        Assert.Equal(InvalidParameter, AjmExports.AjmMemoryRegister(_ctx));
+
+        _ctx[CpuRegister.Rsi] = MemoryBase + 0x400;
+        _ctx[CpuRegister.Rdx] = 0;
+        Assert.Equal(InvalidParameter, AjmExports.AjmMemoryRegister(_ctx));
+
+        _ctx[CpuRegister.Rsi] = 0;
+        Assert.Equal(InvalidParameter, AjmExports.AjmMemoryUnregister(_ctx));
+    }
+
+    [Fact]
     public void InstanceDestroy_RejectsUnknownContextAndSlot()
     {
         var contextId = Initialize();
@@ -158,6 +197,21 @@ public sealed class AjmExportsTests : IDisposable
         }
     }
 
+    [Fact]
+    public void MemoryRegistrationExports_RegisterForBothGenerations()
+    {
+        foreach (var generation in new[] { Generation.Gen4, Generation.Gen5 })
+        {
+            var manager = new ModuleManager();
+            manager.RegisterExports(SharpEmu.Generated.SysAbiExportRegistry.CreateExports(generation));
+
+            Assert.True(manager.TryGetExport("bkRHEYG6lEM", out var register));
+            Assert.Equal("sceAjmMemoryRegister", register.Name);
+            Assert.True(manager.TryGetExport("pIpGiaYkHkM", out var unregister));
+            Assert.Equal("sceAjmMemoryUnregister", unregister.Name);
+        }
+    }
+
     public void Dispose()
     {
         AjmExports.ResetForTests();
@@ -177,6 +231,33 @@ public sealed class AjmExportsTests : IDisposable
         _ctx[CpuRegister.Rsi] = codecType;
         _ctx[CpuRegister.Rdx] = 0;
         return AjmExports.AjmModuleRegister(_ctx);
+    }
+
+    [Fact]
+    public void BatchJobGetStatistics_WritesZeroPendingWorkMarker()
+    {
+        const ulong OutAddress = MemoryBase + 0x700;
+        Span<byte> sentinel = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(sentinel, 0xDEADBEEFDEADBEEF);
+        Assert.True(_memory.TryWrite(OutAddress, sentinel));
+
+        _ctx[CpuRegister.Rdi] = OutAddress;
+        _ctx[CpuRegister.Rsi] = MemoryBase + 0x780;
+        _ctx[CpuRegister.Rdx] = OutAddress;
+
+        Assert.Equal(0, AjmExports.AjmBatchJobGetStatistics(_ctx));
+
+        Span<byte> value = stackalloc byte[sizeof(ulong)];
+        Assert.True(_memory.TryRead(OutAddress, value));
+        Assert.Equal(0UL, BinaryPrimitives.ReadUInt64LittleEndian(value));
+    }
+
+    [Fact]
+    public void BatchJobGetStatistics_RejectsNullOutput()
+    {
+        _ctx[CpuRegister.Rdi] = 0;
+
+        Assert.NotEqual(0, AjmExports.AjmBatchJobGetStatistics(_ctx));
     }
 
     private int CreateInstance(uint contextId, uint codecType, ulong flags, ulong outputAddress)


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Adds concrete ACM batch state/completion behavior and the related AJM calls used by the Gen5 audio startup path.

### ACM

- Stores contexts by a 32-bit context ID
- Writes only the 32-bit context output instead of clobbering an adjacent field
- Allocates nonzero batch IDs while avoiding `UINT32_MAX`
- Parses the submitted descriptor and final `0xB` terminator command
- Records the terminator’s status-block pointer for the submitted batch
- Completes batches synchronously in `sceAcmBatchWait`
- Clears the status timestamp at `status + 8`
- Removes completed batches from the context
- Removes context state on destroy
- Keeps diagnostics behind `SHARPEMU_LOG_ACM`

The caller initializes the completion timestamp with a sentinel and consumes it as an audio clock value. Returning success without updating the status block leaves a garbage timestamp, so this implements the observable output rather than only suppressing an import.

### AJM

- Adds memory register/unregister validation for existing contexts
- Treats guest memory as already visible to the software AJM path
- Implements `sceAjmBatchJobGetStatistics`
- Writes a deterministic zero pending-work value for the synchronous host model
- Returns parameter/context errors for invalid inputs

### Tests

- ACM context creation writes a 32-bit ID without overwriting the next field
- Batch start publishes a usable batch ID
- Batch wait clears the terminator status timestamp
- Invalid descriptors and output pointers follow the error path
- AJM memory registration validates context and parameters
- AJM statistics initialize the guest output

## AI-assisted

The reverse engineering, implementation, and tests were AI-assisted. I reviewed the descriptor sizes, terminator layout, status write, batch lifetime, AJM validation, and synchronous completion model against the source and observed guest command buffers, and I can explain and maintain the change.

## Testing

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release`: green
- `dotnet build src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r linux-x64 -v:minimal`: green
- Ghost of Yōtei (`PPSA26344`, `01.008.000`): ACM completion now initializes the status value consumed by the NCA audio clock

This does not implement hardware audio decoding or asynchronous execution. It models the state and output required by the current synchronous software path.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
