### PR TITLE
agc: support hull pipelines and PM4 conditional execution

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -46,6 +46,7 @@ public static partial class AgcExports
     private const uint ItNumInstances = 0x2F;
     private const uint ItDrawIndexMultiAuto = 0x30;
     private const uint ItDrawIndexOffset2 = 0x35;
+    private const uint ItCondExec = 0x22;
     private const uint ItWriteData = 0x37;
     private const uint ItDispatchDirect = 0x15;
     private const uint ItDispatchIndirect = 0x16;
@@ -84,6 +85,11 @@ public static partial class AgcExports
     private const uint SpiShaderPgmHiEs = 0xC9;
     private const uint SpiShaderPgmLoLs = 0x148;
     private const uint SpiShaderPgmHiLs = 0x149;
+    // Hull/tessellation stage slot, calibrated against the observed Ghost of
+    // Yōtei type-5 shader headers (lo=0x10A hi=0x10B) and this table's Gs
+    // (0x8A/0x8B) and Ls (0x148/0x149) numbering.
+    private const uint SpiShaderPgmLoHs = 0x10A;
+    private const uint SpiShaderPgmHiHs = 0x10B;
     private const uint SpiShaderPgmLoGs = 0x8A;
     private const uint SpiShaderPgmHiGs = 0x8B;
     private const uint SpiPsInputEna = 0x1B3;
@@ -806,7 +812,12 @@ public static partial class AgcExports
         var geometryShaderAddress = ctx[CpuRegister.Rcx];
         var primitiveType = (uint)ctx[CpuRegister.R8];
 
-        if (cxRegistersAddress == 0 || ucRegistersAddress == 0 || hullShaderAddress != 0 || geometryShaderAddress == 0)
+        // The hull argument is optional: Ghost of Yōtei's tessellation
+        // pipelines pass their hull-state block here (0x8009F926D) and the
+        // geometry-derived cx/uc register writes below stay the same. The
+        // hull stage's own registers are not modelled yet, so it is only
+        // recorded in the trace.
+        if (cxRegistersAddress == 0 || ucRegistersAddress == 0 || geometryShaderAddress == 0)
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
@@ -828,7 +839,7 @@ public static partial class AgcExports
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
-        TraceAgc($"agc.create_prim_state cx=0x{cxRegistersAddress:X16} uc=0x{ucRegistersAddress:X16} gs=0x{geometryShaderAddress:X16} type={shaderType} prim=0x{primitiveType:X8}");
+        TraceAgc($"agc.create_prim_state cx=0x{cxRegistersAddress:X16} uc=0x{ucRegistersAddress:X16} hull=0x{hullShaderAddress:X16} gs=0x{geometryShaderAddress:X16} type={shaderType} prim=0x{primitiveType:X8}");
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
@@ -2927,6 +2938,44 @@ public static partial class AgcExports
             $"rsi=0x{ctx[CpuRegister.Rsi]:X16} rdx=0x{ctx[CpuRegister.Rdx]:X16} " +
             $"rcx=0x{ctx[CpuRegister.Rcx]:X16} r8=0x{ctx[CpuRegister.R8]:X16} r9=0x{ctx[CpuRegister.R9]:X16}");
 
+        return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+    #pragma warning restore SHEM006
+
+    // Synthetic label for an uncatalogued NID (the Unknown* convention); the NID is authoritative.
+    // Ghost of Yōtei calls this while building a graphics pipeline: inputs are
+    // two shader objects (byte +0x5A types 2 and 1, either may be null) and the
+    // output is a register-pair table the title submits to its register-shadow
+    // writer with count 0x20 — 32 {offset,value} pairs (0x100 bytes), the
+    // SPI_PS_INPUT_CNTL-sized interpolant mapping. A short fill leaves the
+    // tail as uninitialized stack, and the shadow writer then indexes its
+    // shadow table with the garbage offsets and faults (observed SIGSEGV at
+    // guest 0x801610CC4). All-zero pairs are the deterministic neutral
+    // encoding until the real layout is captured.
+    #pragma warning disable SHEM006
+    [SysAbiExport(
+        Nid = "dbOlWdppb4o",
+        ExportName = "sceAgcUnknownDbOlWdppb4o",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int UnknownDbOlWdppb4o(CpuContext ctx)
+    {
+        var outputAddress = ctx[CpuRegister.Rdi];
+        if (outputAddress == 0)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        Span<byte> blob = stackalloc byte[0x100];
+        blob.Clear();
+        if (!ctx.Memory.TryWrite(outputAddress, blob))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAgc(
+            $"agc.unknown_dbol out=0x{outputAddress:X16} shader_a=0x{ctx[CpuRegister.Rsi]:X16} " +
+            $"shader_b=0x{ctx[CpuRegister.Rdx]:X16}");
         return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
     }
     #pragma warning restore SHEM006
@@ -11000,6 +11049,7 @@ public static partial class AgcExports
             1 => SpiShaderPgmLoPs,
             2 or 6 => SpiShaderPgmLoEs,
             4 => SpiShaderPgmLoGs,
+            5 => SpiShaderPgmLoHs,
             7 => SpiShaderPgmLoLs,
             _ => 0u,
         };
@@ -11009,6 +11059,7 @@ public static partial class AgcExports
             1 => SpiShaderPgmHiPs,
             2 or 6 => SpiShaderPgmHiEs,
             4 => SpiShaderPgmHiGs,
+            5 => SpiShaderPgmHiHs,
             7 => SpiShaderPgmHiLs,
             _ => 0u,
         };
@@ -11958,6 +12009,40 @@ public static partial class AgcExports
             !ctx.TryWriteUInt32(cmd + 4, flags) ||
             !ctx.TryWriteUInt32(cmd + 8, (uint)address & 0xFFFF_FFF0u) ||
             !ctx.TryWriteUInt32(cmd + 12, (uint)(address >> 32)))
+        {
+            return ReturnPointer(ctx, 0);
+        }
+
+        return ReturnPointer(ctx, cmd);
+    }
+
+    /// <summary>
+    /// Emits a PM4 COND_EXEC packet: the GPU skips the following
+    /// <c>execCount</c> command dwords unless the 64-bit predicate at
+    /// <c>address</c> is nonzero. Observed from Ghost of Yōtei's render setup
+    /// as (dcb, predicateAddress, execCountDwords, ...).
+    /// </summary>
+    [SysAbiExport(
+        Nid = "BIPexNBSGog",
+        ExportName = "sceAgcDcbCondExec",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbCondExec(CpuContext ctx)
+    {
+        var dcb = ctx[CpuRegister.Rdi];
+        var address = ctx[CpuRegister.Rsi];
+        var execCount = (uint)ctx[CpuRegister.Rdx] & 0x3FFFu;
+        if (dcb == 0)
+        {
+            return ReturnPointer(ctx, 0);
+        }
+
+        if (!TryAllocateCommandDwords(ctx, dcb, 5, out var cmd) ||
+            !ctx.TryWriteUInt32(cmd, Pm4(5, ItCondExec, RZero)) ||
+            !ctx.TryWriteUInt32(cmd + 4, (uint)address & 0xFFFF_FFFCu) ||
+            !ctx.TryWriteUInt32(cmd + 8, (uint)(address >> 32)) ||
+            !ctx.TryWriteUInt32(cmd + 12, 0) ||
+            !ctx.TryWriteUInt32(cmd + 16, execCount))
         {
             return ReturnPointer(ctx, 0);
         }

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcCondExecTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcCondExecTests.cs
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcCondExecTests
+{
+    private const ulong BaseAddress = 0x1_0000_0000;
+    private const ulong CommandBufferAddress = BaseAddress + 0x100;
+    private const ulong PacketAddress = BaseAddress + 0x400;
+    private const ulong PredicateAddress = BaseAddress + 0x800;
+
+    [Fact]
+    public void DcbCondExec_EmitsPm4CondExecPacket()
+    {
+        var memory = new FakeCpuMemory(BaseAddress, 0x2000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        WriteUInt64(memory, CommandBufferAddress + 0x10, PacketAddress);
+        WriteUInt64(memory, CommandBufferAddress + 0x18, PacketAddress + 0x100);
+
+        ctx[CpuRegister.Rdi] = CommandBufferAddress;
+        ctx[CpuRegister.Rsi] = PredicateAddress + 3; // must be dword-aligned in the packet
+        ctx[CpuRegister.Rdx] = 0x24;
+
+        var result = AgcExports.DcbCondExec(ctx);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(PacketAddress, ctx[CpuRegister.Rax]);
+        Assert.Equal(0xC003_2200u, ReadUInt32(memory, PacketAddress));
+        Assert.Equal(unchecked((uint)PredicateAddress), ReadUInt32(memory, PacketAddress + 4));
+        Assert.Equal((uint)(PredicateAddress >> 32), ReadUInt32(memory, PacketAddress + 8));
+        Assert.Equal(0u, ReadUInt32(memory, PacketAddress + 12));
+        Assert.Equal(0x24u, ReadUInt32(memory, PacketAddress + 16));
+    }
+
+    [Fact]
+    public void DcbCondExec_NullBufferReturnsNullPacket()
+    {
+        var ctx = new CpuContext(new FakeCpuMemory(BaseAddress, 0x100), Generation.Gen5);
+        ctx[CpuRegister.Rdi] = 0;
+
+        AgcExports.DcbCondExec(ctx);
+
+        Assert.Equal(0UL, ctx[CpuRegister.Rax]);
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> value = stackalloc byte[sizeof(uint)];
+        Assert.True(memory.TryRead(address, value));
+        return BinaryPrimitives.ReadUInt32LittleEndian(value);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcHullShaderCreateTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcHullShaderCreateTests.cs
@@ -1,0 +1,73 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcHullShaderCreateTests
+{
+    private const ulong BaseAddress = 0x1_0000_0000;
+    private const ulong HeaderAddress = BaseAddress + 0x100;
+    private const ulong ShRegistersAddress = BaseAddress + 0x200;
+    private const ulong CodeAddress = BaseAddress + 0x4300;
+
+    // Hull/tessellation stage: header type 5 with the 0x10A/0x10B program
+    // register slot observed in Ghost of Yōtei; rejecting it aborts the
+    // title's tessellation pipeline construction mid-way.
+    [Fact]
+    public void CreateShader_AcceptsHullShaderTypeAndPatchesProgramAddress()
+    {
+        var memory = new FakeCpuMemory(BaseAddress, 0x8000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+
+        WriteUInt32(memory, HeaderAddress + 0x00, 0x34333231); // file header
+        WriteUInt32(memory, HeaderAddress + 0x04, 0x18);       // version
+        // Self-relative pointer to the SH register table; other tables absent.
+        WriteUInt64(memory, HeaderAddress + 0x20, ShRegistersAddress - (HeaderAddress + 0x20));
+        memory.TryWrite(HeaderAddress + 0x5A, new byte[] { 5 });
+        memory.TryWrite(HeaderAddress + 0x5C, new byte[] { 2 });
+
+        WriteUInt32(memory, ShRegistersAddress + 0x0, 0x10A);
+        WriteUInt32(memory, ShRegistersAddress + 0x8, 0x10B);
+
+        ctx[CpuRegister.Rdi] = 0;
+        ctx[CpuRegister.Rsi] = HeaderAddress;
+        ctx[CpuRegister.Rdx] = CodeAddress;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.CreateShader(ctx));
+
+        Assert.Equal(
+            (uint)((CodeAddress >> 8) & 0xFFFF_FFFF),
+            ReadUInt32(memory, ShRegistersAddress + 0x4));
+        Assert.Equal(
+            (uint)((CodeAddress >> 40) & 0xFF),
+            ReadUInt32(memory, ShRegistersAddress + 0xC));
+    }
+
+    private static void WriteUInt32(FakeCpuMemory memory, ulong address, uint value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> value = stackalloc byte[sizeof(uint)];
+        Assert.True(memory.TryRead(address, value));
+        return BinaryPrimitives.ReadUInt32LittleEndian(value);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcPrimStateHullVariantTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcPrimStateHullVariantTests.cs
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcPrimStateHullVariantTests
+{
+    private const ulong BaseAddress = 0x1_0000_0000;
+    private const ulong CxRegistersAddress = BaseAddress + 0x100;
+    private const ulong UcRegistersAddress = BaseAddress + 0x200;
+    private const ulong HullStateAddress = BaseAddress + 0x300;
+    private const ulong GeometryShaderAddress = BaseAddress + 0x400;
+    private const ulong SpecialsAddress = BaseAddress + 0x500;
+
+    // Tessellation pipelines pass a non-null hull-state block; the
+    // geometry-derived register writes must still happen instead of an
+    // INVALID_ARGUMENT that leaves the caller's register storage as garbage.
+    [Fact]
+    public void CreatePrimState_AcceptsHullStateBlock()
+    {
+        var memory = new FakeCpuMemory(BaseAddress, 0x1000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+
+        memory.TryWrite(GeometryShaderAddress + 0x5A, new byte[] { 2 });
+        WriteUInt64(memory, GeometryShaderAddress + 0x28, SpecialsAddress);
+
+        // Specials: {register, value} pairs at GeCntl 0x00, StagesEn 0x08,
+        // GsOutPrimType 0x20, GeUserVgprEn 0x28.
+        WriteUInt64(memory, SpecialsAddress + 0x00, 0x0000_0111_0000_0222UL);
+        WriteUInt64(memory, SpecialsAddress + 0x08, 0x0000_0333_0000_0444UL);
+        WriteUInt64(memory, SpecialsAddress + 0x20, 0x0000_0555_0000_0666UL);
+        WriteUInt64(memory, SpecialsAddress + 0x28, 0x0000_0777_0000_0888UL);
+
+        ctx[CpuRegister.Rdi] = CxRegistersAddress;
+        ctx[CpuRegister.Rsi] = UcRegistersAddress;
+        ctx[CpuRegister.Rdx] = HullStateAddress;
+        ctx[CpuRegister.Rcx] = GeometryShaderAddress;
+        ctx[CpuRegister.R8] = 0x11;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.CreatePrimState(ctx));
+
+        Assert.NotEqual(0u, ReadUInt32(memory, CxRegistersAddress));
+        Assert.Equal(0x11u, ReadUInt32(memory, UcRegistersAddress + 20));
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> value = stackalloc byte[sizeof(uint)];
+        Assert.True(memory.TryRead(address, value));
+        return BinaryPrimitives.ReadUInt32LittleEndian(value);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcUnknownLinkageStubTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcUnknownLinkageStubTests.cs
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcUnknownLinkageStubTests
+{
+    private const ulong BaseAddress = 0x1_0000_0000;
+    private const ulong OutputAddress = BaseAddress + 0x100;
+
+    // 32 {offset,value} register pairs: the title always submits this blob
+    // with count 0x20, so a shorter fill leaves garbage pairs.
+    private const int BlobSize = 0x100;
+
+    [Fact]
+    public void UnknownDbOlWdppb4o_ZeroFillsExactlyTheLinkageBlob()
+    {
+        var memory = new FakeCpuMemory(BaseAddress, 0x1000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+
+        var sentinel = new byte[BlobSize + 1];
+        Array.Fill(sentinel, (byte)0xCC);
+        Assert.True(memory.TryWrite(OutputAddress, sentinel));
+
+        ctx[CpuRegister.Rdi] = OutputAddress;
+        ctx[CpuRegister.Rsi] = BaseAddress + 0x800;
+        ctx[CpuRegister.Rdx] = 0;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.UnknownDbOlWdppb4o(ctx));
+
+        var blob = new byte[BlobSize + 1];
+        Assert.True(memory.TryRead(OutputAddress, blob));
+        Assert.All(blob[..BlobSize], value => Assert.Equal(0, value));
+        Assert.Equal(0xCC, blob[BlobSize]);
+    }
+
+    [Fact]
+    public void UnknownDbOlWdppb4o_RejectsNullOutput()
+    {
+        var ctx = new CpuContext(new FakeCpuMemory(BaseAddress, 0x100), Generation.Gen5);
+        ctx[CpuRegister.Rdi] = 0;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            AgcExports.UnknownDbOlWdppb4o(ctx));
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Adds four related AGC pipeline-building contracts required by Gen5 hull/tessellation setup.

### Hull shader program registers

- Accepts shader header type `5`
- Maps the program address through SH register slots `0x10A` / `0x10B`
- Preserves the existing address patching rules used by the other shader stages

### Primitive state

- Accepts a non-null hull-state argument
- Keeps the existing geometry-derived CX/UC register output
- Records the hull pointer for diagnostics instead of rejecting the pipeline form

### Interpolant/linkage output

- Implements the observed `dbOlWdppb4o` export
- Writes the complete `0x100`-byte output
- Produces 32 deterministic zero `{offset, value}` pairs
- Rejects a null output and reports guest-memory failure

A short output left the caller’s remaining register-pair table as stack garbage. The register-shadow writer then consumed invalid offsets.

### PM4 conditional execution

- Implements `sceAgcDcbCondExec`
- Emits a five-dword PM4 `IT_COND_EXEC` packet (`0x22`)
- Writes the 64-bit predicate address
- Applies dword alignment to the low address
- Masks the execution count to the packet field width
- Returns a null packet when the DCB cannot be used

### Tests

- Hull shader type `5` patches slots `0x10A` / `0x10B`
- Hull-form primitive state is accepted
- The unknown linkage export writes all `0x100` bytes and not beyond
- `DcbCondExec` emits the expected five packet dwords
- Null/error paths return the expected result

## AI-assisted

The reverse engineering, implementation, and tests were AI-assisted. I checked the observed shader header, register slots, output size, PM4 packet layout, address alignment, and command-buffer allocation against the source and captured guest behavior, and I can maintain the change.

## Testing

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release`: green
- `dotnet build src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r linux-x64 -v:minimal`: green
- Ghost of Yōtei (`PPSA26344`, `01.008.000`): the type-5 hull pipeline is accepted and the register-shadow crash caused by the short linkage output is removed
- Bounded integration run remained stable for five minutes

This does not complete AGC/PM4 synchronization. Compute submissions can still remain suspended while waiting for label-producing packets that are not yet modeled.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
