### PR TITLE
libs: add concrete outputs for observed Gen5 startup exports

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
@@ -1523,6 +1523,37 @@ public static class KernelRuntimeCompatExports
     }
 
     [SysAbiExport(
+        Nid = "DLORcroUqbc",
+        ExportName = "sceKernelGetOpenPsId",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelGetOpenPsId(CpuContext ctx)
+    {
+        var idAddress = ctx[CpuRegister.Rdi];
+        if (idAddress == 0)
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        Span<byte> id = stackalloc byte[16];
+        "SharpEmuOpenPsId"u8.CopyTo(id);
+        return ctx.Memory.TryWrite(idAddress, id)
+            ? ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK)
+            : ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+    }
+
+    [SysAbiExport(
+        Nid = "tU5e3f9gSiU",
+        ExportName = "sceKernelIsTrinityMode",
+        Target = Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelIsTrinityMode(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
         Nid = "Xjoosiw+XPI",
         ExportName = "sceKernelUuidCreate",
         Target = Generation.Gen4 | Generation.Gen5,

--- a/src/SharpEmu.Libs/Np/NpEntitlementAccessExports.cs
+++ b/src/SharpEmu.Libs/Np/NpEntitlementAccessExports.cs
@@ -7,6 +7,8 @@ namespace SharpEmu.Libs.Np;
 
 public static class NpEntitlementAccessExports
 {
+    private const int NpEntitlementAccessErrorParameter = unchecked((int)0x817D0002);
+    private const uint NpEntitlementAccessSkuFlagFull = 3;
     private const int BootParamClearSize = 0x20;
     private const int EmptyAddcontInfoListSize = 0x10;
 
@@ -86,6 +88,24 @@ public static class NpEntitlementAccessExports
             $"get_addcont_info service=0x{ctx[CpuRegister.Rdi]:X16} label=0x{ctx[CpuRegister.Rsi]:X16} " +
             $"info=0x{infoAddress:X16} -> empty");
         return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "lPDO62PpJIA",
+        ExportName = "sceNpEntitlementAccessGetSkuFlag",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceNpEntitlementAccess")]
+    public static int NpEntitlementAccessGetSkuFlag(CpuContext ctx)
+    {
+        var flagAddress = ctx[CpuRegister.Rdi];
+        if (flagAddress == 0)
+        {
+            return ctx.SetReturn(NpEntitlementAccessErrorParameter);
+        }
+
+        return ctx.TryWriteUInt32(flagAddress, NpEntitlementAccessSkuFlagFull)
+            ? ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK)
+            : ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
     }
 
     private static void TraceNpEntitlementAccess(string message)

--- a/src/SharpEmu.Libs/Np/NpTrophy2Exports.cs
+++ b/src/SharpEmu.Libs/Np/NpTrophy2Exports.cs
@@ -8,6 +8,8 @@ namespace SharpEmu.Libs.Np;
 
 public static class NpTrophy2Exports
 {
+    private const int TrophyDataSize = 0x20;
+    private const int MaxTrophyCount = 128;
     private static int _nextContext = 1;
     private static int _nextHandle = 1;
 
@@ -79,6 +81,81 @@ public static class NpTrophy2Exports
         Target = Generation.Gen5,
         LibraryName = "libSceNpTrophy2")]
     public static int NpTrophy2ShowTrophyList(CpuContext ctx) => ReturnOk(ctx);
+
+    /// <summary>
+    /// Supplies the data-only form used by the Gen5 startup probe. The full
+    /// details structure is intentionally left unsupported; callers receive a
+    /// deterministic empty/locked-compatible record set instead of an
+    /// unresolved import that leaves the output count uninitialized.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "y3zHpdZO6ME",
+        ExportName = "sceNpTrophy2GetTrophyInfoArray",
+        Target = Generation.Gen5,
+        LibraryName = "libSceNpTrophy2")]
+    public static int NpTrophy2GetTrophyInfoArray(CpuContext ctx)
+    {
+        var stackAddress = ctx[CpuRegister.Rsp];
+        if (stackAddress > ulong.MaxValue - sizeof(ulong) ||
+            !ctx.TryReadUInt64(stackAddress + sizeof(ulong), out var outCountAddress))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        if (outCountAddress == 0)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        // The caller reads this value even when the optional details form is
+        // unavailable, so always establish a safe count before validation.
+        if (!ctx.TryWriteUInt32(outCountAddress, 0))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        var capacity = ctx[CpuRegister.Rcx];
+        if (capacity > MaxTrophyCount)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        // R8 points at the richer details structure, whose exact layout is not
+        // yet modelled. Keep this path explicit rather than writing guessed data.
+        if (ctx[CpuRegister.R8] != 0)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_IMPLEMENTED);
+        }
+
+        if (capacity == 0)
+        {
+            return ReturnOk(ctx);
+        }
+
+        var dataAddress = ctx[CpuRegister.R9];
+        if (dataAddress == 0)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        var count = checked((int)capacity);
+        Span<byte> data = stackalloc byte[count * TrophyDataSize];
+        data.Clear();
+        for (var trophyId = 0; trophyId < count; trophyId++)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                data.Slice(trophyId * TrophyDataSize, sizeof(uint)),
+                (uint)trophyId);
+        }
+
+        if (!ctx.Memory.TryWrite(dataAddress, data) ||
+            !ctx.TryWriteUInt32(outCountAddress, (uint)count))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        return ReturnOk(ctx);
+    }
 
     /// <summary>
     /// Gen5 ABI: context, handle, trophy id, then SceNpTrophy2Details and

--- a/tests/SharpEmu.Libs.Tests/Np/NpTrophy2ExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Np/NpTrophy2ExportsTests.cs
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Np;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Np;
+
+public sealed class NpTrophy2ExportsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong StackAddress = MemoryBase + 0x100;
+    private const ulong OutCountAddress = MemoryBase + 0x200;
+    private const ulong DataAddress = MemoryBase + 0x300;
+
+    [Fact]
+    public void GetTrophyInfoArray_ReadsOutCountPointerFromStackAndInitializesIt()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5)
+        {
+            [CpuRegister.Rsp] = StackAddress,
+            [CpuRegister.Rcx] = 0,
+            [CpuRegister.R8] = 0,
+            [CpuRegister.R9] = 0,
+        };
+
+        WriteUInt64(memory, StackAddress + sizeof(ulong), OutCountAddress);
+        WriteUInt32(memory, OutCountAddress, 0xDEADBEEF);
+
+        Assert.Equal(0, NpTrophy2Exports.NpTrophy2GetTrophyInfoArray(context));
+        Assert.Equal(0u, ReadUInt32(memory, OutCountAddress));
+    }
+
+    [Fact]
+    public void GetTrophyInfoArray_WritesDeterministicDataRecordsAndCount()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5)
+        {
+            [CpuRegister.Rsp] = StackAddress,
+            [CpuRegister.Rcx] = 2,
+            [CpuRegister.R8] = 0,
+            [CpuRegister.R9] = DataAddress,
+        };
+
+        WriteUInt64(memory, StackAddress + sizeof(ulong), OutCountAddress);
+        WriteUInt32(memory, OutCountAddress, 0xDEADBEEF);
+
+        Assert.Equal(0, NpTrophy2Exports.NpTrophy2GetTrophyInfoArray(context));
+        Assert.Equal(2u, ReadUInt32(memory, OutCountAddress));
+        Assert.Equal(0u, ReadUInt32(memory, DataAddress));
+        Assert.Equal(1u, ReadUInt32(memory, DataAddress + 0x20));
+        Assert.Equal(0u, ReadUInt32(memory, DataAddress + 0x04));
+        Assert.Equal(0u, ReadUInt32(memory, DataAddress + 0x24));
+    }
+
+    [Fact]
+    public void GetTrophyInfoArray_RejectsCapacityAboveSupportedRange()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5)
+        {
+            [CpuRegister.Rsp] = StackAddress,
+            [CpuRegister.Rcx] = 129,
+        };
+
+        WriteUInt64(memory, StackAddress + sizeof(ulong), OutCountAddress);
+        WriteUInt32(memory, OutCountAddress, 0xDEADBEEF);
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            NpTrophy2Exports.NpTrophy2GetTrophyInfoArray(context));
+        Assert.Equal(0u, ReadUInt32(memory, OutCountAddress));
+    }
+
+    [Fact]
+    public void TrophyInfoArrayExport_RegistersForGen5()
+    {
+        var manager = new ModuleManager();
+        manager.RegisterExports(SharpEmu.Generated.SysAbiExportRegistry.CreateExports(Generation.Gen5));
+
+        Assert.True(manager.TryGetExport("y3zHpdZO6ME", out var export));
+        Assert.Equal("sceNpTrophy2GetTrophyInfoArray", export.Name);
+        Assert.Equal("libSceNpTrophy2", export.LibraryName);
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> value = stackalloc byte[sizeof(uint)];
+        Assert.True(memory.TryRead(address, value));
+        return BinaryPrimitives.ReadUInt32LittleEndian(value);
+    }
+
+    private static void WriteUInt32(FakeCpuMemory memory, ulong address, uint value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+        Assert.True(memory.TryWrite(address, bytes));
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Adds concrete output behavior for four observed Gen5 startup contracts in Kernel, NP Entitlement Access, and NP Trophy2.

### Kernel

- `sceKernelGetOpenPsId` validates the output pointer
- Writes a deterministic 16-byte emulator identifier
- Returns a guest-memory fault when the output cannot be written
- `sceKernelIsTrinityMode` reports false for the current emulated hardware profile

### NP Entitlement Access

- Adds `sceNpEntitlementAccessGetSkuFlag`
- Validates the output pointer
- Writes the full-product SKU flag
- Returns the library parameter error for a null output

### NP Trophy2

- Adds the data-only `sceNpTrophy2GetTrophyInfoArray` form used by the startup probe
- Reads the output-count pointer from the stack ABI position
- Initializes the output count before later validation
- Supports bounded capacities up to 128 records
- Writes deterministic `0x20`-byte records with sequential trophy IDs
- Rejects a missing data buffer when capacity is nonzero
- Returns `NOT_IMPLEMENTED` for the richer details structure instead of fabricating its layout
- Registers the Gen5 NID in the generated export registry

These are observable outputs and validation paths, not success-only imports.

### Tests

- Reads and initializes the stack-passed output-count pointer
- Writes deterministic Trophy2 data records and the final count
- Rejects a capacity above the supported bound while leaving count initialized
- Verifies the Gen5 Trophy2 export registration

## AI-assisted

The investigation, implementation, and tests were AI-assisted. I checked the output sizes, stack argument, validation order, deterministic data, unsupported details path, and export registration against the source and observed startup calls, and I can explain and maintain the changes.

## Testing

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release`: green
- `dotnet build src/SharpEmu.CLI/SharpEmu.CLI.csproj -c Release -r linux-x64 -v:minimal`: green
- Ghost of Yōtei (`PPSA26344`, `01.008.000`): used to identify the startup calls and required output fields

The richer Trophy2 details layout is intentionally not guessed. It remains explicitly unsupported.

### Scope note

This branch touches three unrelated libraries. The preferred submission is to split it into:

1. Kernel OpenPsId/Trinity mode
2. NP Entitlement Access SKU flag
3. NP Trophy2 info array and tests

Submit the combined branch only when the maintainers explicitly accept that grouping.

## Checklist

By submitting this pull request, you confirm that:

- [ ] I have read and followed `CONTRIBUTING.md`.
- [ ] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [ ] I listed the game(s) I tested (or marked the testing section as `N/A`).
