### PR TITLE
kernel: return -1/errno from extended POSIX file exports on failure

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
@@ -46,7 +46,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ezv-RSBNKqI", ExportName = "pread",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixPread(CpuContext ctx) => KernelPreadCore(ctx);
+    public static int PosixPread(CpuContext ctx)
+    {
+        var result = KernelPreadCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "+r3rMFwItV4", ExportName = "sceKernelPread",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -97,7 +103,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "C2kJ-byS5rM", ExportName = "pwrite",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixPwrite(CpuContext ctx) => KernelPwriteCore(ctx);
+    public static int PosixPwrite(CpuContext ctx)
+    {
+        var result = KernelPwriteCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "nKWi-N2HBV4", ExportName = "sceKernelPwrite",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -149,7 +161,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "juWbTNM+8hw", ExportName = "fsync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFsync(CpuContext ctx) => KernelFsyncCore(ctx);
+    public static int PosixFsync(CpuContext ctx)
+    {
+        var result = KernelFsyncCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "fTx66l5iWIA", ExportName = "sceKernelFsync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -210,7 +228,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ih4CD9-gghM", ExportName = "ftruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFtruncate(CpuContext ctx) => KernelFtruncateCore(ctx);
+    public static int PosixFtruncate(CpuContext ctx)
+    {
+        var result = KernelFtruncateCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "VW3TVZiM4-E", ExportName = "sceKernelFtruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -246,7 +270,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ayrtszI7GBg", ExportName = "truncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixTruncate(CpuContext ctx) => KernelTruncateCore(ctx);
+    public static int PosixTruncate(CpuContext ctx)
+    {
+        var result = KernelTruncateCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result);
+    }
 
     [SysAbiExport(Nid = "WlyEA-sLDf0", ExportName = "sceKernelTruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -294,7 +324,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "NN01qLRhiqU", ExportName = "rename",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixRename(CpuContext ctx) => KernelRenameCore(ctx);
+    public static int PosixRename(CpuContext ctx)
+    {
+        var result = KernelRenameCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result);
+    }
 
     [SysAbiExport(Nid = "52NcYU9+lEo", ExportName = "sceKernelRename",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -363,7 +399,10 @@ public static partial class KernelMemoryCompatExports
         {
             if (!_openFiles.TryGetValue(fd, out var stream))
             {
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                return PosixFailure(
+                    ctx,
+                    (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND,
+                    notFoundErrno: Ebadf);
             }
 
             // POSIX dup shares the open file description (and offset), which is
@@ -386,7 +425,10 @@ public static partial class KernelMemoryCompatExports
         {
             if (!_openFiles.TryGetValue(oldFd, out var stream))
             {
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                return PosixFailure(
+                    ctx,
+                    (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND,
+                    notFoundErrno: Ebadf);
             }
 
             if (oldFd == newFd)
@@ -412,7 +454,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "8nY19bKoiZk", ExportName = "fcntl",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFcntl(CpuContext ctx) => KernelFcntlCore(ctx);
+    public static int PosixFcntl(CpuContext ctx)
+    {
+        var result = KernelFcntlCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "SoZkxZkCHaw", ExportName = "sceKernelFcntl",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -1640,13 +1640,12 @@ public static partial class KernelMemoryCompatExports
 
     // Translates a failed raw Orbis kernel result into the libc/POSIX ABI:
     // return -1 with errno set. The raw sceKernel* implementations report the
-    // 0x8002xxxx sentinel through the return value, but the POSIX-named exports
-    // (open/fstat/close/read/write/stat) are called by libc code that expects a
-    // negative result on failure. Leaking the raw sentinel makes callers store
-    // it as a "valid" fd or handle and later dereference it - the null-pointer
-    // access violation seen when Unity's IL2CPP file layer probes an absent
-    // il2cpp.usym. fd-based calls pass notFoundErrno=Ebadf; path-based calls
-    // leave the Enoent default.
+    // 0x8002xxxx sentinel through the return value, but POSIX-named exports are
+    // called by libc code that expects a negative result on failure. Leaking the
+    // raw sentinel makes callers store it as a "valid" fd or handle and later
+    // dereference it - the null-pointer access violation seen when Unity's
+    // IL2CPP file layer probes an absent il2cpp.usym. fd-based calls pass
+    // notFoundErrno=Ebadf; path-based calls leave the Enoent default.
     private static int PosixFailure(CpuContext ctx, int orbisResult, int notFoundErrno = Enoent)
     {
         var errno = orbisResult switch

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelFileExtendedExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelFileExtendedExportsTests.cs
@@ -1,0 +1,115 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+[Collection(KernelMemoryCompatStateCollection.Name)]
+public sealed class KernelFileExtendedExportsTests
+{
+    private const ulong GuestMemoryBase = 0x1_0000_0000;
+    private const ulong PathAddress = GuestMemoryBase + 0x100;
+    private const ulong BufferAddress = GuestMemoryBase + 0x200;
+    private const ulong DestinationPathAddress = GuestMemoryBase + 0x300;
+    private const ulong GuestFsBase = GuestMemoryBase + 0x800;
+    private const ulong TlsErrnoOffset = 0x40;
+    private const int Enoent = 2;
+    private const int Ebadf = 9;
+
+    [Theory]
+    [InlineData(nameof(KernelMemoryCompatExports.PosixPread))]
+    [InlineData(nameof(KernelMemoryCompatExports.PosixPwrite))]
+    [InlineData(nameof(KernelMemoryCompatExports.PosixFsync))]
+    [InlineData(nameof(KernelMemoryCompatExports.PosixFtruncate))]
+    [InlineData(nameof(KernelMemoryCompatExports.PosixDup))]
+    [InlineData(nameof(KernelMemoryCompatExports.PosixDup2))]
+    [InlineData(nameof(KernelMemoryCompatExports.PosixFcntl))]
+    public void PosixFdExport_BadDescriptorReturnsMinusOneWithEbadf(string exportName)
+    {
+        var memory = new FakeCpuMemory(GuestMemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5)
+        {
+            FsBase = GuestFsBase,
+        };
+        context[CpuRegister.Rdi] = 0x80020002; // never-opened / sentinel fd
+
+        int result;
+        switch (exportName)
+        {
+            case nameof(KernelMemoryCompatExports.PosixPread):
+                context[CpuRegister.Rsi] = BufferAddress;
+                context[CpuRegister.Rdx] = 1;
+                result = KernelMemoryCompatExports.PosixPread(context);
+                break;
+            case nameof(KernelMemoryCompatExports.PosixPwrite):
+                context[CpuRegister.Rsi] = BufferAddress;
+                context[CpuRegister.Rdx] = 1;
+                result = KernelMemoryCompatExports.PosixPwrite(context);
+                break;
+            case nameof(KernelMemoryCompatExports.PosixFsync):
+                result = KernelMemoryCompatExports.PosixFsync(context);
+                break;
+            case nameof(KernelMemoryCompatExports.PosixFtruncate):
+                result = KernelMemoryCompatExports.PosixFtruncate(context);
+                break;
+            case nameof(KernelMemoryCompatExports.PosixDup):
+                result = KernelMemoryCompatExports.PosixDup(context);
+                break;
+            case nameof(KernelMemoryCompatExports.PosixDup2):
+                context[CpuRegister.Rsi] = 100;
+                result = KernelMemoryCompatExports.PosixDup2(context);
+                break;
+            case nameof(KernelMemoryCompatExports.PosixFcntl):
+                context[CpuRegister.Rsi] = 0; // F_DUPFD
+                result = KernelMemoryCompatExports.PosixFcntl(context);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(exportName));
+        }
+
+        AssertPosixFailure(context, result, Ebadf);
+    }
+
+    [Theory]
+    [InlineData(nameof(KernelMemoryCompatExports.PosixTruncate))]
+    [InlineData(nameof(KernelMemoryCompatExports.PosixRename))]
+    public void PosixPathExport_MissingPathReturnsMinusOneWithEnoent(string exportName)
+    {
+        var memory = new FakeCpuMemory(GuestMemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5)
+        {
+            FsBase = GuestFsBase,
+        };
+        memory.WriteCString(PathAddress, "/__sharpemu_test_missing__/source");
+        context[CpuRegister.Rdi] = PathAddress;
+
+        int result;
+        switch (exportName)
+        {
+            case nameof(KernelMemoryCompatExports.PosixTruncate):
+                context[CpuRegister.Rsi] = 0;
+                result = KernelMemoryCompatExports.PosixTruncate(context);
+                break;
+            case nameof(KernelMemoryCompatExports.PosixRename):
+                memory.WriteCString(DestinationPathAddress, "/__sharpemu_test_missing__/destination");
+                context[CpuRegister.Rsi] = DestinationPathAddress;
+                result = KernelMemoryCompatExports.PosixRename(context);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(exportName));
+        }
+
+        AssertPosixFailure(context, result, Enoent);
+    }
+
+    private static void AssertPosixFailure(CpuContext context, int result, int expectedErrno)
+    {
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+        Assert.True(context.TryReadInt32(GuestFsBase + TlsErrnoOffset, out var errno));
+        Assert.Equal(expectedErrno, errno);
+    }
+}


### PR DESCRIPTION
Fixes #491

## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

I extended the POSIX error handling from #461 to the 9 file operations listed in #491.

They now return `-1` with the correct `errno` (`EBADF` or `ENOENT`) when they fail.

I did not change the behavior of the `sceKernel*` exports.

I also added tests for all 9 exports.

## Testing

No real-game testing was performed.

- `dotnet test tests/SharpEmu.Libs.Tests --filter KernelFileExtendedExportsTests` — 9/9 passed.
- `dotnet test tests/SharpEmu.Libs.Tests` — 551/551 passed.
- `dotnet build SharpEmu.slnx -c Release` — succeeded.

Existing unrelated warnings are outside the changed files and were not caused by this change.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
