### PR TITLE
Protect pending block/entry-exit/context-transfer state during nested exception delivery

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -4909,20 +4909,36 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 					$"rip=0x{interruptedContinuation.Rip:X16}");
 			}
 
-			if (!TryCallGuestFunction(
-					currentContext,
-					pending.Handler,
-					unchecked((ulong)pending.ExceptionType),
-					exceptionContextAddress,
-					pending.ExceptionStackBase + callbackStackOffset,
-					callbackStackSize,
-					$"kernel exception 0x{pending.ExceptionType:X2} safe point",
-					out var callbackError))
+			// The outer import that led here may already have a pending block
+			// request stashed (e.g. it just registered a cooperative semaphore
+			// wait and hasn't been consumed yet by TryDispatchLeafImport). The
+			// handler below runs its own imports on this same native thread,
+			// sharing that same ThreadStatic slot -- without suspending the
+			// outer request first, an unrelated inner import can consume or
+			// clobber it, silently misattributing the outer wait's block to
+			// the wrong import and leaking its waiter registration forever.
+			var outerPendingBlock = GuestThreadExecution.SuspendPendingBlock();
+			try
 			{
-				Console.Error.WriteLine(
-					$"[LOADER][ERROR] Guest exception safe-point delivery failed: " +
-					$"target=0x{threadHandle:X16} type=0x{pending.ExceptionType:X2} " +
-					$"error={callbackError ?? "unknown"}");
+				if (!TryCallGuestFunction(
+						currentContext,
+						pending.Handler,
+						unchecked((ulong)pending.ExceptionType),
+						exceptionContextAddress,
+						pending.ExceptionStackBase + callbackStackOffset,
+						callbackStackSize,
+						$"kernel exception 0x{pending.ExceptionType:X2} safe point",
+						out var callbackError))
+				{
+					Console.Error.WriteLine(
+						$"[LOADER][ERROR] Guest exception safe-point delivery failed: " +
+						$"target=0x{threadHandle:X16} type=0x{pending.ExceptionType:X2} " +
+						$"error={callbackError ?? "unknown"}");
+				}
+			}
+			finally
+			{
+				GuestThreadExecution.RestorePendingBlock(outerPendingBlock);
 			}
 		}
 		finally

--- a/src/SharpEmu.HLE/GuestThreadExecution.cs
+++ b/src/SharpEmu.HLE/GuestThreadExecution.cs
@@ -304,6 +304,100 @@ public static class GuestThreadExecution
         _currentFiberAddress = previousFiberAddress;
     }
 
+    // A nested guest exception handler (delivered synchronously from
+    // inside an outer import's own dispatch, before that import's own pending
+    // dispatch outcome -- a block request, an entry/exit, or a context
+    // transfer -- has been consumed) runs its own imports on the same
+    // native thread and therefore the same ThreadStatic slots. Without
+    // suspending the outer request first, an unrelated inner import (e.g. a
+    // trivial pthread_self call the handler happens to make) can consume --
+    // and misattribute -- the outer call's still-pending outcome, or simply
+    // clobber it. Save/clear all three groups before the nested call,
+    // restore after.
+    public readonly struct PendingBlockSnapshot
+    {
+        internal readonly string? Reason;
+        internal readonly bool ContinuationValid;
+        internal readonly GuestCpuContinuation Continuation;
+        internal readonly string? WakeKey;
+        internal readonly IGuestThreadBlockWaiter? Waiter;
+        internal readonly long DeadlineTimestamp;
+        internal readonly bool EntryExitPending;
+        internal readonly ulong EntryExitValue;
+        internal readonly string? EntryExitReason;
+        internal readonly bool ContextTransferPending;
+        internal readonly GuestCpuContinuation ContextTransferTarget;
+
+        internal PendingBlockSnapshot(
+            string? reason,
+            bool continuationValid,
+            GuestCpuContinuation continuation,
+            string? wakeKey,
+            IGuestThreadBlockWaiter? waiter,
+            long deadlineTimestamp,
+            bool entryExitPending,
+            ulong entryExitValue,
+            string? entryExitReason,
+            bool contextTransferPending,
+            GuestCpuContinuation contextTransferTarget)
+        {
+            Reason = reason;
+            ContinuationValid = continuationValid;
+            Continuation = continuation;
+            WakeKey = wakeKey;
+            Waiter = waiter;
+            DeadlineTimestamp = deadlineTimestamp;
+            EntryExitPending = entryExitPending;
+            EntryExitValue = entryExitValue;
+            EntryExitReason = entryExitReason;
+            ContextTransferPending = contextTransferPending;
+            ContextTransferTarget = contextTransferTarget;
+        }
+    }
+
+    public static PendingBlockSnapshot SuspendPendingBlock()
+    {
+        var snapshot = new PendingBlockSnapshot(
+            _pendingBlockReason,
+            _pendingBlockContinuationValid,
+            _pendingBlockContinuation,
+            _pendingBlockWakeKey,
+            _pendingBlockWaiter,
+            _pendingBlockDeadlineTimestamp,
+            _pendingEntryExit,
+            _pendingEntryExitValue,
+            _pendingEntryExitReason,
+            _pendingContextTransfer,
+            _pendingContextTransferTarget);
+        _pendingBlockReason = null;
+        _pendingBlockContinuation = default;
+        _pendingBlockContinuationValid = false;
+        _pendingBlockWakeKey = null;
+        _pendingBlockWaiter = null;
+        _pendingBlockDeadlineTimestamp = 0;
+        _pendingEntryExit = false;
+        _pendingEntryExitValue = 0;
+        _pendingEntryExitReason = null;
+        _pendingContextTransfer = false;
+        _pendingContextTransferTarget = default;
+        return snapshot;
+    }
+
+    public static void RestorePendingBlock(PendingBlockSnapshot snapshot)
+    {
+        _pendingEntryExit = snapshot.EntryExitPending;
+        _pendingEntryExitValue = snapshot.EntryExitValue;
+        _pendingEntryExitReason = snapshot.EntryExitReason;
+        _pendingContextTransfer = snapshot.ContextTransferPending;
+        _pendingContextTransferTarget = snapshot.ContextTransferTarget;
+        _pendingBlockReason = snapshot.Reason;
+        _pendingBlockContinuationValid = snapshot.ContinuationValid;
+        _pendingBlockContinuation = snapshot.Continuation;
+        _pendingBlockWakeKey = snapshot.WakeKey;
+        _pendingBlockWaiter = snapshot.Waiter;
+        _pendingBlockDeadlineTimestamp = snapshot.DeadlineTimestamp;
+    }
+
     public static bool RequestCurrentThreadBlock(string reason) => RequestCurrentThreadBlock(null, reason);
 
     public static bool RequestCurrentThreadBlock(


### PR DESCRIPTION
## What changed

`DeliverPendingGuestExceptionAtSafePoint` calls the guest's exception handler via `TryCallGuestFunction` on the same native thread and ThreadStatic slots the interrupted import was using. If that outer import had already stashed a pending block/entry-exit/context-transfer outcome before the safe-point check ran, an unrelated import made by the handler itself (e.g. a routine `pthread_self` call) could consume or clobber it, silently misattributing the outer call's real outcome to the wrong import.

Adds `GuestThreadExecution.SuspendPendingBlock()`/`RestorePendingBlock()`, saving and clearing all three ThreadStatic groups before the nested handler call and restoring them afterward so the interrupted import's own pending outcome survives intact.

## Why

Found while investigating guest exception delivery paths. This is a narrow, self-contained correctness fix, not a behavior change for the common case (no pending outcome to protect).

## Testing

- `dotnet test SharpEmu.slnx` -- 602 passed, 0 failed.
- Rebased cleanly onto current upstream/main.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).