### PR TITLE
Add Darwin fixed-address mach_vm_allocate fallback to HostMemory

### DIFF
--- a/src/SharpEmu.HLE/HostMemory.cs
+++ b/src/SharpEmu.HLE/HostMemory.cs
@@ -232,6 +232,25 @@ public static unsafe class HostMemory
 
                     var exactFlags = OperatingSystem.IsMacOS() ? flags : flags | MAP_FIXED_NOREPLACE;
                     result = mmap((nint)address, (nuint)alignedSize, posixProtect, exactFlags, -1, 0);
+                    if (result != MAP_FAILED && (ulong)result != (ulong)address)
+                    {
+                        munmap(result, (nuint)alignedSize);
+                        result = MAP_FAILED;
+                    }
+
+                    if (result == MAP_FAILED && OperatingSystem.IsMacOS())
+                    {
+                        // The hint-only mmap above didn't land at the requested
+                        // address (Darwin has no MAP_FIXED_NOREPLACE, so a plain
+                        // hint is all we can safely try first). mach_vm_allocate
+                        // with fixed placement either maps the exact range or
+                        // fails outright, without silently clobbering untracked
+                        // host memory (CLR, dyld, JIT, Rosetta) the way raw
+                        // MAP_FIXED could.
+                        Trace($"exact mmap hint failed, retrying with fixed Mach allocation: addr=0x{(ulong)address:X16}");
+                        result = AllocateDarwinFixed((nint)address, alignedSize, posixProtect);
+                    }
+
                     if (result == MAP_FAILED || (ulong)result != (ulong)address)
                     {
                         Trace($"exact mmap failed: addr=0x{(ulong)address:X16} got=0x{(ulong)result:X16} size=0x{alignedSize:X} errno={Marshal.GetLastPInvokeError()}");
@@ -474,6 +493,36 @@ public static unsafe class HostMemory
             };
         }
 
+        private static nint AllocateDarwinFixed(nint requestedAddress, ulong size, int posixProtect)
+        {
+            var address = (ulong)requestedAddress;
+            var result = mach_vm_allocate(mach_task_self(), ref address, size, VM_FLAGS_FIXED);
+            if (result != KERN_SUCCESS || address != (ulong)requestedAddress)
+            {
+                if (result == KERN_SUCCESS)
+                {
+                    _ = mach_vm_deallocate(mach_task_self(), address, size);
+                }
+
+                Trace(
+                    $"fixed Mach allocation failed: addr=0x{(ulong)requestedAddress:X16} " +
+                    $"size=0x{size:X} kern_return={result}");
+                return MAP_FAILED;
+            }
+
+            if (mprotect((nint)address, (nuint)size, posixProtect) == 0)
+            {
+                return (nint)address;
+            }
+
+            var error = Marshal.GetLastPInvokeError();
+            _ = mach_vm_deallocate(mach_task_self(), address, size);
+            Trace(
+                $"fixed Mach allocation protection failed: addr=0x{address:X16} " +
+                $"size=0x{size:X} errno={error}");
+            return MAP_FAILED;
+        }
+
         private static void Trace(string message)
         {
             if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_VMEM"), "1", StringComparison.Ordinal))
@@ -494,5 +543,17 @@ public static unsafe class HostMemory
 
         [DllImport("libc", SetLastError = true)]
         private static extern int mprotect(nint addr, nuint length, int prot);
+
+        private const int KERN_SUCCESS = 0;
+        private const int VM_FLAGS_FIXED = 0;
+
+        [DllImport("libSystem.B.dylib")]
+        private static extern uint mach_task_self();
+
+        [DllImport("libSystem.B.dylib")]
+        private static extern int mach_vm_allocate(uint target, ref ulong address, ulong size, int flags);
+
+        [DllImport("libSystem.B.dylib")]
+        private static extern int mach_vm_deallocate(uint target, ulong address, ulong size);
     }
 }


### PR DESCRIPTION
## What changed

`HostMemory`'s Posix allocator (used by all `sceKernel*` memory calls) only tried an mmap hint for exact-address allocations. Darwin has no `MAP_FIXED_NOREPLACE`, so a hint that lands at the wrong address left the allocation failing with no fallback, unlike the sibling `Host/Posix/PosixHostMemory.cs` allocator, which already has this same `mach_vm_allocate` fallback from #246.

Ports the same fallback here: on macOS, when the hint-only mmap does not land at the requested address, retry with a fixed-placement `mach_vm_allocate`, which either maps the exact range or fails outright without silently clobbering untracked host memory (CLR, dyld, JIT, Rosetta) the way a raw `MAP_FIXED` could.

## Why

Found while investigating a title that needs a fixed-address allocation `HostMemory` currently can't satisfy on macOS. Brings this allocator in line with its sibling so the two don't silently diverge in behavior.

## Testing

- `dotnet test SharpEmu.slnx` -- 602 passed, 0 failed.
- macOS only change, gated by `OperatingSystem.IsMacOS()`; no behavior change on other platforms.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).