### PR TITLE
[Cpu] Widen TLS access pattern scan to the mapped segment base

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -3137,7 +3137,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
         // Astro Bot, for example, has an FS:[0] TLS load near +0x70A0000.
         const ulong MaxScanBytes = 134217728uL;
 		ulong num = _entryPoint;
-		ulong num2 = num + MaxScanBytes;
+		// The entry point can sit well after the start of the mapped exec segment
+		// (e.g. The Last of Us Part I has a raw FS:[0] load below its entry point,
+		// in early-init/PLT code). Widen the scan to the true mapping base so that
+		// code below the entry point still gets its TLS loads rewritten.
+		if (VirtualQuery((void*)_entryPoint, out var entryRegion, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) != 0
+			&& entryRegion.AllocationBase != 0
+			&& entryRegion.AllocationBase < num)
+		{
+			num = entryRegion.AllocationBase;
+		}
+		ulong num2 = _entryPoint + MaxScanBytes;
 		int num3 = 0;
 		int num4 = 0;
 		int num9 = 0;


### PR DESCRIPTION
## What changed

`FindTlsAccessPatterns`/`PatchTlsPatterns` scanned forward from the guest entry point only. The Last of Us Part I has a raw FS:[0] TLS load below its entry point, in early-init/PLT code, so that load was left unpatched and hit SharpEmu's own unbacked TLS instead of the guest TLS stub.

Widens the scan to start at the true allocation base of the entry point's mapped region (via `VirtualQuery`) instead of the entry point itself, so code below the entry point still gets its TLS loads rewritten. The upper bound is unchanged.

## Why

Found while investigating a title whose TLS access sits below its own entry point. Unrelated to #414 (which fixed an off-by-one at the *end* of a different scan, in `JitStubs.cs`) -- this widens the *start* of a different scan in `DirectExecutionBackend.cs`.

## Testing

- `dotnet test SharpEmu.slnx` -- 602 passed, 0 failed.
- Game testing: The Last of Us Part I now reaches its TLS load below the entry point without hitting unbacked TLS at that specific site (a separate, unrelated OS-level allocation constraint still blocks full boot).

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).