### PR TITLE
fix(cpu): prefer native workers for all guest entry stubs

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -5735,23 +5735,13 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			ActiveGuestThreadYieldReason = null;
 			try
 			{
-				// TBB execute-AV recover needs native-worker TLS (eligible/done).
-				// Other guests stay on CallNativeEntry — full native-worker migration
-				// increased splash hangs / UnmanagedCallersOnly (tLTN/tLTO).
-				int nativeReturn;
-				if (name == "tbb_thead")
-				{
-					nativeReturn = RunGuestEntryStub(ptr, hostRspSlot, requireNativeWorker: true);
-				}
-				else
-				{
-					if (!TlsSetValue(_hostRspSlotTlsIndex, (nint)hostRspSlot))
-					{
-						reason = "failed to bind host-RSP storage for guest thread stub";
-						return GuestNativeCallExitReason.Exception;
-					}
-					nativeReturn = CallNativeEntry(ptr);
-				}
+				// Prefer pooled native OS workers so guest stubs do not sit above
+				// CLR-managed frames (UnmanagedCallersOnly FailFast on GTA and
+				// similar titles). tbb_thead still requires a worker — never fall
+				// back to managed inline during the Astro spawn storm.
+				var nativeReturn = name == "tbb_thead"
+					? RunGuestEntryStub(ptr, hostRspSlot, requireNativeWorker: true)
+					: RunGuestEntryStub(ptr, hostRspSlot);
 				if (ActiveGuestThreadYieldRequested)
 				{
 					reason = ActiveGuestThreadYieldReason ?? "guest thread blocked";
@@ -5901,20 +5891,11 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			ActiveGuestThreadYieldReason = null;
 			try
 			{
-				int nativeReturn;
-				if (name == "tbb_thead")
-				{
-					nativeReturn = RunGuestEntryStub(ptr, hostRspSlot, requireNativeWorker: true);
-				}
-				else
-				{
-					if (!TlsSetValue(_hostRspSlotTlsIndex, (nint)hostRspSlot))
-					{
-						reason = "failed to bind host-RSP storage for guest continuation stub";
-						return GuestNativeCallExitReason.Exception;
-					}
-					nativeReturn = CallNativeEntry(ptr);
-				}
+				// Same routing as thread entry: prefer native workers for all
+				// continuations; require them for tbb_thead.
+				var nativeReturn = name == "tbb_thead"
+					? RunGuestEntryStub(ptr, hostRspSlot, requireNativeWorker: true)
+					: RunGuestEntryStub(ptr, hostRspSlot);
 				if (ActiveGuestThreadYieldRequested)
 				{
 					reason = ActiveGuestThreadYieldReason ?? "guest thread blocked";
@@ -6244,7 +6225,9 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			int num6 = -1;
 			try
 			{
-				num6 = CallNativeEntry(ptr);
+				// Main entry also prefers a native worker so the guest process
+				// does not begin above CLR-managed frames on this thread.
+				num6 = RunGuestEntryStub(ptr, num2);
 				Console.Error.WriteLine($"[LOADER][INFO] Guest returned: {num6}");
 				// A host stop has already invalidated the session. Draining guest
 				// continuations here can re-enter a blocked HLE call after its owner


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

GTA V Enhanced FailFasted with `attempted to call a UnmanagedCallersOnly method from managed code` while continuing guest execution from `ExecuteGuestContinuationEntry` on a CLR-managed thread.

This change:

- Routes guest thread entry, continuation, and main process entry through `RunGuestEntryStub` so stubs are not invoked above CLR-managed frames.
- Keeps `requireNativeWorker: true` for `tbb_thead` so Astro's spawn storm never falls back to managed inline.
- Other threads prefer a pooled native worker and fall back to inline `calli` only when workers are unavailable.

## Testing

- GTA V Enhanced (PPSA04264) - Multi-minute North Yankton session with no UnmanagedCallersOnly FailFast after routing all entry paths through `RunGuestEntryStub`. Cutscene audio plays; remaining display freeze is a separate fuse-shader issue.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).