### PR TITLE
kernel: return -1/errno from sibling POSIX file syscalls on failure

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
@@ -46,7 +46,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ezv-RSBNKqI", ExportName = "pread",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixPread(CpuContext ctx) => KernelPreadCore(ctx);
+    public static int PosixPread(CpuContext ctx)
+    {
+        var result = KernelPreadCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? result
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "+r3rMFwItV4", ExportName = "sceKernelPread",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -97,7 +103,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "C2kJ-byS5rM", ExportName = "pwrite",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixPwrite(CpuContext ctx) => KernelPwriteCore(ctx);
+    public static int PosixPwrite(CpuContext ctx)
+    {
+        var result = KernelPwriteCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? result
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "nKWi-N2HBV4", ExportName = "sceKernelPwrite",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -149,7 +161,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "juWbTNM+8hw", ExportName = "fsync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFsync(CpuContext ctx) => KernelFsyncCore(ctx);
+    public static int PosixFsync(CpuContext ctx)
+    {
+        var result = KernelFsyncCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? result
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "fTx66l5iWIA", ExportName = "sceKernelFsync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -157,7 +175,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "KIbJFQ0I1Cg", ExportName = "fdatasync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFdatasync(CpuContext ctx) => KernelFsyncCore(ctx);
+    public static int PosixFdatasync(CpuContext ctx)
+    {
+        var result = KernelFsyncCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? result
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "30Rh4ixbKy4", ExportName = "sceKernelFdatasync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -210,7 +234,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ih4CD9-gghM", ExportName = "ftruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFtruncate(CpuContext ctx) => KernelFtruncateCore(ctx);
+    public static int PosixFtruncate(CpuContext ctx)
+    {
+        var result = KernelFtruncateCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? result
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "VW3TVZiM4-E", ExportName = "sceKernelFtruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -246,7 +276,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ayrtszI7GBg", ExportName = "truncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixTruncate(CpuContext ctx) => KernelTruncateCore(ctx);
+    public static int PosixTruncate(CpuContext ctx)
+    {
+        var result = KernelTruncateCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? result
+            : PosixFailure(ctx, result);
+    }
 
     [SysAbiExport(Nid = "WlyEA-sLDf0", ExportName = "sceKernelTruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -294,7 +330,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "NN01qLRhiqU", ExportName = "rename",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixRename(CpuContext ctx) => KernelRenameCore(ctx);
+    public static int PosixRename(CpuContext ctx)
+    {
+        var result = KernelRenameCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? result
+            : PosixFailure(ctx, result);
+    }
 
     [SysAbiExport(Nid = "52NcYU9+lEo", ExportName = "sceKernelRename",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -363,7 +405,7 @@ public static partial class KernelMemoryCompatExports
         {
             if (!_openFiles.TryGetValue(fd, out var stream))
             {
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                return PosixFailure(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND, notFoundErrno: Ebadf);
             }
 
             // POSIX dup shares the open file description (and offset), which is
@@ -386,7 +428,7 @@ public static partial class KernelMemoryCompatExports
         {
             if (!_openFiles.TryGetValue(oldFd, out var stream))
             {
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                return PosixFailure(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND, notFoundErrno: Ebadf);
             }
 
             if (oldFd == newFd)
@@ -412,7 +454,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "8nY19bKoiZk", ExportName = "fcntl",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFcntl(CpuContext ctx) => KernelFcntlCore(ctx);
+    public static int PosixFcntl(CpuContext ctx)
+    {
+        var result = KernelFcntlCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? result
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "SoZkxZkCHaw", ExportName = "sceKernelFcntl",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelFileExtendedExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelFileExtendedExportsTests.cs
@@ -1,0 +1,182 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+// Regression coverage for the sentinel leak described in #491: the POSIX-named
+// exports in KernelFileExtendedExports.cs must translate a failed raw Orbis
+// result into -1/errno, mirroring the open/fstat/close/read/write fix in #461.
+// Shares KernelMemoryCompatExports' static fd table, so it runs in the same
+// non-parallel collection as KernelMemoryCompatExportsTests.
+[Collection(KernelMemoryCompatStateCollection.Name)]
+public sealed class KernelFileExtendedExportsTests
+{
+    // The 0x8002xxxx OrbisGen2Result "not found" sentinel, misused as a fd -
+    // the exact defect class these exports must no longer leak.
+    private const ulong SentinelFd = 0x80020002;
+
+    [Fact]
+    public void PosixPread_BadDescriptorReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong bufferAddress = memoryBase + 0x200;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = SentinelFd;
+        context[CpuRegister.Rsi] = bufferAddress;
+        context[CpuRegister.Rdx] = 0x40;
+        context[CpuRegister.Rcx] = 0;
+
+        var result = KernelMemoryCompatExports.PosixPread(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void PosixPwrite_BadDescriptorReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong bufferAddress = memoryBase + 0x200;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        memory.WriteCString(bufferAddress, "payload");
+        context[CpuRegister.Rdi] = SentinelFd;
+        context[CpuRegister.Rsi] = bufferAddress;
+        context[CpuRegister.Rdx] = 0x7;
+        context[CpuRegister.Rcx] = 0;
+
+        var result = KernelMemoryCompatExports.PosixPwrite(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void PosixFsync_BadDescriptorReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = SentinelFd;
+
+        var result = KernelMemoryCompatExports.PosixFsync(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void PosixFdatasync_BadDescriptorReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = SentinelFd;
+
+        var result = KernelMemoryCompatExports.PosixFdatasync(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void PosixFtruncate_BadDescriptorReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = SentinelFd;
+        context[CpuRegister.Rsi] = 0;
+
+        var result = KernelMemoryCompatExports.PosixFtruncate(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void PosixTruncate_MissingFileReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong pathAddress = memoryBase + 0x100;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        memory.WriteCString(pathAddress, "/__sharpemu_test_missing__/truncate_target");
+        context[CpuRegister.Rdi] = pathAddress;
+        context[CpuRegister.Rsi] = 0;
+
+        var result = KernelMemoryCompatExports.PosixTruncate(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void PosixRename_MissingFileReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        const ulong fromAddress = memoryBase + 0x100;
+        const ulong toAddress = memoryBase + 0x200;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        memory.WriteCString(fromAddress, "/__sharpemu_test_missing__/rename_from");
+        memory.WriteCString(toAddress, "/__sharpemu_test_missing__/rename_to");
+        context[CpuRegister.Rdi] = fromAddress;
+        context[CpuRegister.Rsi] = toAddress;
+
+        var result = KernelMemoryCompatExports.PosixRename(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void PosixDup_BadDescriptorReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = SentinelFd;
+
+        var result = KernelMemoryCompatExports.PosixDup(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void PosixDup2_BadDescriptorReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = SentinelFd;
+        context[CpuRegister.Rsi] = 99;
+
+        var result = KernelMemoryCompatExports.PosixDup2(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+    }
+
+    [Fact]
+    public void PosixFcntl_DupfdBadDescriptorReturnsMinusOne()
+    {
+        const ulong memoryBase = 0x1_0000_0000;
+        var memory = new FakeCpuMemory(memoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = SentinelFd;
+        context[CpuRegister.Rsi] = 0; // F_DUPFD
+        context[CpuRegister.Rdx] = 0;
+
+        var result = KernelMemoryCompatExports.PosixFcntl(context);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #461 / #491. `pread`, `pwrite`, `fsync`, `fdatasync`, `ftruncate`, `truncate`, `rename`, `dup`, `dup2` and `fcntl` in `KernelFileExtendedExports.cs` had the same sentinel leak already fixed for `open`/`fstat`/`close`/`read`/`write`/`stat` in #461: they returned the raw `sceKernel*` core result on failure, which reports errors via the `0x8002xxxx` `OrbisGen2Result` sentinel. POSIX-named libc entry points are expected to return `-1` with `errno` set instead — leaking the raw sentinel lets a guest store it as a "valid" fd/handle and misuse it later (the exact defect class behind the Unity IL2CPP crash in #461).

## Change

Each POSIX-named export listed in #491 now routes its core result through the existing `PosixFailure` helper before returning, translating a failure into `-1`/`errno` (fd-based calls map a bad descriptor to `EBADF`; path-based calls keep the `ENOENT` default). The raw `sceKernel*` siblings (`sceKernelPread`, `sceKernelFtruncate`, `sceKernelFsync`, `sceKernelFdatasync`, `sceKernelTruncate`, `sceKernelRename`, `sceKernelFcntl`) are untouched and continue returning the raw Orbis result, matching the existing convention from #461.

`dup`/`dup2` have no separate raw `sceKernel*` sibling in this file, so their inline `ORBIS_GEN2_ERROR_NOT_FOUND` return on a bad fd is now wrapped the same way.

## Testing

- Added `tests/SharpEmu.Libs.Tests/Kernel/KernelFileExtendedExportsTests.cs` with one regression test per affected export, asserting a bad fd/missing path returns `-1` with `Rax == ulong.MaxValue`, mirroring the existing `KernelMemoryCompatExportsTests` pattern for `open`/`fstat`/`close`/`read`/`write`.
- `dotnet test tests/SharpEmu.Libs.Tests` — 552 passed, 0 failed (full `SharpEmu.Libs.Tests` suite, .NET 10.0.302 SDK).
- No real-game testing: this closes an ABI contract gap on paths that only trigger during a failed syscall, and I don't have a specific title known to hit these particular failure paths (unlike the Unity IL2CPP case in #461, which had a concrete repro).

## AI-assisted disclosure

Per this repo's AI-Assisted Contributions policy: this change was implemented with Claude Code, extending the pattern and `PosixFailure` helper from #461/PR #461 to the sibling exports named in #491. I reviewed the diff, verified the fd-based/path-based `errno` selection against each function's existing error paths, and ran the full test suite locally before opening this PR. Leaving the "wrote this description myself" checklist item below unchecked accordingly, since Claude drafted this description.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes (unit tests added; full suite passes) — no real-game testing, see above.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations. *(see AI-assisted disclosure above — this description was drafted by Claude Code and reviewed by me)*
- [x] Testing section above documents what was and wasn't verified (marked N/A for real-game testing).

Fixes #491.