### PR TITLE
fix(savedata): contain dot path segments

### DIFF
--- a/src/SharpEmu.Libs/SaveData/SaveDataStorage.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataStorage.cs
@@ -51,7 +51,8 @@ public static class SaveDataStorage
     /// <summary>
     /// Replaces characters that are invalid in a host path segment. Empty or
     /// all-invalid input collapses to "default" so a bad guest name can never
-    /// escape the save root or produce an empty segment.
+    /// escape the save root or produce an empty segment. Dot segments are
+    /// spelled out to remain ordinary directory names.
     /// </summary>
     public static string Sanitize(string value)
     {
@@ -69,7 +70,12 @@ public static class SaveDataStorage
         }
 
         var sanitized = new string(buffer).Trim();
-        return string.IsNullOrWhiteSpace(sanitized) ? "default" : sanitized;
+        return sanitized switch
+        {
+            "." => "_dot_",
+            ".." => "_dotdot_",
+            _ => string.IsNullOrWhiteSpace(sanitized) ? "default" : sanitized,
+        };
     }
 
     /// <summary>Reads a slot's metadata, or defaults if none has been written.</summary>

--- a/tests/SharpEmu.Libs.Tests/SaveDataStorageTests.cs
+++ b/tests/SharpEmu.Libs.Tests/SaveDataStorageTests.cs
@@ -43,6 +43,10 @@ public sealed class SaveDataStorageTests
     [InlineData("a/b", "a_b")]
     [InlineData("", "default")]
     [InlineData("   ", "default")]
+    [InlineData(".", "_dot_")]
+    [InlineData("..", "_dotdot_")]
+    [InlineData(" . ", "_dot_")]
+    [InlineData(" .. ", "_dotdot_")]
     public void SanitizeNeutralizesPathSeparatorsAndEmpties(string input, string expected)
     {
         Assert.Equal(expected, SaveDataStorage.Sanitize(input));
@@ -57,6 +61,23 @@ public sealed class SaveDataStorageTests
         var slot = SaveDataStorage.SlotDir(titleRoot, "../escape");
         Assert.Equal(titleRoot, Path.GetDirectoryName(slot));
         Assert.DoesNotContain(Path.DirectorySeparatorChar, Path.GetFileName(slot));
+    }
+
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData(" . ")]
+    [InlineData(" .. ")]
+    public void DotSegmentsRemainContainedAndDoNotAliasParents(string segment)
+    {
+        var root = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "sharpemu-saves"));
+        var titleRoot = Path.GetFullPath(SaveDataStorage.TitleRoot(root, segment));
+        var slot = Path.GetFullPath(SaveDataStorage.SlotDir(titleRoot, segment));
+
+        Assert.Equal(root, Path.GetDirectoryName(titleRoot));
+        Assert.NotEqual(root, titleRoot);
+        Assert.Equal(titleRoot, Path.GetDirectoryName(slot));
+        Assert.NotEqual(titleRoot, slot);
     }
 
     [Fact]


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Prevents save-data title and slot names that become `.` or `..` after trimming from resolving to parent directories.

**What changed**
- Map post-trim `.` and `..` to ordinary directory names.
- Cover plain and whitespace-padded values at both title and slot levels.

**Why**
These special path segments could alias the current or parent save directory instead of remaining contained as normal child directories.

**AI-assisted**
Research, implementation, and review were AI-assisted. I reviewed the sanitizer behavior, containment tests, and final diff, and I can explain and maintain the change.

## Testing

- `SaveDataStorageTests`: 18 passed.
- `SharpEmu.Libs.Tests`: 550 passed.
- `SharpEmu.slnx` build: succeeded with 0 errors.
- Game testing: `N/A`.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).