### PR TITLE
Add disassemble command to the live debug server

### DIFF
--- a/docs/debugger-server.md
+++ b/docs/debugger-server.md
@@ -100,6 +100,7 @@ number or a `0x`-prefixed hex string.
 | `set-register` | `register`, `value` | — |
 | `read-memory` | `address`, `length` (≤ 65536) | `address`, `length`, `bytes` (hex) |
 | `write-memory` | `address`, `bytes` (hex) | `written` |
+| `disassemble` (`disasm`, `u`) | `address`, `count?` (≤ 512, default 10) | `address`, `instructions[]` (`address`, `length`, `bytes`, `text`, `mnemonic`) |
 | `list-breakpoints` (`breakpoints`) | — | `breakpoints[]` |
 | `add-breakpoint` (`break`) | `address`, `kind?`, `length?` | `breakpoint` |
 | `remove-breakpoint` (`delete-breakpoint`) | `id` | — |

--- a/src/SharpEmu.DebugClient/CommandTranslator.cs
+++ b/src/SharpEmu.DebugClient/CommandTranslator.cs
@@ -70,6 +70,15 @@ internal static class CommandTranslator
                 return parts.Length >= 3
                     ? Request("read-memory", ("address", parts[1]), ("length", parts[2]))
                     : Error("Usage: mem <address> <length>");
+            case "disasm" or "disassemble" or "u":
+                if (parts.Length < 2)
+                {
+                    return Error("Usage: disasm <address> [count]");
+                }
+
+                return parts.Length >= 3
+                    ? Request("disassemble", ("address", parts[1]), ("count", parts[2]))
+                    : Request("disassemble", ("address", parts[1]));
             case "write":
                 return parts.Length >= 3
                     ? Request("write-memory", ("address", parts[1]), ("bytes", parts[2]))
@@ -143,6 +152,7 @@ internal static class CommandTranslator
           regs | registers         Dump integer registers (paused only)
           setreg <reg> <value>     Set a register (rip/rflags/gp, paused only)
           mem <addr> <len>         Read guest memory as hex (paused only)
+          disasm <addr> [count]    Disassemble instructions at address (paused only)
           write <addr> <hex>       Write guest memory from hex (paused only)
           break <addr> [kind] [len]  Add a breakpoint (kind: execute/readwatch/writewatch/accesswatch)
           bp | breakpoints         List breakpoints

--- a/src/SharpEmu.DebugClient/DEVELOPER_READ.md
+++ b/src/SharpEmu.DebugClient/DEVELOPER_READ.md
@@ -68,6 +68,7 @@ dotnet build src/SharpEmu.DebugClient/SharpEmu.DebugClient.csproj
    break 0x00000008801234a0
    continue
    mem 0x00000008802000000 64
+   disasm 0x00000008802000000 20
    ```
 
 ## Invocation
@@ -102,6 +103,7 @@ commands only succeed while the target is **paused**.
 | `setreg <reg> <value>` | `set-register` | Set `rip`, `rflags`, or a GP register. |
 | `mem <addr> <len>` \| `read <addr> <len>` | `read-memory` | Read guest memory as hex. |
 | `write <addr> <hex>` | `write-memory` | Write guest memory from a hex string. |
+| `disasm <addr> [count]` \| `u …` | `disassemble` | Disassemble up to `count` (default 10, max 512) instructions from `addr`. |
 | `break <addr> [kind] [len]` \| `b …` | `add-breakpoint` | Add a breakpoint. `kind`: `execute` (default), `readwatch`, `writewatch`, `accesswatch`. |
 | `bp` \| `breakpoints` | `list-breakpoints` | List breakpoints. |
 | `del <id>` \| `rm <id>` | `remove-breakpoint` | Remove a breakpoint. |

--- a/src/SharpEmu.Debugger/Protocol/DebugCommandDispatcher.cs
+++ b/src/SharpEmu.Debugger/Protocol/DebugCommandDispatcher.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using SharpEmu.Core.Cpu.Disasm;
 using SharpEmu.Debugger.Breakpoints;
 using SharpEmu.Debugger.Session;
 using SharpEmu.HLE;
@@ -37,6 +38,7 @@ public sealed class DebugCommandDispatcher
             "set-register" or "set-reg" => SetRegister(request),
             "read-memory" or "read-mem" => ReadMemory(request),
             "write-memory" or "write-mem" => WriteMemory(request),
+            "disassemble" or "disasm" or "u" => Disassemble(request),
             "list-breakpoints" or "breakpoints" => ListBreakpoints(request),
             "add-breakpoint" or "break" => AddBreakpoint(request),
             "remove-breakpoint" or "delete-breakpoint" => RemoveBreakpoint(request),
@@ -156,6 +158,83 @@ public sealed class DebugCommandDispatcher
         return _session.TryWriteMemory(address, data)
             ? DebugResponse.Success(request.Command, new Dictionary<string, object?> { ["written"] = data.Length })
             : DebugResponse.Failure(request.Command, "Memory is unwritable or target is not paused.");
+    }
+
+    private DebugResponse Disassemble(DebugRequest request)
+    {
+        if (!request.TryGetUInt64("address", out var address))
+        {
+            return DebugResponse.Failure(request.Command, "Expected an 'address'.");
+        }
+
+        var count = DefaultDisassembleCount;
+        if (request.TryGetInt32("count", out var requestedCount))
+        {
+            if (requestedCount <= 0 || requestedCount > MaxDisassembleInstructions)
+            {
+                return DebugResponse.Failure(
+                    request.Command,
+                    $"Expected a 'count' between 1 and {MaxDisassembleInstructions}.");
+            }
+
+            count = requestedCount;
+        }
+
+        var instructions = new List<Dictionary<string, object?>>(count);
+        var cursor = address;
+        for (var i = 0; i < count; i++)
+        {
+            if (!TryReadInstructionBytes(cursor, out var bytes) ||
+                !IcedDecoder.TryDecode(cursor, bytes, out var inst))
+            {
+                break;
+            }
+
+            instructions.Add(new Dictionary<string, object?>
+            {
+                ["address"] = FormatAddress(inst.Rip),
+                ["length"] = inst.Length,
+                ["bytes"] = Convert.ToHexString(inst.Bytes),
+                ["text"] = inst.Text,
+                ["mnemonic"] = inst.Mnemonic,
+            });
+
+            cursor += (ulong)inst.Length;
+        }
+
+        if (instructions.Count == 0)
+        {
+            return DebugResponse.Failure(request.Command, "Memory is unreadable or target is not paused.");
+        }
+
+        return DebugResponse.Success(request.Command, new Dictionary<string, object?>
+        {
+            ["address"] = FormatAddress(address),
+            ["instructions"] = instructions,
+        });
+    }
+
+    // Mirrors IcedDecoder.TryReadGuestBytes: reads up to a full x86 instruction
+    // byte-by-byte so a run stops cleanly at an unmapped page instead of
+    // failing the whole request the way a fixed-size ReadMemory would.
+    private bool TryReadInstructionBytes(ulong address, out byte[] bytes)
+    {
+        Span<byte> buffer = stackalloc byte[MaxInstructionBytes];
+        Span<byte> oneByte = stackalloc byte[1];
+        var readCount = 0;
+        for (var i = 0; i < MaxInstructionBytes; i++)
+        {
+            if (!_session.TryReadMemory(address + (ulong)i, oneByte))
+            {
+                break;
+            }
+
+            buffer[i] = oneByte[0];
+            readCount++;
+        }
+
+        bytes = buffer[..readCount].ToArray();
+        return readCount > 0;
     }
 
     private DebugResponse ListBreakpoints(DebugRequest request)
@@ -337,4 +416,7 @@ public sealed class DebugCommandDispatcher
         => Enum.TryParse(text.Trim(), ignoreCase: true, out kind) && Enum.IsDefined(kind);
 
     private const int MaxMemoryChunk = 64 * 1024;
+    private const int MaxInstructionBytes = 15;
+    private const int DefaultDisassembleCount = 10;
+    private const int MaxDisassembleInstructions = 512;
 }

--- a/tests/SharpEmu.Libs.Tests/Debugger/DebugCommandDispatcherDisassembleTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Debugger/DebugCommandDispatcherDisassembleTests.cs
@@ -1,0 +1,164 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Debugging;
+using SharpEmu.Debugger;
+using SharpEmu.Debugger.Breakpoints;
+using SharpEmu.Debugger.Protocol;
+using SharpEmu.Debugger.Session;
+using SharpEmu.HLE;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Debugger;
+
+public sealed class DebugCommandDispatcherDisassembleTests
+{
+    // nop; ret; mov eax, 1 — a small, unambiguous mix of a 1-byte, another
+    // 1-byte, and a 5-byte instruction so length and cursor advancement are
+    // both exercised.
+    private static readonly byte[] SampleCode = [0x90, 0xC3, 0xB8, 0x01, 0x00, 0x00, 0x00];
+
+    [Fact]
+    public void Disassemble_DecodesRequestedInstructionCount()
+    {
+        var dispatcher = new DebugCommandDispatcher(new FakeSession(0x1000, SampleCode));
+        var request = Parse("""{"command":"disassemble","address":"0x1000","count":3}""");
+
+        var response = dispatcher.Dispatch(request);
+
+        Assert.True(response.Ok);
+        var instructions = Assert.IsAssignableFrom<IReadOnlyList<Dictionary<string, object?>>>(
+            response.Data!["instructions"]);
+        Assert.Equal(3, instructions.Count);
+        Assert.Equal("0x0000000000001000", instructions[0]["address"]);
+        Assert.Equal(1, instructions[0]["length"]);
+        Assert.Equal("0x0000000000001001", instructions[1]["address"]);
+        Assert.Equal(1, instructions[1]["length"]);
+        Assert.Equal("0x0000000000001002", instructions[2]["address"]);
+        Assert.Equal(5, instructions[2]["length"]);
+        Assert.Equal("B801000000", instructions[2]["bytes"]);
+    }
+
+    [Fact]
+    public void Disassemble_StopsEarlyWhenMemoryRunsOut()
+    {
+        // Only SampleCode.Length bytes are readable; the default count (10) asks
+        // for more than that, so the run should stop cleanly instead of failing.
+        var dispatcher = new DebugCommandDispatcher(new FakeSession(0x2000, SampleCode));
+        var request = Parse("""{"command":"disassemble","address":"0x2000"}""");
+
+        var response = dispatcher.Dispatch(request);
+
+        Assert.True(response.Ok);
+        var instructions = Assert.IsAssignableFrom<IReadOnlyList<Dictionary<string, object?>>>(
+            response.Data!["instructions"]);
+        Assert.Equal(3, instructions.Count);
+    }
+
+    [Fact]
+    public void Disassemble_FailsWhenTargetIsNotPaused()
+    {
+        var dispatcher = new DebugCommandDispatcher(new FakeSession(0x1000, code: null));
+        var request = Parse("""{"command":"disassemble","address":"0x1000"}""");
+
+        var response = dispatcher.Dispatch(request);
+
+        Assert.False(response.Ok);
+        Assert.Equal("Memory is unreadable or target is not paused.", response.Error);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(513)]
+    public void Disassemble_RejectsOutOfRangeCount(int count)
+    {
+        var dispatcher = new DebugCommandDispatcher(new FakeSession(0x1000, SampleCode));
+        var request = Parse($$"""{"command":"disassemble","address":"0x1000","count":{{count}}}""");
+
+        var response = dispatcher.Dispatch(request);
+
+        Assert.False(response.Ok);
+    }
+
+    private static DebugRequest Parse(string json)
+    {
+        Assert.True(DebugRequest.TryParse(json, out var request, out var error), error);
+        return request;
+    }
+
+    /// <summary>Minimal <see cref="IDebuggerSession"/> serving fixed bytes from a base address.</summary>
+    private sealed class FakeSession(ulong baseAddress, byte[]? code) : IDebuggerSession, ICpuDebugHook
+    {
+        public DebuggerRunState State => DebuggerRunState.Paused;
+
+        public DebugStopEvent? LastStop => null;
+
+        public BreakpointStore Breakpoints { get; } = new();
+
+        public ICpuDebugHook Hook => this;
+
+        public event EventHandler<DebugStopEvent>? Stopped { add { } remove { } }
+
+        public event EventHandler? Resumed { add { } remove { } }
+
+        public event EventHandler? Terminated { add { } remove { } }
+
+        public bool TryGetRegisters(out DebugRegisterFile registers)
+        {
+            registers = default;
+            return false;
+        }
+
+        public bool TrySetRegister(DebugRegisterId id, ulong value) => false;
+
+        public bool TryReadMemory(ulong address, Span<byte> destination)
+        {
+            if (code is null || address < baseAddress)
+            {
+                return false;
+            }
+
+            var offset = address - baseAddress;
+            if (offset + (ulong)destination.Length > (ulong)code.Length)
+            {
+                return false;
+            }
+
+            code.AsSpan((int)offset, destination.Length).CopyTo(destination);
+            return true;
+        }
+
+        public bool TryWriteMemory(ulong address, ReadOnlySpan<byte> source) => false;
+
+        public bool TryReadXmm(int registerIndex, out ulong low, out ulong high)
+        {
+            low = 0;
+            high = 0;
+            return false;
+        }
+
+        public bool Continue() => false;
+
+        public bool StepFrame() => false;
+
+        public void RequestPause()
+        {
+        }
+
+        public void NotifyTerminated()
+        {
+        }
+
+        public void OnFrameEnter(ICpuDebugFrame frame)
+        {
+        }
+
+        public void OnFrameExit(ICpuDebugFrame frame, OrbisGen2Result result)
+        {
+        }
+
+        public void OnStall(ICpuDebugFrame frame, CpuStallInfo info)
+        {
+        }
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj
+++ b/tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj
@@ -15,6 +15,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <ProjectReference Include="..\..\src\SharpEmu.Libs\SharpEmu.Libs.csproj" />
     <ProjectReference Include="..\..\src\SharpEmu.HLE\SharpEmu.HLE.csproj" />
     <ProjectReference Include="..\..\src\SharpEmu.GUI\SharpEmu.GUI.csproj" />
+    <ProjectReference Include="..\..\src\SharpEmu.Debugger\SharpEmu.Debugger.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

---

The debug protocol has 'read-memory' but there was no way to see actual decoded instructions, only raw hex. So if you were connected to the debug server and wanted to know what instruction was at some address, you had to decode the bytes by hand yourself.

This adds a 'disassemble' command (also works as 'disasm' or 'u') that fixes that. It reuses the existing 'IcedDecoder' from SharpEmu.Core - the same decoder the CPU core already uses internally so there's no new decoding logic, just hooking it up to the debug protocol. For a run of instructions starting at whatever address you give it, it returns the address, length, raw bytes, decoded text, and mnemonic for each one.

One detail: it reads memory byte-by-byte per instruction instead of in one fixed-size chunk, so if the run hits an unmapped page partway through, you still get back the instructions that decoded fine instead of the whole request failing.

Also wired it into the DebugClient REPL, and updated debugger-server.md and DEVELOPER_READ.md to document it.

## Testing

N/A - this is debugger tooling, it doesn't touch guest/game behavior. Ran 'dotnet build' (clean) and the full test suite, and added 5 new unit tests for the command itself (decoding a known instruction sequence, stopping cleanly when memory runs out mid-run, failing properly when the target isn't paused, rejecting a bad 'count' value).

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).