### PR TITLE
fix: GTA verify stack (interpolants, rect-list, AudioOut2, Rewind/Jump, native workers)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="NLayer" Version="1.14.0" />
     <PackageVersion Include="Silk.NET.Input" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.23.0" />

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -5735,23 +5735,13 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			ActiveGuestThreadYieldReason = null;
 			try
 			{
-				// TBB execute-AV recover needs native-worker TLS (eligible/done).
-				// Other guests stay on CallNativeEntry — full native-worker migration
-				// increased splash hangs / UnmanagedCallersOnly (tLTN/tLTO).
-				int nativeReturn;
-				if (name == "tbb_thead")
-				{
-					nativeReturn = RunGuestEntryStub(ptr, hostRspSlot, requireNativeWorker: true);
-				}
-				else
-				{
-					if (!TlsSetValue(_hostRspSlotTlsIndex, (nint)hostRspSlot))
-					{
-						reason = "failed to bind host-RSP storage for guest thread stub";
-						return GuestNativeCallExitReason.Exception;
-					}
-					nativeReturn = CallNativeEntry(ptr);
-				}
+				// Prefer pooled native OS workers so guest stubs do not sit above
+				// CLR-managed frames (UnmanagedCallersOnly FailFast on GTA and
+				// similar titles). tbb_thead still requires a worker — never fall
+				// back to managed inline during the Astro spawn storm.
+				var nativeReturn = name == "tbb_thead"
+					? RunGuestEntryStub(ptr, hostRspSlot, requireNativeWorker: true)
+					: RunGuestEntryStub(ptr, hostRspSlot);
 				if (ActiveGuestThreadYieldRequested)
 				{
 					reason = ActiveGuestThreadYieldReason ?? "guest thread blocked";
@@ -5901,20 +5891,11 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			ActiveGuestThreadYieldReason = null;
 			try
 			{
-				int nativeReturn;
-				if (name == "tbb_thead")
-				{
-					nativeReturn = RunGuestEntryStub(ptr, hostRspSlot, requireNativeWorker: true);
-				}
-				else
-				{
-					if (!TlsSetValue(_hostRspSlotTlsIndex, (nint)hostRspSlot))
-					{
-						reason = "failed to bind host-RSP storage for guest continuation stub";
-						return GuestNativeCallExitReason.Exception;
-					}
-					nativeReturn = CallNativeEntry(ptr);
-				}
+				// Same routing as thread entry: prefer native workers for all
+				// continuations; require them for tbb_thead.
+				var nativeReturn = name == "tbb_thead"
+					? RunGuestEntryStub(ptr, hostRspSlot, requireNativeWorker: true)
+					: RunGuestEntryStub(ptr, hostRspSlot);
 				if (ActiveGuestThreadYieldRequested)
 				{
 					reason = ActiveGuestThreadYieldReason ?? "guest thread blocked";
@@ -6244,7 +6225,9 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			int num6 = -1;
 			try
 			{
-				num6 = CallNativeEntry(ptr);
+				// Main entry also prefers a native worker so the guest process
+				// does not begin above CLR-managed frames on this thread.
+				num6 = RunGuestEntryStub(ptr, num2);
 				Console.Error.WriteLine($"[LOADER][INFO] Guest returned: {num6}");
 				// A host stop has already invalidated the session. Draining guest
 				// continuations here can re-enter a blocked HLE call after its owner

--- a/src/SharpEmu.HLE/Host/Windows/WindowsWaveOutAudio.cs
+++ b/src/SharpEmu.HLE/Host/Windows/WindowsWaveOutAudio.cs
@@ -17,7 +17,9 @@ internal sealed partial class WindowsWaveOutAudio : IHostAudioOutput
         private const uint CallbackEvent = 0x0005_0000;
         private const ushort WaveFormatPcm = 1;
         private const uint WaveHeaderDone = 0x0000_0001;
-        private const int MaximumQueuedPcmBytes = 32 * 1024;
+        // Deeper than the old 32KB (~170ms) queue: FMOD's bursty AudioOut2 Push
+        // pattern underran a shallow buffer and crackled even at stable FPS.
+        private const int MaximumQueuedPcmBytes = 128 * 1024;
 
         private readonly object _gate = new();
         private readonly AutoResetEvent _completion = new(false);

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -215,7 +215,7 @@ public static partial class AgcExports
     private static readonly ConcurrentDictionary<
         (ulong Es, ulong EsState, ulong Ps, ulong PsState, ulong OutputLayout,
          uint OutputCount, uint Attributes, uint PsInputEna, uint PsInputAddr,
-         ulong AliasAlignment),
+         ulong PsInputCntl, ulong AliasAlignment),
         (IGuestCompiledShader Vertex, IGuestCompiledShader Pixel)> _graphicsShaderCache = new();
     private static readonly ConcurrentDictionary<
         (ulong Cs, ulong State, uint LocalX, uint LocalY, uint LocalZ,
@@ -865,53 +865,228 @@ public static partial class AgcExports
         var geometryShaderAddress = ctx[CpuRegister.Rsi];
         var pixelShaderAddress = ctx[CpuRegister.Rdx];
 
-        if (registersAddress == 0 || geometryShaderAddress == 0)
+        if (registersAddress == 0)
         {
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        if (!TryReadUInt64(ctx, geometryShaderAddress + ShaderOutputSemanticsOffset, out var outputSemanticsAddress) ||
-            !TryReadUInt32(ctx, geometryShaderAddress + ShaderNumOutputSemanticsOffset, out var outputSemanticsCount))
-        {
-            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
-        }
-
+        // SPI_PS_INPUT_CNTL maps each PS VINTRP ATTR slot to a VS/GS param export.
+        // Walk PS input semantics, find the GS output with the same semantic id,
+        // and pack the hardware CNTL word (location in bits [4:0], Flat at 0x400).
+        uint inputSemanticsCount = 0;
         ulong inputSemanticsAddress = 0;
-        if (pixelShaderAddress != 0 &&
-            (!TryReadUInt64(ctx, pixelShaderAddress + ShaderInputSemanticsOffset, out inputSemanticsAddress) ||
-             !TryReadUInt32(ctx, pixelShaderAddress + ShaderNumInputSemanticsOffset, out _)))
+        if (pixelShaderAddress != 0)
         {
-            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
-        }
-
-        for (uint i = 0; i < 32; i++)
-        {
-            uint value = 0;
-            if (i < outputSemanticsCount && outputSemanticsAddress != 0)
-            {
-                var flat = false;
-                if (pixelShaderAddress != 0 && inputSemanticsAddress != 0 &&
-                    TryReadUInt32(ctx, inputSemanticsAddress + (i * sizeof(uint)), out var inputSemantic))
-                {
-                    flat = ((inputSemantic >> 22) & 0x1) != 0;
-                }
-
-                value = i | (flat ? 0x400u : 0u);
-            }
-
-            var destination = registersAddress + (i * 8);
-            if (!TryWriteUInt32(ctx, destination, SpiPsInputCntl0 + i) ||
-                !TryWriteUInt32(ctx, destination + sizeof(uint), value))
+            if (!TryReadUInt64(ctx, pixelShaderAddress + ShaderInputSemanticsOffset, out inputSemanticsAddress) ||
+                !TryReadUInt32(ctx, pixelShaderAddress + ShaderNumInputSemanticsOffset, out inputSemanticsCount))
             {
                 return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
             }
         }
 
-        TraceAgc($"agc.create_interpolant_mapping regs=0x{registersAddress:X16} gs=0x{geometryShaderAddress:X16} ps=0x{pixelShaderAddress:X16}");
+        if (inputSemanticsCount == 0 || inputSemanticsAddress == 0)
+        {
+            if (!TryWriteIdentityInterpolantRegisters(ctx, registersAddress, 0))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+
+            TraceAgc(
+                $"agc.create_interpolant_mapping regs=0x{registersAddress:X16} " +
+                $"gs=0x{geometryShaderAddress:X16} ps=0x{pixelShaderAddress:X16} inputs=0");
+            ctx[CpuRegister.Rax] = 0;
+            return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        }
+
+        if (geometryShaderAddress == 0)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        // NumOutputSemantics is a u16 at header +0x56.
+        if (!TryReadUInt64(ctx, geometryShaderAddress + ShaderOutputSemanticsOffset, out var outputSemanticsAddress) ||
+            !TryReadUInt16(ctx, geometryShaderAddress + ShaderNumOutputSemanticsOffset, out var outputSemanticsCount))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        inputSemanticsCount = Math.Min(inputSemanticsCount, 32u);
+        for (uint psIndex = 0; psIndex < inputSemanticsCount; psIndex++)
+        {
+            if (!TryReadUInt32(
+                    ctx,
+                    inputSemanticsAddress + (psIndex * sizeof(uint)),
+                    out var psWord))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+
+            var psSemantic = psWord & 0xFFu;
+            uint? gsWord = null;
+            if (outputSemanticsAddress != 0)
+            {
+                for (uint gsIndex = 0; gsIndex < outputSemanticsCount; gsIndex++)
+                {
+                    if (!TryReadUInt32(
+                            ctx,
+                            outputSemanticsAddress + (gsIndex * sizeof(uint)),
+                            out var candidate))
+                    {
+                        return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+                    }
+
+                    if ((candidate & 0xFFu) == psSemantic)
+                    {
+                        gsWord = candidate;
+                        break;
+                    }
+                }
+            }
+
+            var value = (psWord & 0x0030_0000u) != 0
+                ? CreateInterpolantF16Value(psWord, gsWord)
+                : CreateInterpolantNonF16Value(psWord, gsWord.HasValue);
+            value = gsWord is { } matched
+                ? CreateInterpolantMappingValue(value, psWord, matched)
+                : CreateInterpolantDefaultParamValue(value, psWord);
+
+            if (!TryWriteInterpolantRegister(ctx, registersAddress, psIndex, value))
+            {
+                return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+        }
+
+        if (!TryWriteIdentityInterpolantRegisters(ctx, registersAddress, inputSemanticsCount))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAgc(
+            $"agc.create_interpolant_mapping regs=0x{registersAddress:X16} " +
+            $"gs=0x{geometryShaderAddress:X16} ps=0x{pixelShaderAddress:X16} " +
+            $"inputs={inputSemanticsCount} outputs={outputSemanticsCount}");
         ctx[CpuRegister.Rax] = 0;
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
     #pragma warning restore SHEM004
+
+    private static uint ApplyInterpolantDefaultValue(uint value, uint psWord)
+    {
+        value &= ~0x0000_0300u;
+        value |= ((psWord >> 28) & 0x3u) << 8;
+        return value;
+    }
+
+    private static uint ApplyInterpolantDefaultValueHi(uint value, uint psWord)
+    {
+        value &= ~0x0060_0000u;
+        value |= ((psWord >> 30) & 0x3u) << 21;
+        return value;
+    }
+
+    private static uint CreateInterpolantMappingValue(uint value, uint psWord, uint gsWord)
+    {
+        var flatShade =
+            (psWord & 0x0040_0000u) != 0 || (psWord & 0x0100_0000u) != 0
+                ? 0x0000_0400u
+                : 0u;
+        value &= ~0x0000_001Fu;
+        value |= (gsWord >> 8) & 0x1Fu;
+        value &= ~0x0000_0400u;
+        value |= flatShade;
+        return ApplyInterpolantDefaultValue(value, psWord);
+    }
+
+    private static uint CreateInterpolantDefaultParamValue(uint value, uint psWord)
+    {
+        value &= ~0x0000_001Fu;
+        value &= ~0x0000_0400u;
+        return ApplyInterpolantDefaultValue(value, psWord);
+    }
+
+    private static uint CreateInterpolantF16Value(uint psWord, uint? gsWord)
+    {
+        var value = (psWord << 4) & 0x0300_0000u;
+        if (gsWord is null)
+        {
+            value |= 0x0018_0020u;
+        }
+        else
+        {
+            var commonWord = psWord & gsWord.Value;
+            value &= 0xFFF7_FFDFu;
+            value |= (commonWord >> 15) & 0x20u;
+            value ^= 0x0008_0020u;
+            value &= ~0x0010_0000u;
+            value |= (~commonWord >> 1) & 0x0010_0000u;
+        }
+
+        return ApplyInterpolantDefaultValueHi(value, psWord);
+    }
+
+    private static uint CreateInterpolantNonF16Value(uint psWord, bool hasGsSemantic)
+    {
+        uint value = 0;
+        if ((psWord & 0x0100_0000u) != 0 || !hasGsSemantic)
+        {
+            value |= 0x20u;
+        }
+
+        return value;
+    }
+
+    private static bool TryWriteInterpolantRegister(
+        CpuContext ctx,
+        ulong registersAddress,
+        uint index,
+        uint value)
+    {
+        var destination = registersAddress + (index * 8);
+        return TryWriteUInt32(ctx, destination, SpiPsInputCntl0 + index) &&
+               TryWriteUInt32(ctx, destination + sizeof(uint), value);
+    }
+
+    private static bool TryWriteIdentityInterpolantRegisters(
+        CpuContext ctx,
+        ulong registersAddress,
+        uint firstIndex)
+    {
+        for (uint i = firstIndex; i < 32u; i++)
+        {
+            if (!TryWriteInterpolantRegister(ctx, registersAddress, i, i))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static uint[] ReadPsInputCntlRegisters(IReadOnlyDictionary<uint, uint> cxRegisters)
+    {
+        var cntl = new uint[32];
+        for (uint i = 0; i < 32u; i++)
+        {
+            // Unprogrammed slots default to identity (ATTR i → param i).
+            cntl[i] = cxRegisters.TryGetValue(SpiPsInputCntl0 + i, out var value)
+                ? value
+                : i;
+        }
+
+        return cntl;
+    }
+
+    private static ulong ComputePsInputCntlFingerprint(ReadOnlySpan<uint> cntl)
+    {
+        const ulong prime = 1099511628211UL;
+        var hash = 14695981039346656037UL;
+        foreach (var value in cntl)
+        {
+            hash = (hash ^ value) * prime;
+        }
+
+        return hash;
+    }
 
     // NID captured from shipped titles; the friendly name collides with a real catalog symbol of a different NID. Rename pending AGC API confirmation.
     #pragma warning disable SHEM004
@@ -6522,6 +6697,8 @@ public static partial class AgcExports
         var pixelStateFingerprint = _bakeScalars
             ? ComputeShaderStateFingerprint(pixelEvaluation)
             : ComputeShaderStructuralFingerprint(pixelEvaluation);
+        var psInputCntl = ReadPsInputCntlRegisters(state.CxRegisters);
+        var psInputCntlFingerprint = ComputePsInputCntlFingerprint(psInputCntl);
         var shaderKey = (
             exportShaderAddress,
             exportStateFingerprint,
@@ -6532,6 +6709,7 @@ public static partial class AgcExports
             attributeCount,
             psInputEna,
             psInputAddr,
+            psInputCntlFingerprint,
             _storageBufferOffsetAlignment);
 
         var guestGlobalBuffers =
@@ -6605,6 +6783,7 @@ public static partial class AgcExports
                         scalarRegisterBufferIndex: _bakeScalars ? -1 : guestGlobalBuffers,
                         pixelInputEnable: psInputEna,
                         pixelInputAddress: psInputAddr,
+                        pixelInputCntl: psInputCntl,
                         storageBufferOffsetAlignment:
                             _storageBufferOffsetAlignment) ||
                     !GuestGpu.Current.TryCompileVertexShader(
@@ -10748,6 +10927,7 @@ public static partial class AgcExports
                                  out var compileError,
                                  pixelInputEnable: psInputEna,
                                  pixelInputAddress: psInputAddr,
+                                 pixelInputCntl: ReadPsInputCntlRegisters(state.CxRegisters),
                                  storageBufferOffsetAlignment:
                                      _storageBufferOffsetAlignment))
                         {
@@ -11751,6 +11931,28 @@ public static partial class AgcExports
             _dcbWindowBuffer = null;
             _dcbWindowByteLength = 0;
         }
+    }
+
+    private static bool TryReadUInt16(CpuContext ctx, ulong address, out ushort value)
+    {
+        if (_dcbWindowBuffer is { } window &&
+            address >= _dcbWindowStart &&
+            address - _dcbWindowStart + sizeof(ushort) <= (ulong)_dcbWindowByteLength)
+        {
+            value = BinaryPrimitives.ReadUInt16LittleEndian(
+                window.AsSpan((int)(address - _dcbWindowStart)));
+            return true;
+        }
+
+        Span<byte> buffer = stackalloc byte[sizeof(ushort)];
+        if (!ctx.Memory.TryRead(address, buffer))
+        {
+            value = 0;
+            return false;
+        }
+
+        value = BinaryPrimitives.ReadUInt16LittleEndian(buffer);
+        return true;
     }
 
     private static bool TryReadUInt32(CpuContext ctx, ulong address, out uint value)

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -99,6 +99,10 @@ public static partial class AgcExports
     private const uint ComputeNumThreadZ = 0x209;
     private const uint SpiPsInputCntl0 = 0x191;
     private const uint VgtPrimitiveType = 0x242;
+    private const uint VgtIndexType = 0x243;
+    // GE_INDX_OFFSET — base vertex for DrawIndexed / firstVertex for
+    // DrawIndexAuto. Glyph meshes and UI icon batches rely on this.
+    private const uint GeIndxOffset = 0x24A;
     private const uint PaScScreenScissorTl = 0x0C;
     private const uint PaScScreenScissorBr = 0x0D;
     private const uint CbTargetMask = 0x8E;
@@ -447,6 +451,7 @@ public static partial class AgcExports
         uint AttributeCount,
         uint VertexCount,
         uint InstanceCount,
+        int BaseVertex,
         GuestIndexBuffer? IndexBuffer,
         IReadOnlyList<TranslatedImageBinding> Textures,
         IReadOnlyList<Gen5GlobalMemoryBinding> GlobalMemoryBindings,
@@ -3699,7 +3704,8 @@ public static partial class AgcExports
                         vertexBuffers,
                         pendingComposite.RenderState,
                         pendingComposite.DepthTarget,
-                        pendingComposite.PixelShaderAddress);
+                        pendingComposite.PixelShaderAddress,
+                        pendingComposite.BaseVertex);
                     TraceAgcShader(
                         $"agc.deferred_composite ps=0x{pendingComposite.PixelShaderAddress:X16} " +
                         $"src=0x{pendingComposite.Textures.FirstOrDefault()?.Descriptor.Address ?? 0:X16} " +
@@ -5722,6 +5728,10 @@ public static partial class AgcExports
                 }
 
                 directDestination[startRegister + index] = value;
+                if (op == ItSetUconfigReg)
+                {
+                    ApplyUcIndexTypeIfNeeded(state, startRegister + index, value);
+                }
             }
 
             return;
@@ -5756,6 +5766,25 @@ public static partial class AgcExports
             // Dropping it leaves stale depth/render-control state active in
             // later passes.
             destination[registerOffset] = value;
+            if (register == RUcRegsIndirect)
+            {
+                ApplyUcIndexTypeIfNeeded(state, registerOffset, value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// GraphicsDcbSetIndexSize writes VGT_INDEX_TYPE via SET_UCONFIG_REG.
+    /// Mirror that into <see cref="SubmittedDcbState.IndexSize"/>.
+    /// </summary>
+    private static void ApplyUcIndexTypeIfNeeded(
+        SubmittedDcbState state,
+        uint registerOffset,
+        uint value)
+    {
+        if (registerOffset == VgtIndexType)
+        {
+            state.IndexSize = value & 0x3;
         }
     }
 
@@ -5933,7 +5962,8 @@ public static partial class AgcExports
                 depthOnlyDraw.IndexBuffer,
                 vertexBuffers,
                 renderState,
-                depthOnlyDraw.PixelShaderAddress);
+                depthOnlyDraw.PixelShaderAddress,
+                depthOnlyDraw.BaseVertex);
 
             if (_traceAgcShader)
             {
@@ -6090,7 +6120,8 @@ public static partial class AgcExports
                         sharedVertexBuffers,
                         translatedDraw.RenderState,
                         translatedDraw.DepthTarget,
-                        translatedDraw.PixelShaderAddress);
+                        translatedDraw.PixelShaderAddress,
+                        translatedDraw.BaseVertex);
                 }
             }
             else
@@ -6132,7 +6163,8 @@ public static partial class AgcExports
                         translatedDraw.IndexBuffer,
                         vertexBuffers,
                         renderState,
-                        translatedDraw.PixelShaderAddress);
+                        translatedDraw.PixelShaderAddress,
+                        translatedDraw.BaseVertex);
                 }
                 else
                 {
@@ -6435,6 +6467,7 @@ public static partial class AgcExports
             AttributeCount: 0,
             vertexCount,
             state.InstanceCount,
+            GetBaseVertex(state),
             indexed ? CreateGuestIndexBuffer(ctx, state, vertexCount) : null,
             textures,
             exportEvaluation.GlobalMemoryBindings,
@@ -6623,6 +6656,22 @@ public static partial class AgcExports
             Environment.GetEnvironmentVariable("SHARPEMU_TRACE_TITLE_GLOBALS_LIVE") == "1")
         {
             TraceAstroTitlePixelGlobalProbe(pixelEvaluation);
+        }
+
+        state.UcRegisters.TryGetValue(VgtPrimitiveType, out var earlyPrimitiveType);
+        if (IsRectListPrimitive(earlyPrimitiveType) &&
+            (exportEvaluation.VertexInputs is null || exportEvaluation.VertexInputs.Count == 0) &&
+            !VertexProgramExportsParameters(exportState.Program) &&
+            GetInterpolatedAttributeCount(pixelState) != 0)
+        {
+            ReturnPooledEvaluationArrays(exportEvaluation);
+            ReturnPooledEvaluationArrays(pixelEvaluation);
+            error =
+                $"rect-list-no-param-exports ps_inputs={GetInterpolatedAttributeCount(pixelState)}";
+            TraceAgcShader(
+                $"agc.rect_list_skip es=0x{exportShaderAddress:X16} " +
+                $"ps=0x{pixelShaderAddress:X16} {error}");
+            return false;
         }
 
         // Every bound color target the shader exports to. Deferred renderers
@@ -6914,6 +6963,7 @@ public static partial class AgcExports
             GetInterpolatedAttributeCount(pixelState),
             vertexCount,
             state.InstanceCount,
+            GetBaseVertex(state),
             indexed ? CreateGuestIndexBuffer(ctx, state, vertexCount) : null,
             textures,
             globalMemoryBindings,
@@ -7225,6 +7275,22 @@ public static partial class AgcExports
             ColorFunc: 0,
         };
 
+    private static AgcIndexHelpers.ProsperoIndexType GetProsperoIndexType(SubmittedDcbState state) =>
+        // IndexSize is latched from ItIndexType and from UC VGT_INDEX_TYPE
+        // writes. Do not fall back to a stale UC value when IndexSize is 0 —
+        // that mis-classified 16-bit draws as index8 and blanked meshes.
+        AgcIndexHelpers.Decode(state.IndexSize);
+
+    /// <summary>
+    /// ResolveVertexOffset for the common UC path: GE_INDX_OFFSET is the
+    /// DrawIndexed vertexOffset / DrawAuto firstVertex. Embedded-fetch SGPR
+    /// fallback is not required when the game latches this register (GTA UI).
+    /// </summary>
+    private static int GetBaseVertex(SubmittedDcbState state) =>
+        state.UcRegisters.TryGetValue(GeIndxOffset, out var indexOffset)
+            ? unchecked((int)indexOffset)
+            : 0;
+
     private static GuestIndexBuffer? CreateGuestIndexBuffer(
         CpuContext ctx,
         SubmittedDcbState state,
@@ -7235,17 +7301,40 @@ public static partial class AgcExports
             return null;
         }
 
-        var is32Bit = state.IndexSize != 0;
-        var bytesPerIndex = is32Bit ? sizeof(uint) : sizeof(ushort);
-        var byteOffset = checked((ulong)state.DrawIndexOffset * (uint)bytesPerIndex);
-        var byteCount = checked((int)(indexCount * (uint)bytesPerIndex));
-        var data = GuestDataPool.Shared.Rent(byteCount);
-        var span = data.AsSpan(0, byteCount);
+        var indexType = GetProsperoIndexType(state);
+        var guestBytesPerIndex = AgcIndexHelpers.GetGuestStrideBytes(indexType);
+        var byteOffset = checked((ulong)state.DrawIndexOffset * (uint)guestBytesPerIndex);
+        var guestByteCount = checked((int)(indexCount * (uint)guestBytesPerIndex));
         var address = state.IndexBufferAddress + byteOffset;
+
+        // Host backends only bind u16/u32. Expand kIndex8 -> u16.
+        if (indexType == AgcIndexHelpers.ProsperoIndexType.Index8)
+        {
+            var guestData = GuestDataPool.Shared.Rent(guestByteCount);
+            var guestSpan = guestData.AsSpan(0, guestByteCount);
+            if (!ctx.Memory.TryRead(address, guestSpan) &&
+                !KernelMemoryCompatExports.TryReadTrackedLibcHeap(address, guestSpan))
+            {
+                GuestDataPool.Shared.Return(guestData);
+                return null;
+            }
+
+            var hostByteCount = checked((int)(indexCount * sizeof(ushort)));
+            var hostData = GuestDataPool.Shared.Rent(hostByteCount);
+            AgcIndexHelpers.ExpandIndex8ToU16(
+                guestSpan,
+                hostData.AsSpan(0, hostByteCount));
+            GuestDataPool.Shared.Return(guestData);
+            return new GuestIndexBuffer(hostData, hostByteCount, Is32Bit: false, Pooled: true);
+        }
+
+        var is32Bit = indexType == AgcIndexHelpers.ProsperoIndexType.Index32;
+        var data = GuestDataPool.Shared.Rent(guestByteCount);
+        var span = data.AsSpan(0, guestByteCount);
         if (ctx.Memory.TryRead(address, span) ||
             KernelMemoryCompatExports.TryReadTrackedLibcHeap(address, span))
         {
-            return new GuestIndexBuffer(data, byteCount, is32Bit, Pooled: true);
+            return new GuestIndexBuffer(data, guestByteCount, is32Bit, Pooled: true);
         }
 
         GuestDataPool.Shared.Return(data);
@@ -7259,7 +7348,10 @@ public static partial class AgcExports
         bool indexed,
         out uint recordCount)
     {
-        recordCount = Math.Max(drawCount, Math.Max(state.InstanceCount, 1u));
+        var baseVertex = (uint)Math.Max(GetBaseVertex(state), 0);
+        recordCount = Math.Max(
+            baseVertex + drawCount,
+            Math.Max(state.InstanceCount, 1u));
         if (!indexed)
         {
             return true;
@@ -7270,8 +7362,8 @@ public static partial class AgcExports
             return false;
         }
 
-        var is32Bit = state.IndexSize != 0;
-        var bytesPerIndex = is32Bit ? sizeof(uint) : sizeof(ushort);
+        var indexType = GetProsperoIndexType(state);
+        var bytesPerIndex = AgcIndexHelpers.GetGuestStrideBytes(indexType);
         var byteOffset = checked((ulong)state.DrawIndexOffset * (uint)bytesPerIndex);
         var address = state.IndexBufferAddress + byteOffset;
         const int chunkBytes = 64 * 1024;
@@ -7296,12 +7388,22 @@ public static partial class AgcExports
 
                 for (var index = 0; index < chunkIndices; index++)
                 {
-                    var value = is32Bit
-                        ? BinaryPrimitives.ReadUInt32LittleEndian(
-                            span.Slice(index * sizeof(uint), sizeof(uint)))
-                        : BinaryPrimitives.ReadUInt16LittleEndian(
-                            span.Slice(index * sizeof(ushort), sizeof(ushort)));
-                    if (value == (is32Bit ? uint.MaxValue : ushort.MaxValue))
+                    uint value = indexType switch
+                    {
+                        AgcIndexHelpers.ProsperoIndexType.Index32 =>
+                            BinaryPrimitives.ReadUInt32LittleEndian(
+                                span.Slice(index * sizeof(uint), sizeof(uint))),
+                        AgcIndexHelpers.ProsperoIndexType.Index8 => span[index],
+                        _ => BinaryPrimitives.ReadUInt16LittleEndian(
+                            span.Slice(index * sizeof(ushort), sizeof(ushort))),
+                    };
+                    var restart = indexType switch
+                    {
+                        AgcIndexHelpers.ProsperoIndexType.Index32 => uint.MaxValue,
+                        AgcIndexHelpers.ProsperoIndexType.Index8 => 0xFFu,
+                        _ => ushort.MaxValue,
+                    };
+                    if (value == restart)
                     {
                         // Primitive-restart markers do not address vertex data.
                         continue;
@@ -7321,17 +7423,24 @@ public static partial class AgcExports
         }
 
         var indexedRecords = sawIndex && maxIndex != uint.MaxValue
-            ? maxIndex + 1
-            : 1u;
+            ? baseVertex + maxIndex + 1
+            : Math.Max(baseVertex + 1, 1u);
         recordCount = Math.Max(indexedRecords, Math.Max(state.InstanceCount, 1u));
         if (_traceVertexRanges &&
             Interlocked.Increment(ref _tracedVertexRangeCount) <= 512)
         {
+            var indexBits = indexType switch
+            {
+                AgcIndexHelpers.ProsperoIndexType.Index32 => 32,
+                AgcIndexHelpers.ProsperoIndexType.Index8 => 8,
+                _ => 16,
+            };
             Console.Error.WriteLine(
                 $"[LOADER][TRACE] agc.vertex_range indexed=1 draw_count={drawCount} " +
-                $"max_index={(sawIndex ? maxIndex : 0)} records={recordCount} " +
-                $"instances={state.InstanceCount} index_size={(is32Bit ? 32 : 16)} " +
-                $"index_addr=0x{state.IndexBufferAddress:X16} offset={state.DrawIndexOffset}");
+                $"max_index={(sawIndex ? maxIndex : 0)} base_vertex={baseVertex} " +
+                $"records={recordCount} instances={state.InstanceCount} " +
+                $"index_size={indexBits} index_addr=0x{state.IndexBufferAddress:X16} " +
+                $"offset={state.DrawIndexOffset}");
         }
         return true;
     }
@@ -7340,6 +7449,20 @@ public static partial class AgcExports
         target < ColorTargetCount
             ? (packedMasks >> (int)(target * 4)) & 0xFu
             : 0;
+
+    private static bool VertexProgramExportsParameters(Gen5ShaderProgram program)
+    {
+        foreach (var instruction in program.Instructions)
+        {
+            if (instruction.Control is Gen5ExportControl export &&
+                export.Target is >= 32 and < 64)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private static uint GetInterpolatedAttributeCount(Gen5ShaderState state)
     {
@@ -8045,10 +8168,15 @@ public static partial class AgcExports
                     ? $"{entry.Name}=0x{value:X8}"
                     : $"{entry.Name}=missing"));
         var blend = draw.RenderState.Blend;
+        var rectExpanded = AgcPrimitiveHelpers.GetRectListDrawVertexCount(
+            draw.PrimitiveType,
+            draw.VertexCount,
+            indexed: draw.IndexBuffer is not null,
+            hasVertexBuffers: draw.VertexInputs.Count > 0);
         TraceAgcShader(
             $"agc.shader_draw es=0x{draw.ExportShaderAddress:X16} " +
             $"ps=0x{draw.PixelShaderAddress:X16} spirv={draw.PixelShader.Payload.Length} " +
-            $"primitive=0x{draw.PrimitiveType:X} " +
+            $"primitive=0x{draw.PrimitiveType:X} verts={draw.VertexCount}->{rectExpanded} " +
             $"blend={(blend.Enable ? 1 : 0)}:{blend.ColorSrcFactor}/{blend.ColorDstFactor}/{blend.ColorFunc} " +
             $"write_mask=0x{blend.WriteMask:X} scissor={scissor} viewport={viewport} " +
             $"raster=[{raster}] " +
@@ -9320,36 +9448,51 @@ public static partial class AgcExports
         TranslatedGuestDraw draw,
         IReadOnlyList<GuestVertexBuffer> vertexBuffers)
     {
-        if (draw.PrimitiveType != 0x11 ||
-            draw.IndexBuffer is not null ||
-            vertexBuffers.Count == 0 ||
-            _rectListTraceCount >= 8 ||
-            Interlocked.Increment(ref _rectListTraceCount) > 8)
+        if (!AgcPrimitiveHelpers.IsRectListPrimitive(draw.PrimitiveType) ||
+            _rectListTraceCount >= 16 ||
+            Interlocked.Increment(ref _rectListTraceCount) > 16)
         {
             return;
         }
 
-        var buffer = vertexBuffers[0];
-        var stride = Math.Max(buffer.Stride, 4u);
+        var expanded = AgcPrimitiveHelpers.GetRectListDrawVertexCount(
+            draw.PrimitiveType,
+            draw.VertexCount,
+            indexed: draw.IndexBuffer is not null,
+            hasVertexBuffers: vertexBuffers.Count > 0);
         var text = new System.Text.StringBuilder();
-        for (var vertex = 0; vertex < 3; vertex++)
-        {
-            var baseOffset = (int)(buffer.OffsetBytes + vertex * stride);
-            if (baseOffset + 16 > buffer.Length)
-            {
-                break;
-            }
+        text.Append(
+            $"agc.rectlist prim=0x{draw.PrimitiveType:X} verts={draw.VertexCount}->{expanded} " +
+            $"indexed={(draw.IndexBuffer is not null ? 1 : 0)} vb={vertexBuffers.Count}");
 
-            var x = BitConverter.ToSingle(buffer.Data, baseOffset);
-            var y = BitConverter.ToSingle(buffer.Data, baseOffset + 4);
-            var z = BitConverter.ToSingle(buffer.Data, baseOffset + 8);
-            var w = BitConverter.ToSingle(buffer.Data, baseOffset + 12);
-            text.Append($" v{vertex}=({x:0.###},{y:0.###},{z:0.###},{w:0.###})");
+        if (vertexBuffers.Count > 0)
+        {
+            var buffer = vertexBuffers[0];
+            var stride = Math.Max(buffer.Stride, 4u);
+            text.Append(
+                $" stride={buffer.Stride} " +
+                $"fmt={buffer.DataFormat}/{buffer.NumberFormat}x{buffer.ComponentCount}");
+            for (var vertex = 0; vertex < 3; vertex++)
+            {
+                var baseOffset = (int)(buffer.OffsetBytes + vertex * stride);
+                if (baseOffset + 16 > buffer.Length)
+                {
+                    break;
+                }
+
+                var x = BitConverter.ToSingle(buffer.Data, baseOffset);
+                var y = BitConverter.ToSingle(buffer.Data, baseOffset + 4);
+                var z = BitConverter.ToSingle(buffer.Data, baseOffset + 8);
+                var w = BitConverter.ToSingle(buffer.Data, baseOffset + 12);
+                text.Append($" v{vertex}=({x:0.###},{y:0.###},{z:0.###},{w:0.###})");
+            }
+        }
+        else
+        {
+            text.Append(" procedural=1");
         }
 
-        TraceAgcShader(
-            $"agc.rectlist verts={draw.VertexCount} stride={buffer.Stride} " +
-            $"fmt={buffer.DataFormat}/{buffer.NumberFormat}x{buffer.ComponentCount}{text}");
+        TraceAgcShader(text.ToString());
     }
 
     private static int _textureDumpCount;
@@ -11450,6 +11593,9 @@ public static partial class AgcExports
 
     private static bool IsEsGeometryShaderType(byte shaderType) =>
         shaderType is 2 or 6;
+
+    private static bool IsRectListPrimitive(uint primitiveType) =>
+        AgcPrimitiveHelpers.IsRectListPrimitive(primitiveType);
 
     private static int SetIndirectPatchAddress(CpuContext ctx, string registerSpace)
     {

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -55,6 +55,8 @@ public static partial class AgcExports
     private const uint ItEventWrite = 0x46;
     private const uint ItReleaseMem = 0x49;
     private const uint ItDmaData = 0x50;
+    // Prospero IT_REWIND — 2-dword packet; body dword bit 31 carries RewindState.
+    private const uint ItRewind = 0x59;
     private const uint ItSetContextReg = 0x69;
     private const uint ItSetShReg = 0x76;
     private const uint ItSetUconfigReg = 0x79;
@@ -3397,6 +3399,52 @@ public static partial class AgcExports
                 continue;
             }
 
+            // IT_REWIND: valid bit (body dword bit 31) means subsequent packets
+            // are ready. Hardware polls until SetRewindState patches it; we
+            // suspend the DCB on the same wait registry used by WAIT_REG_MEM.
+            if (op == ItRewind && length >= 2)
+            {
+                if (HandleSubmittedRewind(
+                        ctx,
+                        state,
+                        commandAddress,
+                        currentAddress,
+                        offset,
+                        length,
+                        dwordCount,
+                        tracePackets))
+                {
+                    return true;
+                }
+
+                offset += length;
+                continue;
+            }
+
+            // IT_INDIRECT_BUFFER (4-dword jump): run the nested buffer, then
+            // resume. 14-dword conditional branch form is not implemented yet.
+            if (op == ItIndirectBuffer && length == 4)
+            {
+                if (!TryRunSubmittedIndirectBuffer(
+                        ctx,
+                        gpuState,
+                        state,
+                        currentAddress,
+                        tracePackets,
+                        out var nestedSuspended))
+                {
+                    return false;
+                }
+
+                if (nestedSuspended)
+                {
+                    return true;
+                }
+
+                offset += length;
+                continue;
+            }
+
             if (op == ItNop &&
                 register is RDrawReset or RAcbReset &&
                 length >= 2)
@@ -5095,6 +5143,148 @@ public static partial class AgcExports
             TraceAgc(
                 $"agc.dispatch_indirect_wait dims=0x{dimsAddress:X16} " +
                 $"packet=0x{packetAddress:X16} queue={state.QueueName}");
+        }
+
+        return true;
+    }
+
+    // Returns true when the DCB should suspend until the rewind valid bit is set.
+    private static bool HandleSubmittedRewind(
+        CpuContext ctx,
+        SubmittedDcbState state,
+        ulong commandAddress,
+        ulong packetAddress,
+        uint offset,
+        uint length,
+        uint dwordCount,
+        bool tracePacket)
+    {
+        var bodyAddress = packetAddress + sizeof(uint);
+        if (!TryReadUInt32(ctx, bodyAddress, out var body))
+        {
+            return false;
+        }
+
+        const uint validMask = 1u << 31;
+        if ((body & validMask) != 0)
+        {
+            if (tracePacket)
+            {
+                TraceAgc(
+                    $"agc.dcb.rewind queue={state.QueueName} " +
+                    $"packet=0x{packetAddress:X16} valid=1");
+            }
+
+            return false;
+        }
+
+        if (tracePacket)
+        {
+            TraceAgc(
+                $"agc.dcb.rewind_wait queue={state.QueueName} " +
+                $"packet=0x{packetAddress:X16} body=0x{bodyAddress:X16}");
+        }
+
+        var waiter = new GpuWaitRegistry.WaitingDcb
+        {
+            CommandBufferAddress = commandAddress,
+            ResumeAddress = packetAddress + ((ulong)length * sizeof(uint)),
+            TotalDwords = dwordCount,
+            ResumeOffset = offset + length,
+            ReferenceValue = validMask,
+            Mask = validMask,
+            CompareFunction = 3, // equal
+            ControlValue = 0,
+            Is64Bit = false,
+            IsStandard = false,
+            WaitAddress = bodyAddress,
+            Memory = ctx.Memory,
+            QueueName = state.QueueName,
+            SubmissionId = state.ActiveSubmissionId,
+            RegisteredTicks = System.Diagnostics.Stopwatch.GetTimestamp(),
+            State = state,
+        };
+
+        if (!_gpuWaitSuspendEnabled)
+        {
+            // Force-open: treat as valid so parsing continues. Titles that rely
+            // on patch-before-execute still get a correct packet from the HLE
+            // writers; only the wait-for-valid race is skipped.
+            return false;
+        }
+
+        GpuWaitRegistry.Register(bodyAddress, waiter);
+        var gpuState = _submittedGpuStates.GetValue(
+            ctx.Memory,
+            static _ => new SubmittedGpuState());
+        EnsureGpuWaitMonitor(ctx, gpuState);
+        return true;
+    }
+
+    private static bool TryRunSubmittedIndirectBuffer(
+        CpuContext ctx,
+        SubmittedGpuState gpuState,
+        SubmittedDcbState state,
+        ulong packetAddress,
+        bool tracePackets,
+        out bool suspended)
+    {
+        suspended = false;
+        if (!TryReadUInt32(ctx, packetAddress + 4, out var addressLo) ||
+            !TryReadUInt32(ctx, packetAddress + 8, out var addressHi) ||
+            !TryReadUInt32(ctx, packetAddress + 12, out var control))
+        {
+            TracePacketParseFailure(state, packetAddress, 0, 0, "indirect-buffer-read");
+            return false;
+        }
+
+        var nestedAddress = ((ulong)addressHi << 32) | (addressLo & ~0x3u);
+        var nestedDwords = control & 0xF_FFFFu;
+        if (nestedDwords == 0 || nestedAddress == 0)
+        {
+            if (tracePackets)
+            {
+                TraceAgc(
+                    $"agc.dcb.indirect_buffer queue={state.QueueName} " +
+                    $"packet=0x{packetAddress:X16} empty " +
+                    $"control=0x{control:X8}");
+            }
+
+            return true;
+        }
+
+        if (tracePackets)
+        {
+            TraceAgc(
+                $"agc.dcb.indirect_buffer queue={state.QueueName} " +
+                $"packet=0x{packetAddress:X16} " +
+                $"target=0x{nestedAddress:X16} dwords={nestedDwords} " +
+                $"control=0x{control:X8}");
+        }
+
+        // Nested reads are outside the parent DCB window — clear it so
+        // TryRead* falls through to guest memory for the jump target.
+        var savedWindow = _dcbWindowBuffer;
+        var savedStart = _dcbWindowStart;
+        var savedLength = _dcbWindowByteLength;
+        _dcbWindowBuffer = null;
+        _dcbWindowByteLength = 0;
+        try
+        {
+            // Nested jump shares queue state with the parent buffer.
+            suspended = ParseSubmittedDcbCore(
+                ctx,
+                gpuState,
+                state,
+                nestedAddress,
+                nestedDwords,
+                tracePackets);
+        }
+        finally
+        {
+            _dcbWindowBuffer = savedWindow;
+            _dcbWindowStart = savedStart;
+            _dcbWindowByteLength = savedLength;
         }
 
         return true;
@@ -12472,9 +12662,8 @@ public static partial class AgcExports
             $"[LOADER][TRACE] agc.create_shader dst=0x{destinationAddress:X16} header=0x{headerAddress:X16} code=0x{codeAddress:X16} {detail}");
     }
 
-    // Hardware REWIND is a fixed 2-dword header + valid-bit packet (same floor
-    // as CbNopGetSize). No Rewind writer is implemented yet; size-only is enough
-    // for callers that allocate the packet before filling it.
+    // Hardware REWIND is a fixed 2-dword IT_REWIND packet. Body dword bit 31
+    // holds RewindState (patched later via sceAgcRewindPatchSetRewindState).
     [SysAbiExport(
         Nid = "QIXCsbipds0",
         ExportName = "sceAgcDcbRewindGetSize",
@@ -12486,7 +12675,96 @@ public static partial class AgcExports
         return (int)ctx[CpuRegister.Rax];
     }
 
-    // Matches the 4-dword INDIRECT_BUFFER packet DcbJump writes below.
+    [SysAbiExport(
+        Nid = "0ZOG0jc9nRg",
+        ExportName = "sceAgcAcbRewindGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int AcbRewindGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 2u * sizeof(uint);
+        return (int)ctx[CpuRegister.Rax];
+    }
+
+    [SysAbiExport(
+        Nid = "zfcxg-ewMK8",
+        ExportName = "sceAgcDcbRewind",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbRewind(CpuContext ctx) =>
+        WriteRewindPacket(ctx, ctx[CpuRegister.Rdi], (uint)ctx[CpuRegister.Rsi]);
+
+    [SysAbiExport(
+        Nid = "DwICrVxerkY",
+        ExportName = "sceAgcAcbRewind",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int AcbRewind(CpuContext ctx) =>
+        WriteRewindPacket(ctx, ctx[CpuRegister.Rdi], (uint)ctx[CpuRegister.Rsi]);
+
+    private static int WriteRewindPacket(CpuContext ctx, ulong commandBufferAddress, uint initialState)
+    {
+        if (commandBufferAddress == 0)
+        {
+            return ReturnPointer(ctx, 0);
+        }
+
+        if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 2, out var cmd) ||
+            !ctx.TryWriteUInt32(cmd, Pm4(2, ItRewind, RZero)) ||
+            !ctx.TryWriteUInt32(cmd + 4, (initialState & 1u) << 31))
+        {
+            return ReturnPointer(ctx, 0);
+        }
+
+        return ReturnPointer(ctx, cmd);
+    }
+
+    // Patches dword 1 of an IT_REWIND packet previously returned by DcbRewind /
+    // AcbRewind. Leaving this unresolved returned NOT_FOUND which titles then
+    // treated as a packet pointer (write AV on Subrender).
+    [SysAbiExport(
+        Nid = "ziVA3whp3p4",
+        ExportName = "sceAgcRewindPatchSetRewindState",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int RewindPatchSetRewindState(CpuContext ctx) =>
+        SetRewindPacketState(ctx, ctx[CpuRegister.Rdi], (uint)ctx[CpuRegister.Rsi]);
+
+    [SysAbiExport(
+        Nid = "eWaWyFegzgQ",
+        ExportName = "sceAgcAsyncRewindPatchSetRewindState",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int AsyncRewindPatchSetRewindState(CpuContext ctx) =>
+        SetRewindPacketState(ctx, ctx[CpuRegister.Rdi], (uint)ctx[CpuRegister.Rsi]);
+
+    private static int SetRewindPacketState(CpuContext ctx, ulong packetAddress, uint state)
+    {
+        if (packetAddress == 0)
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        var bodyAddress = packetAddress + sizeof(uint);
+        if (!TryReadUInt32(ctx, bodyAddress, out var body))
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        body = (body & ~(1u << 31)) | ((state & 1u) << 31);
+        if (!ctx.TryWriteUInt32(bodyAddress, body))
+        {
+            return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        // Latch any DCB suspended on this rewind valid bit (registered when
+        // the parser hit IT_REWIND with valid=0). The GPU wait monitor drains
+        // latched waiters on the next CollectSatisfied pass.
+        GpuWaitRegistry.RecordProduced(ctx.Memory, bodyAddress, body);
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    // Matches the 4-dword INDIRECT_BUFFER packet DcbJump / AcbJump write.
     // Returning NOT_FOUND here left callers with a null packet pointer and an
     // immediate write AV on RenderThread.
     [SysAbiExport(
@@ -12501,25 +12779,75 @@ public static partial class AgcExports
     }
 
     [SysAbiExport(
+        Nid = "b-oySn+G2tE",
+        ExportName = "sceAgcAcbJumpGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int AcbJumpGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 4u * sizeof(uint);
+        return (int)ctx[CpuRegister.Rax];
+    }
+
+    // sceAgcDcbJump(CommandBuffer* buf, uint8_t mode, uint8_t cachePolicy,
+    //               const uint32_t* target, uint32_t sizeInDwords)
+    [SysAbiExport(
         Nid = "xSAR0LTcRKM",
         ExportName = "sceAgcDcbJump",
         Target = Generation.Gen5,
         LibraryName = "libSceAgc")]
-    public static int DcbJump(CpuContext ctx)
+    public static int DcbJump(CpuContext ctx) =>
+        WriteIndirectBufferJump(
+            ctx,
+            ctx[CpuRegister.Rdi],
+            (uint)(ctx[CpuRegister.Rsi] & 0xFFu),
+            (uint)(ctx[CpuRegister.Rdx] & 0xFFu),
+            ctx[CpuRegister.Rcx],
+            (uint)ctx[CpuRegister.R8]);
+
+    [SysAbiExport(
+        Nid = "e1DFTg+Sd8U",
+        ExportName = "sceAgcAcbJump",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int AcbJump(CpuContext ctx) =>
+        WriteIndirectBufferJump(
+            ctx,
+            ctx[CpuRegister.Rdi],
+            (uint)(ctx[CpuRegister.Rsi] & 0xFFu),
+            (uint)(ctx[CpuRegister.Rdx] & 0xFFu),
+            ctx[CpuRegister.Rcx],
+            (uint)ctx[CpuRegister.R8]);
+
+    private static int WriteIndirectBufferJump(
+        CpuContext ctx,
+        ulong commandBufferAddress,
+        uint mode,
+        uint cachePolicy,
+        ulong target,
+        uint sizeDwords)
     {
-        var dcb = ctx[CpuRegister.Rdi];
-        var target = ctx[CpuRegister.Rsi];
-        var sizeDwords = (uint)ctx[CpuRegister.Rdx];
-        if (dcb == 0)
+        if (commandBufferAddress == 0)
         {
             return ReturnPointer(ctx, 0);
         }
 
-        if (!TryAllocateCommandDwords(ctx, dcb, 4, out var cmd) ||
+        // Prospero INDIRECT_BUFFER control dword layout:
+        //   bits[19:0]  = size in dwords
+        //   bit 20      = mode
+        //   bits[29:28] = cache policy
+        //   remaining high bits use the 0x0F200000 base flags
+        var control =
+            0x0F20_0000u |
+            ((cachePolicy & 0x3u) << 28) |
+            ((mode & 0x1u) << 20) |
+            (sizeDwords & 0xF_FFFFu);
+
+        if (!TryAllocateCommandDwords(ctx, commandBufferAddress, 4, out var cmd) ||
             !ctx.TryWriteUInt32(cmd, Pm4(4, ItIndirectBuffer, RZero)) ||
-            !ctx.TryWriteUInt32(cmd + 4, (uint)(target & 0xFFFF_FFFFUL)) ||
-            !ctx.TryWriteUInt32(cmd + 8, (uint)((target >> 32) & 0xFFFFUL)) ||
-            !ctx.TryWriteUInt32(cmd + 12, sizeDwords & 0xFFFFF))
+            !ctx.TryWriteUInt32(cmd + 4, (uint)(target & ~0x3UL)) ||
+            !ctx.TryWriteUInt32(cmd + 8, (uint)(target >> 32)) ||
+            !ctx.TryWriteUInt32(cmd + 12, control))
         {
             return ReturnPointer(ctx, 0);
         }

--- a/src/SharpEmu.Libs/Agc/AgcIndexHelpers.cs
+++ b/src/SharpEmu.Libs/Agc/AgcIndexHelpers.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+
+namespace SharpEmu.Libs.Agc;
+
+/// <summary>Prospero/AGC IndexType helpers (gpu_defs / renderDraw index8 expand).</summary>
+internal static class AgcIndexHelpers
+{
+    internal enum ProsperoIndexType : uint
+    {
+        Index16 = 0,
+        Index32 = 1,
+        Index8 = 2,
+    }
+
+    internal static ProsperoIndexType Decode(uint raw) =>
+        (raw & 0x3u) switch
+        {
+            1 => ProsperoIndexType.Index32,
+            2 => ProsperoIndexType.Index8,
+            _ => ProsperoIndexType.Index16,
+        };
+
+    internal static int GetGuestStrideBytes(ProsperoIndexType indexType) =>
+        indexType switch
+        {
+            ProsperoIndexType.Index32 => sizeof(uint),
+            ProsperoIndexType.Index8 => sizeof(byte),
+            _ => sizeof(ushort),
+        };
+
+    /// <summary>Expand guest u8 indices to host u16 (Vulkan/Metal bindable).</summary>
+    internal static void ExpandIndex8ToU16(ReadOnlySpan<byte> source, Span<byte> destination)
+    {
+        if (destination.Length < source.Length * sizeof(ushort))
+        {
+            throw new ArgumentException("destination too small for u8->u16 expansion.");
+        }
+
+        for (var index = 0; index < source.Length; index++)
+        {
+            BinaryPrimitives.WriteUInt16LittleEndian(
+                destination.Slice(index * sizeof(ushort), sizeof(ushort)),
+                source[index]);
+        }
+    }
+}

--- a/src/SharpEmu.Libs/Agc/AgcPrimitiveHelpers.cs
+++ b/src/SharpEmu.Libs/Agc/AgcPrimitiveHelpers.cs
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Libs.Agc;
+
+/// <summary>
+/// Shared Prospero/AGC primitive-type helpers (renderDraw / gpu_defs).
+/// </summary>
+internal static class AgcPrimitiveHelpers
+{
+    internal const uint PrimitiveRectList = 7;
+    internal const uint PrimitiveRectListLegacy = 0x11;
+
+    internal enum GsOutputPrimitiveType : uint
+    {
+        Points = 0,
+        Lines = 1,
+        Triangles = 2,
+        Rectangle2D = 3,
+        RectList = 4,
+    }
+
+    internal static bool IsRectListPrimitive(uint primitiveType) =>
+        primitiveType is PrimitiveRectList or PrimitiveRectListLegacy;
+
+    /// <summary>
+    /// Maps draw prim type to VGT_GS_OUT_PRIM_TYPE when NGG is not enabled
+    /// on the GS (GraphicsPrimitiveTypeToGsOut).
+    /// </summary>
+    internal static uint PrimitiveTypeToGsOut(uint primitiveType) =>
+        primitiveType switch
+        {
+            1 => (uint)GsOutputPrimitiveType.Points, // PointList
+            2 or 3 or 10 or 11 or 18 => (uint)GsOutputPrimitiveType.Lines,
+            PrimitiveRectList => (uint)GsOutputPrimitiveType.Rectangle2D,
+            PrimitiveRectListLegacy => (uint)GsOutputPrimitiveType.RectList,
+            _ => (uint)GsOutputPrimitiveType.Triangles,
+        };
+
+    /// <summary>
+    /// Rect-list auto-draw topology selection.
+    /// NGG single-rect UI quads (DualSense prompts) submit count 1/3/4 and
+    /// must become a 4-vert triangle strip — even when the VS has embedded
+    /// vertex-buffer fetches (those still show up as host VBs). Indexed and
+    /// larger auto counts stay triangle list so the loading video is safe.
+    /// </summary>
+    internal static bool ShouldDrawRectListAsTriangleStrip(
+        uint primitiveType,
+        bool indexed,
+        uint vertexCount,
+        bool hasVertexBuffers = false)
+    {
+        _ = hasVertexBuffers;
+        if (indexed || !IsRectListPrimitive(primitiveType))
+        {
+            return false;
+        }
+
+        if (primitiveType == PrimitiveRectListLegacy)
+        {
+            return true;
+        }
+
+        // NGG kRectList: strip for auto + ngg_rectlist_draw.
+        // Restrict to the single-rect counts GTA UI actually submits.
+        return vertexCount is 1 or 3 or 4;
+    }
+
+    /// <summary>
+    /// Host vertex count for auto rect-list draws that expand to a strip.
+    /// NGG single-rect: always 4. Legacy 0x11: 3 -> 4.
+    /// </summary>
+    internal static uint GetRectListDrawVertexCount(
+        uint primitiveType,
+        uint vertexCount,
+        bool indexed,
+        bool hasVertexBuffers = false)
+    {
+        if (!ShouldDrawRectListAsTriangleStrip(
+                primitiveType,
+                indexed,
+                vertexCount,
+                hasVertexBuffers))
+        {
+            return vertexCount;
+        }
+
+        if (primitiveType == PrimitiveRectList)
+        {
+            return 4;
+        }
+
+        if (primitiveType == PrimitiveRectListLegacy && vertexCount == 3)
+        {
+            return 4;
+        }
+
+        return vertexCount;
+    }
+
+    /// <summary>
+    /// Legacy helper — prefer
+    /// <see cref="ShouldDrawRectListAsTriangleStrip"/>.
+    /// </summary>
+    internal static bool IsRectListTriangleStrip(uint primitiveType) =>
+        IsRectListPrimitive(primitiveType);
+}

--- a/src/SharpEmu.Libs/Audio/AjmExports.cs
+++ b/src/SharpEmu.Libs/Audio/AjmExports.cs
@@ -23,13 +23,32 @@ public static class AjmExports
     private static int _nextContextId;
     private static int _nextBatchId;
 
+    private const uint AjmCodecMp3 = 0;
+
+    private sealed class AjmInstanceState
+    {
+        public required uint Codec { get; init; }
+        public required ulong Flags { get; init; }
+        public AjmMp3Decoder? Mp3 { get; init; }
+
+        public bool PreferPcm16
+        {
+            get
+            {
+                // AjmInstanceFlags: version:3, channels:4, format:3
+                var encoding = (Flags >> 7) & 0x7;
+                return encoding is 0 or 1; // S16 / S32 — we emit S16 for both
+            }
+        }
+    }
+
     private sealed class AjmContextState
     {
         public object Gate { get; } = new();
 
         public HashSet<uint> RegisteredCodecs { get; } = new();
 
-        public Dictionary<uint, uint> InstancesBySlot { get; } = new();
+        public Dictionary<uint, AjmInstanceState> InstancesBySlot { get; } = new();
 
         public int NextInstanceIndex { get; set; }
     }
@@ -169,7 +188,14 @@ public static class AjmExports
             }
 
             state.NextInstanceIndex = nextInstanceIndex;
-            state.InstancesBySlot.Add(instanceSlot, instanceId);
+            state.InstancesBySlot.Add(
+                instanceSlot,
+                new AjmInstanceState
+                {
+                    Codec = codecType,
+                    Flags = flags,
+                    Mp3 = codecType == AjmCodecMp3 ? new AjmMp3Decoder() : null,
+                });
         }
 
         Trace($"instance_create context={contextId} codec={codecType} flags=0x{flags:X} instance=0x{instanceId:X8}");
@@ -229,11 +255,9 @@ public static class AjmExports
     }
 
     /// <summary>
-    /// Enqueues a decode job on a batch. Titles call this on the Bink/AJM hot
-    /// path; leaving it unresolved floods Import WARN spam. This is a silence
-    /// stub, not a codec: advance the batch cursor and report the input as
-    /// consumed with silence produced so the title does not spin on the same
-    /// packet.
+    /// Enqueues a decode job on a batch. GTA V Enhanced streams menu music
+    /// through AJM MP3 (codec 0); we decode eagerly here so BatchStart/Wait
+    /// stay synchronous no-ops.
     /// </summary>
     [SysAbiExport(
         Nid = "39WxhR-ePew",
@@ -255,37 +279,120 @@ public static class AjmExports
             return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
         }
 
-        // Best-effort: bump the batch cursor when the guest filled AjmBatchInfo.
-        // Still succeed without it — the unresolved stub returned 0 and titles
-        // keep calling; failing here would reintroduce hot-path spam via retries.
         _ = TryAppendBatchJob(ctx, infoAddress, AjmJobRunSize);
 
-        // Silence: clear PCM out and claim full input consumed so the guest
-        // advances its bitstream cursor instead of re-submitting forever.
-        if (outputAddress != 0 && outputSize != 0 && outputSize <= MaxSilentPcmBytes)
+        var inputConsumed = 0;
+        var outputWritten = 0;
+        ulong totalSamples = 0;
+        var frames = 0u;
+        var decoded = false;
+
+        if (TryGetInstance(instanceId, out var instance) &&
+            instance.Mp3 is not null &&
+            inputAddress != 0 &&
+            inputSize is > 0 and <= MaxSilentPcmBytes &&
+            outputAddress != 0 &&
+            outputSize is > 0 and <= MaxSilentPcmBytes)
         {
-            ClearGuestMemory(ctx, outputAddress, outputSize);
+            var input = new byte[inputSize];
+            var output = new byte[outputSize];
+            if (ctx.Memory.TryRead(inputAddress, input))
+            {
+                var result = instance.Mp3.Decode(input, output, pcm16: instance.PreferPcm16);
+                if (result.OutputWritten > 0)
+                {
+                    if (!ctx.Memory.TryWrite(outputAddress, output.AsSpan(0, result.OutputWritten)))
+                    {
+                        return ctx.SetReturn(OrbisAjmErrorInvalidParameter);
+                    }
+
+                    // Zero any remainder so stale PCM does not leak into FMOD.
+                    if ((ulong)result.OutputWritten < outputSize)
+                    {
+                        ClearGuestMemory(
+                            ctx,
+                            outputAddress + (ulong)result.OutputWritten,
+                            outputSize - (ulong)result.OutputWritten);
+                    }
+
+                    decoded = true;
+                    inputConsumed = result.InputConsumed;
+                    outputWritten = result.OutputWritten;
+                    frames = result.Frames;
+                    totalSamples = instance.Mp3.TotalDecodedSamples;
+                }
+                else
+                {
+                    inputConsumed = result.InputConsumed;
+                    totalSamples = instance.Mp3.TotalDecodedSamples;
+                }
+            }
+        }
+
+        if (!decoded)
+        {
+            // Fallback: silence + consume input so the guest does not spin.
+            if (outputAddress != 0 && outputSize != 0 && outputSize <= MaxSilentPcmBytes)
+            {
+                ClearGuestMemory(ctx, outputAddress, outputSize);
+            }
+
+            if (inputConsumed == 0)
+            {
+                inputConsumed = inputSize > int.MaxValue ? int.MaxValue : (int)inputSize;
+            }
+
+            if (frames == 0 && (inputSize != 0 || outputSize != 0))
+            {
+                frames = 1;
+            }
         }
 
         WriteDecodeStreamResult(
             ctx,
             resultAddress,
-            inputConsumed: inputSize > int.MaxValue ? int.MaxValue : (int)inputSize,
-            outputWritten: 0,
-            totalDecodedSamples: 0,
-            frames: inputSize != 0 || outputSize != 0 ? 1u : 0u);
+            inputConsumed,
+            outputWritten,
+            totalSamples,
+            frames);
 
         Trace(
             $"batch_job_decode info=0x{infoAddress:X16} instance=0x{instanceId:X8} " +
             $"in=0x{inputAddress:X16}+0x{inputSize:X} out=0x{outputAddress:X16}+0x{outputSize:X} " +
-            $"result=0x{resultAddress:X16}");
+            $"written={outputWritten} frames={frames} result=0x{resultAddress:X16}");
         return ctx.SetReturn(0);
     }
 
+    private static bool TryGetInstance(uint instanceId, out AjmInstanceState instance)
+    {
+        instance = null!;
+        var codec = instanceId >> 14;
+        var slot = instanceId & 0x3FFF;
+        if (slot == 0)
+        {
+            return false;
+        }
+
+        foreach (var context in Contexts.Values)
+        {
+            lock (context.Gate)
+            {
+                if (context.InstancesBySlot.TryGetValue(slot, out var found) &&
+                    found.Codec == codec)
+                {
+                    instance = found;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>
-    /// Submits a built batch. Instant-complete silence stub: publish a batch id
-    /// and clear any error out. Decode sidebands were already filled at
-    /// job-enqueue time.
+    /// Submits a built batch. Hot path after BatchJobDecode; unresolved WARNs
+    /// dominate the log. Instant-complete: publish a batch id and clear any
+    /// error out. Decode sidebands were already filled at job-enqueue time.
     /// </summary>
     [SysAbiExport(
         Nid = "5tOfnaClcqM",
@@ -363,6 +470,7 @@ public static class AjmExports
     private const ulong AjmBatchInfoSizeField = 16;
     private const ulong AjmBatchInfoLastGoodJobField = 24;
     private const ulong AjmJobRunSize = 64;
+    private const int OrbisAjmErrorJobCreation = unchecked((int)0x80930012);
     private const ulong MaxSilentPcmBytes = 1 << 20;
     // AjmSidebandResult (8) + AjmSidebandStream (16) + AjmSidebandMFrame (8).
     private const int DecodeSidebandBytes = 32;

--- a/src/SharpEmu.Libs/Audio/AjmMp3Decoder.cs
+++ b/src/SharpEmu.Libs/Audio/AjmMp3Decoder.cs
@@ -1,0 +1,231 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using NLayer;
+using System.Buffers.Binary;
+using System.Reflection;
+
+namespace SharpEmu.Libs.Audio;
+
+/// <summary>
+/// Stateful AJM MP3 (codec 0) decoder. GTA menu music arrives as ~960-byte
+/// packets that NLayer must decode with a persistent bit-reservoir.
+/// </summary>
+internal sealed class AjmMp3Decoder
+{
+    private static readonly Type? MpegStreamReaderType =
+        typeof(MpegFrameDecoder).Assembly.GetType("NLayer.Decoder.MpegStreamReader");
+
+    private static readonly MethodInfo? NextFrameMethod =
+        MpegStreamReaderType?.GetMethod(
+            "NextFrame",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+    private static readonly MethodInfo? ClearBufferMethod =
+        typeof(MpegFrameDecoder).Assembly.GetType("NLayer.Decoder.FrameBase")
+            ?.GetMethod("ClearBuffer", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+    private readonly MpegFrameDecoder _decoder = new();
+    private readonly object _gate = new();
+    private byte[] _pending = Array.Empty<byte>();
+    private readonly float[] _floatScratch = new float[1152 * 2];
+
+    public ulong TotalDecodedSamples { get; private set; }
+
+    public void Reset()
+    {
+        lock (_gate)
+        {
+            _decoder.Reset();
+            _pending = Array.Empty<byte>();
+            TotalDecodedSamples = 0;
+        }
+    }
+
+    public DecodeResult Decode(ReadOnlySpan<byte> input, Span<byte> output, bool pcm16)
+    {
+        lock (_gate)
+        {
+            if (MpegStreamReaderType is null || NextFrameMethod is null)
+            {
+                return DecodeResult.Failed;
+            }
+
+            var merged = new byte[_pending.Length + input.Length];
+            if (_pending.Length != 0)
+            {
+                _pending.CopyTo(merged, 0);
+            }
+
+            input.CopyTo(merged.AsSpan(_pending.Length));
+
+            using var stream = new MemoryStream(merged, writable: false);
+            object? reader;
+            try
+            {
+                reader = Activator.CreateInstance(
+                    MpegStreamReaderType,
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    binder: null,
+                    args: [stream],
+                    culture: null);
+            }
+            catch
+            {
+                return DecodeResult.Failed;
+            }
+
+            if (reader is null)
+            {
+                return DecodeResult.Failed;
+            }
+
+            var outputOffset = 0;
+            var inputConsumed = 0;
+            var frames = 0u;
+            var samplesThisCall = 0u;
+
+            while (outputOffset < output.Length)
+            {
+                object? frameObj;
+                try
+                {
+                    frameObj = NextFrameMethod.Invoke(reader, null);
+                }
+                catch
+                {
+                    break;
+                }
+
+                if (frameObj is not IMpegFrame frame)
+                {
+                    break;
+                }
+
+                try
+                {
+                    var frameOffset = GetFrameOffset(frameObj);
+                    var frameLength = frame.FrameLength;
+                    if (frameLength <= 0 || frameOffset + frameLength > merged.Length)
+                    {
+                        break;
+                    }
+
+                    int sampleCount;
+                    try
+                    {
+                        sampleCount = _decoder.DecodeFrame(frame, _floatScratch, 0);
+                    }
+                    catch
+                    {
+                        _decoder.Reset();
+                        inputConsumed = frameOffset + frameLength;
+                        continue;
+                    }
+
+                    if (sampleCount <= 0)
+                    {
+                        inputConsumed = frameOffset + frameLength;
+                        continue;
+                    }
+
+                    var channels = frame.ChannelMode == MpegChannelMode.Mono ? 1 : 2;
+                    var bytesPerSample = pcm16 ? 2 : 4;
+                    var byteCount = sampleCount * bytesPerSample;
+                    if (outputOffset + byteCount > output.Length)
+                    {
+                        // Not enough room for this frame — leave it for next job.
+                        break;
+                    }
+
+                    if (pcm16)
+                    {
+                        WritePcm16(_floatScratch.AsSpan(0, sampleCount), output[outputOffset..]);
+                    }
+                    else
+                    {
+                        WriteFloat(_floatScratch.AsSpan(0, sampleCount), output[outputOffset..]);
+                    }
+
+                    outputOffset += byteCount;
+                    inputConsumed = frameOffset + frameLength;
+                    frames++;
+                    samplesThisCall += (uint)(sampleCount / Math.Max(channels, 1));
+                    TotalDecodedSamples += (ulong)(sampleCount / Math.Max(channels, 1));
+                }
+                finally
+                {
+                    try
+                    {
+                        ClearBufferMethod?.Invoke(frameObj, null);
+                    }
+                    catch
+                    {
+                        // best-effort
+                    }
+                }
+            }
+
+            _pending = inputConsumed < merged.Length
+                ? merged[inputConsumed..]
+                : Array.Empty<byte>();
+
+            // Consume the portion of *this* input that left the pending window.
+            var pendingBefore = merged.Length - input.Length;
+            var consumedFromInput = Math.Clamp(inputConsumed - pendingBefore, 0, input.Length);
+
+            return new DecodeResult(
+                Success: frames > 0 || consumedFromInput > 0,
+                InputConsumed: consumedFromInput,
+                OutputWritten: outputOffset,
+                Frames: frames,
+                SamplesThisCall: samplesThisCall);
+        }
+    }
+
+    private static int GetFrameOffset(object frameObj)
+    {
+        for (var type = frameObj.GetType(); type is not null; type = type.BaseType)
+        {
+            var prop = type.GetProperty(
+                "Offset",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            if (prop?.GetValue(frameObj) is long offset)
+            {
+                return checked((int)offset);
+            }
+        }
+
+        return 0;
+    }
+
+    private static void WritePcm16(ReadOnlySpan<float> samples, Span<byte> destination)
+    {
+        for (var i = 0; i < samples.Length; i++)
+        {
+            var sample = samples[i];
+            var scaled = sample < 0f ? sample * 32768f : sample * 32767f;
+            var value = (short)Math.Clamp(MathF.Round(scaled), short.MinValue, short.MaxValue);
+            BinaryPrimitives.WriteInt16LittleEndian(destination[(i * 2)..], value);
+        }
+    }
+
+    private static void WriteFloat(ReadOnlySpan<float> samples, Span<byte> destination)
+    {
+        for (var i = 0; i < samples.Length; i++)
+        {
+            var bits = BitConverter.SingleToInt32Bits(samples[i]);
+            BinaryPrimitives.WriteInt32LittleEndian(destination[(i * 4)..], bits);
+        }
+    }
+
+    internal readonly record struct DecodeResult(
+        bool Success,
+        int InputConsumed,
+        int OutputWritten,
+        uint Frames,
+        uint SamplesThisCall)
+    {
+        public static DecodeResult Failed { get; } = new(false, 0, 0, 0, 0);
+    }
+}

--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
+using SharpEmu.HLE.Host;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -15,36 +17,66 @@ public static class AudioOut2Exports
     // Clearing 0x80 bytes here overwrote the caller's stack canary immediately
     // following the 0x40-byte parameter block.
     private const int AudioOut2ContextParamSize = 0x40;
-    private const int AudioOut2ContextMemorySize = 0x10000;
-    private const int AudioOut2ContextMemoryAlignment = 0x10000;
+    // Keep these modest. GTA V Enhanced stack-allocates QueryMemory results next
+    // to the frame canary: a 16-byte {size,align} write to [rbp-0x38] plants
+    // align at [rbp-0x30] (observed canary=0x100). Size-only (8 bytes) on stack.
+    private const int AudioOut2ContextMemorySize = 0x4000;
+    private const int AudioOut2ContextMemoryAlignment = 0x100;
+    // Exact object body size. Do not page-align to 64K — the RAGE Main Thread
+    // stack-allocates this and a 64K VLA is what planted 0x10000 on the canary.
+    private const int SpeakerArrayHeaderSize = 0x40;
+    private const int SpeakerArrayEntrySize = 0x100;
+    // Extra scratch the title writes after the per-channel entries (coefficients).
+    private const int SpeakerArrayScratchBytes = 0x400;
+    private const uint SpeakerArrayDefaultChannels = 8;
+    private const uint SpeakerArrayMaxChannels = 32;
+    // Field read by GTA at object+0x34 (see AV at eboot+0xB07D: mov eax,[rbx+0x34]).
+    private const int SpeakerArrayDivisorFieldOffset = 0x34;
+    private const int SpeakerArrayResultFieldOffset = 0x3C;
+    private const uint SpeakerArrayDefaultDivisor = 1;
+    private const int SpeakerArrayCoefficientBytes = 0x400;
+    // OrbisAudioOutPortState is 0x20 bytes. Never grow this from r8/r9 — those
+    // regs arrive polluted with GetSize leftovers (0x840/0x10C/0x180) and caused
+    // PortGetState/GetSpeakerInfo to overwrite the speaker-array param block
+    // (param+0x18 == first PortGetState out) and smash the Main Thread canary
+    // with ContextMemoryAlignment (0x100).
+    private const int PortStateSize = 0x20;
+    private const int SpeakerInfoSize = 0x20;
+    private const int PortParamSize = 0x40;
+    private const int AttributeEntrySize = 0x18;
+    private const uint PortAttributeIdPcm = 0;
+    private const ushort PortStateOutputConnectedPrimary = 0x01;
     private static long _nextContextHandle = 1;
     private static long _nextUserHandle = 1;
     private static int _nextPortId;
     private static long _pushTraceCount;
+    private static long _submitTraceCount;
+    private static long _attributePcmTraceCount;
 
-    // Per-context audio parameters captured at ContextCreate so ContextAdvance
-    // can pace to the real playback cadence (grain samples at the sample rate).
+    private static readonly ConcurrentDictionary<ulong, byte> SpeakerArrays = new();
     private static readonly ConcurrentDictionary<ulong, ContextState> Contexts = new();
+    private static readonly ConcurrentDictionary<ulong, PortState> Ports = new();
 
     private sealed class ContextState
     {
         private readonly object _paceGate = new();
         private long _nextAdvanceTimestamp;
 
-        public ContextState(uint frequency, uint channels, uint grainSamples)
+        public ContextState(ulong handle, uint frequency, uint grainSamples, uint queueDepth, IHostAudioStream? backend)
         {
+            Handle = handle;
             Frequency = frequency == 0 ? 48000 : frequency;
-            Channels = channels == 0 ? 2 : channels;
             GrainSamples = grainSamples == 0 ? 256 : grainSamples;
+            QueueDepth = queueDepth == 0 ? 4 : queueDepth;
+            Backend = backend;
         }
 
+        public ulong Handle { get; }
         public uint Frequency { get; }
-        public uint Channels { get; }
         public uint GrainSamples { get; }
+        public uint QueueDepth { get; }
+        public IHostAudioStream? Backend { get; }
 
-        // Blocks the advancing thread until one grain worth of wall-clock time
-        // has elapsed since the previous advance, matching hardware timing so
-        // audio-gated titles neither spin nor drift ahead.
         public void PaceAdvance()
         {
             long delay;
@@ -67,6 +99,45 @@ public static class AudioOut2Exports
             }
         }
     }
+
+    private sealed class PortState
+    {
+        public PortState(
+            ulong handle,
+            ulong contextHandle,
+            ushort portType,
+            uint dataFormat,
+            uint samplingFrequency,
+            uint grainSamples)
+        {
+            Handle = handle;
+            ContextHandle = contextHandle;
+            PortType = portType;
+            DataFormat = dataFormat;
+            SamplingFrequency = samplingFrequency == 0 ? 48000 : samplingFrequency;
+            GrainSamples = grainSamples == 0 ? 256 : grainSamples;
+        }
+
+        public ulong Handle { get; }
+        public ulong ContextHandle { get; }
+        /// <summary>Full Prospero port type (low byte = MAIN/BGM/…, 0x0100 = object).</summary>
+        public ushort PortType { get; }
+        public uint DataFormat { get; }
+        public uint SamplingFrequency { get; }
+        public uint GrainSamples { get; }
+        public ulong PcmAddress;
+    }
+
+    // Two host streams: primary FMOD context (menus) and everything else
+    // (Bink/intro). Mixing those into one waveOut re-crunched audio; the OS
+    // mixer keeps separate devices clean.
+    private static readonly object HostBackendGate = new();
+    private static IHostAudioStream? PrimaryBackend;
+    private static IHostAudioStream? SecondaryBackend;
+    private static string PrimaryBackendName = "none";
+    private static string SecondaryBackendName = "none";
+    private static ulong PrimaryContextHandle;
+    private static readonly object HostSubmitGate = new();
 
     [SysAbiExport(
         Nid = "g2tViFIohHE",
@@ -92,12 +163,17 @@ public static class AudioOut2Exports
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
+        // Layout matches libSceAudioOut2 SceAudioOut2ContextParam (no size prefix):
+        // max_ports, max_object_ports, guarantee_object_ports, queue_depth,
+        // num_grains, flags, reserved...
         Span<byte> param = stackalloc byte[AudioOut2ContextParamSize];
         param.Clear();
-        BinaryPrimitives.WriteUInt32LittleEndian(param[0x00..], AudioOut2ContextParamSize);
-        BinaryPrimitives.WriteUInt32LittleEndian(param[0x04..], 2);
-        BinaryPrimitives.WriteUInt32LittleEndian(param[0x08..], 48000);
-        BinaryPrimitives.WriteUInt32LittleEndian(param[0x0C..], 0x400);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x00..], 256);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x04..], 256);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x08..], 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x0C..], 4);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x10..], 512);
+        BinaryPrimitives.WriteUInt32LittleEndian(param[0x14..], 1);
 
         return ctx.Memory.TryWrite(paramAddress, param)
             ? SetReturn(ctx, 0)
@@ -112,19 +188,36 @@ public static class AudioOut2Exports
     public static int AudioOut2ContextQueryMemory(CpuContext ctx)
     {
         var paramAddress = ctx[CpuRegister.Rdi];
-        var memoryInfoAddress = ctx[CpuRegister.Rsi];
+        var memoryInfoAddress = ResolveGuestOutBuffer(ctx[CpuRegister.Rsi], ctx[CpuRegister.Rdx]);
         if (paramAddress == 0 || memoryInfoAddress == 0)
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        Span<byte> memoryInfo = stackalloc byte[0x20];
+        // Heap: {size, alignment} (16 bytes), matching sceAudioPropagationSystemQueryMemory.
+        // Stack: SIZE ONLY as a full ulong (8 bytes). Writing alignment at +8 is how
+        // [rbp-0x30] became 0x100 on GTA V Enhanced. Do NOT shrink this to uint32 —
+        // Main reads the out as a 64-bit size; a 4-byte write leaves a garbage high
+        // dword (observed 0x7<<32|0x4000) and the allocator aborts with int 0x41.
+        if (IsGuestStackAddress(memoryInfoAddress))
+        {
+            Span<byte> sizeOnly = stackalloc byte[sizeof(ulong)];
+            BinaryPrimitives.WriteUInt64LittleEndian(sizeOnly, AudioOut2ContextMemorySize);
+            Console.Error.WriteLine(
+                $"[LOADER][TRACE] audio_out2.context-query-memory stack-size-only " +
+                $"out=0x{memoryInfoAddress:X} size=0x{AudioOut2ContextMemorySize:X}");
+            return ctx.Memory.TryWrite(memoryInfoAddress, sizeOnly)
+                ? SetReturn(ctx, 0)
+                : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        Span<byte> memoryInfo = stackalloc byte[0x10];
         memoryInfo.Clear();
         BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x00..], AudioOut2ContextMemorySize);
         BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x08..], AudioOut2ContextMemoryAlignment);
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x10..], AudioOut2ContextMemorySize);
-        BinaryPrimitives.WriteUInt64LittleEndian(memoryInfo[0x18..], AudioOut2ContextMemoryAlignment);
-
+        Console.Error.WriteLine(
+            $"[LOADER][TRACE] audio_out2.context-query-memory out=0x{memoryInfoAddress:X} " +
+            $"size=0x{AudioOut2ContextMemorySize:X} align=0x{AudioOut2ContextMemoryAlignment:X}");
         return ctx.Memory.TryWrite(memoryInfoAddress, memoryInfo)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
@@ -146,28 +239,27 @@ public static class AudioOut2Exports
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        // Read channels/frequency/grain from the reset-param blob so the
-        // context can pace advances to the real audio cadence.
-        uint channels = 2;
+        // Prospero AudioOut2 context params are port/queue config, not an AudioOut
+        // open-style frequency/channel block. Sample rate is fixed at 48 kHz.
         uint frequency = 48000;
         uint grain = 256;
+        uint queueDepth = 4;
         Span<byte> param = stackalloc byte[AudioOut2ContextParamSize];
         if (ctx.Memory.TryRead(paramAddress, param))
         {
-            var pc = BinaryPrimitives.ReadUInt32LittleEndian(param[0x04..]);
-            var pf = BinaryPrimitives.ReadUInt32LittleEndian(param[0x08..]);
-            var pg = BinaryPrimitives.ReadUInt32LittleEndian(param[0x0C..]);
-            if (pc is > 0 and <= 8) channels = pc;
-            if (pf is >= 8000 and <= 192000) frequency = pf;
-            // Values below one cache line are flags/counts in observed PS5
-            // callers, not audio grains. Keep the hardware-sized default.
-            if (pg is >= 64 and <= 0x4000) grain = pg;
+            var qd = BinaryPrimitives.ReadUInt32LittleEndian(param[0x0C..]);
+            var ng = BinaryPrimitives.ReadUInt32LittleEndian(param[0x10..]);
+            if (qd is >= 1 and <= 32) queueDepth = qd;
+            if (ng is >= 64 and <= 0x4000) grain = ng;
             TraceAudioOut2($"context-param address=0x{paramAddress:X} bytes={Convert.ToHexString(param)}");
         }
 
         var handle = (ulong)Interlocked.Increment(ref _nextContextHandle);
-        Contexts[handle] = new ContextState(frequency, channels, grain);
-        TraceAudioOut2($"context-create handle=0x{handle:X} frequency={frequency} channels={channels} grain={grain} memory=0x{memoryAddress:X} size=0x{memorySize:X}");
+        // Backend is bound lazily on first real Push (primary vs secondary device).
+        Contexts[handle] = new ContextState(handle, frequency, grain, queueDepth, backend: null);
+        TraceAudioOut2(
+            $"context-create handle=0x{handle:X} frequency={frequency} grain={grain} " +
+            $"queue={queueDepth} memory=0x{memoryAddress:X} size=0x{memorySize:X} backend=pending");
         return TryWriteUInt64(ctx, outContextAddress, handle)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
@@ -180,6 +272,7 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2ContextDestroy(CpuContext ctx)
     {
+        // Shared backend lifetime is process-wide; just drop the context entry.
         Contexts.TryRemove(ctx[CpuRegister.Rdi], out _);
         return SetReturn(ctx, 0);
     }
@@ -198,18 +291,25 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2ContextPush(CpuContext ctx)
     {
+        // ABI: sceAudioOut2ContextPush(ctx, blocking). RSI is a blocking flag
+        // (observed 1), not a PCM pointer. PCM is attached earlier via
+        // PortSetAttributes(attribute_id=PCM) and flushed here.
         var handle = ctx[CpuRegister.Rdi];
-        var traceCount = Interlocked.Increment(ref _pushTraceCount);
-        if (traceCount <= 16)
+        var blocking = unchecked((uint)ctx[CpuRegister.Rsi]);
+        if (Interlocked.Increment(ref _pushTraceCount) <= 8)
         {
-            TraceAudioOut2($"context-push count={traceCount} rdi=0x{handle:X} rsi=0x{ctx[CpuRegister.Rsi]:X} rdx=0x{ctx[CpuRegister.Rdx]:X} rcx=0x{ctx[CpuRegister.Rcx]:X}");
+            TraceAudioOut2($"context-push handle=0x{handle:X} blocking={blocking}");
         }
 
-        if (Contexts.TryGetValue(handle, out var context))
+        if (!Contexts.TryGetValue(handle, out var context))
         {
-            // FMOD's PS5 output path uses ContextPush as the submission clock
-            // and does not call ContextAdvance. Pace pushes to one hardware
-            // grain so the feeder cannot outrun playback and starve the game.
+            return SetReturn(ctx, 0);
+        }
+
+        // Host Submit already blocks on the waveOut queue; only fall back to
+        // software pacing when nothing was queued (silence / non-primary ctx).
+        if (!TrySubmitContextAudio(ctx, context))
+        {
             context.PaceAdvance();
         }
 
@@ -223,11 +323,9 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2ContextAdvance(CpuContext ctx)
     {
-        // Advancing renders one grain of audio on hardware; pace it to the same
-        // wall-clock cadence so the guest audio thread runs at the right speed.
-        if (Contexts.TryGetValue(ctx[CpuRegister.Rdi], out var context))
+        if (Contexts.TryGetValue(ctx[CpuRegister.Rdi], out var state))
         {
-            context.PaceAdvance();
+            state.PaceAdvance();
         }
 
         return SetReturn(ctx, 0);
@@ -240,11 +338,93 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2ContextGetQueueLevel(CpuContext ctx)
     {
-        // The advance path paces synchronously, so the queue is always drained.
-        var levelAddress = ctx[CpuRegister.Rsi];
-        if (levelAddress != 0)
+        // ABI out is a 32-bit queue depth (GTA compares dword [out] to 4). A
+        // uint64 write into a stack slot at [rbp-0x14] next to the canary at
+        // [rbp-0x10] zeroed the canary low half and killed Bink Snd @ eboot+0xAE36.
+        var outLevelAddress = ctx[CpuRegister.Rsi];
+        if (outLevelAddress == 0)
         {
-            _ = TryWriteUInt64(ctx, levelAddress, 0);
+            outLevelAddress = ctx[CpuRegister.Rdx];
+        }
+
+        if (outLevelAddress != 0)
+        {
+            Span<byte> level = stackalloc byte[sizeof(uint)];
+            BinaryPrimitives.WriteUInt32LittleEndian(level, 0);
+            if (!ctx.Memory.TryWrite(outLevelAddress, level))
+            {
+                return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+        }
+
+        return SetReturn(ctx, 0);
+    }
+
+    [SysAbiExport(
+        Nid = "Q8DZkKQ-SYc",
+        ExportName = "sceAudioOut2LoContextGetQueueLevel",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2LoContextGetQueueLevel(CpuContext ctx) =>
+        AudioOut2ContextGetQueueLevel(ctx);
+
+    [SysAbiExport(
+        Nid = "8XTArSPyWHk",
+        ExportName = "sceAudioOut2PortSetAttributes",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2PortSetAttributes(CpuContext ctx)
+    {
+        // sceAudioOut2PortSetAttributes(port, attributes*, num).
+        // Attribute id 0 = PCM; value points at { const void* data }.
+        var portHandle = ctx[CpuRegister.Rdi];
+        var attributesAddress = ctx[CpuRegister.Rsi];
+        var attributeCount = unchecked((uint)ctx[CpuRegister.Rdx]);
+        if (!Ports.TryGetValue(portHandle, out var port))
+        {
+            return SetReturn(ctx, 0);
+        }
+
+        if (attributeCount == 0 || attributesAddress == 0)
+        {
+            return SetReturn(ctx, 0);
+        }
+
+        if (attributeCount > 32)
+        {
+            attributeCount = 32;
+        }
+
+        Span<byte> entry = stackalloc byte[AttributeEntrySize];
+        Span<byte> pcm = stackalloc byte[8];
+        for (uint i = 0; i < attributeCount; i++)
+        {
+            if (!ctx.Memory.TryRead(attributesAddress + (i * AttributeEntrySize), entry))
+            {
+                break;
+            }
+
+            var attributeId = BinaryPrimitives.ReadUInt32LittleEndian(entry);
+            var valueAddress = BinaryPrimitives.ReadUInt64LittleEndian(entry[0x08..]);
+            var valueSize = BinaryPrimitives.ReadUInt64LittleEndian(entry[0x10..]);
+            if (attributeId != PortAttributeIdPcm || valueAddress == 0 || valueSize < 8)
+            {
+                continue;
+            }
+
+            if (!ctx.Memory.TryRead(valueAddress, pcm))
+            {
+                continue;
+            }
+
+            port.PcmAddress = BinaryPrimitives.ReadUInt64LittleEndian(pcm);
+            var n = Interlocked.Increment(ref _attributePcmTraceCount);
+            if (n <= 8 || n % 500 == 0)
+            {
+                TraceAudioOut2(
+                    $"port-set-pcm#{n} port=0x{portHandle:X} pcm=0x{port.PcmAddress:X} " +
+                    $"format=0x{port.DataFormat:X} grains={port.GrainSamples}");
+            }
         }
 
         return SetReturn(ctx, 0);
@@ -257,29 +437,63 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2PortCreate(CpuContext ctx)
     {
-        var type = unchecked((int)ctx[CpuRegister.Rdi]);
+        // sceAudioOut2PortCreate(ctx, PortParam*, outPort*).
+        var contextHandle = ctx[CpuRegister.Rdi];
         var paramAddress = ctx[CpuRegister.Rsi];
-        var outPortAddress = ctx[CpuRegister.Rdx];
-        var contextAddress = ctx[CpuRegister.Rcx];
-        if (type < 0 || type > 255 || paramAddress == 0 || outPortAddress == 0 || contextAddress == 0)
+        var outPortAddress = ResolveGuestOutBuffer(ctx[CpuRegister.Rdx], ctx[CpuRegister.Rcx]);
+        if (outPortAddress == 0)
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        var portId = unchecked((uint)Interlocked.Increment(ref _nextPortId)) & 0xFF;
-        var handle = 0x2000_0000UL | ((ulong)(uint)type << 16) | portId;
-        return TryWriteUInt64(ctx, outPortAddress, handle)
-            ? SetReturn(ctx, 0)
-            : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        ushort portType = 0;
+        uint dataFormat = 0x0000_0200; // float stereo default
+        uint samplingFrequency = 48000;
+        uint grainSamples = 256;
+        if (Contexts.TryGetValue(contextHandle, out var context))
+        {
+            grainSamples = context.GrainSamples;
+            samplingFrequency = context.Frequency;
+        }
+
+        if (paramAddress != 0 && IsPlausibleGuestObjectPointer(paramAddress))
+        {
+            Span<byte> param = stackalloc byte[PortParamSize];
+            if (ctx.Memory.TryRead(paramAddress, param))
+            {
+                portType = BinaryPrimitives.ReadUInt16LittleEndian(param);
+                dataFormat = BinaryPrimitives.ReadUInt32LittleEndian(param[0x04..]);
+                var freq = BinaryPrimitives.ReadUInt32LittleEndian(param[0x08..]);
+                if (freq is >= 8000 and <= 192000)
+                {
+                    samplingFrequency = freq;
+                }
+            }
+        }
+
+        var portId = (uint)Interlocked.Increment(ref _nextPortId);
+        // Handle encodes only the low type byte; PortState keeps the full type
+        // so object ports (0x01xx) can still be filtered at submit time.
+        var handle = 0x2000_0000UL | ((ulong)(portType & 0xFF) << 16) | portId;
+        Ports[handle] = new PortState(
+            handle,
+            contextHandle,
+            portType,
+            dataFormat,
+            samplingFrequency,
+            grainSamples);
+        if (!TryWriteUInt64(ctx, outPortAddress, handle))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAudioOut2(
+            $"port-create handle=0x{handle:X} ctx=0x{contextHandle:X} type=0x{portType:X} " +
+            $"format=0x{dataFormat:X} freq={samplingFrequency} out=0x{outPortAddress:X}");
+        return SetReturn(ctx, 0);
     }
 
-    [SysAbiExport(
-        Nid = "8XTArSPyWHk",
-        ExportName = "sceAudioOut2PortSetAttributes",
-        Target = Generation.Gen5,
-        LibraryName = "libSceAudioOut2")]
-    public static int AudioOut2PortSetAttributes(CpuContext ctx) => SetReturn(ctx, 0);
-
+    // Fixed-size connected stereo state. Do not trust r8/r9 for byte counts.
     [SysAbiExport(
         Nid = "gatEUKG+Ea4",
         ExportName = "sceAudioOut2PortGetState",
@@ -287,27 +501,51 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2PortGetState(CpuContext ctx)
     {
-        var handle = ctx[CpuRegister.Rdi];
-        var stateAddress = ctx[CpuRegister.Rsi];
-        if (handle == 0 || stateAddress == 0)
+        var portHandle = ctx[CpuRegister.Rdi];
+        var stateAddress = ResolveGuestOutBuffer(ctx[CpuRegister.Rsi], ctx[CpuRegister.Rdx]);
+        if (stateAddress == 0)
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        var type = (int)((handle >> 16) & 0xFF);
-        Span<byte> state = stackalloc byte[0x20];
+        // Stack out-buffers with garbage handles were writing 0x20 bytes over
+        // caller frames / canaries (state=0x7FFFDE1FF688 right before fail).
+        // Heap outs still get a real state blob even when the handle wasn't
+        // minted by PortCreate — this title synthesizes port ids itself.
+        if (IsGuestStackAddress(stateAddress))
+        {
+            TraceAudioOut2(
+                $"port-get-state skip-stack handle=0x{portHandle:X} state=0x{stateAddress:X}");
+            return SetReturn(ctx, 0);
+        }
+
+        Span<byte> state = stackalloc byte[PortStateSize];
         state.Clear();
-        var output = type == 2 ? 0x40 : 0x01;
-        var channels = type == 2 ? 1 : 2;
-        BinaryPrimitives.WriteUInt16LittleEndian(state[0x00..], unchecked((ushort)output));
-        state[0x02] = unchecked((byte)channels);
+        //   +0x00 u16 output   = CONNECTED_PRIMARY (1)
+        //   +0x02 u8  channels = from port format when known, else 2
+        //   +0x04 s16 volume   = -1 (N/A for main)
+        byte channels = 2;
+        if (Ports.TryGetValue(portHandle, out var port) &&
+            TryDecodeDataFormat(port.DataFormat, out var decodedChannels, out _, out _))
+        {
+            channels = (byte)Math.Clamp(decodedChannels, 1, 16);
+        }
+
+        BinaryPrimitives.WriteUInt16LittleEndian(state[0x00..], PortStateOutputConnectedPrimary);
+        state[0x02] = channels;
         BinaryPrimitives.WriteInt16LittleEndian(state[0x04..], -1);
 
-        return ctx.Memory.TryWrite(stateAddress, state)
-            ? SetReturn(ctx, 0)
-            : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        if (!ctx.Memory.TryWrite(stateAddress, state))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAudioOut2(
+            $"port-get-state handle=0x{portHandle:X} state=0x{stateAddress:X} bytes=0x{PortStateSize:X}");
+        return SetReturn(ctx, 0);
     }
 
+    // rdi=out buffer, rsi=type/flag (not a pointer). Fixed-size write only.
     [SysAbiExport(
         Nid = "DImz2Ft9E2g",
         ExportName = "sceAudioOut2GetSpeakerInfo",
@@ -315,21 +553,134 @@ public static class AudioOut2Exports
         LibraryName = "libSceAudioOut2")]
     public static int AudioOut2GetSpeakerInfo(CpuContext ctx)
     {
-        var infoAddress = ctx[CpuRegister.Rdi];
+        var infoAddress = ResolveGuestOutBuffer(ctx[CpuRegister.Rdi], ctx[CpuRegister.Rdx]);
         if (infoAddress == 0)
         {
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
-        Span<byte> info = stackalloc byte[0x40];
-        info.Clear();
-        BinaryPrimitives.WriteUInt32LittleEndian(info[0x00..], 1);
-        BinaryPrimitives.WriteUInt32LittleEndian(info[0x04..], 2);
-        BinaryPrimitives.WriteUInt32LittleEndian(info[0x08..], 48000);
+        // Same rule as PortGetState — never bulk-write speaker info onto the stack.
+        if (IsGuestStackAddress(infoAddress))
+        {
+            TraceAudioOut2($"get-speaker-info skip-stack out=0x{infoAddress:X}");
+            return SetReturn(ctx, 0);
+        }
 
-        return ctx.Memory.TryWrite(infoAddress, info)
-            ? SetReturn(ctx, 0)
-            : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        Span<byte> info = stackalloc byte[SpeakerInfoSize];
+        info.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(info[0x00..], 2);
+        BinaryPrimitives.WriteUInt32LittleEndian(info[0x04..], 48000);
+        BinaryPrimitives.WriteUInt16LittleEndian(info[0x08..], PortStateOutputConnectedPrimary);
+
+        if (!ctx.Memory.TryWrite(infoAddress, info))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAudioOut2(
+            $"get-speaker-info out=0x{infoAddress:X} type=0x{ctx[CpuRegister.Rsi]:X} bytes=0x{SpeakerInfoSize:X}");
+        return SetReturn(ctx, 0);
+    }
+
+    // Matches sceAudio3dGetSpeakerArrayMemorySize(uiNumSpeakers, bIs3d): size is
+    // returned directly in rax. Exact channel-scaled body — never a 64K slab.
+    [SysAbiExport(
+        Nid = "G1YOKDJYX2Y",
+        ExportName = "sceAudioOut2GetSpeakerArrayMemorySize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2GetSpeakerArrayMemorySize(CpuContext ctx)
+    {
+        var numChannels = (uint)ctx[CpuRegister.Rdi];
+        if (numChannels == 0 || numChannels > SpeakerArrayMaxChannels)
+        {
+            numChannels = SpeakerArrayDefaultChannels;
+        }
+
+        var size = ComputeSpeakerArrayBytes(numChannels);
+        Console.Error.WriteLine(
+            $"[LOADER][TRACE] audio_out2.speaker-array-get-size rdi=0x{ctx[CpuRegister.Rdi]:X} " +
+            $"rsi=0x{ctx[CpuRegister.Rsi]:X} rdx=0x{ctx[CpuRegister.Rdx]:X} -> 0x{size:X}");
+        ctx[CpuRegister.Rax] = unchecked((ulong)size);
+        return size;
+    }
+
+    [SysAbiExport(
+        Nid = "4BlZurolOAo",
+        ExportName = "sceAudioOut2GetSpeakerArrayCoefficients",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2GetSpeakerArrayCoefficients(CpuContext ctx) =>
+        WriteZeroSpeakerArrayCoefficients(ctx, "coefficients");
+
+    [SysAbiExport(
+        Nid = "28QqMnuuJ9Y",
+        ExportName = "sceAudioOut2GetSpeakerArrayAmbisonicsCoefficients",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2GetSpeakerArrayAmbisonicsCoefficients(CpuContext ctx) =>
+        WriteZeroSpeakerArrayCoefficients(ctx, "ambisonics-coefficients");
+
+    // rdi = param (may share a heap slab with PortGetState/GetSpeakerInfo outs —
+    // do NOT read buffer*/size* from it). rsi = &outHandle, rdx = reserved/size
+    // slot (leave alone), rcx = channels. Always heap-allocate a fresh object.
+    [SysAbiExport(
+        Nid = "+k91hoTuoA8",
+        ExportName = "sceAudioOut2SpeakerArrayCreate",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2SpeakerArrayCreate(CpuContext ctx)
+    {
+        var param = ctx[CpuRegister.Rdi];
+        var outHandleAddress = ctx[CpuRegister.Rsi];
+        var outReservedAddress = ctx[CpuRegister.Rdx];
+        var channels = (uint)ctx[CpuRegister.Rcx];
+        if (channels == 0 || channels > SpeakerArrayMaxChannels)
+        {
+            channels = SpeakerArrayDefaultChannels;
+        }
+
+        if (outHandleAddress == 0)
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        var bytes = ComputeSpeakerArrayBytes(channels);
+        if (!TryAllocateSpeakerArrayMemory(ctx, (ulong)bytes, out var memory) ||
+            !InitializeSpeakerArrayObject(ctx, memory, channels))
+        {
+            Console.Error.WriteLine(
+                $"[LOADER][ERROR] audio_out2.speaker-array-create alloc-failed bytes=0x{bytes:X} " +
+                $"channels={channels}");
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        SpeakerArrays[memory] = 0;
+        // Publish ONLY the out-handle slot. rdx is an adjacent size/reserved
+        // local on GTA's stack — writing it previously fed canary corruption.
+        if (!TryWriteUInt64(ctx, outHandleAddress, memory))
+        {
+            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        Console.Error.WriteLine(
+            $"[LOADER][TRACE] audio_out2.speaker-array-create object=0x{memory:X} bytes=0x{bytes:X} " +
+            $"channels={channels} param=0x{param:X} out=0x{outHandleAddress:X} " +
+            $"reserved=0x{outReservedAddress:X} (untouched)");
+
+        ctx[CpuRegister.Rax] = memory;
+        return 0;
+    }
+
+    [SysAbiExport(
+        Nid = "erCWQR5eKiQ",
+        ExportName = "sceAudioOut2SpeakerArrayDestroy",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2SpeakerArrayDestroy(CpuContext ctx)
+    {
+        SpeakerArrays.TryRemove(ctx[CpuRegister.Rdi], out _);
+        return SetReturn(ctx, 0);
     }
 
     [SysAbiExport(
@@ -337,7 +688,11 @@ public static class AudioOut2Exports
         ExportName = "sceAudioOut2PortDestroy",
         Target = Generation.Gen5,
         LibraryName = "libSceAudioOut2")]
-    public static int AudioOut2PortDestroy(CpuContext ctx) => SetReturn(ctx, 0);
+    public static int AudioOut2PortDestroy(CpuContext ctx)
+    {
+        Ports.TryRemove(ctx[CpuRegister.Rdi], out _);
+        return SetReturn(ctx, 0);
+    }
 
     [SysAbiExport(
         Nid = "IaZXJ9M79uo",
@@ -365,6 +720,494 @@ public static class AudioOut2Exports
         return TryWriteUInt64(ctx, outUserAddress, handle)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+    }
+
+    private static IHostAudioStream? ResolveContextBackend(ContextState context, out string backendName)
+    {
+        lock (HostBackendGate)
+        {
+            if (PrimaryContextHandle == 0)
+            {
+                PrimaryContextHandle = context.Handle;
+            }
+
+            if (context.Handle == PrimaryContextHandle)
+            {
+                if (PrimaryBackend is null)
+                {
+                    try
+                    {
+                        var audio = HostPlatform.Current.Audio;
+                        PrimaryBackend = audio.OpenStereoPcm16Stream(context.Frequency);
+                        PrimaryBackendName = audio.BackendName + "-primary";
+                    }
+                    catch (Exception exception)
+                    {
+                        PrimaryBackendName = "silent";
+                        Console.Error.WriteLine(
+                            $"[LOADER][WARN] AudioOut2 primary backend unavailable: {exception.Message}");
+                    }
+                }
+
+                backendName = PrimaryBackendName;
+                return PrimaryBackend;
+            }
+
+            if (SecondaryBackend is null)
+            {
+                try
+                {
+                    var audio = HostPlatform.Current.Audio;
+                    SecondaryBackend = audio.OpenStereoPcm16Stream(context.Frequency);
+                    SecondaryBackendName = audio.BackendName + "-secondary";
+                }
+                catch (Exception exception)
+                {
+                    SecondaryBackendName = "silent";
+                    Console.Error.WriteLine(
+                        $"[LOADER][WARN] AudioOut2 secondary backend unavailable: {exception.Message}");
+                }
+            }
+
+            backendName = SecondaryBackendName;
+            return SecondaryBackend;
+        }
+    }
+
+    private static bool TrySubmitContextAudio(CpuContext ctx, ContextState context)
+    {
+        var frames = checked((int)context.GrainSamples);
+        if (frames <= 0)
+        {
+            return false;
+        }
+
+        // Serialize submits per process so ArrayPool buffers stay private; primary
+        // and secondary devices still receive independent PCM (no digital sum).
+        lock (HostSubmitGate)
+        {
+            if (!TryPickMainBed(context.Handle, out var mainPort))
+            {
+                mainPort = null;
+            }
+
+            if (!TryPickAuxBed(context.Handle, out var auxPort))
+            {
+                auxPort = null;
+            }
+
+            if (mainPort is null && auxPort is null)
+            {
+                return false;
+            }
+
+            var mix = ArrayPool<float>.Shared.Rent(frames * 2);
+            var source = ArrayPool<byte>.Shared.Rent(frames * 16 * sizeof(float));
+            var output = ArrayPool<byte>.Shared.Rent(frames * AudioPcmConversion.OutputFrameSize);
+            try
+            {
+                mix.AsSpan(0, frames * 2).Clear();
+                var mixedPorts = 0;
+                ulong lastPort = 0;
+                uint lastFormat = 0;
+                var lastChannels = 0;
+
+                // At most one MAIN/BGM + one AUX on this context. Menus stay on
+                // MAIN; intro/Bink rides AUX without stacking every bed.
+                for (var bed = 0; bed < 2; bed++)
+                {
+                    var port = bed == 0 ? mainPort : auxPort;
+                    if (port is null ||
+                        !TryDecodeDataFormat(port.DataFormat, out var ch, out var bps, out var isFloat))
+                    {
+                        continue;
+                    }
+
+                    var byteLength = checked(frames * ch * bps);
+                    if (byteLength <= 0 || byteLength > source.Length)
+                    {
+                        continue;
+                    }
+
+                    var sourceSpan = source.AsSpan(0, byteLength);
+                    if (!ctx.Memory.TryRead(port.PcmAddress, sourceSpan))
+                    {
+                        continue;
+                    }
+
+                    MixPortIntoStereo(
+                        sourceSpan,
+                        mix.AsSpan(0, frames * 2),
+                        frames,
+                        ch,
+                        bps,
+                        isFloat,
+                        additive: mixedPorts > 0);
+                    mixedPorts++;
+                    lastPort = port.Handle;
+                    lastFormat = port.DataFormat;
+                    lastChannels = ch;
+                }
+
+                if (mixedPorts == 0)
+                {
+                    return false;
+                }
+
+                var outputSpan = output.AsSpan(0, frames * AudioPcmConversion.OutputFrameSize);
+                var peak = 0f;
+                var any = false;
+                for (var frame = 0; frame < frames; frame++)
+                {
+                    var left = Math.Clamp(mix[frame * 2], -1f, 1f);
+                    var right = Math.Clamp(mix[(frame * 2) + 1], -1f, 1f);
+                    var framePeak = Math.Max(Math.Abs(left), Math.Abs(right));
+                    if (framePeak > peak)
+                    {
+                        peak = framePeak;
+                    }
+
+                    if (framePeak > 1e-7f)
+                    {
+                        any = true;
+                    }
+
+                    BinaryPrimitives.WriteInt16LittleEndian(
+                        outputSpan[(frame * AudioPcmConversion.OutputFrameSize)..],
+                        FloatToPcm16(left));
+                    BinaryPrimitives.WriteInt16LittleEndian(
+                        outputSpan[((frame * AudioPcmConversion.OutputFrameSize) + 2)..],
+                        FloatToPcm16(right));
+                }
+
+                if (!any)
+                {
+                    return false;
+                }
+
+                // Bind primary only after a real grain so silent early contexts
+                // do not steal the menu device.
+                var backend = ResolveContextBackend(context, out var backendName);
+                if (backend is null)
+                {
+                    return false;
+                }
+
+                var n = Interlocked.Increment(ref _submitTraceCount);
+                if (n <= 8 || n % 200 == 0)
+                {
+                    TraceAudioOut2(
+                        $"context-submit#{n} handle=0x{context.Handle:X} frames={frames} " +
+                        $"ports={mixedPorts} lastPort=0x{lastPort:X} format=0x{lastFormat:X} " +
+                        $"ch={lastChannels} peak={peak:F4} backend={backendName}");
+                }
+
+                return backend.Submit(outputSpan);
+            }
+            finally
+            {
+                ArrayPool<float>.Shared.Return(mix);
+                ArrayPool<byte>.Shared.Return(source);
+                ArrayPool<byte>.Shared.Return(output);
+            }
+        }
+    }
+
+    private static bool TryPickMainBed(ulong contextHandle, out PortState? chosen)
+    {
+        chosen = null;
+        var chosenScore = int.MinValue;
+        foreach (var port in Ports.Values)
+        {
+            if (port.ContextHandle != contextHandle ||
+                port.PcmAddress == 0 ||
+                IsObjectPort(port.PortType) ||
+                !IsMainOrBgmPort(port.PortType) ||
+                !TryDecodeDataFormat(port.DataFormat, out var channels, out _, out _))
+            {
+                continue;
+            }
+
+            var score = channels switch
+            {
+                2 => 300,
+                1 => 200,
+                8 => 100,
+                _ => 50,
+            };
+            if ((port.PortType & 0xFF) == 0)
+            {
+                score += 20; // MAIN over BGM
+            }
+
+            if (score > chosenScore)
+            {
+                chosenScore = score;
+                chosen = port;
+            }
+        }
+
+        return chosen is not null;
+    }
+
+    private static bool TryPickAuxBed(ulong contextHandle, out PortState? chosen)
+    {
+        chosen = null;
+        var chosenScore = int.MinValue;
+        foreach (var port in Ports.Values)
+        {
+            if (port.ContextHandle != contextHandle ||
+                port.PcmAddress == 0 ||
+                IsObjectPort(port.PortType) ||
+                (port.PortType & 0xFF) != 6 ||
+                !TryDecodeDataFormat(port.DataFormat, out var channels, out _, out _))
+            {
+                continue;
+            }
+
+            var score = channels switch
+            {
+                2 => 300,
+                1 => 200,
+                8 => 100,
+                _ => 50,
+            };
+            if (score > chosenScore)
+            {
+                chosenScore = score;
+                chosen = port;
+            }
+        }
+
+        return chosen is not null;
+    }
+
+    private static bool IsMainOrBgmPort(ushort portType)
+    {
+        var kind = portType & 0xFF;
+        return kind is 0 or 1;
+    }
+
+    private static void MixPortIntoStereo(
+        ReadOnlySpan<byte> source,
+        Span<float> mix,
+        int frames,
+        int channels,
+        int bytesPerSample,
+        bool isFloat,
+        bool additive)
+    {
+        var frameSize = channels * bytesPerSample;
+        for (var frame = 0; frame < frames; frame++)
+        {
+            var frameBytes = source.Slice(frame * frameSize, frameSize);
+            float left;
+            float right;
+            if (channels >= 8)
+            {
+                var fl = ReadNormalizedSample(frameBytes, 0, bytesPerSample, isFloat);
+                var fr = ReadNormalizedSample(frameBytes, 1, bytesPerSample, isFloat);
+                var c = ReadNormalizedSample(frameBytes, 2, bytesPerSample, isFloat);
+                var bl = ReadNormalizedSample(frameBytes, 4, bytesPerSample, isFloat);
+                var br = ReadNormalizedSample(frameBytes, 5, bytesPerSample, isFloat);
+                var sl = ReadNormalizedSample(frameBytes, 6, bytesPerSample, isFloat);
+                var sr = ReadNormalizedSample(frameBytes, 7, bytesPerSample, isFloat);
+                const float side = 0.70710678f;
+                left = fl + (c * side) + (bl * side) + (sl * side);
+                right = fr + (c * side) + (br * side) + (sr * side);
+            }
+            else
+            {
+                left = ReadNormalizedSample(frameBytes, 0, bytesPerSample, isFloat);
+                right = channels == 1
+                    ? left
+                    : ReadNormalizedSample(frameBytes, 1, bytesPerSample, isFloat);
+            }
+
+            if (additive)
+            {
+                mix[frame * 2] += left;
+                mix[(frame * 2) + 1] += right;
+            }
+            else
+            {
+                mix[frame * 2] = left;
+                mix[(frame * 2) + 1] = right;
+            }
+        }
+    }
+
+    private static float ReadNormalizedSample(
+        ReadOnlySpan<byte> frame,
+        int channel,
+        int bytesPerSample,
+        bool isFloat)
+    {
+        var sample = frame.Slice(channel * bytesPerSample, bytesPerSample);
+        if (isFloat)
+        {
+            var bits = BinaryPrimitives.ReadInt32LittleEndian(sample);
+            var value = BitConverter.Int32BitsToSingle(bits);
+            return float.IsFinite(value) ? value : 0f;
+        }
+
+        return BinaryPrimitives.ReadInt16LittleEndian(sample) / 32768f;
+    }
+
+    private static short FloatToPcm16(float value)
+    {
+        var scale = value < 0f ? 32768f : short.MaxValue;
+        return (short)Math.Clamp(MathF.Round(value * scale), short.MinValue, short.MaxValue);
+    }
+
+    private static bool IsObjectPort(ushort portType) => (portType & 0xFF00) == 0x0100;
+
+    private static bool TryDecodeDataFormat(
+        uint dataFormat,
+        out int channels,
+        out int bytesPerSample,
+        out bool isFloat)
+    {
+        channels = (int)((dataFormat >> 8) & 0xFF);
+        if (channels == 0)
+        {
+            channels = 2;
+        }
+
+        if (channels is < 1 or > 16)
+        {
+            bytesPerSample = 0;
+            isFloat = false;
+            return false;
+        }
+
+        var dataType = dataFormat & 0x7Fu;
+        isFloat = dataType == 0;
+        bytesPerSample = isFloat ? 4 : dataType == 1 ? 2 : 0;
+        return bytesPerSample != 0;
+    }
+
+    private static int ComputeSpeakerArrayBytes(uint channels) =>
+        SpeakerArrayHeaderSize + (int)(channels * SpeakerArrayEntrySize) + SpeakerArrayScratchBytes;
+
+    private static bool InitializeSpeakerArrayObject(CpuContext ctx, ulong memory, uint channels)
+    {
+        // Header only — never wipe the full GetSize slab (and never touch stack).
+        Span<byte> body = stackalloc byte[SpeakerArrayHeaderSize];
+        body.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(body[0x00..], (uint)SpeakerArrayHeaderSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(body[0x04..], channels);
+        BinaryPrimitives.WriteUInt32LittleEndian(body[SpeakerArrayDivisorFieldOffset..], SpeakerArrayDefaultDivisor);
+        BinaryPrimitives.WriteUInt32LittleEndian(body[SpeakerArrayResultFieldOffset..], 0);
+        return ctx.Memory.TryWrite(memory, body);
+    }
+
+    // Prefer the high guest arena (0x6000_xxxx). TryAllocateHleData advances
+    // _nextVirtualAddress into the title's direct-memory window (~0x1559_xxxx);
+    // publishing an object there made sceKernelBatchMap(fixed, 0x1559C80000,
+    // 0x20000) return NOT_FOUND and abort RenderThread with int 0x41.
+    // Never mint the old 0x1559C0xxxx "cookie" pointers — they are unmapped and
+    // collide with dmem VAs.
+    private static bool TryAllocateSpeakerArrayMemory(CpuContext ctx, ulong bytes, out ulong memory)
+    {
+        memory = 0;
+        var length = Math.Max(bytes, 0x1000UL);
+
+        if (TryAllocateViaGuestAllocator(ctx, length, 0x1000, out memory) &&
+            IsSafeSpeakerArrayAddress(memory))
+        {
+            return true;
+        }
+
+        if (Kernel.KernelMemoryCompatExports.TryAllocateHleData(ctx, length, 0x1000, out memory) &&
+            IsSafeSpeakerArrayAddress(memory))
+        {
+            return true;
+        }
+
+        memory = 0;
+        return false;
+    }
+
+    private static bool TryAllocateViaGuestAllocator(CpuContext ctx, ulong length, ulong alignment, out ulong memory)
+    {
+        memory = 0;
+        var allocator = ctx.Memory as IGuestMemoryAllocator;
+        if (allocator is null && ctx.Memory is ICpuMemoryWrapper { Inner: IGuestMemoryAllocator inner })
+        {
+            allocator = inner;
+        }
+
+        return allocator is not null && allocator.TryAllocateGuestMemory(length, alignment, out memory);
+    }
+
+    private static bool IsSafeSpeakerArrayAddress(ulong value) =>
+        IsPlausibleGuestObjectPointer(value) &&
+        !IsGuestStackAddress(value) &&
+        !IsDirectMemoryWindowAddress(value);
+
+    // GTA V Enhanced BatchMap fixed dmem VAs observed around 0x1559_xxxx_xxxx.
+    // Keep HLE speaker-array objects out of that window.
+    private static bool IsDirectMemoryWindowAddress(ulong value) =>
+        value >= 0x0000_1400_0000_0000UL && value < 0x0000_1800_0000_0000UL;
+
+    private static bool IsPlausibleGuestObjectPointer(ulong value) =>
+        value >= 0x1000_0000UL &&
+        value != 0x10000UL &&
+        value < 0x0000_8000_0000_0000UL;
+
+    // Windows user stacks sit in 0x00007FFFxxxxxxxx. Never treat those as
+    // heap objects we can bulk-initialize.
+    private static bool IsGuestStackAddress(ulong value) =>
+        value >= 0x0000_7FF0_0000_0000UL && value <= 0x0000_7FFF_FFFF_FFFFUL;
+
+    private static ulong ResolveGuestOutBuffer(ulong primary, ulong secondary)
+    {
+        // Accept heap or stack out-buffers (PortGetState legitimately uses both),
+        // but never small integers / size constants.
+        if (IsWritableOutBuffer(primary))
+        {
+            return primary;
+        }
+
+        if (IsWritableOutBuffer(secondary))
+        {
+            return secondary;
+        }
+
+        return 0;
+    }
+
+    private static bool IsWritableOutBuffer(ulong value) =>
+        value != 0 &&
+        value != 0x10000UL &&
+        value >= 0x1000UL &&
+        (IsPlausibleGuestObjectPointer(value) || IsGuestStackAddress(value));
+
+    private static int WriteZeroSpeakerArrayCoefficients(CpuContext ctx, string label)
+    {
+        var destination = ctx[CpuRegister.Rsi];
+        if (destination == 0)
+        {
+            destination = ctx[CpuRegister.Rdx];
+        }
+
+        // Coefficients are large — only wipe real heap objects, never stack.
+        if (destination != 0 &&
+            IsPlausibleGuestObjectPointer(destination) &&
+            !IsGuestStackAddress(destination))
+        {
+            Span<byte> zeros = stackalloc byte[SpeakerArrayCoefficientBytes];
+            zeros.Clear();
+            if (!ctx.Memory.TryWrite(destination, zeros))
+            {
+                TraceAudioOut2($"{label} write-failed dest=0x{destination:X}");
+                return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+        }
+
+        TraceAudioOut2($"{label} ok dest=0x{destination:X}");
+        return SetReturn(ctx, 0);
     }
 
     private static bool TryWriteUInt64(CpuContext ctx, ulong address, ulong value)

--- a/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
@@ -54,6 +54,7 @@ internal interface IGuestGpuBackend
         int scalarRegisterBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1);
 
     bool TryCompileComputeShader(

--- a/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/IGuestGpuBackend.cs
@@ -109,7 +109,8 @@ internal interface IGuestGpuBackend
         GuestIndexBuffer? indexBuffer = null,
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
-        ulong shaderAddress = 0);
+        ulong shaderAddress = 0,
+        int baseVertex = 0);
 
     void SubmitOffscreenTranslatedDraw(
         IGuestCompiledShader pixelShader,
@@ -125,7 +126,8 @@ internal interface IGuestGpuBackend
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
         GuestDepthTarget? depthTarget = null,
-        ulong shaderAddress = 0);
+        ulong shaderAddress = 0,
+        int baseVertex = 0);
 
     void SubmitStorageTranslatedDraw(
         IGuestCompiledShader pixelShader,

--- a/src/SharpEmu.Libs/Gpu/Metal/MetalGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Metal/MetalGuestGpuBackend.cs
@@ -70,6 +70,7 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
         int scalarRegisterBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1)
     {
         shader = null;
@@ -85,6 +86,7 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
                 scalarRegisterBufferIndex,
                 pixelInputEnable,
                 pixelInputAddress,
+                pixelInputCntl,
                 storageBufferOffsetAlignment))
         {
             return false;

--- a/src/SharpEmu.Libs/Gpu/Metal/MetalGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Metal/MetalGuestGpuBackend.cs
@@ -253,7 +253,8 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
         GuestIndexBuffer? indexBuffer = null,
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
-        ulong shaderAddress = 0) =>
+        ulong shaderAddress = 0,
+        int baseVertex = 0) =>
         MetalVideoPresenter.SubmitDepthOnlyTranslatedDraw(
             Msl(pixelShader),
             textures,
@@ -267,7 +268,8 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
             indexBuffer,
             vertexBuffers,
             renderState,
-            shaderAddress);
+            shaderAddress,
+            baseVertex);
 
     public void SubmitOffscreenTranslatedDraw(
         IGuestCompiledShader pixelShader,
@@ -283,7 +285,8 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
         GuestDepthTarget? depthTarget = null,
-        ulong shaderAddress = 0) =>
+        ulong shaderAddress = 0,
+        int baseVertex = 0) =>
         MetalVideoPresenter.SubmitOffscreenTranslatedDraw(
             Msl(pixelShader),
             textures,
@@ -298,7 +301,8 @@ internal sealed class MetalGuestGpuBackend : IGuestGpuBackend
             vertexBuffers,
             renderState,
             depthTarget,
-            shaderAddress);
+            shaderAddress,
+            baseVertex);
 
     public void SubmitStorageTranslatedDraw(
         IGuestCompiledShader pixelShader,

--- a/src/SharpEmu.Libs/Gpu/Metal/MetalVideoPresenter.Draws.cs
+++ b/src/SharpEmu.Libs/Gpu/Metal/MetalVideoPresenter.Draws.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Buffers.Binary;
 using SharpEmu.Libs.Agc;
 using SharpEmu.ShaderCompiler;
 using SharpEmu.ShaderCompiler.Metal;
@@ -87,7 +88,8 @@ internal static partial class MetalVideoPresenter
         uint InstanceCount,
         uint PrimitiveType,
         GuestIndexBuffer? IndexBuffer,
-        GuestRenderState RenderState);
+        GuestRenderState RenderState,
+        int BaseVertex = 0);
 
     private sealed record OffscreenGuestDraw(
         TranslatedGuestDraw Draw,
@@ -245,7 +247,8 @@ internal static partial class MetalVideoPresenter
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers,
         GuestRenderState? renderState,
         GuestDepthTarget? depthTarget,
-        ulong shaderAddress)
+        ulong shaderAddress,
+        int baseVertex = 0)
     {
         if (targets.Count == 0)
         {
@@ -293,7 +296,8 @@ internal static partial class MetalVideoPresenter
                         instanceCount,
                         primitiveType,
                         indexBuffer,
-                        effectiveRenderState),
+                        effectiveRenderState,
+                        baseVertex),
                     ToArray(targets),
                     depthTarget,
                     PublishTarget: true,
@@ -321,7 +325,8 @@ internal static partial class MetalVideoPresenter
         GuestIndexBuffer? indexBuffer,
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers,
         GuestRenderState? renderState,
-        ulong shaderAddress)
+        ulong shaderAddress,
+        int baseVertex = 0)
     {
         if (depthTarget.Address == 0 || depthTarget.Width == 0 || depthTarget.Height == 0)
         {
@@ -348,7 +353,8 @@ internal static partial class MetalVideoPresenter
                         instanceCount,
                         primitiveType,
                         indexBuffer,
-                        renderState ?? GuestRenderState.Default),
+                        renderState ?? GuestRenderState.Default,
+                        baseVertex),
                     [new GuestRenderTarget(Address: 0, depthTarget.Width, depthTarget.Height, Format: 10, NumberType: 0)],
                     depthTarget,
                     PublishTarget: false,
@@ -981,17 +987,38 @@ internal static partial class MetalVideoPresenter
 
     private static void EncodeDrawCall(nint encoder, TranslatedGuestDraw draw)
     {
-        var primitive = GetPrimitiveType(draw.PrimitiveType);
-        var vertexCount = draw.PrimitiveType == 0x11 && draw.IndexBuffer is null
-            ? 4u
-            : draw.VertexCount;
+        var indexed = draw.IndexBuffer is not null;
+        var hasVertexBuffers = draw.VertexBuffers.Length > 0;
+        var primitive = GetPrimitiveType(
+            draw.PrimitiveType,
+            indexed,
+            draw.VertexCount,
+            hasVertexBuffers);
+        var vertexCount = AgcPrimitiveHelpers.GetRectListDrawVertexCount(
+            draw.PrimitiveType,
+            draw.VertexCount,
+            indexed,
+            hasVertexBuffers);
+        var baseVertex = (nuint)Math.Max(draw.BaseVertex, 0);
         if (draw.IndexBuffer is { } indexBuffer)
         {
             var device = MetalNative.Send(encoder, MetalNative.Selector("device"));
             var slice = AllocateUpload(
                 device, Math.Max(indexBuffer.Length, 1), out var buffer, out var offset);
-            indexBuffer.Data.AsSpan(0, Math.Min(indexBuffer.Length, indexBuffer.Data.Length))
-                .CopyTo(slice);
+            var source = indexBuffer.Data.AsSpan(
+                0,
+                Math.Min(indexBuffer.Length, indexBuffer.Data.Length));
+            // Metal drawIndexed without baseVertex: bake GE_INDX_OFFSET into
+            // the uploaded indices so glyph batches still hit the right verts.
+            if (draw.BaseVertex != 0)
+            {
+                BakeBaseVertexIntoIndices(source, slice, indexBuffer.Is32Bit, draw.BaseVertex);
+            }
+            else
+            {
+                source.CopyTo(slice);
+            }
+
             MetalNative.SendDrawIndexedPrimitives(
                 encoder,
                 MetalNative.Selector("drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:"),
@@ -1012,9 +1039,43 @@ internal static partial class MetalVideoPresenter
                 encoder,
                 MetalNative.Selector("drawPrimitives:vertexStart:vertexCount:instanceCount:"),
                 primitive,
-                0,
+                baseVertex,
                 vertexCount,
                 Math.Max(draw.InstanceCount, 1));
+        }
+    }
+
+    private static void BakeBaseVertexIntoIndices(
+        ReadOnlySpan<byte> source,
+        Span<byte> destination,
+        bool is32Bit,
+        int baseVertex)
+    {
+        if (is32Bit)
+        {
+            var count = source.Length / sizeof(uint);
+            for (var index = 0; index < count; index++)
+            {
+                var value = BinaryPrimitives.ReadUInt32LittleEndian(
+                    source.Slice(index * sizeof(uint), sizeof(uint)));
+                var adjusted = unchecked((uint)(value + baseVertex));
+                BinaryPrimitives.WriteUInt32LittleEndian(
+                    destination.Slice(index * sizeof(uint), sizeof(uint)),
+                    adjusted);
+            }
+
+            return;
+        }
+
+        var shortCount = source.Length / sizeof(ushort);
+        for (var index = 0; index < shortCount; index++)
+        {
+            var value = BinaryPrimitives.ReadUInt16LittleEndian(
+                source.Slice(index * sizeof(ushort), sizeof(ushort)));
+            var adjusted = unchecked((ushort)(value + baseVertex));
+            BinaryPrimitives.WriteUInt16LittleEndian(
+                destination.Slice(index * sizeof(ushort), sizeof(ushort)),
+                adjusted);
         }
     }
 
@@ -2059,11 +2120,28 @@ internal static partial class MetalVideoPresenter
 
                 return 3;
             case 6:
-            case 0x11:
                 return 4;
             default:
                 return 3;
         }
+    }
+
+    private static nuint GetPrimitiveType(
+        uint guestPrimitiveType,
+        bool indexed,
+        uint vertexCount,
+        bool hasVertexBuffers)
+    {
+        if (AgcPrimitiveHelpers.ShouldDrawRectListAsTriangleStrip(
+                guestPrimitiveType,
+                indexed,
+                vertexCount,
+                hasVertexBuffers))
+        {
+            return 4; // MTLPrimitiveTypeTriangleStrip
+        }
+
+        return GetPrimitiveType(guestPrimitiveType);
     }
 
     private static bool IsIntegerFormat(Gen5PixelOutputKind kind) =>

--- a/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
@@ -64,6 +64,7 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         int scalarRegisterBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1)
     {
         shader = null;
@@ -79,6 +80,7 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
                 scalarRegisterBufferIndex,
                 pixelInputEnable,
                 pixelInputAddress,
+                pixelInputCntl,
                 storageBufferOffsetAlignment))
         {
             return false;

--- a/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
@@ -181,7 +181,8 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         GuestIndexBuffer? indexBuffer = null,
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
-        ulong shaderAddress = 0) =>
+        ulong shaderAddress = 0,
+        int baseVertex = 0) =>
         VulkanVideoPresenter.SubmitDepthOnlyTranslatedDraw(
             Spirv(pixelShader),
             textures,
@@ -195,7 +196,8 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
             indexBuffer,
             vertexBuffers,
             renderState,
-            shaderAddress);
+            shaderAddress,
+            baseVertex);
 
     public void SubmitOffscreenTranslatedDraw(
         IGuestCompiledShader pixelShader,
@@ -211,7 +213,8 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
         GuestDepthTarget? depthTarget = null,
-        ulong shaderAddress = 0) =>
+        ulong shaderAddress = 0,
+        int baseVertex = 0) =>
         VulkanVideoPresenter.SubmitOffscreenTranslatedDraw(
             Spirv(pixelShader),
             textures,
@@ -226,7 +229,8 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
             vertexBuffers,
             renderState,
             depthTarget,
-            shaderAddress);
+            shaderAddress,
+            baseVertex);
 
     public void SubmitStorageTranslatedDraw(
         IGuestCompiledShader pixelShader,

--- a/src/SharpEmu.Libs/SharpEmu.Libs.csproj
+++ b/src/SharpEmu.Libs/SharpEmu.Libs.csproj
@@ -26,6 +26,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
   <ItemGroup>
     <PackageReference Include="FFmpeg.AutoGen" />
+    <PackageReference Include="NLayer" />
     <PackageReference Include="Silk.NET.Input" />
     <PackageReference Include="Silk.NET.Vulkan" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" />

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -45,7 +45,8 @@ internal sealed record VulkanTranslatedGuestDraw(
     uint InstanceCount,
     uint PrimitiveType,
     GuestIndexBuffer? IndexBuffer,
-    GuestRenderState RenderState);
+    GuestRenderState RenderState,
+    int BaseVertex = 0);
 
 internal sealed record VulkanOffscreenGuestDraw(
     VulkanTranslatedGuestDraw Draw,
@@ -469,7 +470,8 @@ internal static unsafe class VulkanVideoPresenter
         uint.TryParse(Environment.GetEnvironmentVariable("SHARPEMU_SKIP_TALL_COMPUTE_Z"), out var z)
             ? z
             : 0;
-    private const uint GuestPrimitiveRectList = 0x11;
+    private const uint GuestPrimitiveRectList = AgcPrimitiveHelpers.PrimitiveRectListLegacy;
+    private const uint GuestPrimitiveRectListNgg = AgcPrimitiveHelpers.PrimitiveRectList;
 
     private static readonly object _gate = new();
     private readonly record struct PendingGuestWork(
@@ -1029,7 +1031,8 @@ internal static unsafe class VulkanVideoPresenter
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
         GuestDepthTarget? depthTarget = null,
-        ulong shaderAddress = 0)
+        ulong shaderAddress = 0,
+        int baseVertex = 0)
     {
         SubmitOffscreenTranslatedDraw(
             pixelSpirv,
@@ -1045,7 +1048,8 @@ internal static unsafe class VulkanVideoPresenter
             vertexBuffers,
             renderState,
             depthTarget,
-            shaderAddress);
+            shaderAddress,
+            baseVertex);
     }
 
     // Manual scans (targets are <= 8) so the per-draw validation does not
@@ -1098,7 +1102,8 @@ internal static unsafe class VulkanVideoPresenter
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
         GuestDepthTarget? depthTarget = null,
-        ulong shaderAddress = 0)
+        ulong shaderAddress = 0,
+        int baseVertex = 0)
     {
         if (pixelSpirv.Length == 0 ||
             targets.Count == 0 ||
@@ -1165,7 +1170,8 @@ internal static unsafe class VulkanVideoPresenter
                         instanceCount,
                         primitiveType,
                         indexBuffer,
-                        effectiveRenderState),
+                        effectiveRenderState,
+                        baseVertex),
                     targets.ToArray(),
                     depthTarget,
                     PublishTarget: true,
@@ -1190,7 +1196,8 @@ internal static unsafe class VulkanVideoPresenter
         GuestIndexBuffer? indexBuffer = null,
         IReadOnlyList<GuestVertexBuffer>? vertexBuffers = null,
         GuestRenderState? renderState = null,
-        ulong shaderAddress = 0)
+        ulong shaderAddress = 0,
+        int baseVertex = 0)
     {
         if (pixelSpirv.Length == 0 ||
             depthTarget.Address == 0 ||
@@ -1220,7 +1227,8 @@ internal static unsafe class VulkanVideoPresenter
                         instanceCount,
                         primitiveType,
                         indexBuffer,
-                        renderState ?? GuestRenderState.Default),
+                        renderState ?? GuestRenderState.Default,
+                        baseVertex),
                     [new GuestRenderTarget(
                         Address: 0,
                         depthTarget.Width,
@@ -3119,6 +3127,7 @@ internal static unsafe class VulkanVideoPresenter
             public bool Index32Bit;
             public uint VertexCount = 3;
             public uint InstanceCount = 1;
+            public int BaseVertex;
             public PrimitiveTopology Topology = PrimitiveTopology.TriangleList;
             public GuestBlendState[] Blends = [GuestBlendState.Default];
             public GuestBlendConstant BlendConstant;
@@ -6177,9 +6186,18 @@ internal static unsafe class VulkanVideoPresenter
                 GlobalMemoryBuffers =
                     new GlobalBufferResource[draw.GlobalMemoryBuffers.Count],
                 VertexBuffers = new VertexBufferResource[draw.VertexBuffers.Count],
-                VertexCount = GetDrawVertexCount(draw.PrimitiveType, draw.VertexCount, draw.IndexBuffer),
+                VertexCount = GetDrawVertexCount(
+                    draw.PrimitiveType,
+                    draw.VertexCount,
+                    draw.IndexBuffer,
+                    draw.VertexBuffers.Count > 0),
                 InstanceCount = Math.Max(draw.InstanceCount, 1),
-                Topology = GetPrimitiveTopology(draw.PrimitiveType),
+                BaseVertex = draw.BaseVertex,
+                Topology = GetPrimitiveTopology(
+                    draw.PrimitiveType,
+                    indexed: draw.IndexBuffer is not null,
+                    vertexCount: draw.VertexCount,
+                    hasVertexBuffers: draw.VertexBuffers.Count > 0),
                 Blends = draw.RenderState.Blends.ToArray(),
                 BlendConstant = draw.RenderState.BlendConstant,
                 Scissor = draw.RenderState.Scissor,
@@ -9650,7 +9668,11 @@ internal static unsafe class VulkanVideoPresenter
             _vk.FreeMemory(_device, allocation.Memory, null);
         }
 
-        private static PrimitiveTopology GetPrimitiveTopology(uint primitiveType) =>
+        private static PrimitiveTopology GetPrimitiveTopology(
+            uint primitiveType,
+            bool indexed,
+            uint vertexCount,
+            bool hasVertexBuffers) =>
             primitiveType switch
             {
                 1 => PrimitiveTopology.PointList,
@@ -9658,7 +9680,12 @@ internal static unsafe class VulkanVideoPresenter
                 3 => PrimitiveTopology.LineStrip,
                 5 => PrimitiveTopology.TriangleFan,
                 6 => PrimitiveTopology.TriangleStrip,
-                GuestPrimitiveRectList => PrimitiveTopology.TriangleStrip,
+                GuestPrimitiveRectListNgg or GuestPrimitiveRectList
+                    when AgcPrimitiveHelpers.ShouldDrawRectListAsTriangleStrip(
+                        primitiveType,
+                        indexed,
+                        vertexCount,
+                        hasVertexBuffers) => PrimitiveTopology.TriangleStrip,
                 _ => PrimitiveTopology.TriangleList,
             };
 
@@ -9774,15 +9801,13 @@ internal static unsafe class VulkanVideoPresenter
         private static uint GetDrawVertexCount(
             uint primitiveType,
             uint vertexCount,
-            GuestIndexBuffer? indexBuffer)
-        {
-            if (primitiveType == GuestPrimitiveRectList && indexBuffer is null)
-            {
-                return 4;
-            }
-
-            return vertexCount;
-        }
+            GuestIndexBuffer? indexBuffer,
+            bool hasVertexBuffers) =>
+            AgcPrimitiveHelpers.GetRectListDrawVertexCount(
+                primitiveType,
+                vertexCount,
+                indexed: indexBuffer is not null,
+                hasVertexBuffers);
 
         private static BlendFactor ToVkBlendFactor(uint factor) =>
             factor switch
@@ -15665,12 +15690,14 @@ internal static unsafe class VulkanVideoPresenter
                         resources.IndexBuffer,
                         0,
                         resources.Index32Bit ? IndexType.Uint32 : IndexType.Uint16);
+                    // vertexOffset = ResolveVertexOffset(GE_INDX_OFFSET).
+                    // GTA UI glyphs use relative indices + a nonzero base vertex.
                     _vk.CmdDrawIndexed(
                         _commandBuffer,
                         resources.VertexCount,
                         resources.InstanceCount,
                         0,
-                        0,
+                        resources.BaseVertex,
                         0);
                 }
                 else
@@ -15679,7 +15706,7 @@ internal static unsafe class VulkanVideoPresenter
                         _commandBuffer,
                         resources.VertexCount,
                         resources.InstanceCount,
-                        0,
+                        (uint)Math.Max(resources.BaseVertex, 0),
                         0);
                 }
 

--- a/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.cs
@@ -74,6 +74,7 @@ public static partial class Gen5MslTranslator
         int pixelRenderTargetSlot = 0,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1) =>
         TryCompilePixelShader(
             state,
@@ -87,6 +88,7 @@ public static partial class Gen5MslTranslator
             initialScalarBufferIndex,
             pixelInputEnable,
             pixelInputAddress,
+            pixelInputCntl,
             storageBufferOffsetAlignment);
 
     public static bool TryCompilePixelShader(
@@ -101,6 +103,7 @@ public static partial class Gen5MslTranslator
         int initialScalarBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1)
     {
         shader = default!;
@@ -161,7 +164,8 @@ public static partial class Gen5MslTranslator
             pixelOutputBindings: outputs,
             imageBindingBase: imageBindingBase,
             pixelInputEnable: pixelInputEnable,
-            pixelInputAddress: pixelInputAddress);
+            pixelInputAddress: pixelInputAddress,
+            pixelInputCntl: pixelInputCntl);
         return context.TryCompile(out shader, out error);
     }
 
@@ -254,6 +258,7 @@ public static partial class Gen5MslTranslator
         private readonly int _imageBindingBase;
         private readonly uint _pixelInputEnable;
         private readonly uint _pixelInputAddress;
+        private readonly uint[] _pixelInputCntl;
         private readonly Dictionary<uint, int> _imageBindingByPc = [];
         private readonly Dictionary<uint, int> _bufferBindingByPc = [];
         private readonly List<(bool IsStorage, string ComponentKind)> _imageKinds = [];
@@ -294,12 +299,20 @@ public static partial class Gen5MslTranslator
             int imageBindingBase = 0,
             uint pixelInputEnable = 0,
             uint pixelInputAddress = 0,
+            IReadOnlyList<uint>? pixelInputCntl = null,
             int requiredVertexOutputCount = 0)
         {
             _pixelOutputBindings = pixelOutputBindings ?? [];
             _imageBindingBase = imageBindingBase;
             _pixelInputEnable = pixelInputEnable;
             _pixelInputAddress = pixelInputAddress;
+            _pixelInputCntl = new uint[32];
+            for (uint i = 0; i < 32u; i++)
+            {
+                _pixelInputCntl[i] = pixelInputCntl is not null && i < (uint)pixelInputCntl.Count
+                    ? pixelInputCntl[(int)i]
+                    : i;
+            }
             _requiredVertexOutputCount = requiredVertexOutputCount;
             _stage = stage;
             _state = state;
@@ -592,7 +605,13 @@ public static partial class Gen5MslTranslator
                 source.AppendLine("    float4 sharpemu_frag_coord [[position]];");
                 foreach (var attribute in _pixelAttributes)
                 {
-                    source.AppendLine($"    float4 attr{attribute} [[user(locn{attribute})]];");
+                    var cntl = attribute < (uint)_pixelInputCntl.Length
+                        ? _pixelInputCntl[attribute]
+                        : attribute;
+                    var location = cntl & 0x1Fu;
+                    var flat = (cntl & 0x400u) != 0 ? ", flat" : string.Empty;
+                    source.AppendLine(
+                        $"    float4 attr{attribute} [[user(locn{location}){flat}]];");
                 }
 
                 source.AppendLine("};");

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -31,6 +31,7 @@ public static partial class Gen5SpirvTranslator
         int pixelRenderTargetSlot = 0,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1) =>
         TryCompilePixelShader(
             state,
@@ -44,6 +45,7 @@ public static partial class Gen5SpirvTranslator
             initialScalarBufferIndex,
             pixelInputEnable,
             pixelInputAddress,
+            pixelInputCntl,
             storageBufferOffsetAlignment);
 
     public static bool TryCompilePixelShader(
@@ -58,6 +60,7 @@ public static partial class Gen5SpirvTranslator
         int initialScalarBufferIndex = -1,
         uint pixelInputEnable = 0,
         uint pixelInputAddress = 0,
+        IReadOnlyList<uint>? pixelInputCntl = null,
         ulong storageBufferOffsetAlignment = 1)
     {
         if (outputs.Count > 8 || outputs.Any(output => output.GuestSlot > 7))
@@ -99,6 +102,7 @@ public static partial class Gen5SpirvTranslator
             initialScalarBufferIndex,
             pixelInputEnable: pixelInputEnable,
             pixelInputAddress: pixelInputAddress,
+            pixelInputCntl: pixelInputCntl,
             storageBufferOffsetAlignment: storageBufferOffsetAlignment);
         return context.TryCompile(out shader, out error);
     }
@@ -231,6 +235,7 @@ public static partial class Gen5SpirvTranslator
         private readonly int _initialScalarBufferIndex;
         private readonly uint _pixelInputEnable;
         private readonly uint _pixelInputAddress;
+        private readonly uint[] _pixelInputCntl;
         private readonly ulong _storageBufferOffsetAlignment;
         private readonly List<uint> _interfaces = [];
         private readonly Dictionary<uint, uint> _pixelInputs = [];
@@ -343,6 +348,7 @@ public static partial class Gen5SpirvTranslator
             int initialScalarBufferIndex,
             uint pixelInputEnable = 0,
             uint pixelInputAddress = 0,
+            IReadOnlyList<uint>? pixelInputCntl = null,
             int requiredVertexOutputCount = 0,
             uint waveLaneCount = 32,
             ulong storageBufferOffsetAlignment = 1)
@@ -368,6 +374,13 @@ public static partial class Gen5SpirvTranslator
             _initialScalarBufferIndex = initialScalarBufferIndex;
             _pixelInputEnable = pixelInputEnable;
             _pixelInputAddress = pixelInputAddress;
+            _pixelInputCntl = new uint[32];
+            for (uint i = 0; i < 32u; i++)
+            {
+                _pixelInputCntl[i] = pixelInputCntl is not null && i < (uint)pixelInputCntl.Count
+                    ? pixelInputCntl[(int)i]
+                    : i;
+            }
             if (storageBufferOffsetAlignment == 0 ||
                 (storageBufferOffsetAlignment & (storageBufferOffsetAlignment - 1)) != 0 ||
                 storageBufferOffsetAlignment > uint.MaxValue)
@@ -1242,7 +1255,18 @@ public static partial class Gen5SpirvTranslator
                     var variable = _module.AddGlobalVariable(
                         inputVec4Pointer,
                         SpirvStorageClass.Input);
-                    _module.AddDecoration(variable, SpirvDecoration.Location, attribute);
+                    // VINTRP ATTR selects the PS input slot. SPI_PS_INPUT_CNTL
+                    // maps that slot to a VS parameter export location.
+                    var cntl = attribute < (uint)_pixelInputCntl.Length
+                        ? _pixelInputCntl[attribute]
+                        : attribute;
+                    var location = cntl & 0x1Fu;
+                    _module.AddDecoration(variable, SpirvDecoration.Location, location);
+                    if ((cntl & 0x400u) != 0)
+                    {
+                        _module.AddDecoration(variable, SpirvDecoration.Flat);
+                    }
+
                     _pixelInputs.Add(attribute, variable);
                     _interfaces.Add(variable);
                 }

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcRectListIndexHelpersTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcRectListIndexHelpersTests.cs
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+/// <summary>
+/// Regression coverage for the AGC UI path: index8 expansion and rect-list
+/// vertex counts / topology selection.
+/// </summary>
+public sealed class AgcRectListIndexHelpersTests
+{
+    [Theory]
+    [InlineData(0u, 0u, 2)] // Index16
+    [InlineData(1u, 1u, 4)] // Index32
+    [InlineData(2u, 2u, 1)] // Index8
+    [InlineData(0x402u, 2u, 1)] // UC 0x400|size -> Index8
+    public void IndexType_DecodeAndStride_MatchProspero(uint raw, uint expected, int stride)
+    {
+        var decoded = AgcIndexHelpers.Decode(raw);
+        Assert.Equal((AgcIndexHelpers.ProsperoIndexType)expected, decoded);
+        Assert.Equal(stride, AgcIndexHelpers.GetGuestStrideBytes(decoded));
+    }
+
+    [Fact]
+    public void ExpandIndex8ToU16_PreservesValues()
+    {
+        ReadOnlySpan<byte> source = [0x00, 0x01, 0xFF, 0x7F];
+        Span<byte> destination = stackalloc byte[8];
+        AgcIndexHelpers.ExpandIndex8ToU16(source, destination);
+        Assert.Equal(0, BinaryPrimitives.ReadUInt16LittleEndian(destination[..2]));
+        Assert.Equal(1, BinaryPrimitives.ReadUInt16LittleEndian(destination.Slice(2, 2)));
+        Assert.Equal(255, BinaryPrimitives.ReadUInt16LittleEndian(destination.Slice(4, 2)));
+        Assert.Equal(127, BinaryPrimitives.ReadUInt16LittleEndian(destination.Slice(6, 2)));
+    }
+
+    [Theory]
+    // NGG single-rect UI (DualSense): expand even when VBs are present
+    [InlineData(7u, 3u, false, true, 4u)]
+    [InlineData(7u, 1u, false, false, 4u)]
+    [InlineData(7u, 4u, false, true, 4u)]
+    // Indexed / multi-vert auto: keep guest count (loading video)
+    [InlineData(7u, 3u, true, false, 3u)]
+    [InlineData(7u, 6u, false, true, 6u)]
+    [InlineData(7u, 4u, true, true, 4u)]
+    [InlineData(0x11u, 3u, false, false, 4u)]
+    [InlineData(0x11u, 6u, false, false, 6u)]
+    [InlineData(4u, 3u, false, false, 3u)]
+    public void RectListDrawVertexCount_MatchesExpansion(
+        uint primitiveType,
+        uint vertexCount,
+        bool indexed,
+        bool hasVertexBuffers,
+        uint expected)
+    {
+        Assert.Equal(
+            expected,
+            AgcPrimitiveHelpers.GetRectListDrawVertexCount(
+                primitiveType,
+                vertexCount,
+                indexed,
+                hasVertexBuffers));
+    }
+
+    [Theory]
+    [InlineData(7u, false, 3u, true, true)]
+    [InlineData(7u, false, 6u, true, false)]
+    [InlineData(7u, true, 3u, false, false)]
+    [InlineData(0x11u, false, 3u, true, true)]
+    [InlineData(0x11u, true, 3u, false, false)]
+    public void RectListTriangleStrip_MatchesGuards(
+        uint primitiveType,
+        bool indexed,
+        uint vertexCount,
+        bool hasVertexBuffers,
+        bool expected) =>
+        Assert.Equal(
+            expected,
+            AgcPrimitiveHelpers.ShouldDrawRectListAsTriangleStrip(
+                primitiveType,
+                indexed,
+                vertexCount,
+                hasVertexBuffers));
+
+    [Theory]
+    [InlineData(7u, (uint)AgcPrimitiveHelpers.GsOutputPrimitiveType.Rectangle2D)]
+    [InlineData(0x11u, (uint)AgcPrimitiveHelpers.GsOutputPrimitiveType.RectList)]
+    [InlineData(4u, (uint)AgcPrimitiveHelpers.GsOutputPrimitiveType.Triangles)]
+    [InlineData(1u, (uint)AgcPrimitiveHelpers.GsOutputPrimitiveType.Points)]
+    public void PrimitiveTypeToGsOut_MatchesProspero(uint primitiveType, uint expected) =>
+        Assert.Equal(expected, AgcPrimitiveHelpers.PrimitiveTypeToGsOut(primitiveType));
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

Per **Scarecrow**'s instruction, the following closed PRs are being resubmitted here as **one combined PR**, rebased onto current `main`:

| Closed PR | Topic |
|-----------|--------|
| [#551](https://github.com/sharpemu/sharpemu/pull/551) | SPI_PS_INPUT_CNTL PS interpolant mapping |
| [#557](https://github.com/sharpemu/sharpemu/pull/557) | Rect-list / NGG strips, Index8 expand, `GE_INDX_OFFSET` |
| [#573](https://github.com/sharpemu/sharpemu/pull/573) | AudioOut2 host beds, deeper waveOut queue, AJM MP3 |
| [#593](https://github.com/sharpemu/sharpemu/pull/593) | Rewind/Jump writers and `IT_REWIND` waits |
| [#594](https://github.com/sharpemu/sharpemu/pull/594) | Prefer native workers for all guest entry stubs |

This is not new work — it is the same five changes, stacked and conflict-resolved against current upstream (notably Metal presenter churn from recent GPU work).

### What each piece does

1. **Interpolants (#551)** — Pack real `SPI_PS_INPUT_CNTL` from matched PS/GS semantics instead of identity ATTR→param wiring; thread Location/Flat into Vulkan SPIR-V and Metal MSL; fingerprint CNTL in the graphics shader cache key. Fixes clear-heavy / missing logo UI on GTA.

2. **Rect-list / Index8 / base vertex (#557)** — NGG single-rect UI as host triangle-strip, Prospero Index8→u16 expand, base vertex from `GE_INDX_OFFSET`, skip param-less rect-lists. Generic AGC draw/index plumbing with unit tests.

3. **AudioOut2 + AJM MP3 (#573)** — Real host path for `libSceAudioOut2`: PortCreate / PortSetAttributes / ContextPush into dual stereo host streams (MAIN+AUX bed selection), WinMM queue 32→128 KiB, stateful NLayer decode for AJM codec 0. Not full object/Accel audio; other AJM codecs stay silent.

4. **Rewind / Jump (#593)** — Implement `sceAgc*Rewind` / Jump writers and GetSize twins, `sceAgcRewindPatchSetRewindState`, parser waits on `IT_REWIND`, nest-parse 4-dword `IT_INDIRECT_BUFFER`. Stops Subrender AVs from treating `NOT_FOUND` as a packet size.

5. **Native guest entry (#594)** — Route thread entry, continuation, and main entry through `RunGuestEntryStub` so stubs are not called above CLR-managed frames (`UnmanagedCallersOnly` FailFast). Keep hard native-worker requirement for `tbb_thead`.

## Testing

- Grand Theft Auto V Enhanced (PPSA04264, `01.005.000`) on the stacked verify build used for the original PRs:
  - **#551:** GTA logo and loading circles appear (was clear-only UI)
  - **#557:** UI quad / indexed glyph plumbing in place (Scaleform text still weak — out of scope)
  - **#573:** Intro + menu SFX/music audible (was silent)
  - **#593:** Subrender Rewind/Jump AV gone; session progresses past that crash
  - **#594:** Multi-minute North Yankton without `UnmanagedCallersOnly` FailFast on guest entry
- Unit: `FullyQualifiedName~AgcRectListIndexHelpersTests` (from #557)
- Build: Release `win-x64` via `.\build.ps1` on the verify stack

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).