### PR TITLE
docs: resolve XML documentation references

### DIFF
--- a/src/SharpEmu.Core/Cpu/Emulation/BmiInstructionEmulator.cs
+++ b/src/SharpEmu.Core/Cpu/Emulation/BmiInstructionEmulator.cs
@@ -13,12 +13,12 @@ namespace SharpEmu.Core.Cpu.Emulation;
 /// Zen 2 cores implement BMI1/BMI2/ABM, but a host CPU that predates those extensions raises
 /// #UD (STATUS_ILLEGAL_INSTRUCTION) when it meets one of these opcodes. This class provides the
 /// register-only arithmetic so the exception handler can finish the instruction in software and
-/// resume, instead of aborting the title.
+/// resume, instead of aborting the title. The eflags value is updated in place where an
+/// instruction defines its flags.
 ///
 /// The methods deliberately operate on plain integers rather than on the OS CONTEXT record so the
 /// semantics can be unit-tested in isolation; the unsafe register/memory plumbing lives in the
-/// backend adapter. Each method returns the result already masked to the operand width and, where
-/// the instruction is defined to touch flags, updates <paramref name="eflags"/> in place. Flags
+/// backend adapter. Each method returns the result already masked to the operand width. Flags
 /// documented as "undefined" by the vendor manuals are left untouched so behaviour stays
 /// deterministic across hosts.
 /// </summary>

--- a/src/SharpEmu.HLE/Host/Posix/PosixHostInput.cs
+++ b/src/SharpEmu.HLE/Host/Posix/PosixHostInput.cs
@@ -7,7 +7,7 @@ namespace SharpEmu.HLE.Host.Posix;
 /// Bridges a window-provided input source into the host input seam. POSIX
 /// hosts have no user32/XInput/raw-HID readers; keyboard and gamepad state
 /// come from the presenter's GLFW window instead, which registers itself via
-/// <see cref="SetSource"/> once the window exists. Until then (and with no
+/// <see cref="PosixHostInput.SetSource"/> once the window exists. Until then (and with no
 /// window at all, e.g. headless runs) every query reports neutral input.
 /// Rumble and lightbar are unsupported by the GLFW input layer and no-op.
 /// </summary>


### PR DESCRIPTION
## Summary

Resolve two broken XML documentation references reported during a full build:

- qualify the POSIX input registration member as `PosixHostInput.SetSource`, because it is referenced from the input-source interface;
- replace a class-level `paramref` reference to `eflags` in the BMI emulator summary, where no parameter scope exists.

No runtime behaviour changes.

## Testing

- `dotnet build src/SharpEmu.Core/SharpEmu.Core.csproj --configuration Debug --no-restore` — passes without CS1734.
- `dotnet test tests/SharpEmu.SourceGenerators.Tests/SharpEmu.SourceGenerators.Tests.csproj --configuration Debug --no-restore` — 33 passed.
- N/A for game testing: this change only fixes generated API documentation.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

> Draft note: this PR was prepared with AI assistance. Please review the code and rewrite the description in your own words before marking it ready for review.