### PR TITLE
fix(ngs2): reuse render trace buffer

### DIFF
--- a/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
+++ b/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
@@ -496,6 +496,7 @@ public static class Ngs2Exports
             return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
         }
 
+        Span<byte> rbi = stackalloc byte[RenderBufferInfoSize];
         for (uint i = 0; i < bufferInfoCount; i++)
         {
             var entryAddress = bufferInfoAddress + (i * RenderBufferInfoSize);
@@ -527,7 +528,6 @@ public static class Ngs2Exports
 
                 if (ShouldTrace() && Interlocked.Increment(ref _renderInfoDumps) <= 4)
                 {
-                    Span<byte> rbi = stackalloc byte[RenderBufferInfoSize];
                     ctx.Memory.TryRead(entryAddress, rbi);
                     Console.Error.WriteLine(
                         $"[LOADER][TRACE] ngs2.renderbufinfo addr=0x{bufferAddress:X} size={bufferSize} ch={channels} raw={Convert.ToHexString(rbi)}");


### PR DESCRIPTION
## Summary

Move the fixed-size render-buffer-info trace span outside `Ngs2SystemRender`'s buffer loop. The previous `stackalloc` happened once per entry, which triggers CA2014 because repeated stack allocations can exhaust the stack during a long render call.

The trace payload and audio-rendering path are unchanged; each iteration reuses the same 24-byte span.

## Testing

- `dotnet build src/SharpEmu.Libs/SharpEmu.Libs.csproj --configuration Debug --no-restore` — passes; CA2014 is gone.
- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj --configuration Debug --no-restore` — 588 passed.
- N/A for game testing: this is a bounded tracing-memory correction.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

> Draft note: this PR was prepared with AI assistance. Please review the code and rewrite the description in your own words before marking it ready for review.