### PR TITLE
fix(build): select the .NET TaskHost runtime

### DIFF
--- a/src/SharpEmu.HLE/SharpEmu.HLE.csproj
+++ b/src/SharpEmu.HLE/SharpEmu.HLE.csproj
@@ -39,6 +39,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
   <UsingTask TaskName="SharpEmu.SourceGenerators.GenerateAerolibBinaryTask"
              TaskFactory="TaskHostFactory"
+             Runtime="NET"
              AssemblyFile="$(SharpEmuAerolibTaskAssembly)" />
 
   <!-- Runs after ResolveProjectReferences (which builds the task assembly) and before


### PR DESCRIPTION
## Summary

Declare `Runtime="NET"` for the out-of-process `GenerateAerolibBinaryTask`. Newer .NET 10 SDKs use MSBuild 18, where a `TaskHostFactory` task needs an explicit runtime target to be instantiated reliably.

This addresses #607 without changing the task implementation or runtime dependencies.

## Testing

- Clean isolated clone with .NET SDK 10.0.302: `dotnet build src/SharpEmu.HLE/SharpEmu.HLE.csproj --configuration Debug` — passed.
- Repository checkout with the change: `dotnet build src/SharpEmu.HLE/SharpEmu.HLE.csproj --configuration Debug --no-restore` — passed.
- `dotnet test tests/SharpEmu.SourceGenerators.Tests/SharpEmu.SourceGenerators.Tests.csproj --configuration Debug --no-restore` — 33 passed.
- N/A for game testing: build configuration only.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

> Draft note: this PR was prepared with AI assistance. Please review the code and rewrite the description in your own words before marking it ready for review.