### PR TITLE
fix(aerolib): catalog VoiceQoS symbols

### DIFF
--- a/scripts/ps5_names.txt
+++ b/scripts/ps5_names.txt
@@ -143382,7 +143382,9 @@ sceVoiceQoSInitHQ
 sceVoiceQoSReadPacket
 sceVoiceQoSSetConnectionAttribute
 sceVoiceQoSSetLocalEndpointAttribute
+sceVoiceQoSSetMode
 sceVoiceQoSSetRemoteEndpointAttribute
+sceVoiceQoSTerminate
 sceVoiceQoSWritePacket
 sceVoiceReadFromOPort
 sceVoiceResetPort


### PR DESCRIPTION
## Summary

Add `sceVoiceQoSSetMode` and `sceVoiceQoSTerminate` to `scripts/ps5_names.txt`. Their declared NIDs in `VoiceQoSExports` already match the catalog derivation, but the names were absent from the generated aerolib catalog.

This removes the two specific catalog warnings and allows diagnostics to resolve these VoiceQoS NIDs back to their names.

## Testing

- `python3 scripts/aerolib_catalog.py lookup sceVoiceQoSSetMode` → `+0lOiPZjnBI`
- `python3 scripts/aerolib_catalog.py lookup sceVoiceQoSTerminate` → `FuXenJLkk-c`
- `dotnet build src/SharpEmu.Libs/SharpEmu.Libs.csproj --configuration Debug --no-restore` — passed; the two VoiceQoS catalog warnings are gone.
- `dotnet test tests/SharpEmu.SourceGenerators.Tests/SharpEmu.SourceGenerators.Tests.csproj --configuration Debug --no-restore` — 33 passed.
- N/A for game testing: export metadata only.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

> Draft note: this PR was prepared with AI assistance. Please review the code and rewrite the description in your own words before marking it ready for review.