### PR TITLE
fix(logging): use invariant timestamps

### DIFF
--- a/src/SharpEmu.Logging/ConsoleLogSink.cs
+++ b/src/SharpEmu.Logging/ConsoleLogSink.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Globalization;
 using System.IO;
 
 namespace SharpEmu.Logging;
@@ -27,7 +28,7 @@ public sealed class ConsoleLogSink : ISharpEmuLogSink
             if (IncludeTimestamp)
             {
                 writer.Write('[');
-                writer.Write(entry.Timestamp.ToString("HH:mm:ss.fff"));
+                writer.Write(entry.Timestamp.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
                 writer.Write(']');
             }
 

--- a/src/SharpEmu.Logging/FileLogSink.cs
+++ b/src/SharpEmu.Logging/FileLogSink.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -60,7 +61,7 @@ public sealed class FileLogSink : ISharpEmuLogSink, IDisposable
             if (IncludeTimestamp)
             {
                 _writer.Write('[');
-                _writer.Write(entry.Timestamp.ToString("yyyy-MM-dd HH:mm:ss.fff"));
+                _writer.Write(entry.Timestamp.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture));
                 _writer.Write(']');
             }
 

--- a/tests/SharpEmu.Libs.Tests/Logging/SharpEmuLogTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Logging/SharpEmuLogTests.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Globalization;
 using SharpEmu.Logging;
 using Xunit;
 
@@ -8,6 +9,39 @@ namespace SharpEmu.Libs.Tests.Logging;
 
 public sealed class SharpEmuLogTests
 {
+    [Fact]
+    public void FileLogSinkFormatsTimestampsWithInvariantCulture()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sharpemu-{Guid.NewGuid():N}.log");
+        var originalCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("ar-SA");
+            using (var sink = new FileLogSink(path, append: false))
+            {
+                var entry = new LogEntry(
+                    new DateTimeOffset(2026, 7, 25, 14, 5, 6, 789, TimeSpan.Zero),
+                    LogLevel.Info,
+                    "Test",
+                    "message",
+                    "Test.cs",
+                    1,
+                    nameof(FileLogSinkFormatsTimestampsWithInvariantCulture));
+
+                sink.Write(in entry);
+            }
+
+            var line = File.ReadAllText(path);
+            Assert.StartsWith("[2026-07-25 14:05:06.789]", line, StringComparison.Ordinal);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            File.Delete(path);
+        }
+    }
+
     [Theory]
     [InlineData("Trace", LogLevel.Trace)]
     [InlineData("debug", LogLevel.Debug)]


### PR DESCRIPTION
## Summary

Format console and file log timestamps with `CultureInfo.InvariantCulture`. The timestamp layout is part of the diagnostic output, but its date calendar and time separator previously changed with the host culture.

Add a focused file-sink test under `ar-SA` to ensure the timestamp remains stable even when the active culture uses a non-Gregorian calendar.

## Testing

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj --configuration Debug --no-restore --filter FullyQualifiedName~SharpEmu.Libs.Tests.Logging.SharpEmuLogTests` — 16 passed.
- N/A for game testing: logging output only.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

> Draft note: this PR was prepared with AI assistance. Please review the code and rewrite the description in your own words before marking it ready for review.