### PR TITLE
fix(np): register premium callbacks offline

### DIFF
--- a/src/SharpEmu.Libs/Np/NpManagerExports.cs
+++ b/src/SharpEmu.Libs/Np/NpManagerExports.cs
@@ -86,6 +86,31 @@ public static class NpManagerExports
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
+    /// <summary>
+    /// Registers a Premium entitlement callback for an offline profile. No
+    /// entitlement transitions occur without PSN connectivity, so the callback
+    /// is accepted but never invoked.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "+yqjab2fUJA",
+        ExportName = "sceNpRegisterPremiumEventCallback",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceNpManager")]
+    public static int NpRegisterPremiumEventCallback(CpuContext ctx)
+    {
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
+    [SysAbiExport(
+        Nid = "-Rjp3-YViXc",
+        ExportName = "sceNpUnregisterPremiumEventCallback",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceNpManager")]
+    public static int NpUnregisterPremiumEventCallback(CpuContext ctx)
+    {
+        return ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+    }
+
     [SysAbiExport(
         Nid = "qQJfO8HAiaY",
         ExportName = "sceNpRegisterStateCallbackA",

--- a/tests/SharpEmu.Libs.Tests/Np/NpManagerExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Np/NpManagerExportsTests.cs
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Np;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Np;
+
+public sealed class NpManagerExportsTests
+{
+    [Theory]
+    [InlineData("+yqjab2fUJA", "sceNpRegisterPremiumEventCallback")]
+    [InlineData("-Rjp3-YViXc", "sceNpUnregisterPremiumEventCallback")]
+    public void PremiumEventCallbackExportsRegisterForBothGenerations(string nid, string name)
+    {
+        foreach (var generation in new[] { Generation.Gen4, Generation.Gen5 })
+        {
+            var manager = new ModuleManager();
+            manager.RegisterExports(
+                SharpEmu.Generated.SysAbiExportRegistry.CreateExports(generation));
+
+            Assert.True(manager.TryGetExport(nid, out var export));
+            Assert.Equal(name, export.Name);
+            Assert.Equal("libSceNpManager", export.LibraryName);
+        }
+    }
+
+    [Fact]
+    public void PremiumEventCallbackRegistrationSucceedsForOfflineProfile()
+    {
+        var context = new CpuContext(new FakeCpuMemory(0x1_0000_0000, 0x1000), Generation.Gen5);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, NpManagerExports.NpRegisterPremiumEventCallback(context));
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, NpManagerExports.NpUnregisterPremiumEventCallback(context));
+        Assert.Equal(0UL, context[CpuRegister.Rax]);
+    }
+}


### PR DESCRIPTION
## Summary

Add the missing `libSceNpManager` exports for `sceNpRegisterPremiumEventCallback` and `sceNpUnregisterPremiumEventCallback`. The NID catalog already identifies both imports, but no handler was registered, causing callers to receive an unresolved-import error.

The offline NP profile accepts the callback registration but never invokes it, consistent with the existing reachability callback behavior: Premium entitlement transitions require PSN connectivity.

## Testing

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj --configuration Debug --no-restore --filter FullyQualifiedName~SharpEmu.Libs.Tests.Np.NpManagerExportsTests` — 3 passed.
- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj --configuration Debug --no-restore` — 591 passed.
- N/A for game testing: HLE export registration and offline callback contract.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

> Draft note: this PR was prepared with AI assistance. Please review the code and rewrite the description in your own words before marking it ready for review.