### PR TITLE
perf(loader): stack-allocate the PS-NID hash input

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -2074,10 +2074,17 @@ public sealed partial class DirectExecutionBackend
 			0x51, 0x8D, 0x64, 0xA6, 0x35, 0xDE, 0xD8, 0xC1,
 			0xE6, 0xB0, 0x39, 0xB1, 0xC3, 0xE5, 0x52, 0x30,
 		];
-		var nameBytes = Encoding.UTF8.GetBytes(symbolName);
-		var input = new byte[nameBytes.Length + salt.Length];
-		nameBytes.CopyTo(input, 0);
-		salt.CopyTo(input.AsSpan(nameBytes.Length));
+		// Symbol names come from a 512-byte-capped read and are almost always short,
+		// so hash them on the stack, falling back to the heap only for an oversized
+		// name. Avoids the two per-call arrays the previous concat-then-hash used.
+		var nameByteCount = Encoding.UTF8.GetByteCount(symbolName);
+		var inputLength = nameByteCount + salt.Length;
+		Span<byte> input = inputLength <= 256
+			? stackalloc byte[256]
+			: new byte[inputLength];
+		input = input[..inputLength];
+		Encoding.UTF8.GetBytes(symbolName, input[..nameByteCount]);
+		salt.CopyTo(input[nameByteCount..]);
 		Span<byte> digest = stackalloc byte[20];
 		SHA1.HashData(input, digest);
 		var value = BinaryPrimitives.ReadUInt64LittleEndian(digest);


### PR DESCRIPTION
ComputePsNid runs on the symbol-resolution path (sceKernelDlsym and the module-symbol NID fallback), and every call allocated two throwaway arrays: the UTF-8 GetBytes() result and a second buffer to concatenate name+salt before hashing.

Symbol names come from a 512-byte-capped read and are almost always short, so size the input with GetByteCount, build it in a 256-byte stack buffer (heap fallback only for an oversized name), and encode the name straight into it. The hashed bytes -- and therefore the resulting NID -- are unchanged.

Verified: an old-vs-new comparison over 5023 names (including the stack/heap boundary and multi-byte UTF-8) produced identical NIDs, and the import-trampoline, SelfLoader, and Aerolib catalog tests pass on .NET 10.

## Testing

N/A

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
