### PR TITLE
perf(loader): slice the '_'-stripped symbol alias once

### DIFF
--- a/src/SharpEmu.Core/Loader/SelfLoader.cs
+++ b/src/SharpEmu.Core/Loader/SelfLoader.cs
@@ -1616,12 +1616,16 @@ public sealed class SelfLoader : ISelfLoader
             addedAny = true;
         }
 
-        if (symbolName.Length > 1 &&
-            symbolName[0] == '_' &&
-            !runtimeSymbols.ContainsKey(symbolName[1..]))
+        // Slice the '_'-stripped alias once; it was being materialized twice
+        // (probe + insert) for every underscore symbol in the table.
+        if (symbolName.Length > 1 && symbolName[0] == '_')
         {
-            runtimeSymbols[symbolName[1..]] = symbolAddress;
-            addedAny = true;
+            var unprefixed = symbolName[1..];
+            if (!runtimeSymbols.ContainsKey(unprefixed))
+            {
+                runtimeSymbols[unprefixed] = symbolAddress;
+                addedAny = true;
+            }
         }
 
         if (string.Equals(symbolName, "kernel_dynlib_dlsym", StringComparison.Ordinal))


### PR DESCRIPTION
RegisterRuntimeSymbol runs for every symbol in a module's section and dynamic tables. The underscore-alias branch materialized symbolName[1..] twice per matching symbol -- once to probe runtimeSymbols and again to insert -- so every registered leading-underscore symbol allocated a throwaway substring.

Slice it into a local once and reuse it for the probe and the insert. Behavior is unchanged (same keys, same addedAny result); this only drops the duplicate per-symbol substring on the module-load path. SelfLoader, import-trampoline, and Aerolib catalog tests pass on .NET 10.

## Testing
N/A

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
