### PR TITLE
[GPU] Implement AGC indirect draw packets

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -1642,6 +1642,45 @@ public static partial class AgcExports
     }
 
     [SysAbiExport(
+        Nid = "1q1titRBL6o",
+        ExportName = "sceAgcDcbDrawIndirect",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbDrawIndirect(CpuContext ctx)
+    {
+        var commandBufferAddress = ctx[CpuRegister.Rdi];
+        var dataOffset = (uint)ctx[CpuRegister.Rsi];
+        var modifier = ctx[CpuRegister.Rdx];
+        var patchOffsets = DecodeIndirectPatchOffsets(modifier, indexed: false);
+        if (commandBufferAddress == 0 ||
+            !TryAllocateCommandDwords(ctx, commandBufferAddress, 5, out var commandAddress) ||
+            !TryWriteUInt32(ctx, commandAddress, Pm4(5, ItDrawIndirect, 0)) ||
+            !TryWriteUInt32(ctx, commandAddress + 4, dataOffset) ||
+            !TryWriteUInt32(ctx, commandAddress + 8, (uint)patchOffsets) ||
+            !TryWriteUInt32(ctx, commandAddress + 12, (uint)(patchOffsets >> 32)) ||
+            !TryWriteUInt32(ctx, commandAddress + 16, DecodeIndirectDrawInitiator(modifier)))
+        {
+            return ReturnPointer(ctx, 0);
+        }
+
+        TraceAgc(
+            $"agc.dcb_draw_indirect buf=0x{commandBufferAddress:X16} " +
+            $"cmd=0x{commandAddress:X16} offset=0x{dataOffset:X8} modifier=0x{modifier:X16}");
+        return ReturnPointer(ctx, commandAddress);
+    }
+
+    [SysAbiExport(
+        Nid = "cxPZ4Wgvdj8",
+        ExportName = "sceAgcDcbDrawIndirectGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbDrawIndirectGetSize(CpuContext ctx)
+    {
+        ctx[CpuRegister.Rax] = 5u * sizeof(uint);
+        return (int)ctx[CpuRegister.Rax];
+    }
+
+    [SysAbiExport(
         Nid = "t1vNu082-jM",
         ExportName = "sceAgcDcbDrawIndexIndirect",
         Target = Generation.Gen5,
@@ -1650,21 +1689,22 @@ public static partial class AgcExports
     {
         var commandBufferAddress = ctx[CpuRegister.Rdi];
         var dataOffset = (uint)ctx[CpuRegister.Rsi];
-        var modifier = (uint)ctx[CpuRegister.Rdx];
+        var modifier = ctx[CpuRegister.Rdx];
+        var patchOffsets = DecodeIndirectPatchOffsets(modifier, indexed: true);
         if (commandBufferAddress == 0 ||
             !TryAllocateCommandDwords(ctx, commandBufferAddress, 5, out var commandAddress) ||
             !TryWriteUInt32(ctx, commandAddress, Pm4(5, ItDrawIndexIndirect, 0)) ||
             !TryWriteUInt32(ctx, commandAddress + 4, dataOffset) ||
-            !TryWriteUInt32(ctx, commandAddress + 8, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 12, 0) ||
-            !TryWriteUInt32(ctx, commandAddress + 16, modifier))
+            !TryWriteUInt32(ctx, commandAddress + 8, (uint)patchOffsets) ||
+            !TryWriteUInt32(ctx, commandAddress + 12, (uint)(patchOffsets >> 32)) ||
+            !TryWriteUInt32(ctx, commandAddress + 16, DecodeIndirectDrawInitiator(modifier)))
         {
             return ReturnPointer(ctx, 0);
         }
 
         TraceAgc(
             $"agc.dcb_draw_index_indirect buf=0x{commandBufferAddress:X16} " +
-            $"cmd=0x{commandAddress:X16} offset=0x{dataOffset:X8} modifier=0x{modifier:X8}");
+            $"cmd=0x{commandAddress:X16} offset=0x{dataOffset:X8} modifier=0x{modifier:X16}");
         return ReturnPointer(ctx, commandAddress);
     }
 
@@ -1678,6 +1718,36 @@ public static partial class AgcExports
         ctx[CpuRegister.Rax] = 5u * sizeof(uint);
         return (int)ctx[CpuRegister.Rax];
     }
+
+    private static ulong DecodeIndirectPatchOffsets(ulong modifier, bool indexed)
+    {
+        var low = (uint)modifier;
+        var stage = low >> 29;
+        // The modifier names user SGPRs relative to the shader stage's
+        // register window. 0x280 means that the corresponding patch is unused.
+        var sgprBase = stage is 3 or 5 ? 0x10Cu : 0x8Cu;
+        var baseVertexLocation = (low & 0x1) != 0
+            ? sgprBase + ((low >> 9) & 0x1Fu)
+            : 0x280u;
+        var startInstanceLocation = (low & 0x4) != 0
+            ? sgprBase + ((low >> 19) & 0x1Fu)
+            : 0x280u;
+
+        ulong patchOffsets = baseVertexLocation;
+        if (indexed && (low & 0x2) != 0)
+        {
+            var startIndexLocation = sgprBase + ((low >> 14) & 0x1Fu);
+            patchOffsets |= (ulong)startIndexLocation << 16;
+            patchOffsets |= 1ul << 59;
+        }
+
+        return patchOffsets | ((ulong)startInstanceLocation << 32);
+    }
+
+    private static uint DecodeIndirectDrawInitiator(ulong modifier) =>
+        (modifier & (1ul << 32)) != 0
+            ? 2u
+            : (((uint)modifier >> 3) & 0x20u) | 2u;
 
     [SysAbiExport(
         Nid = "rUuVjyR+Rd4",

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcIndirectDrawTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcIndirectDrawTests.cs
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+public sealed class AgcIndirectDrawTests
+{
+    private const ulong BaseAddress = 0x1_0000_0000;
+    private const ulong CommandBufferAddress = BaseAddress + 0x100;
+    private const ulong PacketAddress = BaseAddress + 0x400;
+
+    [Fact]
+    public void DcbDrawIndirect_EmitsGen5PacketLayout()
+    {
+        var memory = CreateMemory(out var ctx);
+        const ulong modifier =
+            (3ul << 29) |
+            (5ul << 9) |
+            (7ul << 19) |
+            0x105ul;
+
+        ctx[CpuRegister.Rdi] = CommandBufferAddress;
+        ctx[CpuRegister.Rsi] = 0x120;
+        ctx[CpuRegister.Rdx] = modifier;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.DcbDrawIndirect(ctx));
+        Assert.Equal(PacketAddress, ctx[CpuRegister.Rax]);
+        Assert.Equal(0xC003_2400u, ReadUInt32(memory, PacketAddress));
+        Assert.Equal(0x120u, ReadUInt32(memory, PacketAddress + 4));
+        Assert.Equal(0x111u, ReadUInt32(memory, PacketAddress + 8));
+        Assert.Equal(0x113u, ReadUInt32(memory, PacketAddress + 12));
+        Assert.Equal(0x22u, ReadUInt32(memory, PacketAddress + 16));
+        Assert.Equal(PacketAddress + 20, ReadUInt64(memory, CommandBufferAddress + 0x10));
+    }
+
+    [Fact]
+    public void DcbDrawIndexIndirect_DecodesIndexedPatchLocations()
+    {
+        var memory = CreateMemory(out var ctx);
+        const ulong modifier =
+            (1ul << 32) |
+            (3ul << 29) |
+            (7ul << 19) |
+            (9ul << 14) |
+            (5ul << 9) |
+            0x7ul;
+
+        ctx[CpuRegister.Rdi] = CommandBufferAddress;
+        ctx[CpuRegister.Rsi] = 0x80;
+        ctx[CpuRegister.Rdx] = modifier;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            AgcExports.DcbDrawIndexIndirect(ctx));
+        Assert.Equal(0xC003_2500u, ReadUInt32(memory, PacketAddress));
+        Assert.Equal(0x80u, ReadUInt32(memory, PacketAddress + 4));
+        Assert.Equal(0x0115_0111u, ReadUInt32(memory, PacketAddress + 8));
+        Assert.Equal(0x0800_0113u, ReadUInt32(memory, PacketAddress + 12));
+        Assert.Equal(2u, ReadUInt32(memory, PacketAddress + 16));
+    }
+
+    [Fact]
+    public void IndirectDrawSizes_AreFiveDwords()
+    {
+        var memory = new FakeCpuMemory(BaseAddress, 0x1000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+
+        Assert.Equal(20, AgcExports.DcbDrawIndirectGetSize(ctx));
+        Assert.Equal(20ul, ctx[CpuRegister.Rax]);
+        Assert.Equal(20, AgcExports.DcbDrawIndexIndirectGetSize(ctx));
+        Assert.Equal(20ul, ctx[CpuRegister.Rax]);
+    }
+
+    private static FakeCpuMemory CreateMemory(out CpuContext ctx)
+    {
+        var memory = new FakeCpuMemory(BaseAddress, 0x1000);
+        ctx = new CpuContext(memory, Generation.Gen5);
+        WriteUInt64(memory, CommandBufferAddress + 0x10, PacketAddress);
+        WriteUInt64(memory, CommandBufferAddress + 0x18, PacketAddress + 0x100);
+        return memory;
+    }
+
+    private static uint ReadUInt32(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> buffer = stackalloc byte[4];
+        Assert.True(memory.TryRead(address, buffer));
+        return BinaryPrimitives.ReadUInt32LittleEndian(buffer);
+    }
+
+    private static ulong ReadUInt64(FakeCpuMemory memory, ulong address)
+    {
+        Span<byte> buffer = stackalloc byte[8];
+        Assert.True(memory.TryRead(address, buffer));
+        return BinaryPrimitives.ReadUInt64LittleEndian(buffer);
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> buffer = stackalloc byte[8];
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+        Assert.True(memory.TryWrite(address, buffer));
+    }
+}


### PR DESCRIPTION
## What changed

- Implements `sceAgcDcbDrawIndirect` and its size query instead of leaving the guest import unresolved.
- Emits the five-dword Gen5 `IT_DRAW_INDIRECT` packet that SharpEmu's submitted-DCB parser already understands.
- Decodes the indirect-draw modifier into the SGPR patch locations and draw initiator.
- Applies the same modifier decoding to the existing indexed-indirect path, which previously wrote zero patch locations and copied the raw modifier into the initiator field.
- Adds packet-layout tests for non-indexed and indexed indirect draws.

## Why

SharpEmu could parse `IT_DRAW_INDIRECT`, but the guest-facing AGC function needed to create that packet was missing. As a result, a title using the function could repeatedly hit an unresolved import and never submit the corresponding geometry.

Issue #618 also mentions this exact unresolved import appearing during Demon's Souls character-model rendering. This PR does not claim an FPS increase without a real-game comparison, but it removes that missing command path with actual packet behavior rather than a success-only stub.

The packet layout and modifier fields were cross-checked against the public KytyPS5 implementation: https://github.com/KytyPS5/KytyPS5/blob/d09a203feb4d992b1302eb6ffc82063a1e083b12/src/libs/agc.cpp#L2228-L2259

## Expected impact

Games can now emit non-indexed indirect draws through AGC, and indexed indirect packets preserve their shader patch metadata. The change is contained in the platform-neutral AGC command builder, so Vulkan, Metal, Linux, Windows and macOS continue to share the same path.

## Testing

- `dotnet build SharpEmu.slnx -c Release --no-restore`: 0 warnings, 0 errors.
- `dotnet test SharpEmu.slnx -c Release --no-build --no-restore`: 655 passed, 0 failed.
- Self-contained `linux-x64` CLI publish completed successfully.
- Real-game testing was not available locally. Demon's Souls character creation is the most relevant gameplay-CI case because that is where #618 reports the unresolved import.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).