### PR TITLE
perf(kernel): pick the lowest module handle with MinBy, not a full sort

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelModuleRegistry.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelModuleRegistry.cs
@@ -377,7 +377,9 @@ public static class KernelModuleRegistry
                 return false;
             }
 
-            var first = _modulesByHandle.Values.OrderBy(entry => entry.Handle).First();
+            // Smallest handle only — a single MinBy pass instead of sorting the
+            // whole module set (and allocating the sort buffer) just to take the first.
+            var first = _modulesByHandle.Values.MinBy(entry => entry.Handle);
             module = first;
             return true;
         }


### PR DESCRIPTION
TryGetFirstModule only needs the module with the smallest handle, but it sorted the entire module set (OrderBy(...).First()) -- allocating a sort buffer -- just to take the first element. Module handles are unique, so MinBy returns the same entry in a single O(n) pass with no allocation.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
