### PR TITLE
perf(gpu): shift/mask the detile block splits instead of integer div/mod

### DIFF
--- a/src/SharpEmu.Libs/Agc/GnmTiling.cs
+++ b/src/SharpEmu.Libs/Agc/GnmTiling.cs
@@ -660,18 +660,30 @@ internal static unsafe class GnmTiling
         }
 
         var isExactXor = parameters.Equation == DetileEquation.ExactXor;
+        // Block dimensions are powers of two (SquareBlockDimensions), so the
+        // per-texel block index and in-block column are a shift and a mask rather
+        // than an integer divide/modulo — the same lowering TryDetile already uses.
+        var blockWidth = parameters.BlockWidth;
+        var blockWidthShift = BitLog2((uint)blockWidth);
+        var blockWidthMask = blockWidth - 1;
+        var blockHeightShift = BitLog2((uint)parameters.BlockHeight);
+        var blockHeightMask = parameters.BlockHeight - 1;
+        var blocksPerRow = parameters.BlocksPerRow;
+        var blockBytes = parameters.BlockBytes;
         for (var y = 0; y < height; y++)
         {
-            var blockY = y / parameters.BlockHeight;
-            var inY = y % parameters.BlockHeight;
+            var blockY = y >> blockHeightShift;
+            var inY = y & blockHeightMask;
+            var rowBlockBase = (long)blockY * blocksPerRow;
+            var tableRowBase = inY * blockWidth;
             var yTerm = isExactXor ? parameters.YByteTerm[y & parameters.YMask] : 0;
             for (var x = 0; x < width; x++)
             {
-                var blockX = x / parameters.BlockWidth;
+                var blockX = x >> blockWidthShift;
                 var inBlockByte = isExactXor
                     ? parameters.XByteTerm[x & parameters.XMask] ^ yTerm
-                    : parameters.BlockTable[inY * parameters.BlockWidth + (x % parameters.BlockWidth)] * bpp;
-                var srcByte = ((long)blockY * parameters.BlocksPerRow + blockX) * parameters.BlockBytes + inBlockByte;
+                    : parameters.BlockTable[tableRowBase + (x & blockWidthMask)] * bpp;
+                var srcByte = (rowBlockBase + blockX) * blockBytes + inBlockByte;
                 var dstByte = ((long)y * width + x) * bpp;
                 if (srcByte < 0 || srcByte + bpp > tiled.Length)
                 {


### PR DESCRIPTION
DetileWithParams is the active CPU detile fallback for the Metal path. Its inner loop computed the block index and in-block column with integer divide/modulo by BlockWidth/BlockHeight for every texel. Those block dimensions are always powers of two (SquareBlockDimensions), so the divide and modulo are exactly a shift and a mask -- the same lowering the sibling TryDetile inner loop already uses.

Precompute the shifts/masks and the per-row block base once, then index with >>/& per texel. This drops a per-texel integer division (tens of cycles) from the deswizzle of every guest tiled texture on the Metal path. Output is byte-identical: the GnmTilingDetile suite (24 cases, including DetileWithParams_MatchesTryDetile across all supported modes/bpp and the multi-layer packing) plus the full SharpEmu.Libs suite (588) pass on .NET 10.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
