### PR TITLE
perf(gpu): carry the detile block byte base instead of a per-texel multiply

### DIFF
--- a/src/SharpEmu.Libs/Agc/GnmTiling.cs
+++ b/src/SharpEmu.Libs/Agc/GnmTiling.cs
@@ -498,34 +498,61 @@ internal static unsafe class GnmTiling
             var detileRow = (int y) =>
             {
                 var blockY = y / blockHeight;
-                var inBlockY = y & (blockHeight - 1);
                 var rowBlockBase = (long)blockY * blocksPerRow;
-                var tableRowBase = inBlockY * blockWidth;
                 var destRowBase = (long)y * elementsWide * bytesPerElement;
-                var yTerm = hasExactXorPattern
-                    ? patternTerms.Y[y & patternTerms.YMask]
-                    : 0;
-                for (var x = 0; x < elementsWide; x++)
+                if (hasExactXorPattern)
                 {
-                    var blockX = x >> blockWidthShift;
-                    var inBlockX = x & blockWidthMask;
-                    var blockIndex = rowBlockBase + blockX;
-                    var sourceByte = hasExactXorPattern
-                        ? blockIndex * blockBytes + (patternTerms.X[x & patternTerms.XMask] ^ yTerm)
-                        : (blockIndex * blockElements + blockTable[tableRowBase + inBlockX]) *
-                          (long)bytesPerElement;
-                    var destByte = destRowBase + (long)x * bytesPerElement;
-                    if (sourceByte < 0 ||
-                        sourceByte + bytesPerElement > sourceLength ||
-                        destByte + bytesPerElement > destinationLength)
+                    // The block's byte base advances by blockBytes every blockWidth
+                    // columns, so walk one block at a time and carry the base forward
+                    // instead of recomputing blockIndex * blockBytes for every texel.
+                    var xTerms = patternTerms.X;
+                    var xMask = patternTerms.XMask;
+                    var yTerm = patternTerms.Y[y & patternTerms.YMask];
+                    var blockByteBase = rowBlockBase * blockBytes;
+                    for (var blockStart = 0; blockStart < elementsWide; blockStart += blockWidth)
                     {
-                        continue;
-                    }
+                        var blockEnd = Math.Min(blockStart + blockWidth, elementsWide);
+                        for (var x = blockStart; x < blockEnd; x++)
+                        {
+                            var sourceByte = blockByteBase + (xTerms[x & xMask] ^ yTerm);
+                            var destByte = destRowBase + (long)x * bytesPerElement;
+                            if (sourceByte < 0 ||
+                                sourceByte + bytesPerElement > sourceLength ||
+                                destByte + bytesPerElement > destinationLength)
+                            {
+                                continue;
+                            }
 
-                    CopyElement(
-                        (byte*)sourceAddress + sourceByte,
-                        (byte*)destinationAddress + destByte,
-                        bytesPerElement);
+                            CopyElement(
+                                (byte*)sourceAddress + sourceByte,
+                                (byte*)destinationAddress + destByte,
+                                bytesPerElement);
+                        }
+
+                        blockByteBase += blockBytes;
+                    }
+                }
+                else
+                {
+                    var tableRowBase = (y & (blockHeight - 1)) * blockWidth;
+                    for (var x = 0; x < elementsWide; x++)
+                    {
+                        var blockIndex = rowBlockBase + (x >> blockWidthShift);
+                        var sourceByte = (blockIndex * blockElements + blockTable[tableRowBase + (x & blockWidthMask)]) *
+                            (long)bytesPerElement;
+                        var destByte = destRowBase + (long)x * bytesPerElement;
+                        if (sourceByte < 0 ||
+                            sourceByte + bytesPerElement > sourceLength ||
+                            destByte + bytesPerElement > destinationLength)
+                        {
+                            continue;
+                        }
+
+                        CopyElement(
+                            (byte*)sourceAddress + sourceByte,
+                            (byte*)destinationAddress + destByte,
+                            bytesPerElement);
+                    }
                 }
             };
 


### PR DESCRIPTION
TryDetile is the CPU deswizzle for guest tiled textures (the Vulkan/ general path). Its per-texel inner loop recomputed blockIndex * blockBytes and split x into blockX/inBlockX for every element, and re-tested the loop-invariant exact-XOR vs block-table equation on every texel.

Specialize the row by equation once, and on the hot exact-XOR path walk a block at a time, carrying blockByteBase forward by blockBytes per block -- so the inner loop is one array load, one XOR and an add, with no per-texel multiply, shift or branch. The block-table path keeps its exact addressing, just hoisted out of the per-texel branch.

Output is byte-identical: the GnmTilingDetile suite (24 cases, which independently re-derive the AddrLib equation and pin TryDetile bit-for-bit across modes 27/9/24/5/8/1, bpp 1..16 and multi-block sizes) plus the full SharpEmu.Libs suite (588) pass on .NET 10.



## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
