### PR TITLE
perf(posix): answer VirtualQuery protection runs in O(1) for uniform regions

### DIFF
--- a/src/SharpEmu.HLE/Host/Posix/PosixHostMemory.cs
+++ b/src/SharpEmu.HLE/Host/Posix/PosixHostMemory.cs
@@ -398,10 +398,23 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
                     // Win32 VirtualQuery reports a run of pages sharing the
                     // same protection, so stop the run where it changes.
                     var protect = region.ProtectAt(pageAddress);
-                    var runEnd = pageAddress + PageSize;
-                    while (runEnd < region.End && region.ProtectAt(runEnd) == protect)
+
+                    // A region with no per-page overrides is uniformly
+                    // DefaultProtect, so the protection run reaches the region end
+                    // without probing each page one dictionary lookup at a time —
+                    // the common case, and O(1) instead of O(pages) for large maps.
+                    ulong runEnd;
+                    if (region.PageProtects is null)
                     {
-                        runEnd += PageSize;
+                        runEnd = region.End;
+                    }
+                    else
+                    {
+                        runEnd = pageAddress + PageSize;
+                        while (runEnd < region.End && region.ProtectAt(runEnd) == protect)
+                        {
+                            runEnd += PageSize;
+                        }
                     }
 
                     info.BaseAddress = pageAddress;

--- a/src/SharpEmu.HLE/Host/Posix/PosixHostMemory.cs
+++ b/src/SharpEmu.HLE/Host/Posix/PosixHostMemory.cs
@@ -430,13 +430,23 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
                 // Untracked host memory (runtime heaps, stacks, libraries) is
                 // reported as a free block reaching to the next tracked region
                 // so scanning callers keep advancing.
+                // Regions are sorted by Base, so binary-search the smallest Base
+                // above pageAddress instead of scanning the keys linearly.
                 var nextBase = ulong.MaxValue;
-                foreach (var regionBase in Regions.Keys)
+                var keys = Regions.Keys;
+                var low = 0;
+                var high = keys.Count - 1;
+                while (low <= high)
                 {
-                    if (regionBase > pageAddress)
+                    var middle = low + ((high - low) >> 1);
+                    if (keys[middle] > pageAddress)
                     {
-                        nextBase = regionBase;
-                        break;
+                        nextBase = keys[middle];
+                        high = middle - 1;
+                    }
+                    else
+                    {
+                        low = middle + 1;
                     }
                 }
 
@@ -453,16 +463,30 @@ internal sealed unsafe class PosixHostMemory : IHostMemory
 
         private static bool OverlapsTrackedRegionLocked(ulong start, ulong size)
         {
+            // Regions are kept non-overlapping and sorted by Base, so only the
+            // region with the greatest Base < end can overlap [start, end): if it
+            // does not, no earlier region does either. Binary-search for it rather
+            // than scanning every tracked region.
             var end = start + size;
-            foreach (var region in Regions.Values)
+            var values = Regions.Values;
+            var low = 0;
+            var high = values.Count - 1;
+            Region? candidate = null;
+            while (low <= high)
             {
-                if (region.Base < end && start < region.End)
+                var middle = low + ((high - low) >> 1);
+                if (values[middle].Base < end)
                 {
-                    return true;
+                    candidate = values[middle];
+                    low = middle + 1;
+                }
+                else
+                {
+                    high = middle - 1;
                 }
             }
 
-            return false;
+            return candidate is not null && start < candidate.End;
         }
 
         private static bool TryFindRegionLocked(ulong address, out Region region)


### PR DESCRIPTION
The Posix host-memory shadow table (the VirtualQuery emulation used on Linux and macOS; Windows uses the native call) reported the run of pages sharing a protection by probing every page with a dictionary lookup. A region with no per-page overrides is uniformly DefaultProtect, so that run always reaches the region end -- but the scan still walked it page by page, O(pages) per query (tens of thousands of iterations for a large map).

Short-circuit the uniform case (PageProtects == null) straight to the region end; regions that carry per-page overrides keep the exact page-by-page scan. The reported RegionSize/Protect are unchanged.

Query has no in-repo test coverage, so the run-length computation was proven with a standalone harness that runs the old page-by-page scan and the new short-circuit over 2,000,000 randomized regions (uniform, and with per-page overrides at random pages, every query offset). Both produced identical run ends. The full SharpEmu.Libs suite (588) also passes on .NET 10.


### Second Commit
Two more linear scans over the Posix host-memory shadow table become binary
searches, using the same non-overlapping sorted-by-Base invariant the table
already maintains (Alloc rejects overlapping mappings before inserting):

- OverlapsTrackedRegionLocked (run on every guest Alloc): only the region with
  the greatest Base < end can overlap the requested range, so binary-search for
  it instead of scanning every tracked region.
- Query's untracked "next region base" fallback: binary-search the smallest Base
  above the queried page instead of a linear key walk.

This commit is meant to complete first one.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
