### PR TITLE
fix(ampr): auto-discover app0 files by hash instead of erroring on unregistered IDs

### DIFF
--- a/src/SharpEmu.Libs/Ampr/AmprExports.cs
+++ b/src/SharpEmu.Libs/Ampr/AmprExports.cs
@@ -25,6 +25,9 @@ public static class AmprExports
     private const uint KernelEventQueueRecordType = 2;
     private const uint WriteAddressRecordType = 3;
     private static readonly ConcurrentDictionary<ulong, CommandBufferState> _commandBuffers = new();
+    private static readonly ConcurrentDictionary<uint, string> _discoveredFileMappings = new();
+    private static bool _app0ScanComplete;
+
     private static readonly ConcurrentDictionary<string, Lazy<CachedHostFile>> _hostFileCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly bool _traceAmpr =
         string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_AMPR"), "1", StringComparison.Ordinal);
@@ -40,21 +43,38 @@ public static class AmprExports
         public ulong CommandCount;
     }
 
-    private sealed class CachedHostFile
+    private sealed class CachedHostFile : IDisposable
     {
         public CachedHostFile(string path)
         {
-            Handle = File.OpenHandle(
-                path,
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.ReadWrite | FileShare.Delete,
-                FileOptions.RandomAccess);
-            Length = RandomAccess.GetLength(Handle);
+            try
+            {
+                Handle = File.OpenHandle(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete,
+                    FileOptions.RandomAccess);
+                Length = RandomAccess.GetLength(Handle);
+            }
+            catch (Exception ex)
+            {
+                if (_traceAmpr)
+                {
+                    Console.Error.WriteLine($"[LOADER][ERROR] CachedHostFile ctor failed: path='{path}' error={ex.GetType().Name}: {ex.Message}");
+                }
+
+                throw;
+            }
         }
 
         public SafeFileHandle Handle { get; }
         public long Length { get; }
+
+        public void Dispose()
+        {
+            Handle?.Dispose();
+        }
     }
 
     [SysAbiExport(
@@ -271,8 +291,53 @@ public static class AmprExports
 
         if (!AmprFileRegistry.TryGetHostPath(fileId, out var hostPath))
         {
-            TraceAmprRead(ctx, commandBuffer, fileId, destination, size, fileOffset, bytesRead: 0, hostPath, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND);
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            // Auto-discover: scan app0 for files matching this FNV-1a hash (one-time)
+            if (!_app0ScanComplete)
+            {
+                _app0ScanComplete = true;
+                var app0Root = KernelMemoryCompatExports.ResolveApp0Root();
+                if (!string.IsNullOrWhiteSpace(app0Root) && Directory.Exists(app0Root))
+                {
+                    foreach (var filePath in Directory.EnumerateFiles(app0Root, "*", SearchOption.AllDirectories))
+                    {
+                        var relativePath = Path.GetRelativePath(app0Root, filePath);
+
+                        // Register with multiple prefixes (games use various path formats)
+                        var guestPaths = new[]
+                        {
+                            "/app0/" + relativePath,
+                            "$//" + relativePath,
+                            "$/" + relativePath,
+                            relativePath,
+                        };
+
+                        foreach (var gp in guestPaths)
+                        {
+                            var id = AmprFileRegistry.ComputeFileId(gp);
+                            if (!_discoveredFileMappings.ContainsKey(id))
+                            {
+                                _discoveredFileMappings[id] = filePath;
+                                AmprFileRegistry.Register(gp, filePath);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Check cache first, then registry
+            if (_discoveredFileMappings.TryGetValue(fileId, out var cachedHostPath))
+            {
+                hostPath = cachedHostPath;
+            }
+            else if (!AmprFileRegistry.TryGetHostPath(fileId, out hostPath))
+            {
+                // Neither the registry nor the app0 scan resolved this file ID — it genuinely
+                // does not exist on the host. Report the real error rather than masking it as
+                // success: a fabricated OK here would hide missing-asset bugs (in this title or
+                // others) instead of surfacing them.
+                TraceAmprRead(ctx, commandBuffer, fileId, destination, size, fileOffset, bytesRead: 0, hostPath: null, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND);
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            }
         }
 
         var result = TryReadFileToGuestMemory(ctx, hostPath, fileOffset, destination, size, out var bytesRead);
@@ -766,10 +831,11 @@ public static class AmprExports
 
         const int ChunkSize = 1024 * 1024;
         var buffer = ArrayPool<byte>.Shared.Rent((int)Math.Min((ulong)ChunkSize, size));
+        CachedHostFile? cachedFile = null;
 
         try
         {
-            if (!TryGetCachedHostFile(hostPath, out var cachedFile, out var openResult))
+            if (!TryGetCachedHostFile(hostPath, out cachedFile!, out var openResult))
             {
                 return openResult;
             }
@@ -821,6 +887,7 @@ public static class AmprExports
         }
         finally
         {
+            cachedFile?.Dispose();
             ArrayPool<byte>.Shared.Return(buffer);
         }
 
@@ -842,24 +909,24 @@ public static class AmprExports
             cachePath = hostPath;
         }
 
-        var lazy = _hostFileCache.GetOrAdd(
-            cachePath,
-            static path => new Lazy<CachedHostFile>(() => new CachedHostFile(path), isThreadSafe: true));
+        if (!System.IO.File.Exists(cachePath))
+        {
+            result = (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            return false;
+        }
 
         try
         {
-            file = lazy.Value;
+            file = new CachedHostFile(cachePath);
             return true;
         }
         catch (UnauthorizedAccessException)
         {
-            _hostFileCache.TryRemove(cachePath, out _);
             result = (int)OrbisGen2Result.ORBIS_GEN2_ERROR_PERMISSION_DENIED;
             return false;
         }
         catch (IOException)
         {
-            _hostFileCache.TryRemove(cachePath, out _);
             result = (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
             return false;
         }

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -5069,7 +5069,7 @@ public static partial class KernelMemoryCompatExports
         return true;
     }
 
-    private static string? ResolveApp0Root()
+    internal static string? ResolveApp0Root()
     {
         var cached = Volatile.Read(ref _cachedApp0Root);
         if (!string.IsNullOrWhiteSpace(cached))


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

- Games looking up app0 files by hash instead of pre-registering them (like Demon's Souls) hit a NOT_FOUND error and froze. On top of that, file handles were leaking without getting evicted.
- Added a one-time /app0/ directory scanner that registers real files using their FNV-1a hash so the game can find them. Made CachedHostFile clean up its handles properly and log real error messages instead of failing silently.

## Testing

- Demon's Souls (PPSA01341) – Tested alongside #640; reaches the main loop successfully.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).