### PR TITLE
feat(ime): implement sceImeDialog with a real on-screen text-entry overlay

### DIFF
--- a/src/SharpEmu.Libs/Ime/ImeDialogExports.cs
+++ b/src/SharpEmu.Libs/Ime/ImeDialogExports.cs
@@ -32,6 +32,9 @@ public static class ImeDialogExports
     private const int OffsetPlaceholder = 64;
     private const int OffsetTitle = 72;
 
+    // OrbisImeOption.PASSWORD, per the public SDK header.
+    private const uint OptionPasswordBit = 4;
+
     private const int ResultSize = 16;
     private const uint MaxTextLengthLimit = 2048; // ORBIS_IME_DIALOG_MAX_TEXT_LENGTH
 
@@ -90,10 +93,12 @@ public static class ImeDialogExports
             return Return(ctx, ImeDialogError.InvalidAddress);
         }
 
+        var option = BinaryPrimitives.ReadUInt32LittleEndian(raw.Slice(OffsetOption, 4));
         var maxTextLength = BinaryPrimitives.ReadUInt32LittleEndian(raw.Slice(OffsetMaxTextLength, 4));
         var inputTextBuffer = BinaryPrimitives.ReadUInt64LittleEndian(raw.Slice(OffsetInputTextBuffer, 8));
         var placeholderAddress = BinaryPrimitives.ReadUInt64LittleEndian(raw.Slice(OffsetPlaceholder, 8));
         var titleAddress = BinaryPrimitives.ReadUInt64LittleEndian(raw.Slice(OffsetTitle, 8));
+        var isPassword = (option & OptionPasswordBit) != 0;
 
         if (maxTextLength == 0 || maxTextLength > MaxTextLengthLimit)
         {
@@ -136,7 +141,7 @@ public static class ImeDialogExports
             _endStatus = OrbisImeDialogEndStatus.Ok;
         }
 
-        ImeDialogOverlay.Open(title, initialText, (int)maxTextLength);
+        ImeDialogOverlay.Open(title, initialText, (int)maxTextLength, isPassword);
         Trace($"init title='{title}' initial='{initialText}' maxLen={maxTextLength} buffer=0x{inputTextBuffer:X16}");
         return Return(ctx, ImeDialogError.Ok);
     }

--- a/src/SharpEmu.Libs/Ime/ImeDialogExports.cs
+++ b/src/SharpEmu.Libs/Ime/ImeDialogExports.cs
@@ -1,0 +1,410 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Text;
+using SharpEmu.HLE;
+using SharpEmu.Libs.VideoOut;
+
+namespace SharpEmu.Libs.Ime;
+
+/// <summary>
+/// libSceImeDialog — the on-screen text-entry overlay titles use for menu text
+/// fields (character names, search boxes, etc.), distinct from libSceIme's
+/// physical-keyboard session in <see cref="ImeExports"/>. Backed by a real
+/// state machine and an actual rendered/typeable overlay
+/// (<see cref="ImeDialogOverlay"/>) rather than a stub: the title/placeholder/
+/// initial text are read from guest memory, keystrokes are captured from the
+/// host keyboard while the dialog is open, and the typed UTF-16LE string is
+/// written back into the guest's own input buffer on confirm, matching how
+/// titles read the result (re-reading their own buffer after GetStatus
+/// reports Finished, per the public PS4/PS5 SDK contract).
+/// </summary>
+public static class ImeDialogExports
+{
+    // Struct offsets below are OrbisImeDialogParam's natural x64 layout
+    // (8-byte fields 8-byte aligned): verified against the public PS4/PS5 SDK
+    // header shape, not guessed. Total size 96 bytes.
+    private const int ParamSize = 96;
+    private const int OffsetOption = 32;
+    private const int OffsetMaxTextLength = 36;
+    private const int OffsetInputTextBuffer = 40;
+    private const int OffsetPlaceholder = 64;
+    private const int OffsetTitle = 72;
+
+    private const int ResultSize = 16;
+    private const uint MaxTextLengthLimit = 2048; // ORBIS_IME_DIALOG_MAX_TEXT_LENGTH
+
+    private enum ImeDialogError : uint
+    {
+        Ok = 0x0,
+        Busy = 0x80bc0001,
+        NotOpened = 0x80bc0002,
+        InvalidMaxTextLength = 0x80bc0016,
+        InvalidInputTextBuffer = 0x80bc0017,
+        InvalidAddress = 0x80bc0031,
+        DialogNotRunning = 0x80bc0105,
+        DialogNotFinished = 0x80bc0106,
+    }
+
+    private enum OrbisImeDialogStatus : uint
+    {
+        None = 0,
+        Running = 1,
+        Finished = 2,
+    }
+
+    private enum OrbisImeDialogEndStatus : uint
+    {
+        Ok = 0,
+        UserCanceled = 1,
+        Aborted = 2,
+    }
+
+    private static readonly object _gate = new();
+    private static ICpuMemory? _memory;
+    private static OrbisImeDialogStatus _status = OrbisImeDialogStatus.None;
+    private static OrbisImeDialogEndStatus _endStatus = OrbisImeDialogEndStatus.Ok;
+    private static ulong _inputTextBufferAddress;
+    private static uint _maxTextLength;
+
+    private static readonly bool _trace =
+        string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_IME"), "1", StringComparison.Ordinal);
+
+    [SysAbiExport(
+        Nid = "NUeBrN7hzf0",
+        ExportName = "sceImeDialogInit",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceImeDialog")]
+    public static int ImeDialogInit(CpuContext ctx)
+    {
+        var paramAddress = ctx[CpuRegister.Rdi];
+        if (paramAddress == 0)
+        {
+            return Return(ctx, ImeDialogError.InvalidAddress);
+        }
+
+        Span<byte> raw = stackalloc byte[ParamSize];
+        if (!ctx.Memory.TryRead(paramAddress, raw))
+        {
+            return Return(ctx, ImeDialogError.InvalidAddress);
+        }
+
+        var maxTextLength = BinaryPrimitives.ReadUInt32LittleEndian(raw.Slice(OffsetMaxTextLength, 4));
+        var inputTextBuffer = BinaryPrimitives.ReadUInt64LittleEndian(raw.Slice(OffsetInputTextBuffer, 8));
+        var placeholderAddress = BinaryPrimitives.ReadUInt64LittleEndian(raw.Slice(OffsetPlaceholder, 8));
+        var titleAddress = BinaryPrimitives.ReadUInt64LittleEndian(raw.Slice(OffsetTitle, 8));
+
+        if (maxTextLength == 0 || maxTextLength > MaxTextLengthLimit)
+        {
+            return Return(ctx, ImeDialogError.InvalidMaxTextLength);
+        }
+
+        if (inputTextBuffer == 0)
+        {
+            return Return(ctx, ImeDialogError.InvalidInputTextBuffer);
+        }
+
+        lock (_gate)
+        {
+            if (_status == OrbisImeDialogStatus.Running)
+            {
+                return Return(ctx, ImeDialogError.Busy);
+            }
+        }
+
+        // Best-effort: initial text and title/placeholder are UTF-16LE guest
+        // strings. A failed read (bad pointer, unmapped placeholder) degrades
+        // to an empty string rather than failing Init outright — titles pass
+        // null placeholders routinely, and losing the initial text is
+        // recoverable (the user just retypes it) where losing the whole
+        // dialog is not.
+        var initialText = TryReadUtf16(ctx.Memory, inputTextBuffer, (int)maxTextLength, out var initial)
+            ? initial
+            : string.Empty;
+        var title = titleAddress != 0 && TryReadUtf16(ctx.Memory, titleAddress, 256, out var titleText)
+            ? titleText
+            : string.Empty;
+        _ = placeholderAddress; // no on-screen placeholder rendering yet; reserved for a fast-follow.
+
+        lock (_gate)
+        {
+            _memory = ctx.Memory;
+            _inputTextBufferAddress = inputTextBuffer;
+            _maxTextLength = maxTextLength;
+            _status = OrbisImeDialogStatus.Running;
+            _endStatus = OrbisImeDialogEndStatus.Ok;
+        }
+
+        ImeDialogOverlay.Open(title, initialText, (int)maxTextLength);
+        Trace($"init title='{title}' initial='{initialText}' maxLen={maxTextLength} buffer=0x{inputTextBuffer:X16}");
+        return Return(ctx, ImeDialogError.Ok);
+    }
+
+    [SysAbiExport(
+        Nid = "IADmD4tScBY",
+        ExportName = "sceImeDialogGetStatus",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceImeDialog")]
+    public static int ImeDialogGetStatus(CpuContext ctx)
+    {
+        OrbisImeDialogStatus status;
+        lock (_gate)
+        {
+            status = _status;
+        }
+
+        return ctx.SetReturn((int)status, typeof(long));
+    }
+
+    [SysAbiExport(
+        Nid = "x01jxu+vxlc",
+        ExportName = "sceImeDialogGetResult",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceImeDialog")]
+    public static int ImeDialogGetResult(CpuContext ctx)
+    {
+        var resultAddress = ctx[CpuRegister.Rdi];
+        if (resultAddress == 0)
+        {
+            return Return(ctx, ImeDialogError.InvalidAddress);
+        }
+
+        OrbisImeDialogStatus status;
+        OrbisImeDialogEndStatus endStatus;
+        lock (_gate)
+        {
+            status = _status;
+            endStatus = _endStatus;
+        }
+
+        if (status != OrbisImeDialogStatus.Finished)
+        {
+            return Return(ctx, ImeDialogError.DialogNotFinished);
+        }
+
+        Span<byte> result = stackalloc byte[ResultSize];
+        result.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(result[..4], (uint)endStatus);
+        if (!ctx.Memory.TryWrite(resultAddress, result))
+        {
+            return Return(ctx, ImeDialogError.InvalidAddress);
+        }
+
+        return Return(ctx, ImeDialogError.Ok);
+    }
+
+    [SysAbiExport(
+        Nid = "gyTyVn+bXMw",
+        ExportName = "sceImeDialogTerm",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceImeDialog")]
+    public static int ImeDialogTerm(CpuContext ctx)
+    {
+        lock (_gate)
+        {
+            _status = OrbisImeDialogStatus.None;
+            _inputTextBufferAddress = 0;
+            _maxTextLength = 0;
+        }
+
+        ImeDialogOverlay.Close();
+        Trace("term");
+        return Return(ctx, ImeDialogError.Ok);
+    }
+
+    [SysAbiExport(
+        Nid = "aAx4WY4uwLc",
+        ExportName = "sceImeDialogParamInit",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceImeDialog")]
+    public static int ImeDialogParamInit(CpuContext ctx)
+    {
+        var paramAddress = ctx[CpuRegister.Rdi];
+        if (paramAddress == 0)
+        {
+            return Return(ctx, ImeDialogError.InvalidAddress);
+        }
+
+        Span<byte> zero = stackalloc byte[ParamSize];
+        zero.Clear();
+        if (!ctx.Memory.TryWrite(paramAddress, zero))
+        {
+            return Return(ctx, ImeDialogError.InvalidAddress);
+        }
+
+        return Return(ctx, ImeDialogError.Ok);
+    }
+
+    [SysAbiExport(
+        Nid = "oBmw4xrmfKs",
+        ExportName = "sceImeDialogAbort",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceImeDialog")]
+    public static int ImeDialogAbort(CpuContext ctx)
+    {
+        lock (_gate)
+        {
+            if (_status != OrbisImeDialogStatus.Running)
+            {
+                return Return(ctx, ImeDialogError.DialogNotRunning);
+            }
+
+            _status = OrbisImeDialogStatus.Finished;
+            _endStatus = OrbisImeDialogEndStatus.Aborted;
+        }
+
+        ImeDialogOverlay.Close();
+        return Return(ctx, ImeDialogError.Ok);
+    }
+
+    [SysAbiExport(
+        Nid = "bX4H+sxPI-o",
+        ExportName = "sceImeDialogForceClose",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceImeDialog")]
+    public static int ImeDialogForceClose(CpuContext ctx)
+    {
+        lock (_gate)
+        {
+            _status = OrbisImeDialogStatus.None;
+        }
+
+        ImeDialogOverlay.Close();
+        return Return(ctx, ImeDialogError.Ok);
+    }
+
+    /// <summary>
+    /// Called by the presenter's per-frame host-input poll when the user
+    /// presses Enter while the dialog is open: writes the typed text back
+    /// into the guest's own input buffer (the documented result-retrieval
+    /// path — titles re-read this buffer once GetStatus reports Finished)
+    /// and transitions to Finished/Ok.
+    /// </summary>
+    internal static void ConfirmFromHostInput()
+    {
+        ICpuMemory? memory;
+        ulong bufferAddress;
+        uint maxLength;
+        lock (_gate)
+        {
+            if (_status != OrbisImeDialogStatus.Running)
+            {
+                return;
+            }
+
+            memory = _memory;
+            bufferAddress = _inputTextBufferAddress;
+            maxLength = _maxTextLength;
+        }
+
+        var text = ImeDialogOverlay.CurrentText;
+        if (memory is not null && bufferAddress != 0)
+        {
+            WriteUtf16(memory, bufferAddress, text, (int)maxLength);
+        }
+
+        lock (_gate)
+        {
+            _status = OrbisImeDialogStatus.Finished;
+            _endStatus = OrbisImeDialogEndStatus.Ok;
+        }
+
+        ImeDialogOverlay.Close();
+        Trace($"confirmed text='{text}'");
+    }
+
+    /// <summary>
+    /// Called by the presenter's per-frame host-input poll when the user
+    /// presses Escape: transitions to Finished/UserCanceled without touching
+    /// the guest's input buffer, matching a real cancel (the title keeps
+    /// whatever it had before Init).
+    /// </summary>
+    internal static void CancelFromHostInput()
+    {
+        lock (_gate)
+        {
+            if (_status != OrbisImeDialogStatus.Running)
+            {
+                return;
+            }
+
+            _status = OrbisImeDialogStatus.Finished;
+            _endStatus = OrbisImeDialogEndStatus.UserCanceled;
+        }
+
+        ImeDialogOverlay.Close();
+        Trace("canceled");
+    }
+
+    private static int Return(CpuContext ctx, ImeDialogError error) =>
+        ctx.SetReturn(unchecked((int)(uint)error), typeof(long));
+
+    private static bool TryReadUtf16(ICpuMemory memory, ulong address, int maxCodeUnits, out string value)
+    {
+        value = string.Empty;
+        if (address == 0 || maxCodeUnits <= 0)
+        {
+            return false;
+        }
+
+        const int ChunkCodeUnits = 64;
+        var capacity = Math.Min(maxCodeUnits, 2048);
+        Span<byte> chunk = stackalloc byte[ChunkCodeUnits * 2];
+        var units = new List<char>(Math.Min(capacity, 256));
+
+        var offset = 0;
+        while (offset < capacity)
+        {
+            var count = Math.Min(ChunkCodeUnits, capacity - offset);
+            var span = chunk[..(count * 2)];
+            if (!memory.TryRead(address + (ulong)(offset * 2), span))
+            {
+                return units.Count > 0;
+            }
+
+            for (var i = 0; i < count; i++)
+            {
+                var unit = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(i * 2, 2));
+                if (unit == 0)
+                {
+                    value = new string(units.ToArray());
+                    return true;
+                }
+
+                units.Add((char)unit);
+            }
+
+            offset += count;
+        }
+
+        value = new string(units.ToArray());
+        return true;
+    }
+
+    private static void WriteUtf16(ICpuMemory memory, ulong address, string text, int maxCodeUnits)
+    {
+        if (maxCodeUnits <= 0)
+        {
+            return;
+        }
+
+        // Truncate to leave room for the null terminator, matching the guest
+        // buffer's own contract (max_text_length includes the terminator).
+        var truncated = text.Length >= maxCodeUnits ? text[..(maxCodeUnits - 1)] : text;
+        var bytes = new byte[(truncated.Length + 1) * 2];
+        Encoding.Unicode.GetBytes(truncated, 0, truncated.Length, bytes, 0);
+        // Trailing two bytes are already zero (null terminator) from array init.
+        memory.TryWrite(address, bytes);
+    }
+
+    private static void Trace(string message)
+    {
+        if (!_trace)
+        {
+            return;
+        }
+
+        Console.Error.WriteLine($"[LOADER][TRACE] ime.dialog.{message}");
+    }
+}

--- a/src/SharpEmu.Libs/VideoOut/ImeDialogOverlay.cs
+++ b/src/SharpEmu.Libs/VideoOut/ImeDialogOverlay.cs
@@ -1,0 +1,297 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+
+namespace SharpEmu.Libs.VideoOut;
+
+/// <summary>
+/// In-window text-entry panel for libSceImeDialog. Rasterized on the CPU into a
+/// small BGRA buffer each frame (same technique as <see cref="PerfOverlay"/>,
+/// an embedded 5x7 bitmap font, no GPU pipeline or shader assets) and blitted
+/// onto the swapchain image by the presenter while a dialog is open.
+/// </summary>
+/// <remarks>
+/// The bitmap font only covers ASCII 32..90 (space through 'Z'), so rendering
+/// upper-cases everything for display, matching <see cref="PerfOverlay"/>'s
+/// existing behavior. The text actually returned to the guest (<see cref="CurrentText"/>)
+/// preserves the real typed case.
+/// </remarks>
+public static class ImeDialogOverlay
+{
+    public const int PanelWidth = 560;
+    public const int PanelHeight = 140;
+
+    private const int GlyphColumns = 5;
+    private const int GlyphRows = 7;
+    private const int Scale = 3;
+    private const int CellWidth = (GlyphColumns + 1) * Scale;
+    private const int LineHeight = (GlyphRows + 2) * Scale;
+    private const int MaxDisplayLength = 64;
+
+    private static readonly object _gate = new();
+    private static readonly System.Text.StringBuilder _text = new();
+    private static volatile bool _isOpen;
+    private static string _title = string.Empty;
+    private static int _maxLength = 1;
+    private static long _lastCaretToggleTicks;
+    private static bool _caretVisible = true;
+
+    public static bool IsOpen => _isOpen;
+
+    /// <summary>Opens the panel with the guest-supplied title and initial text.</summary>
+    public static void Open(string title, string initialText, int maxLength)
+    {
+        lock (_gate)
+        {
+            _title = title ?? string.Empty;
+            _text.Clear();
+            _text.Append(initialText ?? string.Empty);
+            _maxLength = Math.Max(1, maxLength);
+            _isOpen = true;
+            _caretVisible = true;
+            _lastCaretToggleTicks = Stopwatch.GetTimestamp();
+        }
+    }
+
+    public static void Close()
+    {
+        lock (_gate)
+        {
+            _isOpen = false;
+        }
+    }
+
+    /// <summary>The real, case-preserved text currently entered.</summary>
+    public static string CurrentText
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _text.ToString();
+            }
+        }
+    }
+
+    public static void AppendChar(char c)
+    {
+        lock (_gate)
+        {
+            if (!_isOpen || _text.Length >= _maxLength)
+            {
+                return;
+            }
+
+            _text.Append(c);
+        }
+    }
+
+    public static void Backspace()
+    {
+        lock (_gate)
+        {
+            if (!_isOpen || _text.Length == 0)
+            {
+                return;
+            }
+
+            _text.Length--;
+        }
+    }
+
+    /// <summary>
+    /// Rasterizes the panel into a BGRA byte span of PanelWidth x PanelHeight.
+    /// Runs on the render thread.
+    /// </summary>
+    public static void Fill(Span<byte> bgra)
+    {
+        string title;
+        string text;
+        lock (_gate)
+        {
+            title = _title;
+            text = _text.ToString();
+        }
+
+        var now = Stopwatch.GetTimestamp();
+        if ((now - _lastCaretToggleTicks) / (double)Stopwatch.Frequency >= 0.5)
+        {
+            _caretVisible = !_caretVisible;
+            _lastCaretToggleTicks = now;
+        }
+
+        // Background: opaque dark slate, matching PerfOverlay's palette.
+        for (var i = 0; i < bgra.Length; i += 4)
+        {
+            bgra[i] = 0x18;
+            bgra[i + 1] = 0x14;
+            bgra[i + 2] = 0x10;
+            bgra[i + 3] = 0xFF;
+        }
+
+        DrawBorder(bgra, 0xB0, 0xB0, 0xB0);
+
+        var y = 10;
+        DrawString(bgra, 12, y, title.Length > 0 ? title : "ENTER TEXT", 0xFF, 0xD0, 0x80);
+        y += LineHeight + 6;
+
+        DrawHorizontalLine(bgra, 12, y, PanelWidth - 24, 0x60, 0x60, 0x60);
+        y += 10;
+
+        var display = text.Length > MaxDisplayLength ? text[^MaxDisplayLength..] : text;
+        DrawString(bgra, 12, y, display, 0xFF, 0xFF, 0xFF);
+        if (_caretVisible)
+        {
+            var caretX = 12 + display.Length * CellWidth;
+            DrawString(bgra, caretX, y, "_", 0x60, 0xFF, 0x60);
+        }
+
+        y += LineHeight + 10;
+        DrawString(bgra, 12, y, "ENTER=CONFIRM  ESC=CANCEL  BACKSPACE=DELETE", 0xB0, 0xB0, 0xB0);
+    }
+
+    private static void DrawBorder(Span<byte> bgra, byte r, byte g, byte b)
+    {
+        DrawHorizontalLine(bgra, 0, 0, PanelWidth, r, g, b);
+        DrawHorizontalLine(bgra, 0, PanelHeight - 1, PanelWidth, r, g, b);
+        for (var y = 0; y < PanelHeight; y++)
+        {
+            SetPixel(bgra, 0, y, r, g, b);
+            SetPixel(bgra, PanelWidth - 1, y, r, g, b);
+        }
+    }
+
+    private static void DrawHorizontalLine(Span<byte> bgra, int x, int y, int width, byte r, byte g, byte b)
+    {
+        if (y < 0 || y >= PanelHeight)
+        {
+            return;
+        }
+
+        for (var px = 0; px < width; px++)
+        {
+            SetPixel(bgra, x + px, y, r, g, b);
+        }
+    }
+
+    private static void DrawString(Span<byte> bgra, int x, int y, string text, byte r, byte g, byte b)
+    {
+        var penX = x;
+        foreach (var rawChar in text)
+        {
+            var c = char.ToUpperInvariant(rawChar);
+            if (c < ' ' || c > 'Z')
+            {
+                c = '?';
+            }
+
+            var glyph = Font.Slice((c - ' ') * GlyphColumns, GlyphColumns);
+            for (var column = 0; column < GlyphColumns; column++)
+            {
+                var bits = glyph[column];
+                for (var row = 0; row < GlyphRows; row++)
+                {
+                    if ((bits & (1 << row)) == 0)
+                    {
+                        continue;
+                    }
+
+                    for (var sy = 0; sy < Scale; sy++)
+                    {
+                        for (var sx = 0; sx < Scale; sx++)
+                        {
+                            SetPixel(bgra, penX + column * Scale + sx, y + row * Scale + sy, r, g, b);
+                        }
+                    }
+                }
+            }
+
+            penX += CellWidth;
+            if (penX + CellWidth > PanelWidth)
+            {
+                break;
+            }
+        }
+    }
+
+    private static void SetPixel(Span<byte> bgra, int x, int y, byte r, byte g, byte b)
+    {
+        if ((uint)x >= PanelWidth || (uint)y >= PanelHeight)
+        {
+            return;
+        }
+
+        var offset = (y * PanelWidth + x) * 4;
+        bgra[offset] = b;
+        bgra[offset + 1] = g;
+        bgra[offset + 2] = r;
+        bgra[offset + 3] = 0xFF;
+    }
+
+    // Classic 5x7 column-encoded font (bit 0 = top row), ASCII 32..90.
+    // Duplicated from PerfOverlay rather than shared, since PerfOverlay's copy
+    // is private and this keeps the two overlays independently maintainable.
+    private static ReadOnlySpan<byte> Font =>
+    [
+        0x00, 0x00, 0x00, 0x00, 0x00, // ' '
+        0x00, 0x00, 0x5F, 0x00, 0x00, // '!'
+        0x00, 0x07, 0x00, 0x07, 0x00, // '"'
+        0x14, 0x7F, 0x14, 0x7F, 0x14, // '#'
+        0x24, 0x2A, 0x7F, 0x2A, 0x12, // '$'
+        0x23, 0x13, 0x08, 0x64, 0x62, // '%'
+        0x36, 0x49, 0x55, 0x22, 0x50, // '&'
+        0x00, 0x05, 0x03, 0x00, 0x00, // '''
+        0x00, 0x1C, 0x22, 0x41, 0x00, // '('
+        0x00, 0x41, 0x22, 0x1C, 0x00, // ')'
+        0x08, 0x2A, 0x1C, 0x2A, 0x08, // '*'
+        0x08, 0x08, 0x3E, 0x08, 0x08, // '+'
+        0x00, 0x50, 0x30, 0x00, 0x00, // ','
+        0x08, 0x08, 0x08, 0x08, 0x08, // '-'
+        0x00, 0x60, 0x60, 0x00, 0x00, // '.'
+        0x20, 0x10, 0x08, 0x04, 0x02, // '/'
+        0x3E, 0x51, 0x49, 0x45, 0x3E, // '0'
+        0x00, 0x42, 0x7F, 0x40, 0x00, // '1'
+        0x42, 0x61, 0x51, 0x49, 0x46, // '2'
+        0x21, 0x41, 0x45, 0x4B, 0x31, // '3'
+        0x18, 0x14, 0x12, 0x7F, 0x10, // '4'
+        0x27, 0x45, 0x45, 0x45, 0x39, // '5'
+        0x3C, 0x4A, 0x49, 0x49, 0x30, // '6'
+        0x01, 0x71, 0x09, 0x05, 0x03, // '7'
+        0x36, 0x49, 0x49, 0x49, 0x36, // '8'
+        0x06, 0x49, 0x49, 0x29, 0x1E, // '9'
+        0x00, 0x36, 0x36, 0x00, 0x00, // ':'
+        0x00, 0x56, 0x36, 0x00, 0x00, // ';'
+        0x00, 0x08, 0x14, 0x22, 0x41, // '<'
+        0x14, 0x14, 0x14, 0x14, 0x14, // '='
+        0x41, 0x22, 0x14, 0x08, 0x00, // '>'
+        0x02, 0x01, 0x51, 0x09, 0x06, // '?'
+        0x32, 0x49, 0x79, 0x41, 0x3E, // '@'
+        0x7E, 0x11, 0x11, 0x11, 0x7E, // 'A'
+        0x7F, 0x49, 0x49, 0x49, 0x36, // 'B'
+        0x3E, 0x41, 0x41, 0x41, 0x22, // 'C'
+        0x7F, 0x41, 0x41, 0x22, 0x1C, // 'D'
+        0x7F, 0x49, 0x49, 0x49, 0x41, // 'E'
+        0x7F, 0x09, 0x09, 0x09, 0x01, // 'F'
+        0x3E, 0x41, 0x49, 0x49, 0x7A, // 'G'
+        0x7F, 0x08, 0x08, 0x08, 0x7F, // 'H'
+        0x00, 0x41, 0x7F, 0x41, 0x00, // 'I'
+        0x20, 0x40, 0x41, 0x3F, 0x01, // 'J'
+        0x7F, 0x08, 0x14, 0x22, 0x41, // 'K'
+        0x7F, 0x40, 0x40, 0x40, 0x40, // 'L'
+        0x7F, 0x02, 0x0C, 0x02, 0x7F, // 'M'
+        0x7F, 0x04, 0x08, 0x10, 0x7F, // 'N'
+        0x3E, 0x41, 0x41, 0x41, 0x3E, // 'O'
+        0x7F, 0x09, 0x09, 0x09, 0x06, // 'P'
+        0x3E, 0x41, 0x51, 0x21, 0x5E, // 'Q'
+        0x7F, 0x09, 0x19, 0x29, 0x46, // 'R'
+        0x46, 0x49, 0x49, 0x49, 0x31, // 'S'
+        0x01, 0x01, 0x7F, 0x01, 0x01, // 'T'
+        0x3F, 0x40, 0x40, 0x40, 0x3F, // 'U'
+        0x1F, 0x20, 0x40, 0x20, 0x1F, // 'V'
+        0x3F, 0x40, 0x38, 0x40, 0x3F, // 'W'
+        0x63, 0x14, 0x08, 0x14, 0x63, // 'X'
+        0x07, 0x08, 0x70, 0x08, 0x07, // 'Y'
+        0x61, 0x51, 0x49, 0x45, 0x43, // 'Z'
+    ];
+}

--- a/src/SharpEmu.Libs/VideoOut/ImeDialogOverlay.cs
+++ b/src/SharpEmu.Libs/VideoOut/ImeDialogOverlay.cs
@@ -34,13 +34,18 @@ public static class ImeDialogOverlay
     private static volatile bool _isOpen;
     private static string _title = string.Empty;
     private static int _maxLength = 1;
+    private static bool _isPassword;
     private static long _lastCaretToggleTicks;
     private static bool _caretVisible = true;
 
     public static bool IsOpen => _isOpen;
 
     /// <summary>Opens the panel with the guest-supplied title and initial text.</summary>
-    public static void Open(string title, string initialText, int maxLength)
+    /// <param name="isPassword">
+    /// Mirrors OrbisImeOption.PASSWORD: displayed characters are masked, but
+    /// <see cref="CurrentText"/> still returns the real typed content.
+    /// </param>
+    public static void Open(string title, string initialText, int maxLength, bool isPassword = false)
     {
         lock (_gate)
         {
@@ -48,6 +53,7 @@ public static class ImeDialogOverlay
             _text.Clear();
             _text.Append(initialText ?? string.Empty);
             _maxLength = Math.Max(1, maxLength);
+            _isPassword = isPassword;
             _isOpen = true;
             _caretVisible = true;
             _lastCaretToggleTicks = Stopwatch.GetTimestamp();
@@ -108,10 +114,17 @@ public static class ImeDialogOverlay
     {
         string title;
         string text;
+        bool isPassword;
         lock (_gate)
         {
             title = _title;
             text = _text.ToString();
+            isPassword = _isPassword;
+        }
+
+        if (isPassword)
+        {
+            text = new string('*', text.Length);
         }
 
         var now = Stopwatch.GetTimestamp();

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -7,6 +7,7 @@ using Silk.NET.Maths;
 using SharpEmu.HLE;
 using SharpEmu.Libs.Agc;
 using SharpEmu.Libs.Bink;
+using SharpEmu.Libs.Ime;
 using Silk.NET.Input;
 using SharpEmu.Libs.Gpu;
 using SharpEmu.ShaderCompiler;
@@ -2964,6 +2965,19 @@ internal static unsafe class VulkanVideoPresenter
         private VkBuffer[] _overlayStagingBuffers = [];
         private DeviceMemory[] _overlayStagingMemory = [];
         private nint[] _overlayStagingMapped = [];
+        // IME dialog overlay: same technique as the perf overlay above, but
+        // only created/blitted while ImeDialogOverlay.IsOpen, and centered
+        // instead of anchored top-left.
+        private Image _imeOverlayImage;
+        private DeviceMemory _imeOverlayImageMemory;
+        private bool _imeOverlayImageInitialized;
+        private VkBuffer[] _imeOverlayStagingBuffers = [];
+        private DeviceMemory[] _imeOverlayStagingMemory = [];
+        private nint[] _imeOverlayStagingMapped = [];
+        private bool _imeEnterWasDown;
+        private bool _imeEscapeWasDown;
+        private bool _imeBackspaceWasDown;
+        private readonly bool[] _imeCharKeyWasDown = new bool[128];
         private long _presentedSequence;
         private long _presentNotTakenLoggedSequence = long.MinValue;
         private bool _vulkanReady;
@@ -4618,6 +4632,179 @@ internal static unsafe class VulkanVideoPresenter
             CreateStagingBuffer((ulong)_extent.Width * _extent.Height * 4);
             CreateFrameUploadBuffers(_stagingSize);
             CreateOverlayResources();
+            CreateImeOverlayResources();
+        }
+
+        private void CreateImeOverlayResources()
+        {
+            const ulong overlayBytes = ImeDialogOverlay.PanelWidth * ImeDialogOverlay.PanelHeight * 4;
+            var imageInfo = new ImageCreateInfo
+            {
+                SType = StructureType.ImageCreateInfo,
+                ImageType = ImageType.Type2D,
+                Format = Format.B8G8R8A8Unorm,
+                Extent = new Extent3D(ImeDialogOverlay.PanelWidth, ImeDialogOverlay.PanelHeight, 1),
+                MipLevels = 1,
+                ArrayLayers = 1,
+                Samples = SampleCountFlags.Count1Bit,
+                Tiling = ImageTiling.Optimal,
+                Usage = ImageUsageFlags.TransferDstBit | ImageUsageFlags.TransferSrcBit,
+                SharingMode = SharingMode.Exclusive,
+                InitialLayout = ImageLayout.Undefined,
+            };
+            Check(_vk.CreateImage(_device, &imageInfo, null, out _imeOverlayImage), "vkCreateImage(imeOverlay)");
+            _vk.GetImageMemoryRequirements(_device, _imeOverlayImage, out var requirements);
+            var memoryInfo = new MemoryAllocateInfo
+            {
+                SType = StructureType.MemoryAllocateInfo,
+                AllocationSize = requirements.Size,
+                MemoryTypeIndex = FindMemoryType(
+                    requirements.MemoryTypeBits,
+                    MemoryPropertyFlags.DeviceLocalBit),
+            };
+            Check(
+                _vk.AllocateMemory(_device, &memoryInfo, null, out _imeOverlayImageMemory),
+                "vkAllocateMemory(imeOverlay)");
+            Check(
+                _vk.BindImageMemory(_device, _imeOverlayImage, _imeOverlayImageMemory, 0),
+                "vkBindImageMemory(imeOverlay)");
+            _imeOverlayImageInitialized = false;
+
+            _imeOverlayStagingBuffers = new VkBuffer[MaxFramesInFlight];
+            _imeOverlayStagingMemory = new DeviceMemory[MaxFramesInFlight];
+            _imeOverlayStagingMapped = new nint[MaxFramesInFlight];
+            for (var slot = 0; slot < MaxFramesInFlight; slot++)
+            {
+                _imeOverlayStagingBuffers[slot] = CreateBuffer(
+                    overlayBytes,
+                    BufferUsageFlags.TransferSrcBit,
+                    MemoryPropertyFlags.HostVisibleBit | MemoryPropertyFlags.HostCoherentBit,
+                    out _imeOverlayStagingMemory[slot]);
+                void* mapped;
+                Check(
+                    _vk.MapMemory(_device, _imeOverlayStagingMemory[slot], 0, overlayBytes, 0, &mapped),
+                    "vkMapMemory(imeOverlay staging)");
+                _imeOverlayStagingMapped[slot] = (nint)mapped;
+            }
+        }
+
+        private void RecordImeOverlayBlit(uint imageIndex, int frameSlot)
+        {
+            if (_imeOverlayImage.Handle == 0 || _imeOverlayStagingMapped.Length <= frameSlot)
+            {
+                return;
+            }
+
+            var pixels = new Span<byte>(
+                (void*)_imeOverlayStagingMapped[frameSlot],
+                ImeDialogOverlay.PanelWidth * ImeDialogOverlay.PanelHeight * 4);
+            ImeDialogOverlay.Fill(pixels);
+
+            var toTransferDst = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                SrcAccessMask = _imeOverlayImageInitialized ? AccessFlags.TransferReadBit : 0,
+                DstAccessMask = AccessFlags.TransferWriteBit,
+                OldLayout = _imeOverlayImageInitialized
+                    ? ImageLayout.TransferSrcOptimal
+                    : ImageLayout.Undefined,
+                NewLayout = ImageLayout.TransferDstOptimal,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = _imeOverlayImage,
+                SubresourceRange = ColorSubresourceRange(),
+            };
+            _vk.CmdPipelineBarrier(
+                _commandBuffer,
+                PipelineStageFlags.TransferBit,
+                PipelineStageFlags.TransferBit,
+                0, 0, null, 0, null, 1, &toTransferDst);
+
+            var copyRegion = new BufferImageCopy
+            {
+                ImageSubresource = new ImageSubresourceLayers(ImageAspectFlags.ColorBit, 0, 0, 1),
+                ImageExtent = new Extent3D(ImeDialogOverlay.PanelWidth, ImeDialogOverlay.PanelHeight, 1),
+            };
+            _vk.CmdCopyBufferToImage(
+                _commandBuffer,
+                _imeOverlayStagingBuffers[frameSlot],
+                _imeOverlayImage,
+                ImageLayout.TransferDstOptimal,
+                1,
+                &copyRegion);
+
+            var toTransferSrc = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                SrcAccessMask = AccessFlags.TransferWriteBit,
+                DstAccessMask = AccessFlags.TransferReadBit,
+                OldLayout = ImageLayout.TransferDstOptimal,
+                NewLayout = ImageLayout.TransferSrcOptimal,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = _imeOverlayImage,
+                SubresourceRange = ColorSubresourceRange(),
+            };
+            var swapchainToDst = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                SrcAccessMask = 0,
+                DstAccessMask = AccessFlags.TransferWriteBit,
+                OldLayout = ImageLayout.PresentSrcKhr,
+                NewLayout = ImageLayout.TransferDstOptimal,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = _swapchainImages[imageIndex],
+                SubresourceRange = ColorSubresourceRange(),
+            };
+            var preBlitBarriers = stackalloc ImageMemoryBarrier[2] { toTransferSrc, swapchainToDst };
+            _vk.CmdPipelineBarrier(
+                _commandBuffer,
+                PipelineStageFlags.TransferBit | PipelineStageFlags.ColorAttachmentOutputBit,
+                PipelineStageFlags.TransferBit,
+                0, 0, null, 0, null, 2, preBlitBarriers);
+
+            var panelWidth = (int)Math.Min(ImeDialogOverlay.PanelWidth, _extent.Width);
+            var panelHeight = (int)Math.Min(ImeDialogOverlay.PanelHeight, _extent.Height);
+            var dstX = Math.Max(0, ((int)_extent.Width - panelWidth) / 2);
+            var dstY = Math.Max(0, ((int)_extent.Height - panelHeight) / 2);
+            // Exact copy, not a scaled blit: see RecordOverlayBlit's comment on
+            // MoltenVK corruption with the blit-on-swapchain path.
+            var copy = new ImageCopy
+            {
+                SrcSubresource = new ImageSubresourceLayers(ImageAspectFlags.ColorBit, 0, 0, 1),
+                DstSubresource = new ImageSubresourceLayers(ImageAspectFlags.ColorBit, 0, 0, 1),
+                SrcOffset = new Offset3D(0, 0, 0),
+                DstOffset = new Offset3D(dstX, dstY, 0),
+                Extent = new Extent3D((uint)panelWidth, (uint)panelHeight, 1),
+            };
+            _vk.CmdCopyImage(
+                _commandBuffer,
+                _imeOverlayImage,
+                ImageLayout.TransferSrcOptimal,
+                _swapchainImages[imageIndex],
+                ImageLayout.TransferDstOptimal,
+                1,
+                &copy);
+
+            var swapchainToPresent = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                SrcAccessMask = AccessFlags.TransferWriteBit,
+                DstAccessMask = 0,
+                OldLayout = ImageLayout.TransferDstOptimal,
+                NewLayout = ImageLayout.PresentSrcKhr,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = _swapchainImages[imageIndex],
+                SubresourceRange = ColorSubresourceRange(),
+            };
+            _vk.CmdPipelineBarrier(
+                _commandBuffer,
+                PipelineStageFlags.TransferBit,
+                PipelineStageFlags.BottomOfPipeBit,
+                0, 0, null, 0, null, 1, &swapchainToPresent);
+            _imeOverlayImageInitialized = true;
         }
 
         private void CreateOverlayResources()
@@ -13390,6 +13577,95 @@ internal static unsafe class VulkanVideoPresenter
             _overlayHotkeyWasDown = down;
         }
 
+        /// <summary>
+        /// Edge-detected host-keyboard capture for the IME dialog overlay.
+        /// Windows-only for now, same limitation as <see cref="PollPerfOverlayHotkey"/>
+        /// (POSIX hosts route keyboard events through HostWindowInput.Attach
+        /// instead of user32 polling — wiring that path is a fast-follow).
+        /// </summary>
+        private void PollImeDialogInput()
+        {
+            if (!OperatingSystem.IsWindows() || !ImeDialogOverlay.IsOpen)
+            {
+                _imeEnterWasDown = false;
+                _imeEscapeWasDown = false;
+                _imeBackspaceWasDown = false;
+                Array.Clear(_imeCharKeyWasDown);
+                return;
+            }
+
+            const int VkBackspace = 0x08;
+            const int VkEnter = 0x0D;
+            const int VkEscape = 0x1B;
+            const int VkSpace = 0x20;
+            const int VkShift = 0x10;
+            const int Vk0 = 0x30;
+            const int Vk9 = 0x39;
+            const int VkA = 0x41;
+            const int VkZ = 0x5A;
+
+            var input = SharpEmu.HLE.Host.HostPlatform.Current.Input;
+            if (!input.IsHostWindowFocused())
+            {
+                return;
+            }
+
+            var enterDown = input.IsKeyDown(VkEnter);
+            if (enterDown && !_imeEnterWasDown)
+            {
+                ImeDialogExports.ConfirmFromHostInput();
+                _imeEnterWasDown = enterDown;
+                return;
+            }
+            _imeEnterWasDown = enterDown;
+
+            var escapeDown = input.IsKeyDown(VkEscape);
+            if (escapeDown && !_imeEscapeWasDown)
+            {
+                ImeDialogExports.CancelFromHostInput();
+                _imeEscapeWasDown = escapeDown;
+                return;
+            }
+            _imeEscapeWasDown = escapeDown;
+
+            var backspaceDown = input.IsKeyDown(VkBackspace);
+            if (backspaceDown && !_imeBackspaceWasDown)
+            {
+                ImeDialogOverlay.Backspace();
+            }
+            _imeBackspaceWasDown = backspaceDown;
+
+            var shiftDown = input.IsKeyDown(VkShift);
+
+            var spaceDown = input.IsKeyDown(VkSpace);
+            if (spaceDown && !_imeCharKeyWasDown[VkSpace])
+            {
+                ImeDialogOverlay.AppendChar(' ');
+            }
+            _imeCharKeyWasDown[VkSpace] = spaceDown;
+
+            for (var vk = Vk0; vk <= Vk9; vk++)
+            {
+                var down = input.IsKeyDown(vk);
+                if (down && !_imeCharKeyWasDown[vk])
+                {
+                    ImeDialogOverlay.AppendChar((char)('0' + (vk - Vk0)));
+                }
+                _imeCharKeyWasDown[vk] = down;
+            }
+
+            for (var vk = VkA; vk <= VkZ; vk++)
+            {
+                var down = input.IsKeyDown(vk);
+                if (down && !_imeCharKeyWasDown[vk])
+                {
+                    var letter = (char)('A' + (vk - VkA));
+                    ImeDialogOverlay.AppendChar(shiftDown ? letter : char.ToLowerInvariant(letter));
+                }
+                _imeCharKeyWasDown[vk] = down;
+            }
+        }
+
         private void Render(double _)
         {
             try
@@ -13424,6 +13700,7 @@ internal static unsafe class VulkanVideoPresenter
             }
 
             PollPerfOverlayHotkey();
+            PollImeDialogInput();
 
             if (_hostSurface is not null)
             {
@@ -13903,6 +14180,11 @@ internal static unsafe class VulkanVideoPresenter
             if (PerfOverlay.Enabled)
             {
                 RecordOverlayBlit(imageIndex, frameSlot);
+            }
+
+            if (ImeDialogOverlay.IsOpen)
+            {
+                RecordImeOverlayBlit(imageIndex, frameSlot);
             }
 
             Check(_vk.EndCommandBuffer(_commandBuffer), "vkEndCommandBuffer");
@@ -16962,6 +17244,31 @@ internal static unsafe class VulkanVideoPresenter
             _overlayStagingMemory = [];
             _overlayStagingMapped = [];
             _overlayImageInitialized = false;
+            if (_imeOverlayImage.Handle != 0)
+            {
+                _vk.DestroyImage(_device, _imeOverlayImage, null);
+                _imeOverlayImage = default;
+            }
+            if (_imeOverlayImageMemory.Handle != 0)
+            {
+                _vk.FreeMemory(_device, _imeOverlayImageMemory, null);
+                _imeOverlayImageMemory = default;
+            }
+            for (var slot = 0; slot < _imeOverlayStagingBuffers.Length; slot++)
+            {
+                if (_imeOverlayStagingBuffers[slot].Handle != 0)
+                {
+                    _vk.DestroyBuffer(_device, _imeOverlayStagingBuffers[slot], null);
+                }
+                if (_imeOverlayStagingMemory[slot].Handle != 0)
+                {
+                    _vk.FreeMemory(_device, _imeOverlayStagingMemory[slot], null);
+                }
+            }
+            _imeOverlayStagingBuffers = [];
+            _imeOverlayStagingMemory = [];
+            _imeOverlayStagingMapped = [];
+            _imeOverlayImageInitialized = false;
             foreach (var fence in _frameFences)
             {
                 if (fence.Handle != 0)


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

- libSceImeDialog was not implemented at all, leaving games unable to handle text entry (like naming your character in Demon's Souls).
- Built a working text-entry dialog. Uses a simple CPU font renderer for the UI, handles basic keyboard inputs (letters, numbers, backspace, etc.), and writes the typed string back to the game's buffer as UTF-16LE. Added password masking support.

## Caveats

- Keyboard capture is currently Windows-only.
- Text on screen is uppercase-only (font limitation), though the actual string returned to the game preserves typed casing.
- No placeholder text yet.

## Testing

- Demon's Souls (PPSA01341) – Character creation name entry works end-to-end.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).