### PR TITLE
fix(savedata): SaveDataDialog Close/Initialize reject the Finished state their own auto-dismiss reaches

### DIFF
--- a/src/SharpEmu.Libs/SaveData/SaveDataDialogExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataDialogExports.cs
@@ -22,6 +22,14 @@ public static class SaveDataDialogExports
 
     private const int ResultSize = 0x48;
     private const int ButtonIdAffirmative = 1;
+
+    // OrbisSaveDataDialogParam offsets (0x98-byte struct): mode and userData
+    // were previously read from the wrong offsets (0x00 and 0xC8) — 0x00 is
+    // actually the leading CommonDialog::BaseParam.size field, and 0xC8 is
+    // past the end of the struct entirely.
+    private const int ParamModeOffset = 0x34;
+    private const int ParamUserDataOffset = 0x70;
+
     private static int _status;
     private static int _lastMode;
     private static ulong _lastUserData;
@@ -59,8 +67,8 @@ public static class SaveDataDialogExports
             return ctx.SetReturn(ErrorNotInitialized);
         }
 
-        _lastMode = TryReadInt32(ctx, paramAddress, out var mode) ? mode : 0;
-        _lastUserData = ctx.TryReadUInt64(paramAddress + 0xC8, out var userData) ? userData : 0;
+        _lastMode = TryReadInt32(ctx, paramAddress + ParamModeOffset, out var mode) ? mode : 0;
+        _lastUserData = ctx.TryReadUInt64(paramAddress + ParamUserDataOffset, out var userData) ? userData : 0;
 
         // There is no host save dialog yet. Enter RUNNING so the close path sees a live
         // dialog; the guest's next status poll auto-dismisses it (see PollStatus).
@@ -142,11 +150,21 @@ public static class SaveDataDialogExports
         LibraryName = "libSceSaveDataDialog")]
     public static int SaveDataDialogClose(CpuContext ctx)
     {
-        if (Interlocked.CompareExchange(ref _status, StatusFinished, StatusRunning) != StatusRunning)
+        // The auto-dismiss design above (PollStatus) means a title's status poll has
+        // almost always already advanced Running -> Finished by the time it calls
+        // Close — Finished is the same "session over, ready for the next Open" state
+        // Open itself already accepts (see the StatusInitialized-or-StatusFinished
+        // guard there). Requiring strictly Running here made every real Open -> poll
+        // -> GetResult -> Close sequence fail with NotRunning, leaving _status stuck
+        // at Finished forever: the title's next Initialize call then permanently saw
+        // AlreadyInitialized instead of succeeding.
+        var current = Volatile.Read(ref _status);
+        if (current is not (StatusRunning or StatusFinished))
         {
             return ctx.SetReturn(ErrorNotRunning);
         }
 
+        Interlocked.CompareExchange(ref _status, StatusFinished, StatusRunning);
         return ctx.SetReturn(ErrorOk);
     }
 

--- a/src/SharpEmu.Libs/SaveData/SaveDataDialogExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataDialogExports.cs
@@ -41,11 +41,22 @@ public static class SaveDataDialogExports
         LibraryName = "libSceSaveDataDialog")]
     public static int SaveDataDialogInitialize(CpuContext ctx)
     {
-        if (Interlocked.CompareExchange(ref _status, StatusInitialized, StatusNone) != StatusNone)
+        // Finished is a fully-resolved prior session (its result has already been
+        // read via GetResult), not a live one — treating it the same as None here
+        // matches the reuse-without-Terminate pattern Open/Close already apply to
+        // Finished (see the comments there). Requiring strictly None made every
+        // Initialize after the very first successful dialog cycle permanently
+        // fail with AlreadyInitialized, since nothing in a single-shot
+        // system-message flow ever calls Terminate: verified live on Demon's
+        // Souls that with this fix, character creation completes and the title
+        // proceeds into real gameplay, which it never did before.
+        var current = Volatile.Read(ref _status);
+        if (current is not (StatusNone or StatusFinished))
         {
             return ctx.SetReturn(ErrorAlreadyInitialized);
         }
 
+        Volatile.Write(ref _status, StatusInitialized);
         return ctx.SetReturn(ErrorOk);
     }
 


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

- Flawed state checks in the save dialog code. Close required a Running state, but auto-dismiss polling had already moved it to Finished, causing Close to fail and never reset state. Initialize also refused to re-run unless state was strictly None. In Demon's Souls, this triggered an infinite initialization loop that ate tens of gigabytes of RAM within seconds.
- Relaxed Close and Initialize to accept the Finished state as well. Fixed two parameter offset bugs (mode and userData) so they read from the correct struct locations.

## Testing

- Demon's Souls (PPSA01341) – Verified live; the game moves past character finalization and enters actual gameplay for the first time.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).