### PR TITLE
fix(savedata): sceSaveDataGetMountInfo reports used space as free space

### DIFF
--- a/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataExports.cs
@@ -223,10 +223,18 @@ public static class SaveDataExports
 
         var used = SafeDirectorySize(entry.SlotDir);
         var usedBlocks = (ulong)((used + DefaultBlockSize - 1) / DefaultBlockSize);
+        // OrbisSaveDataMountInfo.freeBlocks is genuinely free space (total - used),
+        // not the used amount — shadPS4's reference (savedata.cpp) computes it as
+        // `blocks - size / OrbisSaveDataBlockSize`. Writing usedBlocks directly into
+        // this slot (as the previous code did) made a fresh, empty save directory
+        // report zero free blocks, which is backwards: a title checking available
+        // space would see none free and could show a false "not enough space"
+        // warning even on an essentially-empty 1GiB quota.
+        var freeBlocks = usedBlocks >= DefaultTotalBlocks ? 0UL : DefaultTotalBlocks - usedBlocks;
         Span<byte> info = stackalloc byte[MountInfoSize];
         info.Clear();
         BinaryPrimitives.WriteUInt64LittleEndian(info[0x00..], DefaultTotalBlocks);       // blocks
-        BinaryPrimitives.WriteUInt64LittleEndian(info[0x08..], usedBlocks);               // freeBlocks slot reused as used
+        BinaryPrimitives.WriteUInt64LittleEndian(info[0x08..], freeBlocks);               // freeBlocks
         return ctx.Memory.TryWrite(infoAddress, info)
             ? SetReturn(ctx, 0)
             : SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

- sceSaveDataGetMountInfo was accidentally returning the used block count in the freeBlocks field. A brand-new save directory was reporting zero free space.
- Corrected the math to return actual remaining space (total - used).

## Testing

- Demon's Souls (PPSA01341) – Standalone logic fix, corrected against the reference computation. Evaluated live while investigating issue #641; it did not resolve that specific loop (the title never calls GetMountInfo in that path), but it fixes a genuine, separately-confirmed bug.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).