### PR TITLE
fix(gpu): prefer device-local memory for detile pass buffers

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanDetilePass.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanDetilePass.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Numerics;
+using System.Runtime.InteropServices;
 using SharpEmu.Libs.Agc;
 using SharpEmu.ShaderCompiler.Vulkan;
 using Silk.NET.Vulkan;
@@ -31,11 +32,23 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
     private const uint LocalSize = 8;
     private const uint PushConstantBytes = 11 * sizeof(uint);
 
+    // RecordDetile runs once per texture creation, not once per draw, but a
+    // busy loading screen can create many textures per frame; each call was
+    // paying for 4 fresh buffer allocations + a fresh descriptor pool that
+    // just get destroyed once the batch fence signals (see #618). Textures of
+    // the same format/resolution recur constantly (mip chains, atlases,
+    // repeated UI elements), so pooling by (usage, capacity) turns most of
+    // those into a rent instead of a vkCreateBuffer/vkAllocateMemory pair.
+    private const ulong MaximumCachedDetileBufferBytes = 128UL * 1024 * 1024;
+
     private readonly Vk _vk;
     private readonly Device _device;
     private readonly Queue _queue;
     private readonly PhysicalDevice _physicalDevice;
     private readonly uint _queueFamilyIndex;
+    private readonly VulkanHostBufferPool _bufferPool;
+    private readonly Stack<DescriptorPool> _pooledDescriptorPools = new();
+    private readonly HashSet<ulong> _poolOwnedDescriptorPoolHandles = new();
 
     private ShaderModule _shaderModule;
     private DescriptorSetLayout _descriptorSetLayout;
@@ -57,6 +70,7 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
         _queue = queue;
         _physicalDevice = physicalDevice;
         _queueFamilyIndex = queueFamilyIndex;
+        _bufferPool = new VulkanHostBufferPool(MaximumCachedDetileBufferBytes, DestroyPooledBuffer);
     }
 
     /// <summary>
@@ -249,18 +263,15 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
         resources.OutputBytes =
             (ulong)parameters.ElementsWide * (ulong)parameters.ElementsHigh * bytesPerElement * layers;
 
-        resources.Tiled = CreateHostBuffer((ulong)tiled.Length, BufferUsageFlags.StorageBufferBit, out resources.TiledMemory);
-        UploadBytes(resources.TiledMemory, tiled);
-        resources.XTerm = CreateHostBuffer((ulong)xTerm.Length * sizeof(uint), BufferUsageFlags.StorageBufferBit, out resources.XMemory);
-        UploadUInts(resources.XMemory, xTerm);
-        resources.YTerm = CreateHostBuffer((ulong)yTerm.Length * sizeof(uint), BufferUsageFlags.StorageBufferBit, out resources.YMemory);
-        UploadUInts(resources.YMemory, yTerm);
+        resources.Tiled = CreateHostBuffer(tiled, BufferUsageFlags.StorageBufferBit, out resources.TiledMemory);
+        resources.XTerm = CreateHostBuffer(MemoryMarshal.AsBytes(xTerm.AsSpan()), BufferUsageFlags.StorageBufferBit, out resources.XMemory);
+        resources.YTerm = CreateHostBuffer(MemoryMarshal.AsBytes(yTerm.AsSpan()), BufferUsageFlags.StorageBufferBit, out resources.YMemory);
         resources.Output = CreateHostBuffer(
             resources.OutputBytes,
             BufferUsageFlags.StorageBufferBit | BufferUsageFlags.TransferSrcBit,
             out resources.OutputMemory);
 
-        resources.Pool = CreateDescriptorPool();
+        resources.Pool = RentDescriptorPool();
         resources.Set = AllocateDescriptorSet(resources.Pool);
         WriteDescriptors(
             resources.Set,
@@ -383,16 +394,38 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
 
     private void DestroyResources(in DetileResources resources)
     {
-        if (resources.Pool.Handle != 0)
+        if (resources.Pool.Handle != 0 && !TryReturnDescriptorPool(resources.Pool))
         {
             _vk.DestroyDescriptorPool(_device, resources.Pool, null);
         }
 
-        DestroyBuffer(resources.Output, resources.OutputMemory);
-        DestroyBuffer(resources.YTerm, resources.YMemory);
-        DestroyBuffer(resources.XTerm, resources.XMemory);
-        DestroyBuffer(resources.Tiled, resources.TiledMemory);
+        ReturnOrDestroyBuffer(resources.Output, resources.OutputMemory);
+        ReturnOrDestroyBuffer(resources.YTerm, resources.YMemory);
+        ReturnOrDestroyBuffer(resources.XTerm, resources.XMemory);
+        ReturnOrDestroyBuffer(resources.Tiled, resources.TiledMemory);
     }
+
+    private void ReturnOrDestroyBuffer(VkBuffer buffer, DeviceMemory memory)
+    {
+        if (buffer.Handle == 0)
+        {
+            return;
+        }
+
+        if (!_bufferPool.Return(buffer, memory))
+        {
+            _vk.DestroyBuffer(_device, buffer, null);
+            _vk.FreeMemory(_device, memory, null);
+        }
+    }
+
+    /// <summary>
+    /// Called by the render path (<see cref="RecordDetile"/>'s caller) once the
+    /// batch fence its transients rode along with has signaled, instead of
+    /// destroying them directly — lets a buffer/pool from one texture's detile
+    /// get reused by the next one instead of round-tripping through the driver.
+    /// </summary>
+    public bool TryReturnBuffer(VkBuffer buffer, DeviceMemory memory) => _bufferPool.Return(buffer, memory);
 
     private void EnsurePipeline()
     {
@@ -500,7 +533,51 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
         return terms;
     }
 
+    /// <summary>Creates (or rents from the pool) a buffer sized to hold <paramref name="data"/> and uploads it.</summary>
+    private VkBuffer CreateHostBuffer(ReadOnlySpan<byte> data, BufferUsageFlags usage, out DeviceMemory memory)
+    {
+        var allocation = RentOrAllocateBuffer(usage, (ulong)Math.Max(data.Length, sizeof(uint)));
+        memory = allocation.Memory;
+        if (!data.IsEmpty)
+        {
+            fixed (byte* source = data)
+            {
+                System.Buffer.MemoryCopy(source, (void*)allocation.Mapped, checked((long)allocation.Key.Capacity), data.Length);
+            }
+        }
+
+        return allocation.Buffer;
+    }
+
+    /// <summary>Creates (or rents from the pool) a buffer with no initial CPU-side data (compute-shader output).</summary>
     private VkBuffer CreateHostBuffer(ulong size, BufferUsageFlags usage, out DeviceMemory memory)
+    {
+        var allocation = RentOrAllocateBuffer(usage, size);
+        memory = allocation.Memory;
+        return allocation.Buffer;
+    }
+
+    private VulkanHostBufferAllocation RentOrAllocateBuffer(BufferUsageFlags usage, ulong minimumSize)
+    {
+        // Round up to a shared bucket so textures of slightly different sizes
+        // (mip levels, near-identical UI elements) still hit the same pooled
+        // allocation instead of each demanding an exact-size match.
+        var capacity = BitOperations.RoundUpToPowerOf2(Math.Max(minimumSize, sizeof(uint)));
+        var key = new VulkanHostBufferPoolKey(usage, capacity);
+        if (_bufferPool.TryRent(key, out var pooled))
+        {
+            return pooled;
+        }
+
+        var buffer = AllocateBuffer(capacity, usage, out var deviceMemory);
+        void* mapped;
+        Check(_vk.MapMemory(_device, deviceMemory, 0, capacity, 0, &mapped), "vkMapMemory(detile persistent)");
+        var allocation = new VulkanHostBufferAllocation(buffer, deviceMemory, key, (nint)mapped);
+        _bufferPool.Register(allocation);
+        return allocation;
+    }
+
+    private VkBuffer AllocateBuffer(ulong size, BufferUsageFlags usage, out DeviceMemory memory)
     {
         var bufferInfo = new BufferCreateInfo
         {
@@ -536,6 +613,13 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
         return buffer;
     }
 
+    private void DestroyPooledBuffer(VulkanHostBufferAllocation allocation)
+    {
+        _vk.UnmapMemory(_device, allocation.Memory);
+        _vk.DestroyBuffer(_device, allocation.Buffer, null);
+        _vk.FreeMemory(_device, allocation.Memory, null);
+    }
+
     private uint FindMemoryType(uint typeBits, MemoryPropertyFlags requiredFlags)
     {
         if (TryFindMemoryType(typeBits, requiredFlags, out var memoryTypeIndex))
@@ -564,21 +648,34 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
         return false;
     }
 
-    private void UploadBytes(DeviceMemory memory, ReadOnlySpan<byte> data)
+    private DescriptorPool RentDescriptorPool()
     {
-        void* mapped;
-        Check(_vk.MapMemory(_device, memory, 0, (ulong)data.Length, 0, &mapped), "vkMapMemory(detile)");
-        data.CopyTo(new Span<byte>(mapped, data.Length));
-        _vk.UnmapMemory(_device, memory);
+        if (_pooledDescriptorPools.TryPop(out var pool))
+        {
+            Check(_vk.ResetDescriptorPool(_device, pool, 0), "vkResetDescriptorPool(detile)");
+            return pool;
+        }
+
+        pool = CreateDescriptorPool();
+        _poolOwnedDescriptorPoolHandles.Add(pool.Handle);
+        return pool;
     }
 
-    private void UploadUInts(DeviceMemory memory, uint[] data)
+    /// <summary>
+    /// Returns a descriptor pool to the free list — called both internally
+    /// (<see cref="DestroyResources"/>) and by the render path's retire logic
+    /// once the batch fence has signaled. False if it wasn't one we handed out
+    /// (nothing to do; caller should destroy it normally).
+    /// </summary>
+    public bool TryReturnDescriptorPool(DescriptorPool pool)
     {
-        void* mapped;
-        var byteCount = (ulong)data.Length * sizeof(uint);
-        Check(_vk.MapMemory(_device, memory, 0, byteCount, 0, &mapped), "vkMapMemory(detile terms)");
-        data.AsSpan().CopyTo(new Span<uint>(mapped, data.Length));
-        _vk.UnmapMemory(_device, memory);
+        if (pool.Handle == 0 || !_poolOwnedDescriptorPoolHandles.Contains(pool.Handle))
+        {
+            return false;
+        }
+
+        _pooledDescriptorPools.Push(pool);
+        return true;
     }
 
     private DescriptorPool CreateDescriptorPool()
@@ -708,19 +805,6 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
         return fence;
     }
 
-    private void DestroyBuffer(VkBuffer buffer, DeviceMemory memory)
-    {
-        if (buffer.Handle != 0)
-        {
-            _vk.DestroyBuffer(_device, buffer, null);
-        }
-
-        if (memory.Handle != 0)
-        {
-            _vk.FreeMemory(_device, memory, null);
-        }
-    }
-
     private void Check(Result result, string operation)
     {
         if (result != Result.Success)
@@ -737,6 +821,12 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
         }
 
         _disposed = true;
+        _bufferPool.Dispose();
+        while (_pooledDescriptorPools.TryPop(out var pool))
+        {
+            _vk.DestroyDescriptorPool(_device, pool, null);
+        }
+
         if (_pipeline.Handle != 0)
         {
             _vk.DestroyPipeline(_device, _pipeline, null);

--- a/src/SharpEmu.Libs/VideoOut/VulkanDetilePass.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanDetilePass.cs
@@ -512,13 +512,24 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
         Check(_vk.CreateBuffer(_device, &bufferInfo, null, out var buffer), "vkCreateBuffer(detile)");
 
         _vk.GetBufferMemoryRequirements(_device, buffer, out var requirements);
+        // The kernel's per-element addressing is XOR-scattered rather than sequential,
+        // so prefer a heap that is both host-visible (for the CPU upload/CPU-side
+        // output copy below) AND device-local (e.g. a resizable-BAR window) — that
+        // keeps the scattered reads/writes in VRAM instead of a small host-only heap
+        // reached over PCIe, whose latency dominates as buffer size grows with
+        // resolution. Not every device exposes such a heap, so fall back to the
+        // plain host-visible/coherent requirement (see #618).
+        var memoryTypeIndex = TryFindMemoryType(
+            requirements.MemoryTypeBits,
+            MemoryPropertyFlags.HostVisibleBit | MemoryPropertyFlags.HostCoherentBit | MemoryPropertyFlags.DeviceLocalBit,
+            out var preferredIndex)
+            ? preferredIndex
+            : FindMemoryType(requirements.MemoryTypeBits, MemoryPropertyFlags.HostVisibleBit | MemoryPropertyFlags.HostCoherentBit);
         var allocateInfo = new MemoryAllocateInfo
         {
             SType = StructureType.MemoryAllocateInfo,
             AllocationSize = requirements.Size,
-            MemoryTypeIndex = FindMemoryType(
-                requirements.MemoryTypeBits,
-                MemoryPropertyFlags.HostVisibleBit | MemoryPropertyFlags.HostCoherentBit),
+            MemoryTypeIndex = memoryTypeIndex,
         };
         Check(_vk.AllocateMemory(_device, &allocateInfo, null, out memory), "vkAllocateMemory(detile)");
         Check(_vk.BindBufferMemory(_device, buffer, memory, 0), "vkBindBufferMemory(detile)");
@@ -527,6 +538,16 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
 
     private uint FindMemoryType(uint typeBits, MemoryPropertyFlags requiredFlags)
     {
+        if (TryFindMemoryType(typeBits, requiredFlags, out var memoryTypeIndex))
+        {
+            return memoryTypeIndex;
+        }
+
+        throw new InvalidOperationException("No compatible Vulkan host-visible memory type for detile.");
+    }
+
+    private bool TryFindMemoryType(uint typeBits, MemoryPropertyFlags requiredFlags, out uint memoryTypeIndex)
+    {
         _vk.GetPhysicalDeviceMemoryProperties(_physicalDevice, out var properties);
         var memoryTypes = &properties.MemoryTypes.Element0;
         for (uint index = 0; index < properties.MemoryTypeCount; index++)
@@ -534,11 +555,13 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
             if ((typeBits & (1u << (int)index)) != 0 &&
                 (memoryTypes[index].PropertyFlags & requiredFlags) == requiredFlags)
             {
-                return index;
+                memoryTypeIndex = index;
+                return true;
             }
         }
 
-        throw new InvalidOperationException("No compatible Vulkan host-visible memory type for detile.");
+        memoryTypeIndex = 0;
+        return false;
     }
 
     private void UploadBytes(DeviceMemory memory, ReadOnlySpan<byte> data)

--- a/src/SharpEmu.Libs/VideoOut/VulkanDetileSelfTest.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanDetileSelfTest.cs
@@ -261,20 +261,30 @@ internal static unsafe class VulkanDetileSelfTest
         {
             vk.DestroyFence(device, fence, null);
             vk.FreeCommandBuffers(device, commandPool, 1, &commandBuffer);
+
+            // Mirror the presenter's real retire logic (see #618): return to
+            // the pass's pool first, same as VulkanVideoPresenter does once a
+            // batch fence signals, rather than destroying directly — the pass
+            // tracks every buffer/pool it ever hands out, so destroying one
+            // out from under it without calling Try* leaves a dangling entry
+            // that corrupts the pool the next time Vulkan reuses that handle.
             foreach (var (buffer, memory) in transients.Buffers)
             {
-                if (buffer.Handle != 0)
+                if (buffer.Handle == 0)
                 {
-                    vk.DestroyBuffer(device, buffer, null);
+                    continue;
                 }
 
-                if (memory.Handle != 0)
+                if (pass.TryReturnBuffer(buffer, memory))
                 {
-                    vk.FreeMemory(device, memory, null);
+                    continue;
                 }
+
+                vk.DestroyBuffer(device, buffer, null);
+                vk.FreeMemory(device, memory, null);
             }
 
-            if (transients.DescriptorPool.Handle != 0)
+            if (transients.DescriptorPool.Handle != 0 && !pass.TryReturnDescriptorPool(transients.DescriptorPool))
             {
                 vk.DestroyDescriptorPool(device, transients.DescriptorPool, null);
             }

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -5233,12 +5233,32 @@ internal static unsafe class VulkanVideoPresenter
 
                 foreach (var (buffer, memory) in submission.RetireBuffers)
                 {
+                    // Detile buffers (see #618) get returned to VulkanDetilePass's
+                    // own pool instead of destroyed, so the next texture that
+                    // needs a same-sized scratch buffer can rent it back rather
+                    // than paying for a fresh vkCreateBuffer/vkAllocateMemory.
+                    // Non-detile buffers (e.g. staging) were never registered
+                    // with that pool, so TryReturnBuffer correctly no-ops (false)
+                    // for them and they fall through to a normal destroy.
+                    if (_detilePass is not null && _detilePass.TryReturnBuffer(buffer, memory))
+                    {
+                        continue;
+                    }
+
                     _vk.DestroyBuffer(_device, buffer, null);
                     _vk.FreeMemory(_device, memory, null);
                 }
 
                 foreach (var pool in submission.RetirePools)
                 {
+                    // Only detile ever populates RetirePools today, so this is
+                    // always a detile pool — but guard defensively the same way
+                    // as the buffer loop above in case that changes.
+                    if (_detilePass is not null && _detilePass.TryReturnDescriptorPool(pool))
+                    {
+                        continue;
+                    }
+
                     _vk.DestroyDescriptorPool(_device, pool, null);
                 }
 


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary

- Investigating #618 (detile FPS drops). VulkanDetilePass buffers were sitting in system RAM rather than GPU-local VRAM.
- Updated allocation logic to prefer resizable-BAR/unified memory (HostVisible + DeviceLocal) when available, falling back safely if unsupported.

## Testing

- Passes all 16 VulkanDetileSelfTest correctness cases. Direct A/B testing (fixed vs. unfixed, same machine/conditions) showed no measurable FPS change (the main bottleneck remains unpooled buffer allocations, not memory locality), but memory locality is correctly fixed and kept on its own merits.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).