### PR TITLE
fix(gpu): support Reverse-Z depth ranges for 3D rendering

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -7642,7 +7642,7 @@ public static partial class AgcExports
             var decodedMax = BitConverter.UInt32BitsToSingle(zMaxBits);
             if (float.IsFinite(decodedMin) &&
                 float.IsFinite(decodedMax) &&
-                decodedMax > decodedMin)
+                decodedMax != decodedMin)
             {
                 minDepth = decodedMin;
                 maxDepth = decodedMax;

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -9999,7 +9999,7 @@ internal static unsafe class VulkanVideoPresenter
             }
 
             var minDepth = Math.Clamp(rect.MinDepth, 0f, 1f);
-            var maxDepth = Math.Clamp(rect.MaxDepth, minDepth, 1f);
+            var maxDepth = Math.Clamp(rect.MaxDepth, 0f, 1f);
             return new Viewport(x, y, width, height, minDepth, maxDepth);
         }
 


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Description

This PR fixes Reverse-Z depth viewport range handling in \AgcExports.cs\ and \VulkanVideoPresenter.cs\.

### Technical Context & Root Cause
1. **\AgcExports.cs\ (\DecodeViewport\)**:
   \zMinBits\ and \zMaxBits\ read from AGC hardware registers \PaScVportZMin0\ (0xB4) and \PaScVportZMax0\ (0xB5) were decoded into \decodedMin\ and \decodedMax\. However, \DecodeViewport\ checked \decodedMax > decodedMin\. Modern 3D games configure Reverse-Z depth ranges where \zMinBits\ = 1.0f and \zMaxBits\ = 0.0f (\decodedMin > decodedMax\). The previous condition evaluated to \alse\, discarding the guest's viewport depth bounds and defaulting to \