### PR TITLE
fix(cpu): preserve EFLAGS in POSIX recovery

### DIFF
--- a/docs/superpowers/plans/2026-07-26-posix-eflags-signal-bridge.md
+++ b/docs/superpowers/plans/2026-07-26-posix-eflags-signal-bridge.md
@@ -1,0 +1,321 @@
+<!-- Copyright (C) 2026 SharpEmu Emulator Project -->
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+
+# POSIX Signal EFLAGS Bridge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve guest EFLAGS while SharpEmu recovers BMI/ABM illegal instructions through Linux and macOS signal contexts.
+
+**Architecture:** Extend the existing POSIX-to-Win64 context adapter with one platform-selected EFLAGS offset and a low-32-bit capture/write-back pair. Exercise the production adapter through its established fabricated-signal-frame test seam, using Linux ABI storage on Windows/Linux and Darwin ABI storage on macOS.
+
+**Tech Stack:** C# 14, .NET 10, xUnit, SharpEmu's native direct-execution backend, Git
+
+## Global Constraints
+
+- Linux x86-64 EFLAGS is `gregs[17]`, byte offset 136 from `GetPosixRegisterBase`.
+- Darwin x86-64 EFLAGS is `__rflags`, byte offset 152 from `GetPosixRegisterBase`.
+- Copy only the low 32 bits so the Win64 `CONTEXT.EFlags` contract is exact and upper platform storage bits remain untouched.
+- Write EFLAGS back only after the existing recovery chain returns success.
+- Do not change BMI/ABM instruction semantics, install real signal handlers in tests, bridge Darwin XMM state, add dependencies, or alter public APIs.
+- Keep the patch limited to the POSIX signal bridge, its existing test fixture, and the approved design/plan records.
+
+---
+
+### Task 1: Round-trip EFLAGS through POSIX signal recovery
+
+**Files:**
+
+- Modify: `src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.PosixSignals.cs:42-75,261-369`
+- Move: `tests/SharpEmu.Libs.Tests/Cpu/Sse4aPosixSignalRecoveryTests.cs` to `tests/SharpEmu.Libs.Tests/Cpu/PosixSignalRecoveryTests.cs`
+- Modify: `tests/SharpEmu.Libs.Tests/Cpu/PosixSignalRecoveryTests.cs:13-223`
+
+**Interfaces:**
+
+- Consumes: `DirectExecutionBackend.TryHandlePosixFault(int signal, nint siginfo, nint ucontext)`, `CTX_EFLAGS`, `ReadCtxU32`, and `WriteCtxU32`.
+- Produces: no new public interface; the existing adapter additionally round-trips the platform EFLAGS field.
+
+- [ ] **Step 1: Restore the isolated worktree**
+
+Run:
+
+```powershell
+dotnet restore SharpEmu.slnx --disable-parallel
+```
+
+Expected: exit code 0 and all projects restored.
+
+- [ ] **Step 2: Generalize the existing POSIX recovery test fixture**
+
+Move the test file to `PosixSignalRecoveryTests.cs`, rename the class to
+`PosixSignalRecoveryTests`, and replace its class summary with:
+
+```csharp
+/// <summary>
+/// Coverage for illegal-instruction recovery through the POSIX signal bridge. Tests
+/// fabricate the platform signal frames consumed by TryHandlePosixFault and verify
+/// that recovered register state is written back exactly as sigreturn would restore it.
+/// </summary>
+public sealed unsafe class PosixSignalRecoveryTests
+```
+
+Add these constants beside the existing signal-frame offsets:
+
+```csharp
+private const uint CarryFlag = 1u << 0;
+private const uint ReservedFlag = 1u << 1;
+private const uint ZeroFlag = 1u << 6;
+private const uint DirectionFlag = 1u << 10;
+
+private const int DarwinUcontextMcontextOffset = 48;
+private const int DarwinRaxOffset = 16;
+private const int DarwinRipOffset = 144;
+private const int DarwinRflagsOffset = 152;
+private const int LinuxGregsRaxOffset = 13 * 8;
+private const int LinuxGregsRflagsOffset = 17 * 8;
+```
+
+Replace the existing `FakeSignalFrame` class with this platform-aware fixture:
+
+```csharp
+private sealed class FakeSignalFrame
+{
+    private readonly byte[] _ucontext = new byte[512];
+    private readonly byte[] _mcontext = new byte[512];
+    private readonly byte[] _fpstate = new byte[512];
+    private readonly bool _wireFpstate;
+
+    public FakeSignalFrame(ulong rip, bool wireFpstate = true)
+    {
+        _wireFpstate = wireFpstate;
+        WriteRegisterU64(PlatformRipOffset, rip);
+    }
+
+    public ulong Rax
+    {
+        get => ReadRegisterU64(PlatformRaxOffset);
+        set => WriteRegisterU64(PlatformRaxOffset, value);
+    }
+
+    public uint EFlags
+    {
+        get => ReadRegisterU32(PlatformRflagsOffset);
+        set => WriteRegisterU32(PlatformRflagsOffset, value);
+    }
+
+    public ulong Rip => ReadRegisterU64(PlatformRipOffset);
+
+    public void SetXmmLow(int fxsaveOffset, ulong value)
+    {
+        fixed (byte* fpstate = _fpstate)
+        {
+            *(ulong*)(fpstate + fxsaveOffset) = value;
+        }
+    }
+
+    public ulong XmmLow(int fxsaveOffset)
+    {
+        fixed (byte* fpstate = _fpstate)
+        {
+            return *(ulong*)(fpstate + fxsaveOffset);
+        }
+    }
+
+    public ulong XmmHigh(int fxsaveOffset)
+    {
+        fixed (byte* fpstate = _fpstate)
+        {
+            return *(ulong*)(fpstate + fxsaveOffset + 8);
+        }
+    }
+
+    public bool Dispatch()
+    {
+        EnsureBridgeBackend();
+        fixed (byte* ucontext = _ucontext)
+        fixed (byte* mcontext = _mcontext)
+        fixed (byte* fpstate = _fpstate)
+        {
+            if (OperatingSystem.IsMacOS())
+            {
+                *(byte**)(ucontext + DarwinUcontextMcontextOffset) = mcontext;
+            }
+            else if (_wireFpstate)
+            {
+                *(byte**)(ucontext + LinuxUcontextGregsOffset + LinuxGregsFpstateOffset) = fpstate;
+            }
+
+            return (bool)TryHandlePosixFault.Invoke(
+                null,
+                [PosixSigIll, (nint)0, (nint)ucontext])!;
+        }
+    }
+
+    private static int PlatformRaxOffset =>
+        OperatingSystem.IsMacOS() ? DarwinRaxOffset : LinuxGregsRaxOffset;
+
+    private static int PlatformRipOffset =>
+        OperatingSystem.IsMacOS() ? DarwinRipOffset : LinuxGregsRipOffset;
+
+    private static int PlatformRflagsOffset =>
+        OperatingSystem.IsMacOS() ? DarwinRflagsOffset : LinuxGregsRflagsOffset;
+
+    private byte[] RegisterStorage => OperatingSystem.IsMacOS() ? _mcontext : _ucontext;
+
+    private int RegisterBaseOffset => OperatingSystem.IsMacOS() ? 0 : LinuxUcontextGregsOffset;
+
+    private ulong ReadRegisterU64(int offset)
+    {
+        var storage = RegisterStorage;
+        fixed (byte* registers = storage)
+        {
+            return *(ulong*)(registers + RegisterBaseOffset + offset);
+        }
+    }
+
+    private uint ReadRegisterU32(int offset)
+    {
+        var storage = RegisterStorage;
+        fixed (byte* registers = storage)
+        {
+            return *(uint*)(registers + RegisterBaseOffset + offset);
+        }
+    }
+
+    private void WriteRegisterU64(int offset, ulong value)
+    {
+        var storage = RegisterStorage;
+        fixed (byte* registers = storage)
+        {
+            *(ulong*)(registers + RegisterBaseOffset + offset) = value;
+        }
+    }
+
+    private void WriteRegisterU32(int offset, uint value)
+    {
+        var storage = RegisterStorage;
+        fixed (byte* registers = storage)
+        {
+            *(uint*)(registers + RegisterBaseOffset + offset) = value;
+        }
+    }
+}
+```
+
+Keep the three existing SSE4a tests and their Linux/x64 guards unchanged.
+
+- [ ] **Step 3: Add the failing EFLAGS regression**
+
+Add this test before `RecoveryDeclinesWhenNoXmmStateWasBridged`:
+
+```csharp
+[Fact]
+public void TzcntSigillRoundTripsEflagsThroughTheBridge()
+{
+    if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+    {
+        return;
+    }
+
+    // tzcnt eax, eax
+    var code = AllocateProbeVisibleCode([0xF3, 0x0F, 0xBC, 0xC0]);
+    try
+    {
+        var frame = new FakeSignalFrame((ulong)code)
+        {
+            Rax = 1,
+            EFlags = ReservedFlag | CarryFlag | DirectionFlag,
+        };
+
+        Assert.True(frame.Dispatch());
+
+        Assert.Equal(0UL, frame.Rax);
+        Assert.Equal((ulong)code + 4, frame.Rip);
+        Assert.Equal(0u, frame.EFlags & CarryFlag);
+        Assert.Equal(ZeroFlag, frame.EFlags & ZeroFlag);
+        Assert.Equal(DirectionFlag, frame.EFlags & DirectionFlag);
+    }
+    finally
+    {
+        FreeProbeVisibleCode(code);
+    }
+}
+```
+
+- [ ] **Step 4: Run the regression and record RED**
+
+Run:
+
+```powershell
+dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PosixSignalRecoveryTests.TzcntSigillRoundTripsEflagsThroughTheBridge" --verbosity minimal
+```
+
+Expected: one failed test. `frame.EFlags & CarryFlag` remains `1` instead of
+the expected `0`, proving the current bridge does not write emulated flags
+back to the signal frame.
+
+- [ ] **Step 5: Add the minimal platform EFLAGS bridge**
+
+In `DirectExecutionBackend.PosixSignals.cs`, add this value beside
+`PosixRegisterOffsets`:
+
+```csharp
+private static readonly int PosixEflagsOffset = OperatingSystem.IsMacOS() ? 152 : 17 * 8;
+```
+
+Immediately after the loop that copies GPRs into `contextRecord`, capture
+EFLAGS:
+
+```csharp
+WriteCtxU32(contextRecord, CTX_EFLAGS, *(uint*)(registers + PosixEflagsOffset));
+```
+
+Immediately after the successful-recovery loop that copies GPRs back to the
+platform registers, write EFLAGS back:
+
+```csharp
+*(uint*)(registers + PosixEflagsOffset) = ReadCtxU32(contextRecord, CTX_EFLAGS);
+```
+
+- [ ] **Step 6: Run focused tests and record GREEN**
+
+Run:
+
+```powershell
+dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PosixSignalRecoveryTests" --verbosity minimal
+```
+
+Expected: four passed tests and zero failed tests.
+
+- [ ] **Step 7: Verify the complete solution**
+
+Run:
+
+```powershell
+dotnet build SharpEmu.slnx -c Release --no-restore --verbosity minimal
+dotnet test SharpEmu.slnx -c Release --no-build --no-restore --verbosity minimal
+git diff --check
+git status --short
+```
+
+Expected:
+
+- Release build exits 0.
+- All 653 tests pass: 589 Libs, 27 Metal, 4 ShaderCompiler, and 33 SourceGenerators.
+- `git diff --check` exits 0.
+- Status lists only the source bridge, renamed test, and this plan; the
+  approved design is already committed.
+- No new dependency or proprietary asset appears.
+
+- [ ] **Step 8: Commit the implementation**
+
+Run:
+
+```powershell
+git add src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.PosixSignals.cs tests/SharpEmu.Libs.Tests/Cpu/Sse4aPosixSignalRecoveryTests.cs tests/SharpEmu.Libs.Tests/Cpu/PosixSignalRecoveryTests.cs docs/superpowers/plans/2026-07-26-posix-eflags-signal-bridge.md
+git diff --cached --check
+git commit -m "fix(cpu): preserve EFLAGS in POSIX recovery"
+```
+
+Expected: one implementation commit containing the minimal bridge, regression,
+test-fixture rename, and implementation plan.

--- a/docs/superpowers/specs/2026-07-26-posix-eflags-signal-bridge-design.md
+++ b/docs/superpowers/specs/2026-07-26-posix-eflags-signal-bridge-design.md
@@ -1,0 +1,111 @@
+<!-- Copyright (C) 2026 SharpEmu Emulator Project -->
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+
+# POSIX Signal EFLAGS Bridge Design
+
+## Problem
+
+`DirectExecutionBackend.TryHandlePosixFault` translates Linux and macOS signal
+contexts into the Win64 `CONTEXT` layout used by SharpEmu's shared exception
+recovery code. It currently copies general-purpose and, on Linux, XMM
+registers, but leaves `CONTEXT.EFlags` zero.
+
+The BMI/ABM illegal-instruction fallback reads and updates `CONTEXT.EFlags`.
+After a successful recovery, the POSIX bridge also omits EFLAGS from its
+write-back. Recovered instructions therefore calculate flags from an
+incorrect initial value and resume with stale guest flags on Linux and macOS.
+
+## Goal
+
+Round-trip the low 32 bits of the trapped EFLAGS value through the existing
+Win64 scratch context whenever POSIX fault recovery succeeds.
+
+## Non-goals
+
+- Refactoring the existing register bridge.
+- Changing BMI/ABM emulation semantics.
+- Installing or exercising process-wide signal handlers in tests.
+- Bridging Darwin XMM state.
+- Addressing unrelated CPU, audio, debugger, or analyzer findings.
+
+## Platform ABI mapping
+
+The offsets are relative to the pointer returned by
+`GetPosixRegisterBase`:
+
+- Linux x86-64: `gregs[REG_EFL]`, index 17, byte offset 136.
+- Darwin x86-64: `__darwin_x86_thread_state64.__rflags`, byte offset 152.
+
+Only the low 32 bits are copied because Win64 `CONTEXT.EFlags` is a 32-bit
+field. A 32-bit write-back also preserves any upper storage bits in the
+platform signal context.
+
+## Design
+
+Define a platform-selected EFLAGS offset next to the existing POSIX register
+layout constants.
+
+During signal capture:
+
+1. Resolve the platform register base as today.
+2. Copy the existing general-purpose registers.
+3. Copy the platform EFLAGS value into `CONTEXT.EFlags`.
+4. Run the unchanged recovery chain.
+
+After successful recovery:
+
+1. Copy general-purpose registers back as today.
+2. Copy `CONTEXT.EFlags` back to the platform signal context.
+3. Copy bridged XMM registers back as today.
+
+No register state is written back when recovery declines.
+
+## Regression test
+
+Generalize the existing fabricated POSIX signal-frame fixture so it can expose
+RAX and EFLAGS and can represent both supported x86-64 layouts. Existing Linux
+SSE4a tests remain unchanged in behavior.
+
+Add a regression that dispatches a synthetic `SIGILL` for:
+
+```text
+F3 0F BC C0    tzcnt eax, eax
+```
+
+Initial state:
+
+- RAX = 1.
+- EFLAGS includes the reserved bit, carry flag, and direction flag.
+
+Expected recovered state:
+
+- RAX = 0.
+- RIP advances by four bytes.
+- Carry is cleared.
+- Zero is set.
+- Direction is preserved.
+
+The assertions prove both directions of the bridge: preserving Direction
+requires capture of the initial flags, while changed Carry and Zero values
+require write-back of the emulated result.
+
+The test uses the Linux layout on Linux and Windows hosts and the Darwin layout
+on macOS. Windows execution is a deterministic test of the Linux marshalling
+path; production use remains POSIX-only.
+
+## Verification
+
+- Run the focused POSIX signal recovery tests before and after the production
+  change to record the expected red/green transition.
+- Run the complete Release test suite.
+- Run a Release build and `git diff --check`.
+- Confirm the final diff contains no unrelated changes or new dependencies.
+
+## Risks
+
+- An incorrect ABI offset would corrupt signal-frame state. The regression
+  exercises both layout selections in CI, and the constants stay adjacent to
+  the existing verified register maps.
+- A real signal handler test could destabilize the test process. The design
+  instead invokes the production bridge over a fabricated frame, matching the
+  established SSE4a test seam.

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.PosixSignals.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.PosixSignals.cs
@@ -70,6 +70,7 @@ public sealed unsafe partial class DirectExecutionBackend
 	private static readonly int[] PosixRegisterOffsets = OperatingSystem.IsMacOS()
 		? new[] { 16, 32, 40, 24, 72, 64, 56, 48, 80, 88, 96, 104, 112, 120, 128, 136, 144 }
 		: new[] { 104, 112, 96, 88, 120, 80, 72, 64, 0, 8, 16, 24, 32, 40, 48, 56, 128 };
+	private static readonly int PosixEflagsOffset = OperatingSystem.IsMacOS() ? 152 : 17 * 8;
 
 	private static DirectExecutionBackend? _posixSignalBackend;
 	private static bool _posixSignalHandlersInstalled;
@@ -273,6 +274,7 @@ public sealed unsafe partial class DirectExecutionBackend
 		{
 			WriteCtxU64(contextRecord, CTX_RAX + i * 8, *(ulong*)(registers + offsets[i]));
 		}
+		WriteCtxU32(contextRecord, CTX_EFLAGS, *(uint*)(registers + PosixEflagsOffset));
 
 		// Bridge the XMM registers alongside the GPRs where the layout is
 		// known: on Linux the fpstate pointer and FXSAVE image are kernel
@@ -359,6 +361,7 @@ public sealed unsafe partial class DirectExecutionBackend
 		{
 			*(ulong*)(registers + offsets[i]) = ReadCtxU64(contextRecord, CTX_RAX + i * 8);
 		}
+		*(uint*)(registers + PosixEflagsOffset) = ReadCtxU32(contextRecord, CTX_EFLAGS);
 		if (fpstate != null)
 		{
 			Buffer.MemoryCopy(

--- a/tests/SharpEmu.Libs.Tests/Cpu/PosixSignalRecoveryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/PosixSignalRecoveryTests.cs
@@ -12,20 +12,26 @@ using Xunit;
 namespace SharpEmu.Libs.Tests.Cpu;
 
 /// <summary>
-/// Coverage for the SSE4a EXTRQ/INSERTQ fault recovery through the POSIX signal bridge on
-/// Linux. Each test fabricates the exact frame the kernel hands the SIGILL handler - gregs
-/// whose RIP points at a real EXTRQ/INSERTQ encoding in probe-visible host memory, plus an
-/// FXSAVE image carrying the XMM registers - and drives the production entry point
-/// (TryHandlePosixFault) over it. The bridge must capture the XMM state into the CONTEXT
-/// scratch buffer, the recovery must decode and emulate the instruction, and the write-back
-/// must land the result in the FXSAVE image and advance RIP, because that is precisely what
-/// sigreturn restores on a live fault.
+/// Coverage for illegal-instruction recovery through the POSIX signal bridge. Tests
+/// fabricate the platform signal frames consumed by TryHandlePosixFault and verify
+/// that recovered register state is written back exactly as sigreturn would restore it.
 /// </summary>
-public sealed unsafe class Sse4aPosixSignalRecoveryTests
+public sealed unsafe class PosixSignalRecoveryTests
 {
     private const int PosixSigIll = 4;
+    private const uint CarryFlag = 1u << 0;
+    private const uint ReservedFlag = 1u << 1;
+    private const uint ZeroFlag = 1u << 6;
+    private const uint DirectionFlag = 1u << 10;
+
+    private const int DarwinUcontextMcontextOffset = 48;
+    private const int DarwinRaxOffset = 16;
+    private const int DarwinRipOffset = 144;
+    private const int DarwinRflagsOffset = 152;
     private const int LinuxUcontextGregsOffset = 40;
+    private const int LinuxGregsRaxOffset = 13 * 8;
     private const int LinuxGregsRipOffset = 16 * 8;
+    private const int LinuxGregsRflagsOffset = 17 * 8;
     private const int LinuxGregsFpstateOffset = 184;
     private const int FxsaveXmm0Offset = 160;
     private const int FxsaveXmm1Offset = 176;
@@ -116,6 +122,38 @@ public sealed unsafe class Sse4aPosixSignalRecoveryTests
     }
 
     [Fact]
+    public void TzcntSigillRoundTripsEflagsThroughTheBridge()
+    {
+        if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            return;
+        }
+
+        // tzcnt eax, eax
+        var code = AllocateProbeVisibleCode([0xF3, 0x0F, 0xBC, 0xC0]);
+        try
+        {
+            var frame = new FakeSignalFrame((ulong)code)
+            {
+                Rax = 1,
+                EFlags = ReservedFlag | CarryFlag | DirectionFlag,
+            };
+
+            Assert.True(frame.Dispatch());
+
+            Assert.Equal(0UL, frame.Rax);
+            Assert.Equal((ulong)code + 4, frame.Rip);
+            Assert.Equal(0u, frame.EFlags & CarryFlag);
+            Assert.Equal(ZeroFlag, frame.EFlags & ZeroFlag);
+            Assert.Equal(DirectionFlag, frame.EFlags & DirectionFlag);
+        }
+        finally
+        {
+            FreeProbeVisibleCode(code);
+        }
+    }
+
+    [Fact]
     public void RecoveryDeclinesWhenNoXmmStateWasBridged()
     {
         if (!OperatingSystem.IsLinux() ||
@@ -148,36 +186,32 @@ public sealed unsafe class Sse4aPosixSignalRecoveryTests
         }
     }
 
-    /// <summary>
-    /// The Linux x86-64 signal frame as TryHandlePosixFault consumes it: a ucontext whose
-    /// mcontext gregs sit at +40 (kernel sigcontext layout) with the fpstate pointer at
-    /// gregs+184 aiming at a 512-byte FXSAVE image.
-    /// </summary>
     private sealed class FakeSignalFrame
     {
         private readonly byte[] _ucontext = new byte[512];
+        private readonly byte[] _mcontext = new byte[512];
         private readonly byte[] _fpstate = new byte[512];
         private readonly bool _wireFpstate;
 
         public FakeSignalFrame(ulong rip, bool wireFpstate = true)
         {
             _wireFpstate = wireFpstate;
-            fixed (byte* ucontext = _ucontext)
-            {
-                *(ulong*)(ucontext + LinuxUcontextGregsOffset + LinuxGregsRipOffset) = rip;
-            }
+            WriteRegisterU64(PlatformRipOffset, rip);
         }
 
-        public ulong Rip
+        public ulong Rax
         {
-            get
-            {
-                fixed (byte* ucontext = _ucontext)
-                {
-                    return *(ulong*)(ucontext + LinuxUcontextGregsOffset + LinuxGregsRipOffset);
-                }
-            }
+            get => ReadRegisterU64(PlatformRaxOffset);
+            set => WriteRegisterU64(PlatformRaxOffset, value);
         }
+
+        public uint EFlags
+        {
+            get => ReadRegisterU32(PlatformRflagsOffset);
+            set => WriteRegisterU32(PlatformRflagsOffset, value);
+        }
+
+        public ulong Rip => ReadRegisterU64(PlatformRipOffset);
 
         public void SetXmmLow(int fxsaveOffset, ulong value)
         {
@@ -207,9 +241,14 @@ public sealed unsafe class Sse4aPosixSignalRecoveryTests
         {
             EnsureBridgeBackend();
             fixed (byte* ucontext = _ucontext)
+            fixed (byte* mcontext = _mcontext)
             fixed (byte* fpstate = _fpstate)
             {
-                if (_wireFpstate)
+                if (OperatingSystem.IsMacOS())
+                {
+                    *(byte**)(ucontext + DarwinUcontextMcontextOffset) = mcontext;
+                }
+                else if (_wireFpstate)
                 {
                     *(byte**)(ucontext + LinuxUcontextGregsOffset + LinuxGregsFpstateOffset) = fpstate;
                 }
@@ -217,6 +256,55 @@ public sealed unsafe class Sse4aPosixSignalRecoveryTests
                 return (bool)TryHandlePosixFault.Invoke(
                     null,
                     [PosixSigIll, (nint)0, (nint)ucontext])!;
+            }
+        }
+
+        private static int PlatformRaxOffset =>
+            OperatingSystem.IsMacOS() ? DarwinRaxOffset : LinuxGregsRaxOffset;
+
+        private static int PlatformRipOffset =>
+            OperatingSystem.IsMacOS() ? DarwinRipOffset : LinuxGregsRipOffset;
+
+        private static int PlatformRflagsOffset =>
+            OperatingSystem.IsMacOS() ? DarwinRflagsOffset : LinuxGregsRflagsOffset;
+
+        private byte[] RegisterStorage => OperatingSystem.IsMacOS() ? _mcontext : _ucontext;
+
+        private int RegisterBaseOffset => OperatingSystem.IsMacOS() ? 0 : LinuxUcontextGregsOffset;
+
+        private ulong ReadRegisterU64(int offset)
+        {
+            var storage = RegisterStorage;
+            fixed (byte* registers = storage)
+            {
+                return *(ulong*)(registers + RegisterBaseOffset + offset);
+            }
+        }
+
+        private uint ReadRegisterU32(int offset)
+        {
+            var storage = RegisterStorage;
+            fixed (byte* registers = storage)
+            {
+                return *(uint*)(registers + RegisterBaseOffset + offset);
+            }
+        }
+
+        private void WriteRegisterU64(int offset, ulong value)
+        {
+            var storage = RegisterStorage;
+            fixed (byte* registers = storage)
+            {
+                *(ulong*)(registers + RegisterBaseOffset + offset) = value;
+            }
+        }
+
+        private void WriteRegisterU32(int offset, uint value)
+        {
+            var storage = RegisterStorage;
+            fixed (byte* registers = storage)
+            {
+                *(uint*)(registers + RegisterBaseOffset + offset) = value;
             }
         }
     }


### PR DESCRIPTION
## Summary

SharpEmu routes Linux and macOS faults through recovery code that consumes a
Win64 `CONTEXT` record. `TryHandlePosixFault` copied general-purpose registers
and Linux XMM state into that record, but left `EFlags` at zero. The BMI/ABM
fallback therefore calculated flags from the wrong input, and successful
recovery never returned modified flags to the POSIX signal context.

This change copies the low 32-bit EFLAGS value between the platform signal
frame and `CONTEXT.EFlags`. Linux uses `gregs[17]` at byte offset 136; Darwin
uses `__rflags` at byte offset 152. Write-back remains behind the existing
successful-recovery gate, so declined faults leave the platform frame
untouched.

The POSIX recovery fixture now represents Linux and Darwin register storage.
A synthetic `tzcnt eax, eax` fault verifies the result and instruction pointer,
checks Carry and Zero updates, and proves that an unrelated Direction flag
survives the complete adapter path.

Guest code running on a POSIX host without a required BMI/ABM extension now
resumes with the flags produced by SharpEmu's software fallback.

## Testing

- `PosixSignalRecoveryTests`: 4 passed, 0 failed.
- Complete Release suite: 653 passed, 0 failed.
- Non-incremental Release build: succeeded with 0 errors and the same three
  warnings present on `main`.
- Game testing: N/A. No suitable game and host-CPU combination was available;
  the synthetic SIGILL regression drives the production signal adapter.

## AI assistance

Codex assisted with the audit, implementation, verification, and this initial
draft text. The contributor states that they understand the code and approved
creation of this draft. The self-authorship checklist item remains unchecked
because this description was AI-drafted.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
