### PR TITLE
fix(shader): decode VOP1/VOP2/VOPC instructions in their VOP3 encoding

### DIFF
--- a/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.Alu.cs
@@ -578,11 +578,15 @@ public static partial class Gen5MslTranslator
             {
                 condition = EmitCompareClass(instruction);
             }
-            else if (opcode is "VCmpTruF32" or "VCmpxTruF32" or "VCmpTI32" or "VCmpTU32")
+            else if (opcode is "VCmpTruF32" or "VCmpxTruF32" or
+                     "VCmpTI32" or "VCmpxTI32" or
+                     "VCmpTU32" or "VCmpxTU32")
             {
                 condition = "true";
             }
-            else if (opcode is "VCmpFF32" or "VCmpxFF32" or "VCmpFI32" or "VCmpFU32")
+            else if (opcode is "VCmpFF32" or "VCmpxFF32" or
+                     "VCmpFI32" or "VCmpxFI32" or
+                     "VCmpFU32" or "VCmpxFU32")
             {
                 condition = "false";
             }
@@ -664,14 +668,29 @@ public static partial class Gen5MslTranslator
             }
             else
             {
-                var target = instruction.Control is Gen5SdwaControl
-                    { ScalarDestination: { } scalarDestination }
-                    ? scalarDestination
-                    : VccLoRegister;
-                StoreMaskBit(target, active);
+                StoreMaskBit(CompareDestination(instruction), active);
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Where a non-VCMPX compare writes its wave mask. The VOP3 encoding
+        /// names the destination SGPR pair explicitly and SDWA can override it;
+        /// the compact VOPC encoding has no destination field and always
+        /// targets VCC.
+        /// </summary>
+        private static uint CompareDestination(Gen5ShaderInstruction instruction)
+        {
+            if (instruction.Destinations.Count > 0 &&
+                instruction.Destinations[0].Kind == Gen5OperandKind.ScalarRegister)
+            {
+                return instruction.Destinations[0].Value;
+            }
+
+            return instruction.Control is Gen5SdwaControl { ScalarDestination: { } scalarDestination }
+                ? scalarDestination
+                : VccLoRegister;
         }
 
         private string EmitCompareClass(Gen5ShaderInstruction instruction)

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
@@ -1403,6 +1403,25 @@ public static partial class Gen5SpirvTranslator
         private uint ISubU(uint left, uint right) =>
             _module.AddInstruction(SpirvOp.ISub, _uintType, left, right);
 
+        /// <summary>
+        /// Where a non-VCMPX compare writes its wave mask. The VOP3 encoding
+        /// names the destination SGPR pair explicitly and SDWA can override it;
+        /// the compact VOPC encoding has no destination field and always
+        /// targets VCC.
+        /// </summary>
+        private static uint CompareDestination(Gen5ShaderInstruction instruction)
+        {
+            if (instruction.Destinations.Count > 0 &&
+                instruction.Destinations[0].Kind == Gen5OperandKind.ScalarRegister)
+            {
+                return instruction.Destinations[0].Value;
+            }
+
+            return instruction.Control is Gen5SdwaControl { ScalarDestination: { } scalarDestination }
+                ? scalarDestination
+                : 106u;
+        }
+
         private bool TryEmitVectorCompare(
             Gen5ShaderInstruction instruction,
             out string error)
@@ -1517,11 +1536,15 @@ public static partial class Gen5SpirvTranslator
                     condition,
                     SignedClass(0x020, 0x040, zero));
             }
-            else if (opcode is "VCmpFF32" or "VCmpxFF32" or "VCmpFI32" or "VCmpFU32")
+            else if (opcode is "VCmpFF32" or "VCmpxFF32" or
+                     "VCmpFI32" or "VCmpxFI32" or
+                     "VCmpFU32" or "VCmpxFU32")
             {
                 condition = _module.ConstantBool(false);
             }
-            else if (opcode is "VCmpTruF32" or "VCmpxTruF32" or "VCmpTI32" or "VCmpTU32")
+            else if (opcode is "VCmpTruF32" or "VCmpxTruF32" or
+                     "VCmpTI32" or "VCmpxTI32" or
+                     "VCmpTU32" or "VCmpxTU32")
             {
                 condition = _module.ConstantBool(true);
             }
@@ -1646,11 +1669,7 @@ public static partial class Gen5SpirvTranslator
             }
             else
             {
-                var compareDestination = instruction.Control is Gen5SdwaControl
-                    { ScalarDestination: { } scalarDestination }
-                    ? scalarDestination
-                    : 106u;
-                StoreWaveMask(compareDestination, activeCondition);
+                StoreWaveMask(CompareDestination(instruction), activeCondition);
             }
 
             return true;

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
@@ -910,7 +910,13 @@ public static class Gen5ShaderTranslator
         var src0 = word & 0x1FF;
         sizeDwords = src0 is 0xE9 or 0xEA or 0xF9 or 0xFA or 0xFF ? 2u : 1u;
         error = string.Empty;
-        name = opcode switch
+        name = Vop1Name(opcode);
+
+        return FinishDecode(name, $"unknown-vop1 op=0x{opcode:X2}", out error);
+    }
+
+    private static string Vop1Name(uint opcode) =>
+        opcode switch
         {
             0x00 => "VNop",
             0x01 => "VMovB32",
@@ -950,9 +956,6 @@ public static class Gen5ShaderTranslator
             _ => string.Empty,
         };
 
-        return FinishDecode(name, $"unknown-vop1 op=0x{opcode:X2}", out error);
-    }
-
     private static bool DecodeVop2(uint word, out string name, out uint sizeDwords, out string error)
     {
         var opcode = (word >> 25) & 0x3F;
@@ -970,7 +973,13 @@ public static class Gen5ShaderTranslator
         sizeDwords = opcode is 0x20 or 0x21 or 0x2C or 0x2D ||
             src0 is 0xE9 or 0xEA or 0xF9 or 0xFA or 0xFF ? 2u : 1u;
         error = string.Empty;
-        name = opcode switch
+        name = Vop2Name(opcode);
+
+        return FinishDecode(name, $"unknown-vop2 op=0x{opcode:X2}", out error);
+    }
+
+    private static string Vop2Name(uint opcode) =>
+        opcode switch
         {
             0x01 => "VCndmaskB32",
             0x02 => "VDot2cF32F16",
@@ -1017,16 +1026,19 @@ public static class Gen5ShaderTranslator
             _ => string.Empty,
         };
 
-        return FinishDecode(name, $"unknown-vop2 op=0x{opcode:X2}", out error);
-    }
-
     private static bool DecodeVopc(uint word, out string name, out uint sizeDwords, out string error)
     {
         var opcode = (word >> 17) & 0xFF;
         var src0 = word & 0x1FF;
         sizeDwords = src0 is 0xE9 or 0xEA or 0xF9 or 0xFA or 0xFF ? 2u : 1u;
         error = string.Empty;
-        name = opcode switch
+        name = VopcName(opcode);
+
+        return FinishDecode(name, $"unknown-vopc op=0x{opcode:X2}", out error);
+    }
+
+    private static string VopcName(uint opcode) =>
+        opcode switch
         {
             0x00 => "VCmpFF32",
             0x01 => "VCmpLtF32",
@@ -1096,8 +1108,30 @@ public static class Gen5ShaderTranslator
             _ => string.Empty,
         };
 
-        return FinishDecode(name, $"unknown-vopc op=0x{opcode:X2}", out error);
-    }
+    // GFX10 re-encodes most VOP1/VOP2/VOPC instructions in VOP3 form so they can
+    // carry the abs/neg source modifiers, clamp/omod, an SGPR src1, or (for
+    // compares) a destination other than VCC. The VOP3 opcode is derived from the
+    // original opcode by a fixed offset per class, matching LLVM's GFX10 encoding
+    // classes: VOPC uses VOP3a_gfx10<{0, op}>, VOP2 uses VOP3e_gfx10<{0,1,0,0,
+    // op[5:0]}> and VOP1 uses VOP3e_gfx10<{0,1,1,op[6:0]}>.
+    private const uint Vop3EncodedVop2Base = 0x100;
+    private const uint Vop3EncodedVop1Base = 0x180;
+
+    // VOPC occupies the bottom of the VOP3 opcode space, so the range test is
+    // just "below the VOP2 window".
+    private static bool IsVop3EncodedVopc(uint vop3Opcode) =>
+        vop3Opcode < Vop3EncodedVop2Base;
+
+    private static string Vop3EncodedName(uint vop3Opcode) => vop3Opcode switch
+    {
+        < Vop3EncodedVop2Base => VopcName(vop3Opcode),
+        // VOP2 is a 6-bit opcode, so only 0x100-0x13F is a re-encoded VOP2;
+        // 0x140 onwards is VOP3-only territory.
+        < Vop3EncodedVop2Base + 0x40 => Vop2Name(vop3Opcode - Vop3EncodedVop2Base),
+        >= Vop3EncodedVop1Base and < Vop3EncodedVop1Base + 0x80 =>
+            Vop1Name(vop3Opcode - Vop3EncodedVop1Base),
+        _ => string.Empty,
+    };
 
     private static bool DecodeVop3(
         uint word,
@@ -1123,17 +1157,10 @@ public static class Gen5ShaderTranslator
                 0x176 => "VMadU64U32",
                 _ => $"Vop3bRaw{opcode:X3}",
             }
-            : opcode switch
+            : Vop3EncodedName(opcode) is { Length: > 0 } reEncoded
+                ? reEncoded
+                : opcode switch
         {
-            0x101 => "VCndmaskB32",
-            0x103 => "VAddF32",
-            0x104 => "VSubF32",
-            0x108 => "VMulF32",
-            0x10F => "VMinF32",
-            0x110 => "VMaxF32",
-            0x11F => "VMacF32",
-            0x12B => "VFmacF32",
-            0x12F => "VCvtPkrtzF16F32",
             0x141 => "VMadF32",
             0x143 => "VMadU32U24",
             0x144 => "VCubeidF32",
@@ -2013,15 +2040,21 @@ public static class Gen5ShaderTranslator
                     Gen5Operand.Source((extra >> 9) & 0x1FF, literal),
                     Gen5Operand.Source((extra >> 18) & 0x1FF, literal),
                 ];
+                var vop3Opcode = (word >> 16) & 0x3FF;
                 destinations = [Gen5Operand.Vector(word & 0xFF)];
-                if (opcode == "VReadlaneB32")
+                if (opcode == "VReadlaneB32" || IsVop3EncodedVopc(vop3Opcode))
                 {
                     // V_READLANE uses the VOP3A vdst byte even though the
                     // destination register is scalar. Bits 8-14 are the
                     // distinct sdst field used by VOP3B encodings.
+                    //
+                    // A VOP3-encoded compare reuses the same byte as its sdst:
+                    // VOPC has no vector destination, and the whole reason a
+                    // compare takes the VOP3 form is usually that the result
+                    // goes somewhere other than VCC.
                     destinations = [Gen5Operand.Scalar(word & 0xFF)];
                 }
-                var isVop3B = IsVop3BOpcode((word >> 16) & 0x3FF);
+                var isVop3B = IsVop3BOpcode(vop3Opcode);
                 control = new Gen5Vop3Control(
                     isVop3B ? 0 : (word >> 8) & 0x7,
                     (extra >> 29) & 0x7,

--- a/tests/SharpEmu.Libs.Tests/Agc/Gen5Vop3EncodedOpcodeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/Gen5Vop3EncodedOpcodeTests.cs
@@ -1,0 +1,193 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+// GFX10 re-encodes VOP1, VOP2 and VOPC instructions in VOP3 form whenever they need
+// source modifiers, clamp/omod, an SGPR src1, or a compare destination other than VCC.
+// These lock the opcode-space mapping (VOPC at 0x000, VOP2 at 0x100, VOP1 at 0x180) and
+// the VOPC-specific detail that the vdst byte is an SGPR pair, not a VGPR.
+//
+// Word layout (VOP3A): word0 [31:26]=0x35, [25:16]=op, [15]=clamp, [14:11]=op_sel,
+// [10:8]=abs, [7:0]=vdst/sdst; word1 [8:0]=src0, [17:9]=src1, [26:18]=src2,
+// [28:27]=omod, [31:29]=neg. Register operands encode VGPR n as 256+n.
+public sealed class Gen5Vop3EncodedOpcodeTests
+{
+    private const ulong ShaderAddress = 0x1_0000_0000;
+    private const uint Vop3 = 0xD400_0000;
+    private const uint V0 = 0x100;
+    private const uint V1 = 0x101;
+
+    [Fact]
+    public void Vop3EncodedCompare_KeepsVopcNameAndWritesScalarDestination()
+    {
+        // v_cmp_lt_f32_e64 s[10:11], v0, v1 - VOPC op 0x01 sits at VOP3 op 0x001.
+        var instruction = DecodeSingle(Vop3 | (0x001u << 16) | 10u, V0 | (V1 << 9));
+
+        Assert.Equal("VCmpLtF32", instruction.Opcode);
+        Assert.Equal(Gen5ShaderEncoding.Vop3, instruction.Encoding);
+
+        // The whole reason a compare takes the VOP3 form is usually that the result
+        // goes somewhere other than VCC, so the destination must survive as an SGPR.
+        var destination = Assert.Single(instruction.Destinations);
+        Assert.Equal(Gen5OperandKind.ScalarRegister, destination.Kind);
+        Assert.Equal(10u, destination.Value);
+    }
+
+    [Fact]
+    public void Vop3EncodedVop1_KeepsVop1NameAndVectorDestination()
+    {
+        // v_rcp_f32_e64 v1, -v0 - VOP1 op 0x2A sits at VOP3 op 0x1AA, neg bit set.
+        var instruction = DecodeSingle(Vop3 | (0x1AAu << 16) | 1u, V0 | (1u << 29));
+
+        Assert.Equal("VRcpF32", instruction.Opcode);
+        Assert.Equal(new[] { Gen5Operand.Vector(1) }, instruction.Destinations);
+
+        var control = Assert.IsType<Gen5Vop3Control>(instruction.Control);
+        Assert.Equal(1u, control.NegateMask);
+    }
+
+    [Fact]
+    public void Vop3EncodedVop2_KeepsVop2NameAndAcceptsScalarSource1()
+    {
+        // v_sub_f32_e64 v2, v0, s3 - VOP2 op 0x04 sits at VOP3 op 0x104. An SGPR in
+        // src1 is exactly the case the compact VOP2 encoding cannot express.
+        var instruction = DecodeSingle(Vop3 | (0x104u << 16) | 2u, V0 | (3u << 9));
+
+        Assert.Equal("VSubF32", instruction.Opcode);
+        Assert.Equal(new[] { Gen5Operand.Vector(2) }, instruction.Destinations);
+        Assert.Equal(Gen5Operand.Source(3), instruction.Sources[1]);
+    }
+
+    [Fact]
+    public void Vop3OnlyOpcodes_AreNotShadowedByTheReEncodingRanges()
+    {
+        // VOP2 is a 6-bit opcode, so the re-encoding window stops at 0x13F and 0x141
+        // stays V_MAD_F32 rather than being read as a VOP2.
+        Assert.Equal("VMadF32", DecodeSingle(Vop3 | (0x141u << 16), V0).Opcode);
+        Assert.Equal("VMulHiI32", DecodeSingle(Vop3 | (0x16Cu << 16), V0).Opcode);
+    }
+
+    [Fact]
+    public void Vop3EncodedCompares_CompileToSpirvComparisons()
+    {
+        // v_cmp_lt_f32_e64 s[10:11], v0, v1 ; v_cmp_ge_u32_e64 s[12:13], v0, v1
+        // Before the VOP3 opcode ranges were decoded these bailed out of translation
+        // with "unsupported vector opcode Vop3Raw001", failing the whole draw.
+        var opcodes = CompileCompute(
+        [
+            Vop3 | (0x001u << 16) | 10u, V0 | (V1 << 9),
+            Vop3 | (0x0C6u << 16) | 12u, V0 | (V1 << 9),
+        ]);
+
+        Assert.Contains((ushort)SpirvOp.FOrdLessThan, opcodes);
+        Assert.Contains((ushort)SpirvOp.UGreaterThanEqual, opcodes);
+    }
+
+    [Fact]
+    public void Vop3EncodedVop1AndVop2_CompileToSpirvArithmetic()
+    {
+        // v_rcp_f32_e64 v1, v0 ; v_sub_f32_e64 v2, v0, v1
+        var opcodes = CompileCompute(
+        [
+            Vop3 | (0x1AAu << 16) | 1u, V0,
+            Vop3 | (0x104u << 16) | 2u, V0 | (V1 << 9),
+        ]);
+
+        // V_RCP_F32 lowers to a reciprocal divide rather than a GLSL extended
+        // instruction, so the divide is what proves it reached the emitter.
+        Assert.Contains((ushort)SpirvOp.FSub, opcodes);
+        Assert.Contains((ushort)SpirvOp.FDiv, opcodes);
+    }
+
+    [Fact]
+    public void AlwaysFalseAndAlwaysTrueIntegerCompares_CompileInBothCmpAndCmpxForms()
+    {
+        // v_cmpx_f_i32_e64 / v_cmpx_t_u32_e64 - the VCMPX halves of the constant
+        // compares. Only the VCMP halves were handled, so these failed translation.
+        var opcodes = CompileCompute(
+        [
+            Vop3 | (0x090u << 16), V0 | (V1 << 9),
+            Vop3 | (0x0D7u << 16), V0 | (V1 << 9),
+        ]);
+
+        Assert.NotEmpty(opcodes);
+    }
+
+    private static Gen5ShaderInstruction DecodeSingle(params uint[] words)
+    {
+        var state = CreateState(words);
+        return state.Program.Instructions[0];
+    }
+
+    private static Gen5ShaderState CreateState(uint[] words)
+    {
+        var memory = new FakeCpuMemory(ShaderAddress, 0x2000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Gen5ShaderAtomicDecodeTests.WriteProgram(memory, ShaderAddress, words);
+        Assert.True(
+            Gen5ShaderTranslator.TryCreateState(
+                ctx,
+                ShaderAddress,
+                0,
+                new Dictionary<uint, uint>
+                {
+                    [Gen5ShaderAtomicDecodeTests.ComputePgmRsrc2Register] = 16u << 1,
+                },
+                Gen5ShaderAtomicDecodeTests.ComputeUserDataRegister,
+                out var state,
+                out var error),
+            error);
+        return state;
+    }
+
+    private static HashSet<ushort> CompileCompute(uint[] words)
+    {
+        var memory = new FakeCpuMemory(ShaderAddress, 0x2000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Gen5ShaderAtomicDecodeTests.WriteProgram(memory, ShaderAddress, words);
+        Assert.True(
+            Gen5ShaderTranslator.TryCreateState(
+                ctx,
+                ShaderAddress,
+                0,
+                new Dictionary<uint, uint>
+                {
+                    [Gen5ShaderAtomicDecodeTests.ComputePgmRsrc2Register] = 16u << 1,
+                },
+                Gen5ShaderAtomicDecodeTests.ComputeUserDataRegister,
+                out var state,
+                out var error),
+            error);
+        Assert.True(
+            Gen5ShaderScalarEvaluator.TryEvaluate(ctx, state, out var evaluation, out error),
+            error);
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileComputeShader(
+                state,
+                evaluation,
+                1,
+                1,
+                1,
+                out var shader,
+                out error),
+            error);
+
+        var opcodes = new HashSet<ushort>();
+        for (var offset = 5 * sizeof(uint); offset + sizeof(uint) <= shader.Spirv.Length;)
+        {
+            var word = BinaryPrimitives.ReadUInt32LittleEndian(
+                shader.Spirv.AsSpan(offset, sizeof(uint)));
+            opcodes.Add((ushort)word);
+            offset += Math.Max((int)(word >> 16), 1) * sizeof(uint);
+        }
+
+        return opcodes;
+    }
+}

--- a/tools/SharpEmu.Tools.ShaderDump/Program.cs
+++ b/tools/SharpEmu.Tools.ShaderDump/Program.cs
@@ -123,6 +123,17 @@ const ulong ProgramAddress = 0x100000;
         0xBFA30000,             // s_waitcnt_depctr 0x0
         0xBF810000,             // s_endpgm
     ]),
+    // VOP1/VOP2/VOPC instructions in their VOP3 re-encoding, which is what a
+    // compiler emits when it needs source modifiers, an SGPR src1, or a compare
+    // destination other than VCC, so CI's spirv-val covers the emitted module.
+    ("vop3-encoded", true, [
+        0x7E0002FF, 0x3F800000, // v_mov_b32 v0, 1.0f
+        0x7E0202FF, 0x40000000, // v_mov_b32 v1, 2.0f
+        0xD401000A, 0x00020300, // v_cmp_lt_f32_e64 s[10:11], v0, v1
+        0xD5AA0002, 0x20000100, // v_rcp_f32_e64 v2, -v0
+        0xD5040003, 0x00020101, // v_sub_f32_e64 v3, v1, v0
+        0xBF810000,             // s_endpgm
+    ]),
     // s_round_mode / s_denorm_mode write the FP MODE state and must keep
     // failing decode loudly until their semantics are modeled (see #108);
     // this program pins that behavior.


### PR DESCRIPTION
## What this fixes

GFX10 lets most VOP1, VOP2 and VOPC instructions be re-encoded in VOP3 form. A
shader compiler reaches for that form whenever the instruction needs abs/neg
source modifiers, clamp/omod, an SGPR in `src1` (the compact VOP2 form only
allows a VGPR there), or — for a compare — a destination other than VCC.

`DecodeVop3` listed nine of those opcodes by hand. Everything else fell through
to the `Vop3Raw{op}` fallback, which decodes without complaint and then fails in
the backend with `unsupported vector opcode Vop3Raw001`. Since an unsupported
opcode fails the whole program, one re-encoded compare anywhere in a shader was
enough to drop the draw.

## The mapping

The VOP3 opcode is the original opcode plus a fixed offset per class:

| Class | LLVM GFX10 encoding class | VOP3 opcode |
|---|---|---|
| VOPC | `VOP3a_gfx10<{0, op}>` | `0x000 + op` |
| VOP2 | `VOP3e_gfx10<{0,1,0,0, op[5:0]}>` | `0x100 + op` |
| VOP1 | `VOP3e_gfx10<{0,1,1, op[6:0]}>` | `0x180 + op` |

I took those from `VOP1Instructions.td`, `VOP2Instructions.td` and
`VOPCInstructions.td` in LLVM's AMDGPU backend (release/19.x), in the
`VOP1_Real_e64_gfx10`, `VOP2_Real_e64_gfx10` and `VOPC_Real_gfx10` multiclasses.

The nine opcodes already in the table agree with the rule exactly — 0x101
`VCndmaskB32`, 0x103 `VAddF32`, 0x104 `VSubF32`, 0x108 `VMulF32`, 0x10F
`VMinF32`, 0x110 `VMaxF32`, 0x11F `VMacF32`, 0x12B `VFmacF32`, 0x12F
`VCvtPkrtzF16F32` are all `0x100 + VOP2 op`. They are redundant once the ranges
are routed properly, so I removed them rather than keep two sources of truth.

## The destination change

This part is not just naming, and it's the part worth reviewing closely.

`VOPC_Real_gfx10` sets `let Inst{7-0} = sdst`. A VOP3-encoded compare writes an
SGPR pair, not a VGPR — VOPC has no vector destination at all. If only the names
were fixed, two things would go wrong:

- the wave mask would quietly land in VCC instead of the SGPR pair the shader
  named, which is a wrong result rather than an honest failure;
- the backward "what last defined VGPR n" search in `Gen5ShaderScalarEvaluator`
  matches on `Kind: VectorRegister`, so it would treat the compare as a
  definition of the VGPR whose index happens to equal its `sdst`.

So the decoder now produces a scalar destination operand for that range, and
both backends prefer an explicit scalar destination over VCC. The existing SDWA
path and the VCC default are unchanged.

`V_CMPX` in VOP3 form is unaffected: it is EXEC-only on GFX10 and both backends
already route it to EXEC, ignoring the destination.

## Also included

`VCmpFI32`, `VCmpTI32`, `VCmpFU32` and `VCmpTU32` (the always-false and
always-true integer compares) were handled but their `VCmpx` siblings were not.
Those four only became reachable because of this change, so leaving them out
would mean shipping four new translation failures. Fixed in both backends.

## Measurements

I swept the opcode space by assembling a one-instruction program and running it
through `TryCreateState` -> `TryEvaluate` -> `TryCompileComputeShader`, counting
the opcodes that come back with an `unsupported ...` error:

| | before | after |
|---|---|---|
| VOP3 `0x000-0x0FF` (VOPC) failing | 256 | 0 |
| VOP3 `0x180-0x1FF` (VOP1) failing | 128 | 96 |
| total over the swept space | 978 | 661 |

The 96 that remain are VOP1 opcodes with no entry in the VOP1 table either.
That's a separate gap and I have not touched it here.

## Tests

Seven new cases in `Gen5Vop3EncodedOpcodeTests`, all synthetic encodings built
from the ISA word layout:

- a VOP3 compare keeps its VOPC name and takes a scalar destination;
- a VOP3-encoded VOP1 keeps its name and its neg modifier;
- a VOP3-encoded VOP2 keeps its name and accepts an SGPR `src1`;
- VOP3-only opcodes at 0x141 and 0x16C are not shadowed by the new ranges;
- compares, VOP1 and VOP2 in VOP3 form reach SPIR-V emission;
- the `VCmpx` constant compares compile.

I also added a `vop3-encoded` program to the ShaderDump corpus so the pinned
`spirv-val` step in CI runs over the emitted module rather than only the unit
tests asserting on opcodes.

## Testing

- Build: `dotnet build SharpEmu.slnx -c Release` — 0 errors, 0 warnings.
- Tests: `dotnet test SharpEmu.slnx -c Release` — 659 pass, 0 fail (652 before).
- ShaderDump: `RESULT: all programs behaved as expected`. The new program decodes
  as `ops=VMovB32:2,VCmpLtF32:1,VRcpF32:1,VSubF32:1,SEndpgm:1`.

I have not run this against a real title, so I can't claim a before/after on any
game. The change is confined to the decoder and the two shader backends, and
every opcode it newly accepts routes into translation paths that already existed
and were already exercised. I'm relying on the gameplay bot for Dreaming Sarah
and Dead Cells, and I'd appreciate a Demon's Souls check.

## Known limitations

- VOP1 opcodes outside the current table still fall through to `Vop3Raw`, in
  both the VOP3 range and the plain VOP1 encoding.
- `V_MOVREL{S,D,SD}_B32`, `V_CVT_PK_{U,I}16_{U,I}32`, `V_DOT2C_F32_F16` and the
  `V_SAD_*` family still fail translation. They're unrelated to the encoding
  question and belong in their own changes.
- I did not run `spirv-val` locally (no Vulkan SDK on this machine); the Linux CI
  job covers it.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
