### PR TITLE
fix(cpu): bridge Darwin mcontext XMM state for SSE4a #UD recovery (#328)

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Amd64Compat.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Amd64Compat.cs
@@ -51,11 +51,10 @@ public sealed partial class DirectExecutionBackend
         // round-trips through the real ucontext, so it works on every supported OS. EXTRQ/
         // INSERTQ additionally read and write an XMM register: on Windows contextRecord is the
         // live CONTEXT the OS resumes the thread from, so touching the Xmm0.. slots is visible
-        // to the guest, and on Linux the bridge copies the mcontext's FXSAVE image into the
-        // Xmm0.. slots and writes them back through sigreturn (_posixXmmContextBridged). On
-        // Darwin the XMM area is still a zeroed scratch buffer - running this there would
-        // silently compute a result from stale bytes and then discard whatever it "wrote", so
-        // the recovery declines until that bridge exists.
+        // to the guest, and on Linux and Darwin the bridge copies the mcontext's XMM image
+        // into the Xmm0.. slots and writes them back through sigreturn (_posixXmmContextBridged).
+        // The flag stays false on any host where that round-trip is not wired up, so the
+        // recovery declines rather than computing from stale bytes and discarding the result.
         return (OperatingSystem.IsWindows() || _posixXmmContextBridged) &&
             TryRecoverSse4aExtractInsert(contextRecord, rip);
     }

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.PosixSignals.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.PosixSignals.cs
@@ -63,6 +63,14 @@ public sealed unsafe partial class DirectExecutionBackend
 	private const int FxsaveXmmOffset = 160;
 	private const int XmmBlockSize = 16 * 16;
 
+	// Darwin embeds x86_float_state64 inline in __darwin_mcontext64 - there is
+	// no fpstate pointer to chase. __es(16) + __ss(168) place the float state
+	// at +184, and __fpu_xmm0 sits 168 bytes into it (reserved + control words
+	// + 8 STMM slots), so xmm0..15 occupy the 256-byte block at mcontext+352.
+	// GetPosixRegisterBase returns that mcontext for macOS, so the XMM block is
+	// read and written in place rather than through Linux's fpstate indirection.
+	private const int DarwinMcontextXmmOffset = 352;
+
 	// Byte offsets of the general registers relative to GetPosixRegisterBase,
 	// ordered to match the contiguous Win64 CONTEXT block CTX_RAX..CTX_RIP
 	// (rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi, r8..r15, rip). Verified
@@ -143,8 +151,12 @@ public sealed unsafe partial class DirectExecutionBackend
 	{
 		byte* fakeUcontext = stackalloc byte[512];
 		new Span<byte>(fakeUcontext, 512).Clear();
-		byte* fakeMcontext = stackalloc byte[512];
-		new Span<byte>(fakeMcontext, 512).Clear();
+		// Sized past Darwin's inline XMM block: the bridge reads and writes 256
+		// bytes at mcontext+352 (=608), so a 512-byte fake mcontext would let
+		// the warmup fault over-read/write the stack. Real __darwin_mcontext64
+		// is smaller than this; the slack is harmless.
+		byte* fakeMcontext = stackalloc byte[1024];
+		new Span<byte>(fakeMcontext, 1024).Clear();
 		if (OperatingSystem.IsMacOS())
 		{
 			*(byte**)(fakeUcontext + DarwinUcontextMcontextOffset) = fakeMcontext;
@@ -275,24 +287,34 @@ public sealed unsafe partial class DirectExecutionBackend
 		}
 
 		// Bridge the XMM registers alongside the GPRs where the layout is
-		// known: on Linux the fpstate pointer and FXSAVE image are kernel
-		// ABI, so recovery paths that read or write XMM state (SSE4a
+		// known, so recovery paths that read or write XMM state (SSE4a
 		// EXTRQ/INSERTQ) see the live registers and their writes reach the
-		// guest through sigreturn.
-		byte* fpstate = null;
+		// guest through sigreturn. Linux locates the FXSAVE image through the
+		// kernel's fpstate pointer (which can be absent); Darwin embeds the
+		// float state inline in the mcontext, so the block is addressed
+		// directly. Both resolve to a single pointer at the live xmm0 slot.
+		byte* xmm = null;
 		if (OperatingSystem.IsLinux())
 		{
-			fpstate = *(byte**)(registers + LinuxGregsFpstateOffset);
+			byte* fpstate = *(byte**)(registers + LinuxGregsFpstateOffset);
 			if (fpstate != null)
 			{
-				Buffer.MemoryCopy(
-					fpstate + FxsaveXmmOffset,
-					contextRecord + Win64ContextXmm0Offset,
-					XmmBlockSize,
-					XmmBlockSize);
+				xmm = fpstate + FxsaveXmmOffset;
 			}
 		}
-		_posixXmmContextBridged = fpstate != null;
+		else if (OperatingSystem.IsMacOS())
+		{
+			xmm = registers + DarwinMcontextXmmOffset;
+		}
+		if (xmm != null)
+		{
+			Buffer.MemoryCopy(
+				xmm,
+				contextRecord + Win64ContextXmm0Offset,
+				XmmBlockSize,
+				XmmBlockSize);
+		}
+		_posixXmmContextBridged = xmm != null;
 
 		EXCEPTION_RECORD record = default;
 		record.ExceptionAddress = (void*)ReadCtxU64(contextRecord, CTX_RIP);
@@ -359,11 +381,11 @@ public sealed unsafe partial class DirectExecutionBackend
 		{
 			*(ulong*)(registers + offsets[i]) = ReadCtxU64(contextRecord, CTX_RAX + i * 8);
 		}
-		if (fpstate != null)
+		if (xmm != null)
 		{
 			Buffer.MemoryCopy(
 				contextRecord + Win64ContextXmm0Offset,
-				fpstate + FxsaveXmmOffset,
+				xmm,
 				XmmBlockSize,
 				XmmBlockSize);
 		}


### PR DESCRIPTION
> **DRAFT — description not yet written by the contributor.**
> Everything under "Summary (raw material)" was generated with AI assistance as
> raw facts. Per `CONTRIBUTING.md` I need to **rewrite it in my own words**, fill
> in the Testing section with a real PPSA15552 run, and complete the checklist
> before marking this ready. Do not review/merge while this banner is here.

Refs #328

## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary (raw material — rewrite in your own words, then delete this section)

- **Problem.** The generic SSE4a `EXTRQ`/`INSERTQ` #UD recovery
  (`TryRecoverSse4aExtractInsert`, from #449/#482) is gated on
  `_posixXmmContextBridged`. That flag stays `false` on Darwin because the POSIX
  signal bridge (`DirectExecutionBackend.PosixSignals.cs`) only copies the live
  XMM registers into/out of the fake CONTEXT on Linux, where they hang off the
  kernel's `fpstate` pointer. Darwin embeds `x86_float_state64` inline in
  `__darwin_mcontext64`, so there was no bridge and recovery correctly declined
  rather than compute from a zeroed scratch buffer. Net effect: guest SSE4a is
  an unrecoverable SIGILL (exit 132) on Apple Silicon under Rosetta 2 — issue
  #328, gap identified by @zambasaurus.
- **Fix.** Resolve the inline XMM block directly for macOS at `mcontext + 352`
  (Linux keeps its `fpstate`-pointer path); both platforms now feed a single
  `xmm` pointer used for the read (before recovery) and the write-back (before
  `sigreturn`). Flipping `_posixXmmContextBridged` true there activates the
  existing, register/encoding-agnostic recovery with no change to the recovery
  logic itself. The warm-up fake mcontext is enlarged (512 → 1024) so the inline
  read/write doesn't over-run the stack buffer.
- **Offset provenance.** `+352` confirmed via `offsetof` against the macOS SDK
  headers (cross-compiled `x86_64`, run under Rosetta): `__es(16) + __ss(168)`
  puts `x86_float_state64` at +184, `__fpu_xmm0` 168 bytes in → +352
  (`__fpu_xmm1` at +368, `sizeof(__darwin_mcontext64)` = 712).
- **Scope caveats to keep in the final description:** Darwin-only and not
  exercisable in CI (the Linux branch is the exact mirror); and it trades the
  fast self-describing SIGILL for a hang in the Ngs2 loop (#259), so the two
  likely want to land together.

## Testing

<!-- REPLACE with a real PPSA15552 run before marking ready. Raw facts so far: -->
- Build: `SharpEmu.Core` compiles clean (0 errors; warnings pre-existing).
- Offset verified against the live macOS SDK via `offsetof` (see above).
- **Not yet run end-to-end.** Need a Dead Cells (PPSA15552) `osx-x64` run
  confirming SIGILL → `recovered=True` → "emulating SSE4a in software", no exit
  132, then the expected Ngs2 stall (#259).

## Checklist

By submitting this pull request, you confirm that:

- [ ] I have read and followed `CONTRIBUTING.md`.
- [ ] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [ ] I listed the game(s) I tested (or marked the testing section as `N/A`).
