### PR TITLE
[GUI] Upgrade Avalonia to 12.1.0 and enable compiled bindings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,10 +7,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.3.18" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.18" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.18" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.18" />
+    <PackageVersion Include="Avalonia" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
     <PackageVersion Include="FFmpeg.AutoGen" Version="7.1.1" />
     <PackageVersion Include="Iced" Version="1.21.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.14.8" />
@@ -23,8 +23,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.Windowing" Version="2.23.0" />
-    <!-- Transitive of Avalonia.Desktop; pinned to fix GHSA-xrw6-gwf8-vvr9 -->
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
+    <!-- Transitive of Avalonia.Desktop; pinned. Avalonia 12 requires 0.94.1+. -->
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.94.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
   </ItemGroup>

--- a/src/SharpEmu.GUI/ConsoleWindow.cs
+++ b/src/SharpEmu.GUI/ConsoleWindow.cs
@@ -6,6 +6,7 @@ using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input.Platform;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform;
@@ -40,7 +41,7 @@ public sealed class ConsoleWindow : Window
 
         _searchBox = new TextBox
         {
-            Watermark = loc.Get("Console.SearchWatermark"),
+            PlaceholderText = loc.Get("Console.SearchWatermark"),
             Width = 320,
             Margin = new Thickness(0, 0, 12, 0),
         };

--- a/src/SharpEmu.GUI/Localization.cs
+++ b/src/SharpEmu.GUI/Localization.cs
@@ -5,6 +5,8 @@ using System.Text.Json;
 
 namespace SharpEmu.GUI;
 
+public sealed record LanguageInfo(string Code, string NativeName);
+
 /// <summary>
 /// Loads UI strings for the launcher. Every language ships embedded in the
 /// assembly (see SharpEmu.GUI.csproj) so a release build is fully
@@ -15,8 +17,6 @@ namespace SharpEmu.GUI;
 public sealed class Localization
 {
     public static Localization Instance { get; } = new();
-
-    public sealed record LanguageInfo(string Code, string NativeName);
 
     private const string EmbeddedResourcePrefix = "Languages.";
     private const string EmbeddedResourceSuffix = ".json";
@@ -242,7 +242,7 @@ public sealed class Localization
         result = loaded;
         return true;
     }
-    
+
     private bool TryLoad(string code, string json)
     {
         if (TryLoad(json, out var dict))

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -8,6 +8,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
         xmlns:local="clr-namespace:SharpEmu.GUI"
         xmlns:primitives="clr-namespace:Avalonia.Controls.Primitives;assembly=Avalonia.Controls"
         x:Class="SharpEmu.GUI.MainWindow"
+        x:CompileBindings="False"
         Title="SharpEmu"
         Width="1280" Height="820"
         MinWidth="980" MinHeight="640"
@@ -15,7 +16,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
         WindowStartupLocation="CenterScreen"
         Background="{StaticResource BgBrush}"
         ExtendClientAreaToDecorationsHint="True"
-        ExtendClientAreaChromeHints="PreferSystemChrome"
+        WindowDecorations="Full"
         ExtendClientAreaTitleBarHeightHint="44"
         Icon="avares://SharpEmu.GUI/Assets/SharpEmu.ico"
         KeyDown="OnKeyDown">
@@ -84,7 +85,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
         <StackPanel Grid.Column="2" x:Name="LibraryToolbar" Orientation="Horizontal" Spacing="8"
                     VerticalAlignment="Center">
-          <TextBox x:Name="SearchBox" Watermark="Search library…" Width="240" VerticalAlignment="Center" />
+          <TextBox x:Name="SearchBox" PlaceholderText="Search library…" Width="240" VerticalAlignment="Center" />
           <Button x:Name="AddFolderButton" Classes="ghost" Content="＋ Add folder" VerticalAlignment="Center" />
           <Button x:Name="RescanButton" Classes="ghost" Content="⟳ Rescan" VerticalAlignment="Center" />
           <Button x:Name="OpenFileButton" Classes="ghost" Content="Open file…" VerticalAlignment="Center" />
@@ -498,7 +499,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
           <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" Margin="16,12,16,8">
             <TextBlock x:Name="ConsoleSectionTitle" Classes="sectionTitle" Text="CONSOLE" VerticalAlignment="Center" />
             <TextBox Grid.Column="1" FontSize="12" Margin="0,0,12,0" x:Name="ConsoleSearchBox"
-                    Watermark="Search..." Width="320" />
+                    PlaceholderText="Search..." Width="320" />
             <CheckBox Grid.Column="2" x:Name="AutoScrollCheck" Content="Auto-scroll" IsChecked="True"
                     FontSize="12" Margin="0,0,12,0" />
             <Button Grid.Column="3" x:Name="DetachConsoleButton" Classes="ghost" Content="Split" FontSize="12"

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -8,7 +8,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
         xmlns:local="clr-namespace:SharpEmu.GUI"
         xmlns:primitives="clr-namespace:Avalonia.Controls.Primitives;assembly=Avalonia.Controls"
         x:Class="SharpEmu.GUI.MainWindow"
-        x:CompileBindings="False"
         Title="SharpEmu"
         Width="1280" Height="820"
         MinWidth="980" MinHeight="640"
@@ -274,8 +273,13 @@ SPDX-License-Identifier: GPL-2.0-or-later
                       <local:SettingRow x:Name="LanguageRow" Label="Emulator language"
                                         Description="Language used throughout the launcher. Applies immediately.">
                         <ComboBox x:Name="LanguageBox" Width="160"
-                                  VerticalAlignment="Center" CornerRadius="8"
-                                  DisplayMemberBinding="{Binding NativeName}" />
+                                  VerticalAlignment="Center" CornerRadius="8">
+                          <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="local:LanguageInfo">
+                              <TextBlock Text="{Binding NativeName}" />
+                            </DataTemplate>
+                          </ComboBox.ItemTemplate>
+                        </ComboBox>
                       </local:SettingRow>
 
                       <local:SettingRow x:Name="TitleMusicRow" Label="Title music"

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -149,7 +149,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
               </ItemsPanelTemplate>
             </ListBox.ItemsPanel>
             <ListBox.ItemTemplate>
-              <DataTemplate>
+              <DataTemplate x:DataType="local:GameEntry" x:CompileBindings="True">
                 <StackPanel Width="128" Height="172" Spacing="7">
                   <Border Classes="coverShadow" Width="128" Height="128">
                     <Border Classes="coverClip">
@@ -512,7 +512,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
           <ListBox Grid.Row="1" x:Name="ConsoleList" Classes="console" BorderThickness="0,1,0,0"
                    BorderBrush="{StaticResource CardBorderBrush}" CornerRadius="0,0,12,12">
             <ListBox.ItemTemplate>
-              <DataTemplate>
+              <DataTemplate x:DataType="local:LogLine" x:CompileBindings="True">
                 <TextBlock Text="{Binding Text}" Foreground="{Binding Brush}" TextWrapping="NoWrap" />
               </DataTemplate>
             </ListBox.ItemTemplate>
@@ -528,7 +528,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
             <!-- Selected game cover thumbnail -->
             <Border Grid.Column="0" Classes="coverClip" Width="56" Height="56" CornerRadius="8"
                     VerticalAlignment="Center">
-              <Panel x:Name="SelectedCoverPanel">
+              <Panel x:Name="SelectedCoverPanel"
+                     x:DataType="local:GameEntry"
+                     x:CompileBindings="True">
                 <Border Background="{Binding PlaceholderBrush, FallbackValue={x:Null}}"
                         IsVisible="{Binding !HasCover, FallbackValue=False}">
                   <TextBlock Text="{Binding Initials}" FontSize="20" FontWeight="Bold"
@@ -549,7 +551,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
                 <!-- Title id / version / size badges, right next to the
                      title. The title's own MaxWidth (not a "*" column) is
                      what keeps them from drifting to the far right. -->
-                <StackPanel Grid.Column="1" x:Name="SelectedBadgesRow" Orientation="Horizontal" Spacing="6"
+                <StackPanel Grid.Column="1" x:Name="SelectedBadgesRow"
+                            x:DataType="local:GameEntry"
+                            x:CompileBindings="True"
+                            Orientation="Horizontal" Spacing="6"
                             IsVisible="False" VerticalAlignment="Center">
                   <Border Classes="pill" IsVisible="{Binding HasTitleId, FallbackValue=False}">
                     <TextBlock Text="{Binding TitleId}" FontSize="10" FontWeight="SemiBold"

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
@@ -613,7 +614,7 @@ public partial class MainWindow : Window
         LibraryTabButton.Content = loc.Get("Page.Library");
         OptionsTabButton.Content = loc.Get("Page.Options");
 
-        SearchBox.Watermark = loc.Get("Library.SearchWatermark");
+        SearchBox.PlaceholderText = loc.Get("Library.SearchWatermark");
         AddFolderButton.Content = loc.Get("Library.AddFolder");
         RescanButton.Content = loc.Get("Library.Rescan");
         OpenFileButton.Content = loc.Get("Library.OpenFile");
@@ -691,7 +692,7 @@ public partial class MainWindow : Window
         }
 
         ConsoleSectionTitle.Text = loc.Get("Console.Title");
-        ConsoleSearchBox.Watermark = loc.Get("Console.SearchWatermark");
+        ConsoleSearchBox.PlaceholderText = loc.Get("Console.SearchWatermark");
         AutoScrollCheck.Content = loc.Get("Console.AutoScroll");
         DetachConsoleButton.Content = loc.Get("Console.Split");
         CopyLogButton.Content = loc.Get("Console.Copy");
@@ -792,7 +793,7 @@ public partial class MainWindow : Window
             // Leaving F11 should restore a monitor-sized window with the
             // launcher chrome, not fall back to the design-time window size.
             WindowState = WindowState.Maximized;
-            ExtendClientAreaChromeHints = ExtendClientAreaChromeHints.PreferSystemChrome;
+            WindowDecorations = WindowDecorations.Full;
             TitleBar.IsVisible = true;
             StatusBar.IsVisible = true;
             if (_gameFullscreen)
@@ -813,7 +814,7 @@ public partial class MainWindow : Window
         else
         {
             WindowState = WindowState.FullScreen;
-            ExtendClientAreaChromeHints = ExtendClientAreaChromeHints.NoChrome;
+            WindowDecorations = WindowDecorations.None;
             TitleBar.IsVisible = false;
             StatusBar.IsVisible = false;
             if (_isRunning && !_isStopping && !_awaitingFirstFrame && GameView.IsVisible)

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -592,7 +592,7 @@ public partial class MainWindow : Window
 
     private void OnLanguageChanged()
     {
-        if (LanguageBox.SelectedItem is not Localization.LanguageInfo language)
+        if (LanguageBox.SelectedItem is not LanguageInfo language)
         {
             return;
         }


### PR DESCRIPTION
## Motivation

The Avalonia 12 upgrade was previously into #606. Since that PR is being split into smaller parts, this moves only the framework migration and required compatibility changes into a standalone PR

This should also provide a clean base for the next GUI changes without requiring the entire redesign to be reviewed at once

## Changes

- Updated Avalonia packages from 11.3.18 to 12.1.0
- Updated the pinned `Tmds.DBus.Protocol` version required by Avalonia 12
- Replaced the deprecated `TextBox.Watermark` property with `PlaceholderText`
- Migrated the removed `ExtendClientAreaChromeHints` API to `WindowDecorations`
- Updated clipboard extension imports for the Avalonia 12 namespace changes
- Enabled compiled bindings across the launcher XAML
- Added typed bindings for game cards, console rows, selected-game metadata and the language selector
- Moved `LanguageInfo` into a standalone model so the language template can also use compiled bindings
- No layout or visual redesign is included in this PR

## Testing

- `dotnet build SharpEmu.slnx -c Release --no-restore`  completed with 0 warnings and 0 errors
- `dotnet test SharpEmu.slnx -c Release --no-build` all 717 tests passed
- Game testing: Dream Sarah, but here are no emulator runtime or game compatibility code was changed

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).