### PR TITLE
Harden agent harness acceptance evidence

### DIFF
--- a/.agents/skills/sharpemu-boot-triage/SKILL.md
+++ b/.agents/skills/sharpemu-boot-triage/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: sharpemu-boot-triage
+description: Diagnose SharpEmu launch failures, crashes, hangs, unresolved imports, missing modules, guest exceptions, and failures through video initialization using bounded run artifacts. Do not use for general navigation, pixel-only regressions, research, or optimization.
+---
+
+<!-- Copyright (C) 2026 SharpEmu Emulator Project -->
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+
+# SharpEmu boot triage
+
+## Inputs
+
+Require a validated local profile and, for comparisons, a before-run ID. Keep target binaries and paths outside Git.
+
+## Workflow
+
+1. Run `.\scripts\agent-harness.ps1 doctor` and `profile validate --profile <profile>`.
+2. Run the exact profile with `.\scripts\agent-harness.ps1 run --profile <profile>`. Do not relax its 180-second maximum or process-tree cleanup.
+3. Read `run.json`, `events.jsonl`, `stdout.log`, `stderr.log`, and `emulator.log` from the reported `.local/runs/<run-id>/` directory.
+4. Find the earliest structured milestone or error that differs from the before-run. Distinguish host crash, guest failure, timeout, unresolved import, shader failure, graphics failure, and no-frame evidence.
+5. State one falsifiable hypothesis. Use the source index to locate the smallest owning source and nearest test surface.
+6. Test actual guest-visible state, inputs, outputs, errors, and side effects. Never begin with a stub, fake success, suppressed error, or title-specific value.
+7. Preserve the run before changing code; rerun the same profile afterward.
+
+## Output
+
+Return run IDs, commit SHAs, exact command/profile, duration, exit classification, highest proven milestone, earliest divergence, supporting log/event records, frame status, hypothesis, minimal source/test surface, and limitations.

--- a/.agents/skills/sharpemu-clean-room-research/SKILL.md
+++ b/.agents/skills/sharpemu-clean-room-research/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: sharpemu-clean-room-research
+description: Research unknown PS5 ABI or API behavior, AGC or RDNA packets and instructions, public kernel or FreeBSD behavior, ELF relocations, calling conventions, and licensed public emulator comparisons. Do not use for routine source navigation or to obtain restricted material.
+---
+
+<!-- Copyright (C) 2026 SharpEmu Emulator Project -->
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+
+# SharpEmu clean-room research
+
+## Inputs
+
+Require one precise, falsifiable research question and the guest-visible behavior it affects.
+
+## Workflow
+
+1. Search the checked-out SharpEmu source and tests first.
+2. Search official public specifications and source next, then AMD, Khronos, FreeBSD, System V ABI, and language/runtime references.
+3. Use reproducible clean-room observations after specifications. Consult maintained open-source emulator implementations only after license review; use community wikis only as leads.
+4. Exclude keys, leaked SDKs, proprietary modules, exploit repositories, unauthorized dumps, and access-control bypasses. Stop if the question requires them.
+5. Corroborate material claims. Distinguish `specification`, `public implementation`, `community inference`, and `original observation`.
+6. Append one JSON object per source to `.local/research/research.jsonl` with `question`, `url`, `title`, `accessDate`, `claim`, `sourceClass`, `confidence`, and `license` fields. Do not track the ledger.
+7. Convert evidence into the smallest generic implementation hypothesis; do not copy source or create a source dump.
+
+## Output
+
+Return the question, concise findings, corroborating sources, licenses, confidence, unresolved contradictions, guest-visible hypothesis, and proposed narrow test. Cite public URLs and clearly label inference.

--- a/.agents/skills/sharpemu-code-navigation/SKILL.md
+++ b/.agents/skills/sharpemu-code-navigation/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: sharpemu-code-navigation
+description: Locate SharpEmu implementations, symbols, subsystem ownership, long-file regions, and relevant tests with the tracked-file Roslyn source index. Use for code-flow or ownership questions. Do not use for runtime failure diagnosis, visual comparison, research, or performance measurement.
+---
+
+<!-- Copyright (C) 2026 SharpEmu Emulator Project -->
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+
+# SharpEmu code navigation
+
+## Inputs
+
+Accept a symbol, namespace, subsystem, tracked path, behavior, or test target. Ask for one only when none can be inferred.
+
+## Workflow
+
+1. Run `.\scripts\agent-harness.ps1 index status`. Run `index build` when missing or stale.
+2. Begin with at most 20 results. Query a symbol with `index query --symbol <name> --limit 20`; filter with `--namespace` or `--kind` when useful.
+3. Use `index outline --symbol <name>` or `index outline --path <tracked-path>` before reading a long file.
+4. Use `index map --project <name>` for declared `ProjectReference` ownership. Label this relationship as MSBuild syntax, not a runtime call edge.
+5. Use `index text --pattern <text> --limit 20`, then `rg`, only when syntax queries cannot answer the question. Label text occurrences as heuristic.
+6. Read only the line ranges that contain the declaration, callers, state, and nearest tests. Expand when evidence requires it.
+7. Verify conclusions against the checked-out source; do not infer semantics from a name alone.
+
+## Output
+
+Return the relative path, project, namespace, symbol, exact line range, relationship type (`syntax`, `declared project reference`, or `heuristic text`), nearest tests, and any uncertainty. Never dump a whole long source file.

--- a/.agents/skills/sharpemu-performance-investigation/SKILL.md
+++ b/.agents/skills/sharpemu-performance-investigation/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: sharpemu-performance-investigation
+description: Measure and diagnose SharpEmu frame-rate, startup-time, allocation, CPU-emulation, shader-translation, Vulkan synchronization, or presentation regressions. Do not use before correctness is established or for unmeasured optimization requests.
+---
+
+<!-- Copyright (C) 2026 SharpEmu Emulator Project -->
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+
+# SharpEmu performance investigation
+
+## Inputs
+
+Require a correctness-preserving local profile, a measurable symptom, and a baseline commit or run set.
+
+## Workflow
+
+1. Validate correctness and capture a baseline before optimizing.
+2. Record commit, build configuration, profile, hardware fingerprint, GPU, driver, command, and relevant environment from run artifacts.
+3. Separate compilation, startup, CPU emulation, allocation, shader translation, GPU work, synchronization, and presentation. Choose the smallest measurable boundary.
+4. Warm up where applicable and collect multiple equivalent runs. Use wall time, process CPU time, peak memory, milestone times, and frame times only when actually available.
+5. Compare matching builds, profiles, capture policy, and hardware. Report median, range, and run IDs; do not select a lucky run.
+6. Use installed vendor tools only when they fit the measured boundary. Record their versions and collection settings.
+7. Change code only after identifying a bottleneck. Preserve guest-visible behavior and keep disabled instrumentation off hot paths.
+8. Repeat the same measurements and run correctness tests after the change. Separate observation from causal conclusion.
+
+## Output
+
+Return baseline and after run sets, configuration/fingerprint, raw measurements, median and spread, isolated cost center, hypothesis, correctness evidence, limitations, and confidence. Do not claim improvement from a single run.

--- a/.agents/skills/sharpemu-visual-regression/SKILL.md
+++ b/.agents/skills/sharpemu-visual-regression/SKILL.md
@@ -20,7 +20,8 @@ Accept one run ID for diagnosis or before/after run IDs for comparison. Require 
 4. For two runs, run `visual compare --before <before-id> --after <after-id>`. Reject silent baseline replacement and report incompatible source or resolution.
 5. Compare luminance, near-black/white percentages, alpha anomalies, difference hash, changed-pixel ratio, and normalized difference. Metrics are evidence, not a correctness oracle.
 6. Correlate pixels with `events.jsonl`, logs, command/profile, build fingerprint, shader output, and applicable specifications.
-7. Keep screenshots, raw frames, and contact sheets under `.local/`; never add target-game images to Git.
+7. Treat `first-host-frame`, splash, and key-art presentation only as host-path evidence; require separate direct guest submission/render evidence for guest-graphics progress.
+8. Keep screenshots, raw frames, and contact sheets under `.local/`; never add target-game images to Git.
 
 ## Output
 

--- a/.agents/skills/sharpemu-visual-regression/SKILL.md
+++ b/.agents/skills/sharpemu-visual-regression/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: sharpemu-visual-regression
+description: Investigate black, blank, frozen, corrupt, missing, or incorrectly colored SharpEmu output and compare two emulator runs, including shader, layout, depth, synchronization, and presentation symptoms. Do not use when no visual claim or run evidence is involved.
+---
+
+<!-- Copyright (C) 2026 SharpEmu Emulator Project -->
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+
+# SharpEmu visual regression
+
+## Inputs
+
+Accept one run ID for diagnosis or before/after run IDs for comparison. Require compatible capture source and resolution before making a direct pixel claim.
+
+## Workflow
+
+1. Prefer emulator-native final-swapchain capture. Treat `window-fallback` as nondeterministic and verify it belongs to the emulator process.
+2. Run `visual analyze --run <run-id>` and inspect `visual.json`, every relevant PNG, and `contact-sheet.png` visually.
+3. Classify exactly one state: no frame produced; capture failed; blank frame; frozen sequence; changing but visibly incorrect output; or apparently meaningful output.
+4. For two runs, run `visual compare --before <before-id> --after <after-id>`. Reject silent baseline replacement and report incompatible source or resolution.
+5. Compare luminance, near-black/white percentages, alpha anomalies, difference hash, changed-pixel ratio, and normalized difference. Metrics are evidence, not a correctness oracle.
+6. Correlate pixels with `events.jsonl`, logs, command/profile, build fingerprint, shader output, and applicable specifications.
+7. Keep screenshots, raw frames, and contact sheets under `.local/`; never add target-game images to Git.
+
+## Output
+
+Return capture source, frame count, inspected image paths, visible observations, classification, metric deltas, relevant events/logs, comparability limits, and confidence. Never accept a baseline automatically or call different pixels an improvement by themselves.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+<!-- Copyright (C) 2026 SharpEmu Emulator Project -->
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+
+# SharpEmu agent guide
+
+## Mission
+
+Demon's Souls 01.004.000 is the priority compatibility target. Implement generic, accurate emulator behavior: model what a guest can observe instead of adding title-specific success paths. A visual change is evidence, not proof of correctness. Never fabricate “more progress” by suppressing errors, returning invented success, or bypassing required state.
+
+## Read first
+
+Read in this order for every task:
+
+1. `AGENTS.md`
+2. `ARCHITECTURE.md`
+3. `README.md`
+4. `CONTRIBUTING.md`
+5. the nearest relevant source and tests
+
+The checked-out source is authoritative. Keep private game files, keys, captures, logs, dumps, and research notes outside tracked files; generated harness material belongs under `.local/`.
+
+## First five minutes
+
+1. Run `git status --short --branch`; preserve unrelated work.
+2. Run `.\scripts\agent-harness.ps1 doctor`.
+3. Run `.\scripts\agent-harness.ps1 index status`; run `index build` when refresh is recommended.
+4. Name the exact current milestone and evidence that proves it.
+5. For runtime work, validate the local profile and collect an unchanged before-run.
+6. State one falsifiable hypothesis before changing production code.
+
+## Navigate with bounded context
+
+Use the Roslyn index before reading a long file:
+
+```powershell
+.\scripts\agent-harness.ps1 index query --symbol VideoOut --limit 20
+.\scripts\agent-harness.ps1 index outline --symbol VulkanVideoPresenter --limit 20
+.\scripts\agent-harness.ps1 index outline --path src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs --limit 20
+.\scripts\agent-harness.ps1 index map --project SharpEmu.Core
+.\scripts\agent-harness.ps1 index text --pattern DispatchEntry --limit 20
+```
+
+Use `rg` second, then read precise line ranges. Do not dump a long file merely to find a symbol or repeatedly reread files already indexed. Treat declarations and `ProjectReference` edges as syntax evidence; treat text occurrences as heuristics, not proven call edges. Review changes with `git diff` plus symbol-level context, expanding only when evidence requires it.
+
+## Research hierarchy
+
+Prefer sources in this order:
+
+1. checked-out SharpEmu source and tests;
+2. official public specifications and source;
+3. AMD, Khronos, FreeBSD, System V ABI, and language/runtime references;
+4. reproducible clean-room observations;
+5. maintained open-source emulator implementations after license review;
+6. community wikis as secondary leads only.
+
+Do not use keys, leaked SDK material, proprietary modules, exploit repositories, unauthorized dumps, or access-control bypasses. Record public research evidence under `.local/research/`, with claim, source class, URL, access date, confidence, and license.
+
+## Development discipline
+
+- Change one hypothesis or tightly related problem at a time.
+- Model real guest-visible inputs, outputs, errors, state, ordering, and side effects.
+- Replace uncertainty with a failing test or explicit diagnostic, never a fake handle, zero, success return, or silent fallback.
+- Avoid speculative export batches and title-specific magic values in core emulation.
+- Add tests at the narrowest useful layer and preserve unrelated behavior.
+- Keep production fast paths unchanged when optional instrumentation is disabled.
+- Understand and review every generated line. Follow repository formatting and REUSE/SPDX rules.
+- Never weaken a validation path just to reach a later boot milestone.
+
+Runtime fixes require before/after run IDs, exact commit SHAs, exact command and profile, relevant logs and structured events, earliest changed milestone, graphics screenshot or explicit no-frame evidence, tests, known limitations, and an explanation of why the implementation is generic.
+
+## Visual evidence
+
+Use emulator-native final-swapchain raw capture first. Window client-area capture is a labelled, nondeterministic fallback and is not a stable pixel baseline. Inspect every material image, not only its hash or metrics. Never replace a baseline merely to pass comparison, and never equate changed pixels with improvement. Correlate pixels with logs, structured events, shader output, command/profile, build fingerprint, and specifications. Keep all target-game images local-only.
+
+Distinguish no frame produced, capture failure, blank frame, frozen sequence, changing but visibly incorrect output, and apparently meaningful output. Use:
+
+```powershell
+.\scripts\agent-harness.ps1 visual analyze --run <run-id>
+.\scripts\agent-harness.ps1 visual compare --before <before-id> --after <after-id>
+```
+
+## Performance evidence
+
+Correctness comes first. Compare matching commits, build configurations, profiles, capture policies, and hardware fingerprints. Warm up when appropriate; measure multiple runs and report median plus spread instead of one favorable result. Separate compilation, startup, CPU emulation, allocation, shader translation, GPU work, synchronization, and presentation. Do not claim an optimization without measurements and unchanged correctness evidence.
+
+## Validation matrix
+
+Run the narrow row while iterating and the final row before completion.
+
+| Change | Required commands |
+|---|---|
+| Documentation or skills only | `git diff --check`; `.\scripts\agent-harness.ps1 skills validate` |
+| Harness or source index | `dotnet test tests/SharpEmu.Tools.AgentHarness.Tests/SharpEmu.Tools.AgentHarness.Tests.csproj`; `.\scripts\agent-harness.ps1 doctor`; `.\scripts\agent-harness.ps1 index build`; `.\scripts\agent-harness.ps1 synthetic visual` |
+| Loader, Core, HLE, or libraries | `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj` |
+| Shader compiler | `dotnet test tests/SharpEmu.ShaderCompiler.Tests/SharpEmu.ShaderCompiler.Tests.csproj`; `dotnet test tests/SharpEmu.ShaderCompiler.Metal.Tests/SharpEmu.ShaderCompiler.Metal.Tests.csproj` |
+| AGC, GPU, or VideoOut | `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj --filter "FullyQualifiedName~Gpu|FullyQualifiedName~VideoOut|FullyQualifiedName~Agc"`; run and inspect the relevant local profile when the path is exercised |
+| GUI or CLI | `dotnet build SharpEmu.slnx -c Debug`; exercise the changed command or UI path |
+| Performance | `dotnet build SharpEmu.slnx -c Release`; collect repeated equivalent harness runs and their `.local/runs/*/metrics.json` |
+| Final full validation | `dotnet restore SharpEmu.slnx`; `dotnet build SharpEmu.slnx -c Debug --no-restore`; `dotnet build SharpEmu.slnx -c Release --no-restore`; `dotnet test SharpEmu.slnx -c Debug --no-build --no-restore`; `reuse lint`; `git diff --check` |
+
+Local target execution is always bounded:
+
+```powershell
+.\scripts\agent-harness.ps1 profile validate --profile .local\profiles\demons-souls-01.004.000.json
+.\scripts\agent-harness.ps1 run --profile .local\profiles\demons-souls-01.004.000.json
+```
+
+Do not commit `.local/` output or private paths copied from it.
+
+## Completion gate
+
+Do not claim completion until targeted and required full tests pass, required builds pass, generated artifacts and material images are inspected, `git diff` is reviewed, private-data scanning is clean, and the final report names its evidence and limitations. A blocked game input does not justify weakening repository, harness, or synthetic validation.
+
+## Review for emulator-specific hazards
+
+- Replace fabricated emulator behavior with guest-visible state machines, documented errors, and narrow tests.
+- Pair every state transition with tests for ordering, repeat calls, teardown, and error paths.
+- Validate guest ranges, lengths, alignment, overflow, and access before reading or writing; copy through the repository memory boundary rather than trusting a guest pointer as a host pointer.
+- Use checked arithmetic for offsets, sizes, pitches, counts, and address ranges before allocations or native calls.
+- Keep guest virtual addresses distinct from translated or allocated host addresses; make conversions explicit at `PhysicalVirtualMemory` or the owning abstraction.
+- Derive Vulkan layouts, stages, access masks, queue ownership, and resource lifetime from the producing and consuming operations; add validation-backed tests or captures.
+- Surface unsupported shader semantics with structured diagnostics; implement and validate the real translation rather than silently substituting another instruction.
+- Put generic platform behavior behind the owning subsystem and test it across inputs; keep title identifiers out of production decisions.
+- Generate synthetic fixtures at test time and keep proprietary binaries, hashes, paths, screenshots, and logs outside Git; inspect staged files before committing.
+- Guard diagnostics at the entry point and keep disabled branches allocation- and copy-free on normal hot paths; verify ordinary runs do not create harness artifacts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ Use emulator-native final-swapchain raw capture first. Window client-area captur
 
 Distinguish no frame produced, capture failure, blank frame, frozen sequence, changing but visibly incorrect output, and apparently meaningful output. Use:
 
+`first-host-frame` proves only that the host presentation/capture path produced a frame. It does not prove that the guest submitted or rendered a valid image. Claim guest-graphics progress only from separate direct guest submission/shader evidence; describe splash or key-art presentation as host presentation, never successful game rendering.
+
 ```powershell
 .\scripts\agent-harness.ps1 visual analyze --run <run-id>
 .\scripts\agent-harness.ps1 visual compare --before <before-id> --after <after-id>

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -99,7 +99,7 @@ Graphics state spans guest queues and labels, decoded commands, translated shade
 
 `src/SharpEmu.Logging` provides normal logs and runtime summaries. The CLI accepts log-file, log-level, and bounded import-trace options. `src/SharpEmu.Debugger` and `src/SharpEmu.DebugClient` implement the loopback debugger protocol; the CLI hosts the server when requested. Existing logging and debug paths remain primary diagnostics.
 
-The harness adds JSONL lifecycle events only when `--harness-config` is explicitly supplied. Events identify milestones such as metadata load, module load, guest entry, VideoOut open, graphics submission, shader translation, first presentation, exit, and host exception. They supplement logs; they do not replace the debugger or alter guest results.
+The harness adds JSONL lifecycle events only when `--harness-config` is explicitly supplied. Events identify milestones such as metadata load, module load, guest entry, VideoOut open, graphics submission, shader translation, first presentation, exit, and host exception. The first-host-frame milestone proves only the host presentation/capture path; it does not prove a valid guest submission or render. Guest-graphics progress requires separate direct evidence, and a presented splash or key art is not successful game rendering. Events supplement logs; they do not replace the debugger or alter guest results.
 
 ## 9. Tests and tools
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,146 @@
+<!-- Copyright (C) 2026 SharpEmu Emulator Project -->
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+
+# SharpEmu architecture
+
+## 1. Purpose and non-goals
+
+SharpEmu is a research-oriented PlayStation 5 emulator. The executable loads a game ELF, maps guest memory, resolves imports to high-level emulation (HLE) libraries, enters native guest code, interprets platform graphics work, translates shaders, and presents through a host backend. Host implementations must reproduce guest-visible contracts; this architecture does not make host APIs interchangeable with console APIs, and the agent harness is not an alternate emulator implementation.
+
+## 2. Host and guest boundary
+
+Guest addresses and host addresses meet in `src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs`. Loader mappings, CPU dispatch, HLE functions, and GPU resources use this boundary; a guest pointer is never ordinary trusted host memory. `src/SharpEmu.HLE/` supplies host-side facilities used by HLE libraries, while `src/SharpEmu.Libs/` exposes console-facing library behavior. Native handles, pointers, lengths, and lifetimes must be validated at the owning boundary.
+
+```mermaid
+flowchart LR
+    Guest["Guest ELF and native code"] --> Loader["SharpEmu.Core loader and runtime"]
+    Loader <--> Memory["PhysicalVirtualMemory"]
+    Loader <--> Libraries["SharpEmu.Libs HLE exports"]
+    Libraries --> Host["SharpEmu.HLE host services"]
+    Guest --> AGC["AGC command production"]
+    AGC --> GPU["SharpEmu.Libs GPU backend"]
+    GPU --> Shaders["ShaderCompiler parse and translation"]
+    GPU --> Presenter["VulkanVideoPresenter"]
+    Presenter --> Surface["GUI child surface or CLI-owned window"]
+    Harness["AgentHarness opt-in orchestration"] -. config and artifacts .-> Loader
+    Harness -. final-frame telemetry .-> Presenter
+```
+
+## 3. Launch and boot flow
+
+`src/SharpEmu.CLI/Program.cs` is the process entry point. With no command-line game it enters the GUI path; with an eboot it parses diagnostics options, constructs the runtime, and starts emulation. `src/SharpEmu.GUI/EmulatorProcess.cs` launches the CLI as a child for GUI play, and `src/SharpEmu.GUI/GameSurfaceHost.cs` owns the host surface relationship.
+
+`src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs` coordinates boot. `src/SharpEmu.Core/Loader/SelfLoader.cs` reads and maps the eboot ELF, applies supported relocation/import information, and reads adjacent metadata. The runtime creates the memory and CPU-dispatch facilities, registers the main module, loads adjacent modules, runs module initializers, and calls `CpuDispatcher.DispatchEntry` to enter native guest execution.
+
+Imports are registered and resolved by `src/SharpEmu.HLE/ModuleManager.cs` and its source-generated export registry. Kernel-like library contracts live in the appropriate `src/SharpEmu.Libs/` subsystem, supported by the host primitives in `src/SharpEmu.HLE/`; they do not belong in the CLI or harness.
+
+```mermaid
+sequenceDiagram
+    participant UI as GUI or CLI
+    participant RT as SharpEmuRuntime
+    participant SL as SelfLoader
+    participant MEM as PhysicalVirtualMemory
+    participant MM as ModuleManager
+    participant CPU as CpuDispatcher
+    participant GPU as Guest GPU backend
+    participant VP as VulkanVideoPresenter
+    UI->>RT: Run eboot and options
+    RT->>SL: Load executable and metadata
+    SL->>MEM: Reserve, map, and populate segments
+    RT->>MM: Register main and adjacent modules
+    MM-->>SL: Resolve registered imports
+    RT->>CPU: DispatchEntry(entry, arguments)
+    CPU->>MM: Invoke HLE exports as imported
+    CPU->>GPU: Submit interpreted graphics work
+    GPU->>VP: Render and compose final image
+    VP->>VP: Transition, optional capture, present
+    VP-->>UI: Display through owned host surface
+```
+
+## 4. Graphics and presentation flow
+
+AGC-facing exports and command handling are under `src/SharpEmu.Libs/Agc/` and `src/SharpEmu.Libs/Gpu/`. `VulkanGuestGpuBackend` owns the Vulkan guest-GPU execution path and delegates presentation to `src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs`. VideoOut exports and display-buffer lifecycle live under `src/SharpEmu.Libs/VideoOut/`.
+
+Shader parsing and platform-independent translation live in `src/SharpEmu.ShaderCompiler/`. `src/SharpEmu.ShaderCompiler.Vulkan/` emits the Vulkan/SPIR-V host representation; `src/SharpEmu.ShaderCompiler.Metal/` owns the Metal path. Shader semantics and host Vulkan submission are distinct responsibilities.
+
+The presenter records swapchain transitions and final rendering, applies overlay work, and submits presentation. Opt-in harness capture attaches immediately before presentation, copying the final swapchain image through an existing host-visible staging buffer with explicit image barriers. When disabled, it adds no capture copy, wait, mapping, or file output.
+
+## 5. Project and module map
+
+| Project | Ownership |
+|---|---|
+| `src/SharpEmu.CLI` | Process entry, command-line mode, GUI selection, top-level diagnostics and mitigation setup |
+| `src/SharpEmu.GUI` | Desktop UI, child emulator process, and game surface hosting |
+| `src/SharpEmu.Core` | Runtime lifecycle, ELF/self loading, guest memory, CPU dispatch, module representation |
+| `src/SharpEmu.Libs` | Guest-facing HLE libraries, import registry, AGC/GPU/VideoOut, audio, input, and platform services |
+| `src/SharpEmu.HLE` | Reusable host-side service implementations and OS abstractions used by HLE libraries |
+| `src/SharpEmu.ShaderCompiler` | Shader decoding, intermediate semantics, validation, and common translation |
+| `src/SharpEmu.ShaderCompiler.Vulkan` | Vulkan/SPIR-V shader emission |
+| `src/SharpEmu.ShaderCompiler.Metal` | Metal shader emission |
+| `src/SharpEmu.Logging` | Logging, build provenance, summaries, and opt-in structured harness telemetry |
+| `src/SharpEmu.Debugger` / `SharpEmu.DebugClient` | Debug protocol server-side integration and client model |
+| `src/SharpEmu.SourceGenerators` | Compile-time export and catalog generation/analyzers |
+| `tools/SharpEmu.Tools.AgentHarness` | Local orchestration, index, bounded runs, visual analysis, and private-input validation |
+| `tools/SharpEmu.Tools.ShaderDump` / `GpuConformance` | Focused shader and GPU investigation utilities |
+
+## 6. Dependency and ownership boundaries
+
+The CLI and GUI compose the emulator; guest semantics remain in Core, Libs, HLE, and shader projects. Core owns loading, memory, and execution lifecycle. Libs owns named guest APIs and routes host work through HLE abstractions. Source generators create registry glue but do not define runtime policy. Shader backends depend on the common shader model, while VideoOut/GPU owns host device and presentation coordination.
+
+Move behavior to the project that owns the guest-visible contract. Avoid dependencies from production projects onto test or tool projects. The agent harness may launch and observe production code, but production code depends only on the small telemetry facility in `SharpEmu.Logging`, never on the harness executable.
+
+## 7. Runtime state and lifecycle
+
+The runtime lifetime begins with memory, loader, dispatcher, module registry, and configured HLE services. Module registration precedes import resolution and initializer execution; guest entry follows those steps. Teardown must stop guest activity before releasing libraries, GPU work, presenter resources, and memory. Repeated open/close and shutdown paths are state transitions, not interchangeable success returns.
+
+Graphics state spans guest queues and labels, decoded commands, translated shaders, host buffers/images, synchronization objects, swapchain images, and presentation slots. Resource lifetime and synchronization must follow the actual producer/consumer chain.
+
+## 8. Observability and debugger path
+
+`src/SharpEmu.Logging` provides normal logs and runtime summaries. The CLI accepts log-file, log-level, and bounded import-trace options. `src/SharpEmu.Debugger` and `src/SharpEmu.DebugClient` implement the loopback debugger protocol; the CLI hosts the server when requested. Existing logging and debug paths remain primary diagnostics.
+
+The harness adds JSONL lifecycle events only when `--harness-config` is explicitly supplied. Events identify milestones such as metadata load, module load, guest entry, VideoOut open, graphics submission, shader translation, first presentation, exit, and host exception. They supplement logs; they do not replace the debugger or alter guest results.
+
+## 9. Tests and tools
+
+`tests/SharpEmu.Libs.Tests` covers Core-adjacent, HLE, library, CPU, GPU, and VideoOut behavior. Shader tests are split across `SharpEmu.ShaderCompiler.Tests` and `SharpEmu.ShaderCompiler.Metal.Tests`; generator tests live in `SharpEmu.SourceGenerators.Tests`. `tests/SharpEmu.Tools.AgentHarness.Tests` covers Roslyn indexing, tracked-file/incremental behavior, process-tree cleanup, raw pixel normalization, PNGs, metrics, comparison, and archive-path safety.
+
+Use `scripts/agent-harness.ps1` as the stable local entry point. Generated indexes and runs are under `.local/index/<commit>/` and `.local/runs/<run-id>/` and are not source assets.
+
+## 10. Agent-harness boundary
+
+The harness validates local profiles, launches the existing CLI in a Windows Job Object, applies a hard timeout, captures its existing stdout/stderr/logging, writes structured artifacts, and analyzes opt-in frames. Its game-input command validates and stages legally supplied local archives outside Git. It must neither understand game code nor implement guest APIs.
+
+Production attachments are narrow: CLI configuration, lifecycle event calls in the existing runtime/library paths, and a guarded final-swapchain copy. Ordinary launches without `--harness-config` do not create events or frame artifacts.
+
+## 11. Architectural invariants
+
+- Guest pointers are untrusted guest addresses, not ordinary host pointers.
+- Host services model guest-visible behavior, including errors, ordering, and side effects.
+- Loader, HLE, shader translation, GPU execution, and presentation have separate ownership.
+- Shader translation and host Vulkan execution are separate concerns.
+- Vulkan synchronization follows actual resource transitions and lifetime.
+- Instrumentation is explicit, bounded, behavior-neutral, and inert when disabled.
+- Private game data, run artifacts, captures, and research ledgers remain outside the repository.
+- The harness orchestrates the emulator and must never become an alternate implementation of emulator semantics.
+
+## 12. Where to change what
+
+| Issue | Start here | Verify with |
+|---|---|---|
+| ELF segment, relocation, metadata, adjacent module | `SharpEmu.Core/Loader/SelfLoader.cs`, `Runtime/SharpEmuRuntime.cs` | Loader/runtime events and narrow Libs tests |
+| Guest memory or address translation | `SharpEmu.Core/Memory/PhysicalVirtualMemory.cs` | Range/overflow/lifetime tests |
+| Import or guest library behavior | `SharpEmu.HLE/ModuleManager.cs`, owning Libs folder, supporting HLE host service | Export registry and owning library tests |
+| CPU entry or native dispatch | `SharpEmu.Core/Cpu/`, runtime dispatch call | CPU tests, exception/event evidence |
+| AGC command or guest GPU state | `SharpEmu.Libs/Agc/`, `SharpEmu.Libs/Gpu/` | GPU tests, validation logs, bounded capture |
+| Shader decode or semantics | `SharpEmu.ShaderCompiler` | common compiler tests and shader dump |
+| SPIR-V/Vulkan shader emission | `SharpEmu.ShaderCompiler.Vulkan` | compiler tests and external validator when installed |
+| Display buffers, swapchain, presentation | `SharpEmu.Libs/VideoOut/` | VideoOut tests, Vulkan validation, native capture |
+| GUI process or embedded surface | `SharpEmu.GUI/EmulatorProcess.cs`, `SharpEmu.GUI/GameSurfaceHost.cs` | GUI/CLI build and owned-window exercise |
+| Logs or debugger | `SharpEmu.Logging`, `SharpEmu.Debugger`, `SharpEmu.DebugClient` | log/event schema and loopback protocol tests |
+| Source navigation or run orchestration | `SharpEmu.Tools.AgentHarness`, `scripts/agent-harness.ps1` | harness tests and synthetic run |
+| Performance | owning subsystem after measurement | repeated equivalent run metrics and correctness tests |
+
+## 13. Intentional uncertainty
+
+Some guest APIs and AGC packets are intentionally incomplete, and support varies by exercised command or shader feature. A registered export does not by itself prove contract completeness; a text match does not prove a runtime call edge; successful presentation does not prove correct rendering. Where source, public specification, and reproducible observation do not establish behavior, record the uncertainty and add evidence rather than filling it with assumed console semantics.

--- a/SharpEmu.slnx
+++ b/SharpEmu.slnx
@@ -19,9 +19,13 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <Project Path="src/SharpEmu.SourceGenerators/SharpEmu.SourceGenerators.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/SharpEmu.Tools.AgentHarness.Tests/SharpEmu.Tools.AgentHarness.Tests.csproj" />
     <Project Path="tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj" />
     <Project Path="tests/SharpEmu.ShaderCompiler.Metal.Tests/SharpEmu.ShaderCompiler.Metal.Tests.csproj" />
     <Project Path="tests/SharpEmu.ShaderCompiler.Tests/SharpEmu.ShaderCompiler.Tests.csproj" />
     <Project Path="tests/SharpEmu.SourceGenerators.Tests/SharpEmu.SourceGenerators.Tests.csproj" />
+  </Folder>
+  <Folder Name="/tools/">
+    <Project Path="tools/SharpEmu.Tools.AgentHarness/SharpEmu.Tools.AgentHarness.csproj" />
   </Folder>
 </Solution>

--- a/scripts/agent-harness.ps1
+++ b/scripts/agent-harness.ps1
@@ -1,0 +1,21 @@
+# Copyright (C) 2026 SharpEmu Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $HarnessArguments
+)
+
+$ErrorActionPreference = 'Stop'
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$project = Join-Path $repositoryRoot 'tools/SharpEmu.Tools.AgentHarness/SharpEmu.Tools.AgentHarness.csproj'
+
+Push-Location $repositoryRoot
+try {
+    & dotnet run --project $project -- @HarnessArguments
+    exit $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}

--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -52,6 +52,7 @@ internal static partial class Program
         finally
         {
             DropConsoleFileMirror();
+            HarnessTelemetry.Shutdown();
             SharpEmuLog.Shutdown();
         }
     }
@@ -250,6 +251,25 @@ internal static partial class Program
             return 1;
         }
 
+        if (!TryGetHarnessConfigArgument(emulatorArgs, out var harnessConfigPath, out var harnessConfigError))
+        {
+            Console.Error.WriteLine($"[LOADER][ERROR] {harnessConfigError}");
+            return 1;
+        }
+        if (!string.IsNullOrWhiteSpace(harnessConfigPath))
+        {
+            try
+            {
+                HarnessTelemetry.Configure(harnessConfigPath);
+                HarnessTelemetry.Emit("session.started", 0, new { processId = Environment.ProcessId });
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine($"[LOADER][ERROR] Invalid harness configuration: {exception.Message}");
+                return 1;
+            }
+        }
+
         HostSessionControl.SetEmbeddedHostSurface(
             hostSurface?.WindowHandle ?? 0,
             hostSurface?.DisplayHandle ?? 0);
@@ -334,6 +354,7 @@ internal static partial class Program
             }
             catch (Exception ex)
             {
+                HarnessTelemetry.Emit("host.exception", null, new { type = ex.GetType().FullName, ex.Message });
                 Console.Error.WriteLine($"[DEBUG] Exception: {ex}");
                 Log.Error("SharpEmu failed to run.", ex);
                 return 3;
@@ -741,6 +762,42 @@ internal static partial class Program
         return false;
     }
 
+    private static bool TryGetHarnessConfigArgument(
+        IReadOnlyList<string> args,
+        out string? path,
+        out string error)
+    {
+        path = null;
+        error = string.Empty;
+        for (var index = 0; index < args.Count; index++)
+        {
+            var argument = args[index];
+            if (string.Equals(argument, "--harness-config", StringComparison.OrdinalIgnoreCase))
+            {
+                if (index + 1 >= args.Count || string.IsNullOrWhiteSpace(args[index + 1]))
+                {
+                    error = "--harness-config requires a local JSON path.";
+                    return false;
+                }
+                path = args[index + 1];
+                return true;
+            }
+
+            const string prefix = "--harness-config=";
+            if (argument.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                path = argument[prefix.Length..];
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    error = "--harness-config requires a local JSON path.";
+                    return false;
+                }
+                return true;
+            }
+        }
+        return true;
+    }
+
     private static string BuildDefaultLogFilePath(string? ebootPath)
     {
         var baseDirectory = AppContext.BaseDirectory;
@@ -1042,7 +1099,7 @@ internal static partial class Program
 
     private static void PrintUsage()
     {
-        Log.Info("Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] [--cpu-engine=<native>] [--log-level=<level>] [--log-file[=<path>]] [--debug-server[=host:port]] <path-to-eboot.bin>");
+        Log.Info("Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] [--cpu-engine=<native>] [--log-level=<level>] [--log-file[=<path>]] [--debug-server[=host:port]] [--harness-config=<local-json-path>] <path-to-eboot.bin>");
         Log.Info(@"Example: SharpEmu.CLI --cpu-engine=native --trace-imports=64 --log-level=debug --log-file ""E:\Games\...\eboot.bin""");
         Log.Info("Debug server: --debug-server starts a live debug listener (default 127.0.0.1:5714); connect with SharpEmu.DebugClient.");
     }
@@ -1119,6 +1176,23 @@ internal static partial class Program
             // rejected as an unknown option or mistaken for the eboot path.
             if (string.Equals(argument, "--debug-server", StringComparison.OrdinalIgnoreCase) ||
                 argument.StartsWith("--debug-server=", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (string.Equals(argument, "--harness-config", StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                {
+                    ebootPath = string.Empty;
+                    runtimeOptions = default;
+                    logFilePath = null;
+                    return false;
+                }
+                i++;
+                continue;
+            }
+            if (argument.StartsWith("--harness-config=", StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }

--- a/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
+++ b/src/SharpEmu.Core/Runtime/SharpEmuRuntime.cs
@@ -13,6 +13,7 @@ using SharpEmu.Libs.AppContent;
 using SharpEmu.Libs.SaveData;
 using SharpEmu.Libs.Fiber;
 using SharpEmu.Libs.SystemService;
+using SharpEmu.Logging;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
@@ -142,10 +143,24 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
         FiberExports.ResetRuntimeState();
         KernelModuleRegistry.Reset();
         var image = LoadImage(normalizedEbootPath);
+        if (HarnessTelemetry.IsEnabled)
+        {
+            HarnessTelemetry.Emit(
+                "metadata.loaded",
+                1,
+                new { image.TitleId, image.Version, image.Title });
+        }
         VideoOutExports.ConfigureApplicationInfo(image.Title, image.TitleId, image.Version);
         SaveDataExports.ConfigureApplicationInfo(image.TitleId);
         SystemServiceExports.ConfigureApplicationInfo(image.TitleId);
         _ = RegisterLoadedModule(normalizedEbootPath, image, isMain: true, isSystemModule: false);
+        if (HarnessTelemetry.IsEnabled)
+        {
+            HarnessTelemetry.Emit(
+                "main-executable.loaded",
+                3,
+                new { image.EntryPoint, mappedRegionCount = image.MappedRegions.Count });
+        }
         KernelRuntimeCompatExports.ConfigureProcessProcParamAddress(image.ProcParamAddress);
         Console.Error.WriteLine($"[RUNTIME] Entry: 0x{image.EntryPoint:X16}");
         var generation = image.ElfHeader.AbiVersion == 2 ? Generation.Gen5 : Generation.Gen4;
@@ -175,11 +190,13 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
             LastMilestoneLog = _cpuDispatcher.LastMilestoneLog;
             LastSessionSummary = BuildSessionSummary(_cpuDispatcher.LastSessionSummary);
             LastBasicBlockTrace = _cpuDispatcher.LastBasicBlockTrace;
+            if (HarnessTelemetry.IsEnabled) HarnessTelemetry.Emit("guest.exit", 4, new { result = failedInitializerResult.ToString(), during = "initializer" });
             return failedInitializerResult;
         }
 
         Console.Error.WriteLine($"[RUNTIME] Dispatching, gen: {generation}");
         Console.Error.WriteLine($"[RUNTIME] About to call DispatchEntry with entryPoint=0x{image.EntryPoint:X16}");
+        if (HarnessTelemetry.IsEnabled) HarnessTelemetry.Emit("guest.entry-started", 4, new { image.EntryPoint, generation = generation.ToString() });
 
         var result = _cpuDispatcher.DispatchEntry(
             image.EntryPoint,
@@ -191,6 +208,7 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
 
         Console.Error.WriteLine($"[RUNTIME] DispatchEntry returned: {result}");
         Console.Error.WriteLine($"[RUNTIME] Dispatch result: {result}");
+        if (HarnessTelemetry.IsEnabled) HarnessTelemetry.Emit("guest.exit", 4, new { result = result.ToString() });
 
         // Stop is a host operation, not an emulation failure. The detailed
         // trace and session-summary builders can traverse a partially torn
@@ -727,6 +745,13 @@ public sealed class SharpEmuRuntime : ISharpEmuRuntime
                     string.Equals(moduleName, "libfmodstudio.prx", StringComparison.OrdinalIgnoreCase);
                 loadedImages.Add(new LoadedModuleImage(modulePath, moduleImage, moduleHandle, startAtBoot));
                 loadedModules++;
+                if (HarnessTelemetry.IsEnabled)
+                {
+                    HarnessTelemetry.Emit(
+                        "module.loaded",
+                        5,
+                        new { module = Path.GetFileName(modulePath), moduleImage.EntryPoint, importCount = moduleImage.ImportStubs.Count });
+                }
 
                 Console.Error.WriteLine(
                     $"[RUNTIME] Loaded module {Path.GetFileName(modulePath)}: entry=0x{moduleImage.EntryPoint:X16}, imports={moduleImage.ImportStubs.Count}, symbols={moduleImage.RuntimeSymbols.Count}");

--- a/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
+++ b/src/SharpEmu.Libs/Gpu/Vulkan/VulkanGuestGpuBackend.cs
@@ -15,6 +15,7 @@ namespace SharpEmu.Libs.Gpu.Vulkan;
 /// </summary>
 internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
 {
+    private static int _harnessShaderObserved;
     public string BackendName => "Vulkan";
 
     private static readonly IGuestCompiledShader DepthOnlyFragmentShader =
@@ -399,8 +400,14 @@ internal sealed class VulkanGuestGpuBackend : IGuestGpuBackend
     public ulong GuestStorageBufferOffsetAlignment =>
         VulkanVideoPresenter.GuestStorageBufferOffsetAlignment;
 
-    public void CountShaderCompilation() =>
+    public void CountShaderCompilation()
+    {
         VulkanVideoPresenter.CountSpirvCompilation();
+        if (SharpEmu.Logging.HarnessTelemetry.IsEnabled && Interlocked.Exchange(ref _harnessShaderObserved, 1) == 0)
+        {
+            SharpEmu.Logging.HarnessTelemetry.Emit("shader.translation-observed", 9);
+        }
+    }
 
     public (long Draws, double DrawMs, long Pipelines, long ShaderCompilations) ReadAndResetPerfCounters() =>
         VulkanVideoPresenter.ReadAndResetPerfCounters();

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -7,6 +7,7 @@ using SharpEmu.Libs.Diagnostics;
 using SharpEmu.Libs.Gpu;
 using SharpEmu.Libs.Audio;
 using SharpEmu.Libs.Kernel;
+using SharpEmu.Logging;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
@@ -81,6 +82,8 @@ public static class VideoOutExports
     private static long _frameRateWindowStart = Stopwatch.GetTimestamp();
     private static long _submittedFrameCount;
     private static int _diagnosticFlipCount;
+    private static int _harnessVideoOutOpened;
+    private static int _harnessGraphicsObserved;
     private static readonly int _holdFirstFlipMilliseconds =
         int.TryParse(Environment.GetEnvironmentVariable("SHARPEMU_HOLD_FIRST_FLIP_MS"), out var holdMs)
             ? Math.Clamp(holdMs, 0, 60_000)
@@ -98,6 +101,8 @@ public static class VideoOutExports
 
     public static void ConfigureApplicationInfo(string? title, string? titleId, string? version)
     {
+        Interlocked.Exchange(ref _harnessVideoOutOpened, 0);
+        Interlocked.Exchange(ref _harnessGraphicsObserved, 0);
         var parts = new List<string>();
         if (!string.IsNullOrWhiteSpace(title))
         {
@@ -280,6 +285,10 @@ public static class VideoOutExports
                 OpenTimestamp = openedAt,
                 LastVblankTimestamp = openedAt,
             };
+            if (HarnessTelemetry.IsEnabled && Interlocked.Exchange(ref _harnessVideoOutOpened, 1) == 0)
+            {
+                HarnessTelemetry.Emit("video-output.opened", 7, new { handle });
+            }
             return handle;
         }
     }
@@ -1245,6 +1254,13 @@ public static class VideoOutExports
         LoadProgressDiagnostics.TraceGpuWaitSnapshot(ctx.Memory);
         ReportFrameRate(presented: false);
         var diagnosticFlipNumber = Interlocked.Increment(ref _diagnosticFlipCount);
+        if (HarnessTelemetry.IsEnabled && Interlocked.Exchange(ref _harnessGraphicsObserved, 1) == 0)
+        {
+            HarnessTelemetry.Emit(
+                "graphics.submit-observed",
+                8,
+                new { handle, bufferIndex, guestImageSubmitted, guestImageAddress });
+        }
         if (_holdFirstFlipMilliseconds > 0 && diagnosticFlipNumber == _holdFlipNumber)
         {
             Console.Error.WriteLine(

--- a/src/SharpEmu.Libs/VideoOut/VulkanHarnessCapturePolicy.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanHarnessCapturePolicy.cs
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Silk.NET.Vulkan;
+
+namespace SharpEmu.Libs.VideoOut;
+
+internal readonly record struct LegacyImageBarrierContract(
+    ImageLayout OldLayout,
+    ImageLayout NewLayout,
+    PipelineStageFlags SourceStage,
+    PipelineStageFlags DestinationStage,
+    AccessFlags SourceAccess,
+    AccessFlags DestinationAccess);
+
+internal static class VulkanHarnessCapturePolicy
+{
+    public static LegacyImageBarrierContract PresentToTransfer { get; } = new(
+        ImageLayout.PresentSrcKhr,
+        ImageLayout.TransferSrcOptimal,
+        PipelineStageFlags.AllCommandsBit,
+        PipelineStageFlags.TransferBit,
+        AccessFlags.MemoryWriteBit,
+        AccessFlags.TransferReadBit);
+
+    public static LegacyImageBarrierContract TransferToPresent { get; } = new(
+        ImageLayout.TransferSrcOptimal,
+        ImageLayout.PresentSrcKhr,
+        PipelineStageFlags.TransferBit,
+        PipelineStageFlags.BottomOfPipeBit,
+        AccessFlags.TransferReadBit,
+        0);
+
+    public static bool IsCanonicalFourByteFormat(Format format) => format is
+        Format.B8G8R8A8Unorm or Format.B8G8R8A8Srgb or
+        Format.R8G8B8A8Unorm or Format.R8G8B8A8Srgb;
+
+    public static void EnsureCaptureFormat(Format format)
+    {
+        if (!IsCanonicalFourByteFormat(format))
+        {
+            throw new NotSupportedException($"Harness capture does not support swapchain format '{format}'.");
+        }
+    }
+
+    public static bool ShouldRecord(bool instrumentationEnabled, bool frameRequested) =>
+        instrumentationEnabled && frameRequested;
+}

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -14579,7 +14579,9 @@ internal static unsafe class VulkanVideoPresenter
             if (HarnessTelemetry.IsEnabled)
             {
                 var harnessFrameNumber = ++_harnessFrameNumber;
-                if (HarnessTelemetry.ShouldCaptureNativeFrame(harnessFrameNumber))
+                if (VulkanHarnessCapturePolicy.ShouldRecord(
+                        instrumentationEnabled: true,
+                        HarnessTelemetry.ShouldCaptureNativeFrame(harnessFrameNumber)))
                 {
                     RecordHarnessCapture(imageIndex, harnessFrameNumber);
                 }
@@ -17193,13 +17195,18 @@ internal static unsafe class VulkanVideoPresenter
 
         private void RecordHarnessCapture(uint imageIndex, long frameNumber)
         {
+            VulkanHarnessCapturePolicy.EnsureCaptureFormat(_swapchainFormat);
+            var acquire = VulkanHarnessCapturePolicy.PresentToTransfer;
             var toTransfer = new ImageMemoryBarrier
             {
                 SType = StructureType.ImageMemoryBarrier,
-                SrcAccessMask = AccessFlags.MemoryReadBit,
-                DstAccessMask = AccessFlags.TransferReadBit,
-                OldLayout = ImageLayout.PresentSrcKhr,
-                NewLayout = ImageLayout.TransferSrcOptimal,
+                // The image may have been written by transfer, color-attachment,
+                // or shader work earlier in this command buffer. A conservative
+                // legacy barrier covers those writers before transfer read.
+                SrcAccessMask = acquire.SourceAccess,
+                DstAccessMask = acquire.DestinationAccess,
+                OldLayout = acquire.OldLayout,
+                NewLayout = acquire.NewLayout,
                 SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
                 DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
                 Image = _swapchainImages[imageIndex],
@@ -17207,8 +17214,8 @@ internal static unsafe class VulkanVideoPresenter
             };
             _vk.CmdPipelineBarrier(
                 _commandBuffer,
-                PipelineStageFlags.BottomOfPipeBit,
-                PipelineStageFlags.TransferBit,
+                acquire.SourceStage,
+                acquire.DestinationStage,
                 0,
                 0,
                 null,
@@ -17232,13 +17239,17 @@ internal static unsafe class VulkanVideoPresenter
                 _stagingBuffer,
                 1,
                 &copyRegion);
+            var restore = VulkanHarnessCapturePolicy.TransferToPresent;
             var toPresent = new ImageMemoryBarrier
             {
                 SType = StructureType.ImageMemoryBarrier,
-                SrcAccessMask = AccessFlags.TransferReadBit,
-                DstAccessMask = AccessFlags.MemoryReadBit,
-                OldLayout = ImageLayout.TransferSrcOptimal,
-                NewLayout = ImageLayout.PresentSrcKhr,
+                SrcAccessMask = restore.SourceAccess,
+                // Presentation is external to the pipeline. In the legacy API,
+                // BOTTOM_OF_PIPE with no destination access is the equivalent
+                // of synchronization2 NONE before the signal semaphore.
+                DstAccessMask = restore.DestinationAccess,
+                OldLayout = restore.OldLayout,
+                NewLayout = restore.NewLayout,
                 SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
                 DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
                 Image = _swapchainImages[imageIndex],
@@ -17246,8 +17257,8 @@ internal static unsafe class VulkanVideoPresenter
             };
             _vk.CmdPipelineBarrier(
                 _commandBuffer,
-                PipelineStageFlags.TransferBit,
-                PipelineStageFlags.BottomOfPipeBit,
+                restore.SourceStage,
+                restore.DestinationStage,
                 0,
                 0,
                 null,

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -11,6 +11,7 @@ using Silk.NET.Input;
 using SharpEmu.Libs.Gpu;
 using SharpEmu.ShaderCompiler;
 using SharpEmu.ShaderCompiler.Vulkan;
+using SharpEmu.Logging;
 using Silk.NET.Vulkan;
 using Silk.NET.Vulkan.Extensions.KHR;
 using Silk.NET.Vulkan.Extensions.EXT;
@@ -3238,6 +3239,7 @@ internal static unsafe class VulkanVideoPresenter
         private Framebuffer[] _framebuffers = [];
         private bool[] _imageInitialized = [];
         private Format _swapchainFormat;
+        private ColorSpaceKHR _swapchainColorSpace;
         private Extent2D _extent;
         private RenderPass _renderPass;
         private PipelineLayout _pipelineLayout;
@@ -3339,6 +3341,10 @@ internal static unsafe class VulkanVideoPresenter
         private bool _tracedPresentedSwapchain;
         private bool _swapchainReadbackPending;
         private long _presentedSwapchainCount;
+        private long _harnessFrameNumber;
+        private bool _harnessCapturePending;
+        private long _harnessCaptureFrameNumber;
+        private bool _harnessFirstFrameEventEmitted;
         private static int _guestImageDumpSequence;
         private readonly System.Collections.Concurrent.ConcurrentQueue<GuestImageResource> _pendingAliasImageDumps = new();
         private bool _deviceLost;
@@ -4832,6 +4838,7 @@ internal static unsafe class VulkanVideoPresenter
 
             var surfaceFormat = ChooseSurfaceFormat(formats);
             _swapchainFormat = surfaceFormat.Format;
+            _swapchainColorSpace = surfaceFormat.ColorSpace;
             _extent = ChooseExtent(capabilities);
             Bink2MovieBridge.SetPresentationSize(_extent.Width, _extent.Height);
             var presentMode = ChoosePresentMode();
@@ -14569,6 +14576,15 @@ internal static unsafe class VulkanVideoPresenter
                 RecordOverlayBlit(imageIndex, frameSlot);
             }
 
+            if (HarnessTelemetry.IsEnabled)
+            {
+                var harnessFrameNumber = ++_harnessFrameNumber;
+                if (HarnessTelemetry.ShouldCaptureNativeFrame(harnessFrameNumber))
+                {
+                    RecordHarnessCapture(imageIndex, harnessFrameNumber);
+                }
+            }
+
             Check(_vk.EndCommandBuffer(_commandBuffer), "vkEndCommandBuffer");
 
             var imageAvailable = _frameImageAvailable[frameSlot];
@@ -14624,15 +14640,27 @@ internal static unsafe class VulkanVideoPresenter
             recreateAfterPresent |= presentResult == Result.SuboptimalKhr;
             VideoOutExports.ReportPresentedFrame();
             PerfOverlay.RecordPresent();
+            if (HarnessTelemetry.IsEnabled && !_harnessFirstFrameEventEmitted)
+            {
+                _harnessFirstFrameEventEmitted = true;
+                HarnessTelemetry.Emit(
+                    "frame.presented",
+                    10,
+                    new { width = _extent.Width, height = _extent.Height, format = _swapchainFormat.ToString() });
+            }
             if (_hostSurface is not null && !_firstHostFramePresented)
             {
                 _firstHostFramePresented = true;
                 NotifyFirstHostFramePresented(_hostSurface);
             }
-            if (_swapchainReadbackPending || !_pendingAliasImageDumps.IsEmpty)
+            if (_harnessCapturePending || _swapchainReadbackPending || !_pendingAliasImageDumps.IsEmpty)
             {
                 // Diagnostics read back GPU memory and need this frame done.
                 WaitFrameSlot(frameSlot);
+                if (_harnessCapturePending)
+                {
+                    WriteHarnessSwapchainReadback();
+                }
                 if (_swapchainReadbackPending)
                 {
                     TraceSwapchainReadback();
@@ -17156,6 +17184,100 @@ internal static unsafe class VulkanVideoPresenter
 						_tracedPresentedSwapchain = false;
 					}
                 }
+            }
+            finally
+            {
+                _vk.UnmapMemory(_device, _stagingMemory);
+            }
+        }
+
+        private void RecordHarnessCapture(uint imageIndex, long frameNumber)
+        {
+            var toTransfer = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                SrcAccessMask = AccessFlags.MemoryReadBit,
+                DstAccessMask = AccessFlags.TransferReadBit,
+                OldLayout = ImageLayout.PresentSrcKhr,
+                NewLayout = ImageLayout.TransferSrcOptimal,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = _swapchainImages[imageIndex],
+                SubresourceRange = ColorSubresourceRange(),
+            };
+            _vk.CmdPipelineBarrier(
+                _commandBuffer,
+                PipelineStageFlags.BottomOfPipeBit,
+                PipelineStageFlags.TransferBit,
+                0,
+                0,
+                null,
+                0,
+                null,
+                1,
+                &toTransfer);
+            var copyRegion = new BufferImageCopy
+            {
+                ImageSubresource = new ImageSubresourceLayers
+                {
+                    AspectMask = ImageAspectFlags.ColorBit,
+                    LayerCount = 1,
+                },
+                ImageExtent = new Extent3D(_extent.Width, _extent.Height, 1),
+            };
+            _vk.CmdCopyImageToBuffer(
+                _commandBuffer,
+                _swapchainImages[imageIndex],
+                ImageLayout.TransferSrcOptimal,
+                _stagingBuffer,
+                1,
+                &copyRegion);
+            var toPresent = new ImageMemoryBarrier
+            {
+                SType = StructureType.ImageMemoryBarrier,
+                SrcAccessMask = AccessFlags.TransferReadBit,
+                DstAccessMask = AccessFlags.MemoryReadBit,
+                OldLayout = ImageLayout.TransferSrcOptimal,
+                NewLayout = ImageLayout.PresentSrcKhr,
+                SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                Image = _swapchainImages[imageIndex],
+                SubresourceRange = ColorSubresourceRange(),
+            };
+            _vk.CmdPipelineBarrier(
+                _commandBuffer,
+                PipelineStageFlags.TransferBit,
+                PipelineStageFlags.BottomOfPipeBit,
+                0,
+                0,
+                null,
+                0,
+                null,
+                1,
+                &toPresent);
+            _harnessCapturePending = true;
+            _harnessCaptureFrameNumber = frameNumber;
+        }
+
+        private void WriteHarnessSwapchainReadback()
+        {
+            _harnessCapturePending = false;
+            var byteCount = checked((ulong)_extent.Width * _extent.Height * 4);
+            void* mapped;
+            Check(
+                _vk.MapMemory(_device, _stagingMemory, 0, byteCount, 0, &mapped),
+                "vkMapMemory(harness frame readback)");
+            try
+            {
+                HarnessTelemetry.WriteNativeFrame(
+                    new ReadOnlySpan<byte>(mapped, checked((int)byteCount)),
+                    checked((int)_extent.Width),
+                    checked((int)_extent.Height),
+                    checked((int)_extent.Width * 4),
+                    _swapchainFormat.ToString(),
+                    _harnessCaptureFrameNumber,
+                    _swapchainColorSpace.ToString(),
+                    flipVertical: false);
             }
             finally
             {

--- a/src/SharpEmu.Logging/HarnessTelemetry.cs
+++ b/src/SharpEmu.Logging/HarnessTelemetry.cs
@@ -1,0 +1,205 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace SharpEmu.Logging;
+
+/// <summary>
+/// Optional, local-only structured diagnostics for the external agent harness.
+/// The default null session makes all instrumentation calls behavior-neutral.
+/// </summary>
+public static class HarnessTelemetry
+{
+    private static Session? _session;
+
+    public static bool IsEnabled => Volatile.Read(ref _session) is not null;
+
+    public static void Configure(string configurationPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configurationPath);
+        var fullPath = Path.GetFullPath(configurationPath);
+        using var document = JsonDocument.Parse(File.ReadAllText(fullPath));
+        var root = document.RootElement;
+        var schemaVersion = root.GetProperty("schemaVersion").GetString();
+        if (!string.Equals(schemaVersion, "1.0.0", StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"Unsupported harness configuration schema '{schemaVersion}'.");
+        }
+
+        var eventsPath = Path.GetFullPath(root.GetProperty("eventsPath").GetString()
+            ?? throw new InvalidDataException("Harness eventsPath is required."));
+        var frameDirectory = Path.GetFullPath(root.GetProperty("rawFrameDirectory").GetString()
+            ?? throw new InvalidDataException("Harness rawFrameDirectory is required."));
+        var redactionRoots = root.TryGetProperty("redactionRoots", out var roots)
+            ? roots.EnumerateArray().Select(item => Path.GetFullPath(item.GetString()!)).ToArray()
+            : [];
+        var capture = root.TryGetProperty("capture", out var captureElement)
+            ? CaptureConfiguration.Parse(captureElement)
+            : new CaptureConfiguration(false, true, [], 0, 0);
+        Directory.CreateDirectory(Path.GetDirectoryName(eventsPath)!);
+        Directory.CreateDirectory(frameDirectory);
+        var session = new Session(eventsPath, frameDirectory, redactionRoots, capture);
+        var previous = Interlocked.Exchange(ref _session, session);
+        previous?.Dispose();
+    }
+
+    public static void Emit(string kind, int? milestone = null, object? data = null)
+    {
+        var session = Volatile.Read(ref _session);
+        session?.Emit(kind, milestone, data);
+    }
+
+    public static string Redact(string value)
+    {
+        var session = Volatile.Read(ref _session);
+        return session?.Redact(value) ?? value;
+    }
+
+    public static bool ShouldCaptureNativeFrame(long frameNumber)
+    {
+        var session = Volatile.Read(ref _session);
+        return session?.ShouldCapture(frameNumber) == true;
+    }
+
+    public static void WriteNativeFrame(
+        ReadOnlySpan<byte> bytes,
+        int width,
+        int height,
+        int rowPitch,
+        string format,
+        long frameNumber,
+        string? colorSpace = null,
+        bool flipVertical = false)
+    {
+        var session = Volatile.Read(ref _session);
+        session?.WriteNativeFrame(bytes, width, height, rowPitch, format, frameNumber, colorSpace, flipVertical);
+    }
+
+    public static void Shutdown()
+    {
+        var session = Interlocked.Exchange(ref _session, null);
+        session?.Dispose();
+    }
+
+    private sealed class Session : IDisposable
+    {
+        private readonly object _sync = new();
+        private readonly StreamWriter _events;
+        private readonly string _frameDirectory;
+        private readonly string[] _redactionRoots;
+        private readonly CaptureConfiguration _capture;
+        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+        private readonly HashSet<long> _requestedFrames = [];
+        private long _sequence;
+        private int _capturedFrames;
+        private bool _disposed;
+
+        public Session(string eventsPath, string frameDirectory, string[] redactionRoots, CaptureConfiguration capture)
+        {
+            _events = new StreamWriter(eventsPath, append: true) { AutoFlush = true };
+            _frameDirectory = frameDirectory;
+            _redactionRoots = redactionRoots;
+            _capture = capture;
+        }
+
+        public void Emit(string kind, int? milestone, object? data)
+        {
+            lock (_sync)
+            {
+                if (_disposed) return;
+                var entry = new
+                {
+                    schemaVersion = "1.0.0",
+                    sequence = ++_sequence,
+                    utcTimestamp = DateTimeOffset.UtcNow,
+                    monotonicMilliseconds = _stopwatch.Elapsed.TotalMilliseconds,
+                    kind,
+                    milestone,
+                    data,
+                };
+                var json = JsonSerializer.Serialize(entry);
+                foreach (var root in _redactionRoots)
+                {
+                    json = json.Replace(JsonEncodedText.Encode(root).ToString(), $"<private-root-{Array.IndexOf(_redactionRoots, root) + 1}>", StringComparison.OrdinalIgnoreCase);
+                    json = json.Replace(root, $"<private-root-{Array.IndexOf(_redactionRoots, root) + 1}>", StringComparison.OrdinalIgnoreCase);
+                }
+                _events.WriteLine(json);
+            }
+        }
+
+        public string Redact(string value)
+        {
+            for (var index = 0; index < _redactionRoots.Length; index++)
+            {
+                value = value.Replace(_redactionRoots[index], $"<private-root-{index + 1}>", StringComparison.OrdinalIgnoreCase);
+            }
+            return value;
+        }
+
+        public bool ShouldCapture(long frameNumber)
+        {
+            if (!_capture.Enabled || _capture.MaxFrames <= 0) return false;
+            lock (_sync)
+            {
+                if (_disposed || _capturedFrames >= _capture.MaxFrames || _requestedFrames.Contains(frameNumber)) return false;
+                var requested = _capture.FirstFrame && frameNumber == 1 ||
+                    _capture.FrameNumbers.Contains(frameNumber) ||
+                    _capture.Interval > 0 && frameNumber % _capture.Interval == 0;
+                if (!requested) return false;
+                _requestedFrames.Add(frameNumber);
+                _capturedFrames++;
+                return true;
+            }
+        }
+
+        public void WriteNativeFrame(ReadOnlySpan<byte> bytes, int width, int height, int rowPitch, string format, long frameNumber, string? colorSpace, bool flipVertical)
+        {
+            lock (_sync)
+            {
+                if (_disposed) return;
+                var stem = $"native-{frameNumber:D8}";
+                var rawFile = stem + ".raw";
+                File.WriteAllBytes(Path.Combine(_frameDirectory, rawFile), bytes.ToArray());
+                var descriptor = new
+                {
+                    rawFile,
+                    width,
+                    height,
+                    rowPitch,
+                    format,
+                    captureSource = "emulator-native-final-frame",
+                    frameNumber,
+                    elapsedSeconds = _stopwatch.Elapsed.TotalSeconds,
+                    utcTimestamp = DateTimeOffset.UtcNow,
+                    colorSpace,
+                    flipVertical,
+                    nearestMilestone = "first-frame-available",
+                };
+                File.WriteAllText(Path.Combine(_frameDirectory, stem + ".raw.json"), JsonSerializer.Serialize(descriptor));
+                Emit("capture.frame-written", 10, new { frameNumber, width, height, format, rawFile });
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_sync)
+            {
+                if (_disposed) return;
+                _disposed = true;
+                _events.Dispose();
+            }
+        }
+    }
+
+    private sealed record CaptureConfiguration(bool Enabled, bool FirstFrame, long[] FrameNumbers, int Interval, int MaxFrames)
+    {
+        public static CaptureConfiguration Parse(JsonElement element) => new(
+            element.TryGetProperty("enabled", out var enabled) && enabled.GetBoolean(),
+            !element.TryGetProperty("firstFrame", out var firstFrame) || firstFrame.GetBoolean(),
+            element.TryGetProperty("frameNumbers", out var numbers) ? numbers.EnumerateArray().Select(item => item.GetInt64()).ToArray() : [],
+            element.TryGetProperty("interval", out var interval) ? Math.Max(0, interval.GetInt32()) : 0,
+            element.TryGetProperty("maxFrames", out var maximum) ? Math.Clamp(maximum.GetInt32(), 0, 8) : 0);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanHarnessCapturePolicyTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanHarnessCapturePolicyTests.cs
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Libs.VideoOut;
+using Silk.NET.Vulkan;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VulkanHarnessCapturePolicyTests
+{
+    [Theory]
+    [InlineData(Format.B8G8R8A8Unorm)]
+    [InlineData(Format.B8G8R8A8Srgb)]
+    [InlineData(Format.R8G8B8A8Unorm)]
+    [InlineData(Format.R8G8B8A8Srgb)]
+    public void CanonicalFourByteFormatsAreSupported(Format format)
+    {
+        Assert.True(VulkanHarnessCapturePolicy.IsCanonicalFourByteFormat(format));
+        VulkanHarnessCapturePolicy.EnsureCaptureFormat(format);
+    }
+
+    [Fact]
+    public void UnsupportedSurfaceFormatIsRejected()
+    {
+        Assert.Throws<NotSupportedException>(() => VulkanHarnessCapturePolicy.EnsureCaptureFormat(Format.R16G16B16A16Sfloat));
+    }
+
+    [Fact]
+    public void CaptureBarrierRestoresPresentLayoutWithoutBottomOfPipeMemoryReadPairing()
+    {
+        var acquire = VulkanHarnessCapturePolicy.PresentToTransfer;
+        var restore = VulkanHarnessCapturePolicy.TransferToPresent;
+        Assert.Equal(ImageLayout.PresentSrcKhr, acquire.OldLayout);
+        Assert.Equal(ImageLayout.TransferSrcOptimal, acquire.NewLayout);
+        Assert.Equal(PipelineStageFlags.AllCommandsBit, acquire.SourceStage);
+        Assert.Equal(AccessFlags.MemoryWriteBit, acquire.SourceAccess);
+        Assert.Equal(ImageLayout.TransferSrcOptimal, restore.OldLayout);
+        Assert.Equal(ImageLayout.PresentSrcKhr, restore.NewLayout);
+        Assert.Equal(PipelineStageFlags.BottomOfPipeBit, restore.DestinationStage);
+        Assert.Equal((AccessFlags)0, restore.DestinationAccess);
+    }
+
+    [Fact]
+    public void DisabledInstrumentationRecordsNoCaptureWork()
+    {
+        Assert.False(VulkanHarnessCapturePolicy.ShouldRecord(instrumentationEnabled: false, frameRequested: true));
+        Assert.True(VulkanHarnessCapturePolicy.ShouldRecord(instrumentationEnabled: true, frameRequested: true));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/VideoOut/VulkanNativeCaptureIntegrationTests.cs
+++ b/tests/SharpEmu.Libs.Tests/VideoOut/VulkanNativeCaptureIntegrationTests.cs
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+using SharpEmu.Libs.VideoOut;
+using SharpEmu.Logging;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.VideoOut;
+
+public sealed class VulkanNativeCaptureIntegrationTests
+{
+    [Fact]
+    public async Task SyntheticFrameCapturesWithValidationWhenExplicitlyRequested()
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_RUN_VULKAN_CAPTURE_INTEGRATION"), "1", StringComparison.Ordinal)) return;
+
+        var configuredOutput = Environment.GetEnvironmentVariable("SHARPEMU_VULKAN_CAPTURE_OUTPUT");
+        var output = string.IsNullOrWhiteSpace(configuredOutput)
+            ? Path.Combine(Path.GetTempPath(), "sharpemu-vulkan-capture", Guid.NewGuid().ToString("N"))
+            : Path.GetFullPath(configuredOutput);
+        var frames = Path.Combine(output, "frames");
+        Directory.CreateDirectory(frames);
+        var eventsPath = Path.Combine(output, "events.jsonl");
+        var configPath = Path.Combine(output, "harness-config.json");
+        await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(new
+        {
+            schemaVersion = "1.0.0",
+            eventsPath,
+            rawFrameDirectory = frames,
+            redactionRoots = Array.Empty<string>(),
+            capture = new { enabled = true, firstFrame = true, frameNumbers = Array.Empty<long>(), interval = 0, maxFrames = 1 },
+        }));
+
+        var originalError = Console.Error;
+        using var error = new StringWriter();
+        Console.SetError(error);
+        try
+        {
+            Environment.SetEnvironmentVariable("SHARPEMU_VK_VALIDATION", "1");
+            HarnessTelemetry.Configure(configPath);
+            var pixels = new byte[64 * 64 * 4];
+            for (var offset = 0; offset < pixels.Length; offset += 4)
+            {
+                pixels[offset] = 0x20;
+                pixels[offset + 1] = 0x80;
+                pixels[offset + 2] = 0xE0;
+                pixels[offset + 3] = 0xFF;
+            }
+            VulkanVideoPresenter.Submit(pixels, 64, 64);
+            VulkanVideoPresenter.EnsureStarted(64, 64);
+            var deadline = DateTime.UtcNow.AddSeconds(20);
+            while (!Directory.EnumerateFiles(frames, "*.raw.json").Any() && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(100);
+            }
+            VulkanVideoPresenter.RequestClose();
+            await Task.Delay(1_000);
+            HarnessTelemetry.Shutdown();
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+
+        var log = error.ToString();
+        await File.WriteAllTextAsync(Path.Combine(output, "validation-messages.log"), log);
+        var active = log.Contains("Vulkan Validation Layers active", StringComparison.OrdinalIgnoreCase);
+        var unavailable = log.Contains("validation", StringComparison.OrdinalIgnoreCase) && log.Contains("not found", StringComparison.OrdinalIgnoreCase);
+        var messages = log.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).Where(line => line.StartsWith("[VULKAN]", StringComparison.OrdinalIgnoreCase)).Take(100).ToArray();
+        var captured = Directory.EnumerateFiles(frames, "*.raw.json").Any();
+        await File.WriteAllTextAsync(Path.Combine(output, "validation-status.json"), JsonSerializer.Serialize(new
+        {
+            validationStatus = active ? "active" : unavailable ? "unavailable" : "requested-not-confirmed",
+            captured,
+            validationMessageCount = messages.Length,
+            messages,
+        }, new JsonSerializerOptions { WriteIndented = true }));
+
+        if (unavailable) return;
+        Assert.True(active, log);
+        Assert.True(captured, log);
+        Assert.DoesNotContain(messages, message => message.StartsWith("[VULKAN][ERROR]", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/SharpEmu.Tools.AgentHarness.Tests/DoctorTests.cs
+++ b/tests/SharpEmu.Tools.AgentHarness.Tests/DoctorTests.cs
@@ -1,0 +1,137 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+
+namespace SharpEmu.Tools.AgentHarness.Tests;
+
+public sealed class DoctorTests
+{
+    [Fact]
+    public async Task MissingProfileIsNotTargetReady()
+    {
+        using var fixture = ProfileFixture.Create();
+        var (_, validation) = await ProfileLoader.LoadAndValidateAsync(fixture.Repository, "missing.json");
+        Assert.False(validation.Valid);
+        Assert.False(DoctorCommand.IsTargetReady(validation, environmentOnly: false));
+        Assert.True(DoctorCommand.IsTargetReady(validation, environmentOnly: true));
+    }
+
+    [Fact]
+    public async Task MalformedProfileIsNotTargetReady()
+    {
+        using var fixture = ProfileFixture.Create();
+        fixture.GitFixture.Write("profile.json", "{");
+        var (_, validation) = await ProfileLoader.LoadAndValidateAsync(fixture.Repository, "profile.json");
+        Assert.False(validation.Valid);
+        Assert.False(DoctorCommand.IsTargetReady(validation, environmentOnly: false));
+    }
+
+    [Fact]
+    public async Task MissingEbootIsNotTargetReady()
+    {
+        using var fixture = ProfileFixture.Create();
+        fixture.WriteProfile(ebootPath: Path.Combine(fixture.GitFixture.Path, "missing-eboot.bin"));
+        var (_, validation) = await ProfileLoader.LoadAndValidateAsync(fixture.Repository, "profile.json");
+        Assert.False(validation.EbootExists);
+        Assert.False(DoctorCommand.IsTargetReady(validation, environmentOnly: false));
+    }
+
+    [Fact]
+    public async Task ChangedEbootWithStaleExpectedHashIsNotTargetReady()
+    {
+        using var fixture = ProfileFixture.Create();
+        fixture.WriteProfile();
+        await File.AppendAllTextAsync(fixture.EbootPath, "changed");
+        var (_, validation) = await ProfileLoader.LoadAndValidateAsync(fixture.Repository, "profile.json");
+        Assert.Equal("mismatched", validation.HashStatus);
+        Assert.False(validation.EbootHashMatches);
+        Assert.False(DoctorCommand.IsTargetReady(validation, environmentOnly: false));
+    }
+
+    [Fact]
+    public async Task WrongTitleIdIsNotTargetReady()
+    {
+        using var fixture = ProfileFixture.Create();
+        fixture.WriteProfile(verifiedTitleId: "WRONG00000");
+        var (_, validation) = await ProfileLoader.LoadAndValidateAsync(fixture.Repository, "profile.json");
+        Assert.Contains(validation.Errors, error => error.Contains("Title ID contradicts", StringComparison.Ordinal));
+        Assert.False(DoctorCommand.IsTargetReady(validation, environmentOnly: false));
+    }
+
+    [Fact]
+    public async Task WrongVersionIsNotTargetReady()
+    {
+        using var fixture = ProfileFixture.Create();
+        fixture.WriteProfile(verifiedVersion: "99.999.999");
+        var (_, validation) = await ProfileLoader.LoadAndValidateAsync(fixture.Repository, "profile.json");
+        Assert.Contains(validation.Errors, error => error.Contains("version contradicts", StringComparison.Ordinal));
+        Assert.False(DoctorCommand.IsTargetReady(validation, environmentOnly: false));
+    }
+
+    [Fact]
+    public async Task ValidProfileAndMatchingHashAreTargetReady()
+    {
+        using var fixture = ProfileFixture.Create();
+        fixture.WriteProfile();
+        var (_, validation) = await ProfileLoader.LoadAndValidateAsync(fixture.Repository, "profile.json");
+        Assert.True(validation.Valid);
+        Assert.True(validation.EbootHashMatches);
+        Assert.Equal("matched", validation.HashStatus);
+        Assert.True(DoctorCommand.IsTargetReady(validation, environmentOnly: false));
+    }
+
+    [Fact]
+    public async Task FastModeReportsUnverifiedAndNeverMatched()
+    {
+        using var fixture = ProfileFixture.Create();
+        fixture.WriteProfile();
+        var (_, validation) = await ProfileLoader.LoadAndValidateAsync(fixture.Repository, "profile.json", verifyHash: false);
+        Assert.True(validation.Valid);
+        Assert.False(validation.EbootHashMatches);
+        Assert.Equal("not-verified", validation.HashStatus);
+        Assert.False(DoctorCommand.IsTargetReady(validation, environmentOnly: false));
+    }
+
+    private sealed class ProfileFixture : IDisposable
+    {
+        private ProfileFixture(TemporaryGitRepository gitFixture)
+        {
+            GitFixture = gitFixture;
+            Repository = GitRepository.Discover(gitFixture.Path);
+            EbootPath = Path.Combine(gitFixture.Path, "private", "eboot.bin");
+            Directory.CreateDirectory(Path.GetDirectoryName(EbootPath)!);
+            File.WriteAllBytes(EbootPath, [1, 2, 3, 4]);
+        }
+
+        public TemporaryGitRepository GitFixture { get; }
+        public GitRepository Repository { get; }
+        public string EbootPath { get; }
+
+        public static ProfileFixture Create() => new(TemporaryGitRepository.Create());
+
+        public void WriteProfile(string? ebootPath = null, string verifiedTitleId = "PPSA01341", string verifiedVersion = "01.004.000")
+        {
+            var selectedEboot = ebootPath ?? EbootPath;
+            var profile = new LocalRunProfile
+            {
+                TargetName = "Synthetic target",
+                ExpectedTitleId = "PPSA01341",
+                ExpectedVersion = "01.004.000",
+                EbootPath = selectedEboot,
+                EbootSha256 = File.Exists(selectedEboot) ? GitRepository.Sha256File(selectedEboot) : new string('0', 64),
+                Metadata = new TargetMetadata
+                {
+                    TitleIdVerified = true,
+                    VerifiedTitleId = verifiedTitleId,
+                    VersionVerified = true,
+                    VerifiedVersion = verifiedVersion,
+                    VersionStatus = "verified",
+                },
+            };
+            GitFixture.Write("profile.json", JsonSerializer.Serialize(profile, Program.JsonOptions));
+        }
+
+        public void Dispose() => GitFixture.Dispose();
+    }
+}

--- a/tests/SharpEmu.Tools.AgentHarness.Tests/GlobalUsings.cs
+++ b/tests/SharpEmu.Tools.AgentHarness.Tests/GlobalUsings.cs
@@ -1,0 +1,5 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+global using SharpEmu.Tools.AgentHarness;
+global using Xunit;

--- a/tests/SharpEmu.Tools.AgentHarness.Tests/SafetyTests.cs
+++ b/tests/SharpEmu.Tools.AgentHarness.Tests/SafetyTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Diagnostics;
+using System.Text.Json;
 
 namespace SharpEmu.Tools.AgentHarness.Tests;
 
@@ -73,6 +74,7 @@ public sealed class SafetyTests
             Assert.True(result.TimedOut);
             Assert.True(result.JobObjectOwned);
             Assert.True(result.ProcessTreeCleaned);
+            Assert.Equal(0u, result.ActiveProcessCountAfterCleanup);
             Assert.Equal("windows-job-object-process-tree", result.ResourceMeasurementScope);
             Assert.True(File.Exists(pidPath));
             var childPid = int.Parse((await File.ReadAllTextAsync(pidPath)).Trim());
@@ -82,6 +84,200 @@ public sealed class SafetyTests
         finally
         {
             if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CancellationTerminatesImmediateChildAndIsNotReportedAsTimeout()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        var directory = Path.Combine(Path.GetTempPath(), "sharpemu-harness-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var pidPath = Path.Combine(directory, "child.pid");
+        try
+        {
+            var script = $"$child = Start-Process powershell.exe -PassThru -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 30'; Set-Content -LiteralPath '{pidPath.Replace("'", "''", StringComparison.Ordinal)}' -Value $child.Id; Start-Sleep -Seconds 30";
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            var result = await BoundedProcessRunner.RunAsync(
+                "powershell.exe",
+                ["-NoProfile", "-NonInteractive", "-Command", script],
+                directory,
+                new Dictionary<string, string?>(),
+                TimeSpan.FromSeconds(10),
+                Path.Combine(directory, "stdout.log"),
+                Path.Combine(directory, "stderr.log"),
+                cancellationToken: cancellation.Token);
+            Assert.True(result.Canceled);
+            Assert.False(result.TimedOut);
+            Assert.True(result.ProcessTreeCleaned);
+            Assert.Equal(0u, result.ActiveProcessCountAfterCleanup);
+            Assert.True(File.Exists(pidPath));
+            var childPid = int.Parse((await File.ReadAllTextAsync(pidPath)).Trim());
+            Assert.Throws<ArgumentException>(() => Process.GetProcessById(childPid));
+        }
+        finally
+        {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WindowsArgumentQuotingPreservesSpacesQuotesAndTrailingSlashes()
+    {
+        Assert.Equal("plain", WindowsSuspendedProcess.QuoteArgument("plain"));
+        Assert.Equal("\"two words\"", WindowsSuspendedProcess.QuoteArgument("two words"));
+        Assert.Equal("\"quoted\\\"value\"", WindowsSuspendedProcess.QuoteArgument("quoted\"value"));
+        Assert.Equal("\"C:\\path with space\\\\\"", WindowsSuspendedProcess.QuoteArgument("C:\\path with space\\"));
+    }
+
+    [Fact]
+    public async Task MalformedEventsAreCountedWithSafeLineCategories()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "sharpemu-harness-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "events.jsonl");
+        try
+        {
+            await File.WriteAllLinesAsync(path,
+            [
+                "{\"kind\":\"metadata.loaded\",\"milestone\":1}",
+                "not-json private-value",
+                "[]",
+                "{\"milestone\":2}",
+                "{\"kind\":\"bad\",\"milestone\":\"two\"}",
+            ]);
+            var evidence = await RunCommand.ReadEventsAsync(path);
+            Assert.Single(evidence.Events);
+            Assert.Equal(4, evidence.ParseErrorCount);
+            Assert.Equal(new[] { 2, 3, 4, 5 }, evidence.ParseErrors.Select(error => error.Line));
+            Assert.Equal(new[] { "invalid-json", "non-object-json", "missing-or-invalid-kind", "invalid-milestone" }, evidence.ParseErrors.Select(error => error.Category));
+            Assert.DoesNotContain(evidence.ParseErrors, error => error.Category.Contains("private-value", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RedactionUsesStandardTokensAndSanitizesFailureArtifacts()
+    {
+        using var fixture = TemporaryGitRepository.Create();
+        var repository = GitRepository.Discover(fixture.Path);
+        var privateRoot = Path.Combine(fixture.Path, "private", "games", "TARGET", "VERSION");
+        var run = Path.Combine(fixture.Path, ".local", "runs", "failed");
+        Directory.CreateDirectory(run);
+        var map = RunArtifactRedactor.CreateStandardMap(repository, [privateRoot]);
+        var originalInput = Path.Combine(privateRoot, "eboot.bin");
+        Directory.CreateDirectory(privateRoot);
+        await File.WriteAllTextAsync(originalInput, "private-input-must-not-change");
+        await File.WriteAllTextAsync(Path.Combine(run, "run.json"), JsonSerializer.Serialize(new { error = $"failed at {originalInput} under {repository.Root} and {Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}" }));
+        await RunArtifactRedactor.RedactAsync(run, map);
+        var redacted = await File.ReadAllTextAsync(Path.Combine(run, "run.json"));
+        Assert.Contains("<private-game-root>", redacted);
+        Assert.Contains("<repo>", redacted);
+        Assert.Contains("<user-home>", redacted);
+        Assert.Equal("private-input-must-not-change", await File.ReadAllTextAsync(originalInput));
+    }
+
+    [Fact]
+    public void PrivateScannerCoversTrackedPathsValuesHashesAndCredentialPatterns()
+    {
+        using var fixture = TemporaryGitRepository.Create();
+        var privateRoot = Path.GetFullPath(Path.Combine(fixture.Path, "..", "private-root"));
+        var privateHash = new string('a', 64);
+        var credential = "gh" + "p_" + new string('Z', 24);
+        fixture.Write(".local/profile.json", "{}");
+        fixture.Write("artifacts/game.zip", "synthetic");
+        fixture.Write("captures/demons-souls-new.png", "synthetic");
+        fixture.Write("config.txt", $"root={privateRoot}\nhash={privateHash}\ntoken={credential}");
+        fixture.Git("add", ".");
+        var result = PrivateDataScanner.Scan(GitRepository.Discover(fixture.Path), [privateRoot], [privateHash]);
+        Assert.False(result.Passed);
+        Assert.Equal("tracked paths plus non-binary current working-tree contents up to 5242880 bytes per Git-indexed file", result.Scope);
+        Assert.Contains(result.Findings, finding => finding.Category == "tracked-local-path");
+        Assert.Contains(result.Findings, finding => finding.Category == "prohibited-artifact-extension");
+        Assert.Contains(result.Findings, finding => finding.Category == "unapproved-tracked-image");
+        Assert.Contains(result.Findings, finding => finding.Category == "configured-private-value");
+        Assert.Contains(result.Findings, finding => finding.Category == "credential-pattern");
+        Assert.Empty(result.ExecutionFailures);
+        Assert.Equal("no-match", PrivateDataScanner.ClassifyGitGrepExitCode(1));
+        Assert.Equal("failure", PrivateDataScanner.ClassifyGitGrepExitCode(2));
+    }
+
+    [Fact]
+    public void ExtractionProvenanceAndCanonicalContainmentRejectMismatches()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "sharpemu-harness-tests", Guid.NewGuid().ToString("N"));
+        var expected = new ExtractionProvenance("1.0.0", DateTimeOffset.UtcNow, "archive-hash", 123, "7-Zip", Path.Combine(root, "7z.exe"), "24.0", root);
+        Assert.True(GameInputCommand.ProvenanceMatches(expected, expected with { CreatedUtc = expected.CreatedUtc.AddHours(1) }));
+        Assert.False(GameInputCommand.ProvenanceMatches(expected, expected with { ArchiveSha256 = "stale" }));
+        Assert.False(GameInputCommand.ProvenanceMatches(expected, expected with { ArchiveSizeBytes = 124 }));
+        Assert.False(GameInputCommand.ProvenanceMatches(expected, expected with { ExtractionUtilityVersion = "old" }));
+        Assert.True(GameInputCommand.IsCanonicalDescendant(root, Path.Combine(root, "game", "eboot.bin")));
+        Assert.False(GameInputCommand.IsCanonicalDescendant(root, Path.Combine(root, "..", "escape", "eboot.bin")));
+    }
+
+    [Fact]
+    public async Task ReuseMetadataIsReparsedFromSyntheticExtractedFiles()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "sharpemu-harness-tests", Guid.NewGuid().ToString("N"));
+        var game = Path.Combine(root, "game");
+        var eboot = Path.Combine(game, "eboot.bin");
+        Directory.CreateDirectory(Path.Combine(game, "sce_sys"));
+        try
+        {
+            await File.WriteAllBytesAsync(eboot, [1, 2, 3]);
+            await File.WriteAllTextAsync(Path.Combine(game, "sce_sys", "param.json"), "{\"titleId\":\"TARGET00001\",\"contentVersion\":\"01.000.000\"}");
+            var metadata = GameInputCommand.TryFindMetadata(eboot, root);
+            Assert.Equal("TARGET00001", metadata.TitleId);
+            Assert.Equal("01.000.000", metadata.Version);
+            Assert.True(GameInputCommand.IsCanonicalDescendant(root, metadata.SourcePath!));
+            Assert.False(GameInputCommand.HasReparsePoint(root, eboot));
+            Assert.True(GameInputCommand.HasReparsePoint(root, Path.Combine(root, "missing", "eboot.bin")));
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SyntheticArchiveUtilityIsKilledAtItsHardTimeout()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        await Assert.ThrowsAsync<TimeoutException>(() => GameInputCommand.RunUtilityAsync(
+            "powershell.exe",
+            ["-NoProfile", "-NonInteractive", "-Command", "Start-Sleep -Seconds 10"],
+            Path.GetTempPath(),
+            TimeSpan.FromMilliseconds(250)));
+    }
+
+    [Fact]
+    public async Task VulkanValidationMessagesAreCollectedWithoutOverclaimingAvailability()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllLinesAsync(path,
+            [
+                "[LOADER][INFO] Vulkan Validation Layers active (SHARPEMU_VK_VALIDATION=1).",
+                "[VULKAN][WARN] synthetic validation warning",
+            ]);
+            var evidence = await RunCommand.CollectVulkanValidationAsync(path, new Dictionary<string, string?> { ["SHARPEMU_VK_VALIDATION"] = "1" });
+            Assert.True(evidence.Requested);
+            Assert.Equal("active", evidence.Status);
+            Assert.Equal(1, evidence.MessageCount);
+            Assert.Single(evidence.Messages);
+
+            await File.WriteAllTextAsync(path, "[LOADER][WARN] validation layer not found");
+            evidence = await RunCommand.CollectVulkanValidationAsync(path, new Dictionary<string, string?> { ["SHARPEMU_VK_VALIDATION"] = "1" });
+            Assert.Equal("unavailable", evidence.Status);
+            Assert.Empty(evidence.Messages);
+        }
+        finally
+        {
+            File.Delete(path);
         }
     }
 }

--- a/tests/SharpEmu.Tools.AgentHarness.Tests/SafetyTests.cs
+++ b/tests/SharpEmu.Tools.AgentHarness.Tests/SafetyTests.cs
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+
+namespace SharpEmu.Tools.AgentHarness.Tests;
+
+public sealed class SafetyTests
+{
+    [Fact]
+    public void SkillFrontmatterRequiresExactNameAndPreciseDescription()
+    {
+        var errors = new List<string>();
+        SkillCommand.ValidateFrontmatter(
+            "example-skill",
+            "---\nname: example-skill\ndescription: Use for a precise bounded workflow, and do not use for unrelated requests.\n---\n# Example\n",
+            errors);
+        Assert.Empty(errors);
+
+        SkillCommand.ValidateFrontmatter("other-name", "---\nname: wrong\ndescription: short\n---\n", errors);
+        Assert.NotEmpty(errors);
+    }
+
+    [Fact]
+    public void RunArtifactRedactionHandlesPlainAndJsonEncodedRoots()
+    {
+        var root = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "private", "game"));
+        var jsonRoot = System.Text.Json.JsonEncodedText.Encode(root).ToString();
+        var redacted = RunArtifactRedactor.RedactText($"plain={root}\njson={jsonRoot}", [root]);
+        Assert.DoesNotContain(root, redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(jsonRoot, redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(2, redacted.Split("<private-root-1>", StringSplitOptions.None).Length - 1);
+    }
+
+    [Theory]
+    [InlineData("..\\escape.bin")]
+    [InlineData("C:\\escape.bin")]
+    [InlineData("\\\\server\\share\\escape.bin")]
+    [InlineData("safe\\stream:secret")]
+    public void ArchiveValidatorRejectsUnsafePaths(string path) => Assert.NotNull(GameInputCommand.ValidateArchivePath(path));
+
+    [Fact]
+    public void ArchiveValidatorAcceptsOrdinaryRelativePath()
+    {
+        Assert.Null(GameInputCommand.ValidateArchivePath("game\\sce_sys\\param.json"));
+        Assert.NotNull(GameInputCommand.ValidateArchivePath("game\\link", "reparse"));
+        Assert.False(GameInputCommand.HasArchiveLinkTarget("Symbolic Link = "));
+        Assert.False(GameInputCommand.HasArchiveLinkTarget("Hard Link =    "));
+        Assert.True(GameInputCommand.HasArchiveLinkTarget("Symbolic Link = ..\\target"));
+    }
+
+    [Fact]
+    public async Task TimeoutTerminatesTheWindowsProcessTree()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        var directory = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "sharpemu-harness-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var pidPath = System.IO.Path.Combine(directory, "child.pid");
+        var stdout = System.IO.Path.Combine(directory, "stdout.log");
+        var stderr = System.IO.Path.Combine(directory, "stderr.log");
+        var script = $"$child = Start-Process powershell.exe -PassThru -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 30'; Set-Content -LiteralPath '{pidPath.Replace("'", "''", StringComparison.Ordinal)}' -Value $child.Id; Start-Sleep -Seconds 30";
+        try
+        {
+            var result = await BoundedProcessRunner.RunAsync(
+                "powershell.exe",
+                ["-NoProfile", "-NonInteractive", "-Command", script],
+                directory,
+                new Dictionary<string, string?>(),
+                TimeSpan.FromSeconds(2),
+                stdout,
+                stderr);
+
+            Assert.True(result.TimedOut);
+            Assert.True(result.JobObjectOwned);
+            Assert.True(result.ProcessTreeCleaned);
+            Assert.Equal("windows-job-object-process-tree", result.ResourceMeasurementScope);
+            Assert.True(File.Exists(pidPath));
+            var childPid = int.Parse((await File.ReadAllTextAsync(pidPath)).Trim());
+            await Task.Delay(250);
+            Assert.Throws<ArgumentException>(() => Process.GetProcessById(childPid));
+        }
+        finally
+        {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/SharpEmu.Tools.AgentHarness.Tests/SharpEmu.Tools.AgentHarness.Tests.csproj
+++ b/tests/SharpEmu.Tools.AgentHarness.Tests/SharpEmu.Tools.AgentHarness.Tests.csproj
@@ -1,0 +1,24 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\SharpEmu.Tools.AgentHarness\SharpEmu.Tools.AgentHarness.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/SharpEmu.Tools.AgentHarness.Tests/SourceIndexTests.cs
+++ b/tests/SharpEmu.Tools.AgentHarness.Tests/SourceIndexTests.cs
@@ -65,11 +65,23 @@ public sealed class SourceIndexTests
         var oldHash = first.Files.Single(file => file.Path == "src/App/Tracked.cs").Sha256;
 
         repository.Write("src/App/Tracked.cs", "namespace App; public class After { public void Changed() { } }");
+        var stale = await store.GetStatusAsync();
+        Assert.False(stale.Current);
+        Assert.Empty(stale.AddedTrackedTextFiles);
+        Assert.Empty(stale.RemovedTrackedFiles);
+        Assert.Equal(["src/App/Tracked.cs"], stale.ContentModifiedTrackedFiles);
+        await Assert.ThrowsAsync<SourceIndexStaleException>(() => store.LoadCurrentAsync());
+
         var second = await store.BuildAsync();
         Assert.NotEqual(oldHash, second.Files.Single(file => file.Path == "src/App/Tracked.cs").Sha256);
         Assert.Contains(second.Symbols, symbol => symbol.Name == "Changed");
         Assert.DoesNotContain(second.Symbols, symbol => symbol.Name == "Before");
         Assert.Equal(first.Commit, second.Commit);
+        var current = await store.GetStatusAsync();
+        Assert.True(current.Current);
+        var queryable = await store.LoadCurrentAsync();
+        var changed = Assert.Single(queryable.Symbols, symbol => symbol.Name == "Changed");
+        Assert.Equal(1, changed.StartLine);
 
         var json = await File.ReadAllTextAsync(store.IndexPath);
         using var document = JsonDocument.Parse(json);

--- a/tests/SharpEmu.Tools.AgentHarness.Tests/SourceIndexTests.cs
+++ b/tests/SharpEmu.Tools.AgentHarness.Tests/SourceIndexTests.cs
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+
+namespace SharpEmu.Tools.AgentHarness.Tests;
+
+public sealed class SourceIndexTests
+{
+    [Fact]
+    public void RoslynIndexerCoversModernAndMalformedCSharp()
+    {
+        const string source = """
+            using System;
+            namespace Demo.Tools;
+
+            public partial record Root<T>(T Value)
+            {
+                public Root() : this(default!) { }
+                public T Item { get; init; }
+                public static Root<T> operator +(Root<T> left, Root<T> right) => left;
+                public TResult Convert<TResult>(Func<T, TResult> convert) => convert(Value);
+
+                private struct Nested { public int Number; }
+            }
+
+            public interface IService { void Run(); }
+            public enum Mode { First }
+            public class Broken { public void Missing(
+            """;
+
+        var result = CSharpFileIndexer.Index("src/Demo.cs", "Demo", "hash", source);
+
+        Assert.Contains("Demo.Tools", result.File.Namespaces);
+        Assert.Contains("Root", result.File.TopLevelDeclarations);
+        Assert.Contains(result.Symbols, symbol => symbol is { Name: "Root", Kind: "record", Accessibility: "public" });
+        Assert.Contains(result.Symbols, symbol => symbol is { Kind: "constructor", ContainingType: "Root" });
+        Assert.Contains(result.Symbols, symbol => symbol is { Name: "Item", Kind: "property" });
+        Assert.Contains(result.Symbols, symbol => symbol is { Kind: "operator", Name: "operator +" });
+        Assert.Contains(result.Symbols, symbol => symbol is { Name: "Convert", Kind: "method" } && symbol.Signature.Contains("TResult", StringComparison.Ordinal));
+        Assert.Contains(result.Symbols, symbol => symbol is { Name: "Nested", Kind: "struct", ContainingType: "Root" });
+        Assert.Contains(result.Symbols, symbol => symbol is { Name: "IService", Kind: "interface" });
+        Assert.Contains(result.Symbols, symbol => symbol is { Name: "Mode", Kind: "enum" });
+        Assert.Contains(result.Symbols, symbol => symbol.Name == "Broken");
+        Assert.All(result.Symbols, symbol => Assert.True(symbol.StartLine > 0 && symbol.EndLine >= symbol.StartLine));
+    }
+
+    [Fact]
+    public async Task IndexUsesTrackedFilesAndRefreshesDirtyFileByHash()
+    {
+        using var repository = TemporaryGitRepository.Create();
+        repository.Write("src/App/App.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        repository.Write("src/App/Tracked.cs", "namespace App; public class Before { }");
+        repository.Write(".gitignore", "ignored.cs\n");
+        repository.Git("add", ".");
+        repository.Git("-c", "user.name=Harness Tests", "-c", "user.email=harness@example.invalid", "commit", "-m", "fixture");
+        repository.Write("untracked.cs", "public class Untracked { }");
+        repository.Write("ignored.cs", "public class Ignored { }");
+
+        var git = GitRepository.Discover(repository.Path);
+        var store = new SourceIndexStore(git);
+        var first = await store.BuildAsync();
+        Assert.Contains(first.Files, file => file.Path == "src/App/Tracked.cs" && file.Project == "App");
+        Assert.DoesNotContain(first.Files, file => file.Path is "untracked.cs" or "ignored.cs");
+        var oldHash = first.Files.Single(file => file.Path == "src/App/Tracked.cs").Sha256;
+
+        repository.Write("src/App/Tracked.cs", "namespace App; public class After { public void Changed() { } }");
+        var second = await store.BuildAsync();
+        Assert.NotEqual(oldHash, second.Files.Single(file => file.Path == "src/App/Tracked.cs").Sha256);
+        Assert.Contains(second.Symbols, symbol => symbol.Name == "Changed");
+        Assert.DoesNotContain(second.Symbols, symbol => symbol.Name == "Before");
+        Assert.Equal(first.Commit, second.Commit);
+
+        var json = await File.ReadAllTextAsync(store.IndexPath);
+        using var document = JsonDocument.Parse(json);
+        Assert.Equal(SourceIndexStore.SchemaVersion, document.RootElement.GetProperty("schemaVersion").GetString());
+    }
+
+    [Fact]
+    public void QueryLimitsAreBounded()
+    {
+        Assert.Equal(20, new CommandArguments([]).IntValue("--limit", 20, 1, 160));
+        Assert.Equal(160, new CommandArguments(["--limit", "9999"]).IntValue("--limit", 20, 1, 160));
+        Assert.Equal(1, new CommandArguments(["--limit=0"]).IntValue("--limit", 20, 1, 160));
+    }
+}
+
+internal sealed class TemporaryGitRepository : IDisposable
+{
+    private TemporaryGitRepository(string path) => Path = path;
+
+    public string Path { get; }
+
+    public static TemporaryGitRepository Create()
+    {
+        var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "sharpemu-harness-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        var repository = new TemporaryGitRepository(path);
+        repository.Git("init", "--quiet");
+        return repository;
+    }
+
+    public void Write(string relativePath, string contents)
+    {
+        var fullPath = System.IO.Path.Combine(Path, relativePath.Replace('/', System.IO.Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, contents);
+    }
+
+    public void Git(params string[] arguments)
+    {
+        var result = ProcessUtility.RunCapture("git", ["-C", Path, .. arguments], Path);
+        Assert.True(result.ExitCode == 0, result.Stderr);
+    }
+
+    public void Dispose()
+    {
+        if (!Directory.Exists(Path)) return;
+        foreach (var file in Directory.EnumerateFiles(Path, "*", SearchOption.AllDirectories)) File.SetAttributes(file, FileAttributes.Normal);
+        Directory.Delete(Path, recursive: true);
+    }
+}

--- a/tests/SharpEmu.Tools.AgentHarness.Tests/VisualTests.cs
+++ b/tests/SharpEmu.Tools.AgentHarness.Tests/VisualTests.cs
@@ -1,0 +1,96 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Tools.AgentHarness.Tests;
+
+public sealed class VisualTests
+{
+    [Fact]
+    public void RawConversionHonorsBgraRowPitchAndVerticalOrientation()
+    {
+        byte[] raw =
+        [
+            30, 20, 10, 255, 60, 50, 40, 255, 0, 0, 0, 0,
+            90, 80, 70, 255, 120, 110, 100, 255, 0, 0, 0, 0,
+        ];
+
+        var image = RgbaImage.FromRaw(2, 2, raw, "B8G8R8A8_UNORM", rowPitch: 12, flipVertical: true);
+
+        Assert.Equal(new byte[] { 70, 80, 90, 255, 100, 110, 120, 255, 10, 20, 30, 255, 40, 50, 60, 255 }, image.Pixels);
+    }
+
+    [Fact]
+    public void PngRoundTripPreservesExactRgbaPixels()
+    {
+        var image = SyntheticCommand.Checkerboard(17, 11, 0);
+        var directory = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "sharpemu-harness-tests", Guid.NewGuid().ToString("N"));
+        var path = System.IO.Path.Combine(directory, "roundtrip.png");
+        try
+        {
+            PngCodec.Write(path, image);
+            var decoded = PngCodec.Read(path);
+            Assert.Equal(image.Width, decoded.Width);
+            Assert.Equal(image.Height, decoded.Height);
+            Assert.Equal(image.Pixels, decoded.Pixels);
+        }
+        finally
+        {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void MetricsDetectBlankFrozenAndChangedFrames()
+    {
+        var black = new RgbaImage(8, 8, Enumerable.Range(0, 64).SelectMany(_ => new byte[] { 0, 0, 0, 255 }).ToArray());
+        var checker = SyntheticCommand.Checkerboard(8, 8, 0);
+        var shifted = SyntheticCommand.Checkerboard(8, 8, 1);
+
+        Assert.True(VisualAnalyzer.Analyze(black, "hash").LikelyBlank);
+        Assert.False(VisualAnalyzer.Analyze(checker, "hash").LikelyBlank);
+        Assert.True(VisualAnalyzer.IsFrozen([checker, new RgbaImage(checker.Width, checker.Height, [.. checker.Pixels])]));
+        Assert.False(VisualAnalyzer.IsFrozen([checker, shifted]));
+        Assert.True(VisualAnalyzer.Compare(checker, shifted).ChangedPixelRatio > 0.9);
+        Assert.Equal(checker.Pixels.Length, VisualAnalyzer.AbsoluteDifference(checker, shifted).Pixels.Length);
+    }
+
+    [Fact]
+    public void ContactSheetHasDeterministicGeometry()
+    {
+        var image = SyntheticCommand.Checkerboard(32, 18, 0);
+        var sheet = ContactSheet.Create("RUN", [(image, "FRAME ONE"), (image, "FRAME TWO"), (image, "FRAME THREE"), (image, "FRAME FOUR")]);
+        Assert.Equal(960, sheet.Width);
+        Assert.Equal(474, sheet.Height);
+        Assert.All(sheet.Pixels.Where((_, index) => index % 4 == 3), alpha => Assert.Equal(255, alpha));
+    }
+
+    [Fact]
+    public async Task VisualAnalysisAssociatesRawDescriptorWithEncodedPng()
+    {
+        var directory = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "sharpemu-harness-tests", Guid.NewGuid().ToString("N"));
+        var frames = System.IO.Path.Combine(directory, "frames");
+        Directory.CreateDirectory(frames);
+        try
+        {
+            var raw = new byte[] { 1, 2, 3, 255 };
+            await File.WriteAllBytesAsync(System.IO.Path.Combine(frames, "native-00000001.raw"), raw);
+            var descriptor = new RawFrameDescriptor(
+                "native-00000001.raw", 1, 1, 4, "R8G8B8A8_UNORM", "emulator-native-final-frame", 1, 0.5,
+                DateTimeOffset.UtcNow, "sRGB", false, "first-frame-available");
+            await File.WriteAllTextAsync(
+                System.IO.Path.Combine(frames, "native-00000001.raw.json"),
+                System.Text.Json.JsonSerializer.Serialize(descriptor, Program.JsonOptions));
+
+            var report = await VisualCommand.AnalyzeRunAsync(directory);
+
+            var frame = Assert.Single(report.Frames);
+            Assert.Equal("emulator-native-final-frame", frame.CaptureSource);
+            Assert.Equal(1, frame.FrameNumber);
+            Assert.Equal("R8G8B8A8_UNORM", frame.SourcePixelFormat);
+        }
+        finally
+        {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/SharpEmu.Tools.AgentHarness.Tests/VisualTests.cs
+++ b/tests/SharpEmu.Tools.AgentHarness.Tests/VisualTests.cs
@@ -93,4 +93,192 @@ public sealed class VisualTests
             if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
         }
     }
+
+    [Fact]
+    public async Task VisualEncodingFailureDoesNotPersistPrivateExceptionDetails()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "sharpemu-harness-tests", Guid.NewGuid().ToString("N"));
+        var frames = Path.Combine(directory, "frames");
+        Directory.CreateDirectory(frames);
+        try
+        {
+            var privatePath = Path.Combine(directory, "private-input", "missing.raw");
+            var descriptor = new RawFrameDescriptor(
+                privatePath, 1, 1, 4, "R8G8B8A8_UNORM", "synthetic", 1, 0.5,
+                DateTimeOffset.UtcNow, "sRGB", false, null);
+            await File.WriteAllTextAsync(
+                Path.Combine(frames, "invalid.raw.json"),
+                System.Text.Json.JsonSerializer.Serialize(descriptor, Program.JsonOptions));
+
+            var report = await VisualCommand.AnalyzeRunAsync(directory);
+
+            Assert.Equal("capture-failed", report.CaptureStatus);
+            var warning = Assert.Single(report.Warnings);
+            Assert.DoesNotContain(privatePath, warning, StringComparison.OrdinalIgnoreCase);
+            Assert.EndsWith("Exception.", warning, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task MatchingRunsAreStrictlyComparable()
+    {
+        using var fixture = await VisualComparisonFixture.CreateAsync();
+        var (report, exitCode) = await VisualCommand.CompareRunsAsync(fixture.Before, fixture.After, requestedFrame: null, exploratory: false);
+        Assert.Equal(0, exitCode);
+        Assert.Equal("strictly-comparable", report.Classification);
+        Assert.True(report.StrictComparabilityProven);
+        Assert.NotNull(report.PixelDifference);
+    }
+
+    [Theory]
+    [InlineData("repositorySha", "different-commit")]
+    [InlineData("executableSha256", "different-executable")]
+    [InlineData("buildConfiguration", "Release")]
+    public async Task BuildIdentityDifferencesAreNotStrictlyComparable(string property, string value)
+    {
+        using var fixture = await VisualComparisonFixture.CreateAsync(afterRunOverrides: new Dictionary<string, string> { [property] = value });
+        var (report, exitCode) = await VisualCommand.CompareRunsAsync(fixture.Before, fixture.After, null, exploratory: false);
+        Assert.Equal(2, exitCode);
+        Assert.Equal("pixel-comparable-environment-unverified", report.Classification);
+        Assert.Null(report.PixelDifference);
+    }
+
+    [Fact]
+    public async Task DifferentHardwareIsNotStrictlyComparable()
+    {
+        using var fixture = await VisualComparisonFixture.CreateAsync(afterHardwareFingerprint: "hardware-b");
+        var (report, exitCode) = await VisualCommand.CompareRunsAsync(fixture.Before, fixture.After, null, exploratory: false);
+        Assert.Equal(2, exitCode);
+        Assert.Equal("pixel-comparable-environment-unverified", report.Classification);
+    }
+
+    [Fact]
+    public async Task DifferentProfileIsNotPixelComparable()
+    {
+        using var fixture = await VisualComparisonFixture.CreateAsync(afterRunOverrides: new Dictionary<string, string> { ["profile"] = "profile-b" });
+        var (report, exitCode) = await VisualCommand.CompareRunsAsync(fixture.Before, fixture.After, null, exploratory: false);
+        Assert.Equal(2, exitCode);
+        Assert.Equal("not-comparable", report.Classification);
+    }
+
+    [Fact]
+    public async Task DifferentCapturePolicyIsNotPixelComparable()
+    {
+        using var fixture = await VisualComparisonFixture.CreateAsync(afterCaptureInterval: 30);
+        var (report, exitCode) = await VisualCommand.CompareRunsAsync(fixture.Before, fixture.After, null, exploratory: false);
+        Assert.Equal(2, exitCode);
+        Assert.Equal("not-comparable", report.Classification);
+    }
+
+    [Fact]
+    public async Task MissingEnvironmentMetadataCannotBeStrict()
+    {
+        using var fixture = await VisualComparisonFixture.CreateAsync(omitAfterEnvironment: true);
+        var (report, exitCode) = await VisualCommand.CompareRunsAsync(fixture.Before, fixture.After, null, exploratory: false);
+        Assert.Equal(2, exitCode);
+        Assert.Equal("pixel-comparable-environment-unverified", report.Classification);
+        Assert.Contains(report.Fields, field => field.Name == "hardware fingerprint" && field.Status == "missing");
+    }
+
+    [Fact]
+    public async Task MismatchedFrameNumbersAreNotSilentlyCompared()
+    {
+        using var fixture = await VisualComparisonFixture.CreateAsync(afterFrame: 2);
+        var (report, exitCode) = await VisualCommand.CompareRunsAsync(fixture.Before, fixture.After, null, exploratory: true);
+        Assert.Equal(2, exitCode);
+        Assert.Equal("not-comparable", report.Classification);
+        Assert.Null(report.PixelDifference);
+    }
+
+    [Fact]
+    public async Task ExploratoryOverridePermitsPixelsWithoutCorrectnessConclusion()
+    {
+        using var fixture = await VisualComparisonFixture.CreateAsync(afterRunOverrides: new Dictionary<string, string> { ["repositorySha"] = "different-commit" });
+        var (report, exitCode) = await VisualCommand.CompareRunsAsync(fixture.Before, fixture.After, requestedFrame: 1, exploratory: true);
+        Assert.Equal(0, exitCode);
+        Assert.Equal("pixel-comparable-environment-unverified", report.Classification);
+        Assert.NotNull(report.PixelDifference);
+        Assert.Contains("do not establish", report.PixelConclusion, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class VisualComparisonFixture : IDisposable
+    {
+        private VisualComparisonFixture(string root)
+        {
+            Root = root;
+            Before = Path.Combine(root, "before");
+            After = Path.Combine(root, "after");
+        }
+
+        public string Root { get; }
+        public string Before { get; }
+        public string After { get; }
+
+        public static async Task<VisualComparisonFixture> CreateAsync(
+            IReadOnlyDictionary<string, string>? afterRunOverrides = null,
+            string afterHardwareFingerprint = "hardware-a",
+            int afterCaptureInterval = 0,
+            bool omitAfterEnvironment = false,
+            long afterFrame = 1)
+        {
+            var fixture = new VisualComparisonFixture(Path.Combine(Path.GetTempPath(), "sharpemu-harness-tests", Guid.NewGuid().ToString("N")));
+            Directory.CreateDirectory(fixture.Before);
+            Directory.CreateDirectory(fixture.After);
+            await WriteFrameAsync(fixture.Before, 1, 0);
+            await WriteFrameAsync(fixture.After, afterFrame, 1);
+            await WriteRunMetadataAsync(fixture.Before, null, "hardware-a", 0, omitEnvironment: false);
+            await WriteRunMetadataAsync(fixture.After, afterRunOverrides, afterHardwareFingerprint, afterCaptureInterval, omitAfterEnvironment);
+            return fixture;
+        }
+
+        private static async Task WriteFrameAsync(string run, long frameNumber, int shift)
+        {
+            var frames = Path.Combine(run, "frames");
+            Directory.CreateDirectory(frames);
+            var image = SyntheticCommand.Checkerboard(8, 8, shift);
+            var rawName = $"native-{frameNumber:D8}.raw";
+            await File.WriteAllBytesAsync(Path.Combine(frames, rawName), image.Pixels);
+            var descriptor = new RawFrameDescriptor(rawName, image.Width, image.Height, image.Stride, "R8G8B8A8_UNORM", "emulator-native-final-frame", frameNumber, 1.0, DateTimeOffset.UtcNow, "sRGB", false, "first-host-frame");
+            await File.WriteAllTextAsync(Path.Combine(frames, rawName + ".json"), System.Text.Json.JsonSerializer.Serialize(descriptor, Program.JsonOptions));
+        }
+
+        private static async Task WriteRunMetadataAsync(
+            string run,
+            IReadOnlyDictionary<string, string>? overrides,
+            string hardwareFingerprint,
+            int captureInterval,
+            bool omitEnvironment)
+        {
+            var values = new Dictionary<string, string>
+            {
+                ["profile"] = "profile-a",
+                ["targetId"] = "TARGET00001",
+                ["expectedVersion"] = "01.000.000",
+                ["verifiedVersion"] = "01.000.000",
+                ["buildConfiguration"] = "Debug",
+                ["repositorySha"] = "commit-a",
+                ["executableSha256"] = "executable-a",
+            };
+            if (overrides is not null) foreach (var pair in overrides) values[pair.Key] = pair.Value;
+            await File.WriteAllTextAsync(Path.Combine(run, "run.json"), System.Text.Json.JsonSerializer.Serialize(values, Program.JsonOptions));
+            await File.WriteAllTextAsync(Path.Combine(run, "harness-config.json"), System.Text.Json.JsonSerializer.Serialize(new { capture = new { enabled = true, firstFrame = true, frameNumbers = Array.Empty<long>(), interval = captureInterval, maxFrames = 8 } }, Program.JsonOptions));
+            if (!omitEnvironment)
+            {
+                await File.WriteAllTextAsync(Path.Combine(run, "environment.json"), System.Text.Json.JsonSerializer.Serialize(new
+                {
+                    hardwareFingerprint,
+                    phaseZeroHardware = new { gpus = new[] { new { model = "Synthetic GPU", driver = "1.0" } } },
+                }, Program.JsonOptions));
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Root)) Directory.Delete(Root, recursive: true);
+        }
+    }
 }

--- a/tools/SharpEmu.Tools.AgentHarness/BoundedProcessRunner.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/BoundedProcessRunner.cs
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Diagnostics;
+using System.IO.Pipes;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace SharpEmu.Tools.AgentHarness;
 
 internal sealed record BoundedProcessResult(
     int? ExitCode,
     bool TimedOut,
+    bool Canceled,
     bool Crash,
     DateTimeOffset StartUtc,
     DateTimeOffset EndUtc,
@@ -18,6 +21,7 @@ internal sealed record BoundedProcessResult(
     string ResourceMeasurementScope,
     bool JobObjectOwned,
     bool ProcessTreeCleaned,
+    uint? ActiveProcessCountAfterCleanup,
     IReadOnlyList<string> Warnings);
 
 internal static class BoundedProcessRunner
@@ -37,114 +41,400 @@ internal static class BoundedProcessRunner
         var start = DateTimeOffset.UtcNow;
         using var stdout = new StreamWriter(stdoutPath, append: false) { AutoFlush = true };
         using var stderr = new StreamWriter(stderrPath, append: false) { AutoFlush = true };
-        using var process = new Process
-        {
-            StartInfo = new ProcessStartInfo(executable)
-            {
-                WorkingDirectory = workingDirectory,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = false,
-            },
-            EnableRaisingEvents = true,
-        };
-        foreach (var argument in arguments) process.StartInfo.ArgumentList.Add(argument);
-        foreach (var pair in environment) process.StartInfo.Environment[pair.Key] = pair.Value;
-        process.OutputDataReceived += (_, eventArgs) => { if (eventArgs.Data is not null) lock (stdout) stdout.WriteLine(eventArgs.Data); };
-        process.ErrorDataReceived += (_, eventArgs) => { if (eventArgs.Data is not null) lock (stderr) stderr.WriteLine(eventArgs.Data); };
-
-        process.Start();
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-        using var job = WindowsJob.TryCreateAndAssign(process, out var jobWarning);
-        if (jobWarning is not null) warnings.Add(jobWarning);
-        var jobOwned = job is not null;
-        var stopwatch = Stopwatch.StartNew();
-        var peakWorkingSet = 0L;
-        var lastCpu = TimeSpan.Zero;
-        using var sampleCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var sampler = Task.Run(async () =>
-        {
-            while (!sampleCancellation.IsCancellationRequested && !process.HasExited)
-            {
-                try
-                {
-                    process.Refresh();
-                    peakWorkingSet = Math.Max(peakWorkingSet, process.WorkingSet64);
-                    lastCpu = process.TotalProcessorTime;
-                    if (sample is not null) await sample(process, stopwatch.Elapsed);
-                }
-                catch (InvalidOperationException)
-                {
-                    break;
-                }
-                await Task.Delay(250, sampleCancellation.Token).ConfigureAwait(false);
-            }
-        }, sampleCancellation.Token);
-
-        var timedOut = false;
+        Process? process = null;
+        WindowsSuspendedProcess? suspended = null;
+        WindowsJob? job = null;
+        Task stdoutReader = Task.CompletedTask;
+        Task stderrReader = Task.CompletedTask;
         try
         {
-            var exitTask = process.WaitForExitAsync(cancellationToken);
-            var completed = await Task.WhenAny(exitTask, Task.Delay(timeout, cancellationToken));
-            if (completed != exitTask)
+            if (OperatingSystem.IsWindows())
             {
-                timedOut = true;
-                if (process.CloseMainWindow())
+                job = WindowsJob.TryCreate(out var jobWarning)
+                    ?? throw new InvalidOperationException(jobWarning ?? "Windows Job Object creation failed before launch.");
+                suspended = WindowsSuspendedProcess.Start(executable, arguments, workingDirectory, environment);
+                process = suspended.Process;
+                if (!job.TryAssign(process, out jobWarning))
                 {
-                    await Task.WhenAny(process.WaitForExitAsync(CancellationToken.None), Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None));
+                    suspended.Terminate();
+                    throw new InvalidOperationException(jobWarning ?? "Windows Job Object assignment failed before resume.");
                 }
-                if (!process.HasExited)
-                {
-                    if (job is not null) job.Terminate();
-                    else process.Kill(entireProcessTree: true);
-                    await process.WaitForExitAsync(CancellationToken.None);
-                }
+                stdoutReader = CopyLinesAsync(suspended.StandardOutput, stdout);
+                stderrReader = CopyLinesAsync(suspended.StandardError, stderr);
+                suspended.Resume();
             }
             else
             {
-                await exitTask;
+                process = new Process
+                {
+                    StartInfo = new ProcessStartInfo(executable)
+                    {
+                        WorkingDirectory = workingDirectory,
+                        UseShellExecute = false,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        CreateNoWindow = false,
+                    },
+                    EnableRaisingEvents = true,
+                };
+                foreach (var argument in arguments) process.StartInfo.ArgumentList.Add(argument);
+                foreach (var pair in environment) process.StartInfo.Environment[pair.Key] = pair.Value;
+                process.Start();
+                stdoutReader = CopyLinesAsync(process.StandardOutput, stdout);
+                stderrReader = CopyLinesAsync(process.StandardError, stderr);
             }
+        }
+        catch
+        {
+            suspended?.Dispose();
+            process?.Dispose();
+            job?.Dispose();
+            throw;
+        }
+
+        var jobOwned = job is not null;
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var peakWorkingSet = 0L;
+            var lastCpu = TimeSpan.Zero;
+            using var sampleCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var sampler = Task.Run(async () =>
+            {
+                while (!sampleCancellation.IsCancellationRequested && !process.HasExited)
+                {
+                    try
+                    {
+                        process.Refresh();
+                        peakWorkingSet = Math.Max(peakWorkingSet, process.WorkingSet64);
+                        lastCpu = process.TotalProcessorTime;
+                        if (sample is not null) await sample(process, stopwatch.Elapsed);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        break;
+                    }
+                    await Task.Delay(250, sampleCancellation.Token).ConfigureAwait(false);
+                }
+            }, sampleCancellation.Token);
+
+            var timedOut = false;
+            var canceled = false;
+            try
+            {
+                var exitTask = process.WaitForExitAsync(CancellationToken.None);
+                var timeoutTask = Task.Delay(timeout, CancellationToken.None);
+                var cancellationTask = cancellationToken.CanBeCanceled
+                    ? Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+                    : Task.Delay(Timeout.InfiniteTimeSpan, CancellationToken.None);
+                var completed = await Task.WhenAny(exitTask, timeoutTask, cancellationTask);
+                if (completed != exitTask)
+                {
+                    canceled = completed == cancellationTask;
+                    timedOut = !canceled;
+                    if (process.CloseMainWindow())
+                    {
+                        await Task.WhenAny(process.WaitForExitAsync(CancellationToken.None), Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None));
+                    }
+                    if (!process.HasExited)
+                    {
+                        if (job is not null) job.Terminate();
+                        else process.Kill(entireProcessTree: true);
+                        await process.WaitForExitAsync(CancellationToken.None);
+                    }
+                }
+                else
+                {
+                    await exitTask;
+                }
+            }
+            finally
+            {
+                await sampleCancellation.CancelAsync();
+                try { await sampler; } catch (OperationCanceledException) { }
+                if (!process.HasExited) process.WaitForExit();
+            }
+
+            stopwatch.Stop();
+            if (job is not null && job.TryGetActiveProcessCount(out var remaining, out var cleanupWarning) && remaining != 0)
+            {
+                job.Terminate();
+                for (var attempt = 0; attempt < 40 && remaining != 0; attempt++)
+                {
+                    await Task.Delay(25, CancellationToken.None);
+                    if (!job.TryGetActiveProcessCount(out remaining, out cleanupWarning)) break;
+                }
+            }
+            var end = DateTimeOffset.UtcNow;
+            int? exitCode = null;
+            if (process.HasExited) exitCode = process.ExitCode;
+            uint? activeAfterCleanup = null;
+            var cleaned = job is null && process.HasExited;
+            var resourceScope = "root-process";
+            string? accountingWarning = null;
+            if (job is not null && job.TryReadAccounting(out var jobCpu, out var peakJobMemory, out var activeProcesses, out accountingWarning))
+            {
+                lastCpu = jobCpu;
+                peakWorkingSet = Math.Max(peakWorkingSet, peakJobMemory);
+                resourceScope = "windows-job-object-process-tree";
+                activeAfterCleanup = activeProcesses;
+                cleaned = activeProcesses == 0;
+            }
+            else if (accountingWarning is not null)
+            {
+                warnings.Add(accountingWarning);
+                cleaned = false;
+            }
+            await Task.WhenAll(stdoutReader, stderrReader);
+            var result = new BoundedProcessResult(
+                exitCode,
+                timedOut,
+                canceled,
+                !timedOut && !canceled && exitCode is not (null or 0 or 4),
+                start,
+                end,
+                stopwatch.Elapsed.TotalSeconds,
+                lastCpu.TotalSeconds,
+                peakWorkingSet,
+                resourceScope,
+                jobOwned,
+                cleaned,
+                activeAfterCleanup,
+                warnings);
+            return result;
         }
         finally
         {
-            await sampleCancellation.CancelAsync();
-            try { await sampler; } catch (OperationCanceledException) { }
-            process.WaitForExit();
+            job?.Dispose();
+            suspended?.Dispose();
+            process.Dispose();
+        }
+    }
+
+    private static async Task CopyLinesAsync(StreamReader reader, StreamWriter writer)
+    {
+        while (await reader.ReadLineAsync(CancellationToken.None) is { } line)
+        {
+            lock (writer) writer.WriteLine(line);
+        }
+    }
+}
+
+internal sealed class WindowsSuspendedProcess : IDisposable
+{
+    private const uint CreateSuspended = 0x00000004;
+    private const uint CreateUnicodeEnvironment = 0x00000400;
+    private const uint StartfUseStdHandles = 0x00000100;
+    private const uint GenericRead = 0x80000000;
+    private const uint FileShareRead = 0x00000001;
+    private const uint FileShareWrite = 0x00000002;
+    private const uint OpenExisting = 3;
+    private nint _threadHandle;
+    private readonly AnonymousPipeServerStream _stdoutPipe;
+    private readonly AnonymousPipeServerStream _stderrPipe;
+
+    private WindowsSuspendedProcess(Process process, nint threadHandle, AnonymousPipeServerStream stdoutPipe, AnonymousPipeServerStream stderrPipe)
+    {
+        Process = process;
+        _threadHandle = threadHandle;
+        _stdoutPipe = stdoutPipe;
+        _stderrPipe = stderrPipe;
+        StandardOutput = new StreamReader(stdoutPipe, Encoding.UTF8, true, 4096, leaveOpen: true);
+        StandardError = new StreamReader(stderrPipe, Encoding.UTF8, true, 4096, leaveOpen: true);
+    }
+
+    public Process Process { get; }
+
+    public StreamReader StandardOutput { get; }
+
+    public StreamReader StandardError { get; }
+
+    public static WindowsSuspendedProcess Start(
+        string executable,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string?> environment)
+    {
+        executable = ResolveExecutable(executable, workingDirectory);
+        var stdoutPipe = new AnonymousPipeServerStream(PipeDirection.In, HandleInheritability.Inheritable);
+        var stderrPipe = new AnonymousPipeServerStream(PipeDirection.In, HandleInheritability.Inheritable);
+        var security = new SecurityAttributes { Length = Marshal.SizeOf<SecurityAttributes>(), InheritHandle = true };
+        var nullInput = CreateFileW("NUL", GenericRead, FileShareRead | FileShareWrite, ref security, OpenExisting, 0, 0);
+        if (nullInput == -1)
+        {
+            stdoutPipe.Dispose();
+            stderrPipe.Dispose();
+            throw new InvalidOperationException($"Opening NUL for suspended process input failed ({Marshal.GetLastWin32Error()}).");
         }
 
-        stopwatch.Stop();
-        var end = DateTimeOffset.UtcNow;
-        int? exitCode = null;
-        if (process.HasExited) exitCode = process.ExitCode;
-        var cleaned = process.HasExited;
-        var resourceScope = "root-process";
-        string? accountingWarning = null;
-        if (job is not null && job.TryReadAccounting(out var jobCpu, out var peakJobMemory, out accountingWarning))
+        var startup = new StartupInfo
         {
-            lastCpu = jobCpu;
-            peakWorkingSet = Math.Max(peakWorkingSet, peakJobMemory);
-            resourceScope = "windows-job-object-process-tree";
-        }
-        else if (accountingWarning is not null)
+            Size = Marshal.SizeOf<StartupInfo>(),
+            Flags = StartfUseStdHandles,
+            StandardInput = nullInput,
+            StandardOutput = stdoutPipe.ClientSafePipeHandle.DangerousGetHandle(),
+            StandardError = stderrPipe.ClientSafePipeHandle.DangerousGetHandle(),
+        };
+        var commandLine = new StringBuilder(string.Join(' ', new[] { executable }.Concat(arguments).Select(QuoteArgument)));
+        var environmentBlock = CreateEnvironmentBlock(environment);
+        try
         {
-            warnings.Add(accountingWarning);
+            if (!CreateProcessW(
+                    executable,
+                    commandLine,
+                    0,
+                    0,
+                    true,
+                    CreateSuspended | CreateUnicodeEnvironment,
+                    environmentBlock,
+                    workingDirectory,
+                    ref startup,
+                    out var processInformation))
+            {
+                throw new InvalidOperationException($"Suspended process creation failed ({Marshal.GetLastWin32Error()}).");
+            }
+
+            stdoutPipe.DisposeLocalCopyOfClientHandle();
+            stderrPipe.DisposeLocalCopyOfClientHandle();
+            var process = Process.GetProcessById(checked((int)processInformation.ProcessId));
+            process.EnableRaisingEvents = true;
+            CloseHandle(processInformation.ProcessHandle);
+            return new WindowsSuspendedProcess(process, processInformation.ThreadHandle, stdoutPipe, stderrPipe);
         }
-        return new BoundedProcessResult(
-            exitCode,
-            timedOut,
-            !timedOut && exitCode is not (null or 0 or 4),
-            start,
-            end,
-            stopwatch.Elapsed.TotalSeconds,
-            lastCpu.TotalSeconds,
-            peakWorkingSet,
-            resourceScope,
-            jobOwned,
-            cleaned,
-            warnings);
+        catch
+        {
+            stdoutPipe.Dispose();
+            stderrPipe.Dispose();
+            throw;
+        }
+        finally
+        {
+            if (environmentBlock != 0) Marshal.FreeHGlobal(environmentBlock);
+            CloseHandle(nullInput);
+        }
     }
+
+    public void Resume()
+    {
+        if (_threadHandle == 0 || ResumeThread(_threadHandle) == uint.MaxValue)
+        {
+            Terminate();
+            throw new InvalidOperationException($"Resuming the contained process failed ({Marshal.GetLastWin32Error()}).");
+        }
+        CloseHandle(_threadHandle);
+        _threadHandle = 0;
+    }
+
+    public void Terminate()
+    {
+        try { if (!Process.HasExited) Process.Kill(entireProcessTree: false); } catch (InvalidOperationException) { }
+    }
+
+    public void Dispose()
+    {
+        if (_threadHandle != 0) CloseHandle(_threadHandle);
+        _threadHandle = 0;
+        StandardOutput.Dispose();
+        StandardError.Dispose();
+        _stdoutPipe.Dispose();
+        _stderrPipe.Dispose();
+    }
+
+    internal static string QuoteArgument(string value)
+    {
+        if (value.Length > 0 && value.All(character => !char.IsWhiteSpace(character) && character != '"')) return value;
+        var result = new StringBuilder("\"");
+        var backslashes = 0;
+        foreach (var character in value)
+        {
+            if (character == '\\')
+            {
+                backslashes++;
+                continue;
+            }
+            if (character == '"')
+            {
+                result.Append('\\', backslashes * 2 + 1).Append('"');
+                backslashes = 0;
+                continue;
+            }
+            result.Append('\\', backslashes).Append(character);
+            backslashes = 0;
+        }
+        result.Append('\\', backslashes * 2).Append('"');
+        return result.ToString();
+    }
+
+    private static nint CreateEnvironmentBlock(IReadOnlyDictionary<string, string?> overrides)
+    {
+        var values = Environment.GetEnvironmentVariables()
+            .Cast<System.Collections.DictionaryEntry>()
+            .ToDictionary(entry => (string)entry.Key, entry => (string?)entry.Value, StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in overrides)
+        {
+            if (pair.Value is null) values.Remove(pair.Key); else values[pair.Key] = pair.Value;
+        }
+        var block = string.Join('\0', values.OrderBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase).Select(pair => $"{pair.Key}={pair.Value}")) + "\0\0";
+        return Marshal.StringToHGlobalUni(block);
+    }
+
+    private static string ResolveExecutable(string executable, string workingDirectory)
+    {
+        if (Path.IsPathFullyQualified(executable)) return Path.GetFullPath(executable);
+        var names = Path.HasExtension(executable) ? new[] { executable } : new[] { executable, executable + ".exe" };
+        foreach (var directory in new[] { workingDirectory }.Concat((Environment.GetEnvironmentVariable("PATH") ?? string.Empty).Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)))
+        {
+            foreach (var name in names)
+            {
+                var candidate = Path.GetFullPath(name, directory.Trim('"'));
+                if (File.Exists(candidate)) return candidate;
+            }
+        }
+        throw new FileNotFoundException($"Executable '{executable}' was not found on PATH.");
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SecurityAttributes
+    {
+        public int Length;
+        public nint SecurityDescriptor;
+        [MarshalAs(UnmanagedType.Bool)] public bool InheritHandle;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct StartupInfo
+    {
+        public int Size;
+        public string? Reserved;
+        public string? Desktop;
+        public string? Title;
+        public uint X, Y, XSize, YSize, XCountChars, YCountChars, FillAttribute, Flags;
+        public ushort ShowWindow, Reserved2Size;
+        public nint Reserved2, StandardInput, StandardOutput, StandardError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ProcessInformation
+    {
+        public nint ProcessHandle;
+        public nint ThreadHandle;
+        public uint ProcessId;
+        public uint ThreadId;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CreateProcessW(string applicationName, StringBuilder commandLine, nint processAttributes, nint threadAttributes, [MarshalAs(UnmanagedType.Bool)] bool inheritHandles, uint creationFlags, nint environment, string currentDirectory, ref StartupInfo startupInfo, out ProcessInformation processInformation);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern nint CreateFileW(string fileName, uint desiredAccess, uint shareMode, ref SecurityAttributes securityAttributes, uint creationDisposition, uint flags, nint template);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint ResumeThread(nint thread);
+
+    [DllImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(nint handle);
 }
 
 internal sealed class WindowsJob : IDisposable
@@ -156,14 +446,14 @@ internal sealed class WindowsJob : IDisposable
 
     private WindowsJob(nint handle) => _handle = handle;
 
-    public static WindowsJob? TryCreateAndAssign(Process process, out string? warning)
+    public static WindowsJob? TryCreate(out string? warning)
     {
         warning = null;
         if (!OperatingSystem.IsWindows()) return null;
         var handle = CreateJobObjectW(0, null);
         if (handle == 0)
         {
-            warning = $"Windows Job Object creation failed ({Marshal.GetLastWin32Error()}); process-tree kill fallback is active.";
+            warning = $"Windows Job Object creation failed ({Marshal.GetLastWin32Error()}); launch was refused.";
             return null;
         }
         var job = new WindowsJob(handle);
@@ -176,10 +466,9 @@ internal sealed class WindowsJob : IDisposable
         try
         {
             Marshal.StructureToPtr(info, memory, false);
-            if (!SetInformationJobObject(handle, ExtendedLimitInformationClass, memory, (uint)size) ||
-                !AssignProcessToJobObject(handle, process.Handle))
+            if (!SetInformationJobObject(handle, ExtendedLimitInformationClass, memory, (uint)size))
             {
-                warning = $"Windows Job Object assignment failed ({Marshal.GetLastWin32Error()}); process-tree kill fallback is active.";
+                warning = $"Windows Job Object configuration failed ({Marshal.GetLastWin32Error()}); launch was refused.";
                 job.Dispose();
                 return null;
             }
@@ -191,15 +480,24 @@ internal sealed class WindowsJob : IDisposable
         return job;
     }
 
+    public bool TryAssign(Process process, out string? warning)
+    {
+        warning = null;
+        if (_handle != 0 && AssignProcessToJobObject(_handle, process.Handle)) return true;
+        warning = $"Windows Job Object assignment failed ({Marshal.GetLastWin32Error()}); the suspended process was terminated before guest execution.";
+        return false;
+    }
+
     public void Terminate()
     {
         if (_handle != 0) _ = TerminateJobObject(_handle, 1460);
     }
 
-    public bool TryReadAccounting(out TimeSpan cpuTime, out long peakJobMemory, out string? warning)
+    public bool TryReadAccounting(out TimeSpan cpuTime, out long peakJobMemory, out uint activeProcesses, out string? warning)
     {
         cpuTime = TimeSpan.Zero;
         peakJobMemory = 0;
+        activeProcesses = 0;
         warning = null;
         if (_handle == 0) return false;
         var accountingSize = Marshal.SizeOf<JobObjectBasicAccountingInformation>();
@@ -218,6 +516,7 @@ internal sealed class WindowsJob : IDisposable
             var limits = Marshal.PtrToStructure<JobObjectExtendedLimitInformation>(extendedMemory);
             cpuTime = TimeSpan.FromTicks(checked(accounting.TotalUserTime + accounting.TotalKernelTime));
             peakJobMemory = checked((long)limits.PeakJobMemoryUsed);
+            activeProcesses = accounting.ActiveProcesses;
             return true;
         }
         finally
@@ -225,6 +524,12 @@ internal sealed class WindowsJob : IDisposable
             Marshal.FreeHGlobal(accountingMemory);
             Marshal.FreeHGlobal(extendedMemory);
         }
+    }
+
+    public bool TryGetActiveProcessCount(out uint activeProcesses, out string? warning)
+    {
+        var result = TryReadAccounting(out _, out _, out activeProcesses, out warning);
+        return result;
     }
 
     public void Dispose()

--- a/tools/SharpEmu.Tools.AgentHarness/BoundedProcessRunner.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/BoundedProcessRunner.cs
@@ -1,0 +1,300 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal sealed record BoundedProcessResult(
+    int? ExitCode,
+    bool TimedOut,
+    bool Crash,
+    DateTimeOffset StartUtc,
+    DateTimeOffset EndUtc,
+    double ElapsedSeconds,
+    double CpuSeconds,
+    long PeakWorkingSetBytes,
+    string ResourceMeasurementScope,
+    bool JobObjectOwned,
+    bool ProcessTreeCleaned,
+    IReadOnlyList<string> Warnings);
+
+internal static class BoundedProcessRunner
+{
+    public static async Task<BoundedProcessResult> RunAsync(
+        string executable,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string?> environment,
+        TimeSpan timeout,
+        string stdoutPath,
+        string stderrPath,
+        Func<Process, TimeSpan, Task>? sample = null,
+        CancellationToken cancellationToken = default)
+    {
+        var warnings = new List<string>();
+        var start = DateTimeOffset.UtcNow;
+        using var stdout = new StreamWriter(stdoutPath, append: false) { AutoFlush = true };
+        using var stderr = new StreamWriter(stderrPath, append: false) { AutoFlush = true };
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo(executable)
+            {
+                WorkingDirectory = workingDirectory,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = false,
+            },
+            EnableRaisingEvents = true,
+        };
+        foreach (var argument in arguments) process.StartInfo.ArgumentList.Add(argument);
+        foreach (var pair in environment) process.StartInfo.Environment[pair.Key] = pair.Value;
+        process.OutputDataReceived += (_, eventArgs) => { if (eventArgs.Data is not null) lock (stdout) stdout.WriteLine(eventArgs.Data); };
+        process.ErrorDataReceived += (_, eventArgs) => { if (eventArgs.Data is not null) lock (stderr) stderr.WriteLine(eventArgs.Data); };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        using var job = WindowsJob.TryCreateAndAssign(process, out var jobWarning);
+        if (jobWarning is not null) warnings.Add(jobWarning);
+        var jobOwned = job is not null;
+        var stopwatch = Stopwatch.StartNew();
+        var peakWorkingSet = 0L;
+        var lastCpu = TimeSpan.Zero;
+        using var sampleCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var sampler = Task.Run(async () =>
+        {
+            while (!sampleCancellation.IsCancellationRequested && !process.HasExited)
+            {
+                try
+                {
+                    process.Refresh();
+                    peakWorkingSet = Math.Max(peakWorkingSet, process.WorkingSet64);
+                    lastCpu = process.TotalProcessorTime;
+                    if (sample is not null) await sample(process, stopwatch.Elapsed);
+                }
+                catch (InvalidOperationException)
+                {
+                    break;
+                }
+                await Task.Delay(250, sampleCancellation.Token).ConfigureAwait(false);
+            }
+        }, sampleCancellation.Token);
+
+        var timedOut = false;
+        try
+        {
+            var exitTask = process.WaitForExitAsync(cancellationToken);
+            var completed = await Task.WhenAny(exitTask, Task.Delay(timeout, cancellationToken));
+            if (completed != exitTask)
+            {
+                timedOut = true;
+                if (process.CloseMainWindow())
+                {
+                    await Task.WhenAny(process.WaitForExitAsync(CancellationToken.None), Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None));
+                }
+                if (!process.HasExited)
+                {
+                    if (job is not null) job.Terminate();
+                    else process.Kill(entireProcessTree: true);
+                    await process.WaitForExitAsync(CancellationToken.None);
+                }
+            }
+            else
+            {
+                await exitTask;
+            }
+        }
+        finally
+        {
+            await sampleCancellation.CancelAsync();
+            try { await sampler; } catch (OperationCanceledException) { }
+            process.WaitForExit();
+        }
+
+        stopwatch.Stop();
+        var end = DateTimeOffset.UtcNow;
+        int? exitCode = null;
+        if (process.HasExited) exitCode = process.ExitCode;
+        var cleaned = process.HasExited;
+        var resourceScope = "root-process";
+        string? accountingWarning = null;
+        if (job is not null && job.TryReadAccounting(out var jobCpu, out var peakJobMemory, out accountingWarning))
+        {
+            lastCpu = jobCpu;
+            peakWorkingSet = Math.Max(peakWorkingSet, peakJobMemory);
+            resourceScope = "windows-job-object-process-tree";
+        }
+        else if (accountingWarning is not null)
+        {
+            warnings.Add(accountingWarning);
+        }
+        return new BoundedProcessResult(
+            exitCode,
+            timedOut,
+            !timedOut && exitCode is not (null or 0 or 4),
+            start,
+            end,
+            stopwatch.Elapsed.TotalSeconds,
+            lastCpu.TotalSeconds,
+            peakWorkingSet,
+            resourceScope,
+            jobOwned,
+            cleaned,
+            warnings);
+    }
+}
+
+internal sealed class WindowsJob : IDisposable
+{
+    private const uint JobObjectLimitKillOnJobClose = 0x00002000;
+    private const int ExtendedLimitInformationClass = 9;
+    private const int BasicAccountingInformationClass = 1;
+    private nint _handle;
+
+    private WindowsJob(nint handle) => _handle = handle;
+
+    public static WindowsJob? TryCreateAndAssign(Process process, out string? warning)
+    {
+        warning = null;
+        if (!OperatingSystem.IsWindows()) return null;
+        var handle = CreateJobObjectW(0, null);
+        if (handle == 0)
+        {
+            warning = $"Windows Job Object creation failed ({Marshal.GetLastWin32Error()}); process-tree kill fallback is active.";
+            return null;
+        }
+        var job = new WindowsJob(handle);
+        var info = new JobObjectExtendedLimitInformation
+        {
+            BasicLimitInformation = new JobObjectBasicLimitInformation { LimitFlags = JobObjectLimitKillOnJobClose },
+        };
+        var size = Marshal.SizeOf<JobObjectExtendedLimitInformation>();
+        var memory = Marshal.AllocHGlobal(size);
+        try
+        {
+            Marshal.StructureToPtr(info, memory, false);
+            if (!SetInformationJobObject(handle, ExtendedLimitInformationClass, memory, (uint)size) ||
+                !AssignProcessToJobObject(handle, process.Handle))
+            {
+                warning = $"Windows Job Object assignment failed ({Marshal.GetLastWin32Error()}); process-tree kill fallback is active.";
+                job.Dispose();
+                return null;
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(memory);
+        }
+        return job;
+    }
+
+    public void Terminate()
+    {
+        if (_handle != 0) _ = TerminateJobObject(_handle, 1460);
+    }
+
+    public bool TryReadAccounting(out TimeSpan cpuTime, out long peakJobMemory, out string? warning)
+    {
+        cpuTime = TimeSpan.Zero;
+        peakJobMemory = 0;
+        warning = null;
+        if (_handle == 0) return false;
+        var accountingSize = Marshal.SizeOf<JobObjectBasicAccountingInformation>();
+        var extendedSize = Marshal.SizeOf<JobObjectExtendedLimitInformation>();
+        var accountingMemory = Marshal.AllocHGlobal(accountingSize);
+        var extendedMemory = Marshal.AllocHGlobal(extendedSize);
+        try
+        {
+            if (!QueryInformationJobObject(_handle, BasicAccountingInformationClass, accountingMemory, (uint)accountingSize, out _) ||
+                !QueryInformationJobObject(_handle, ExtendedLimitInformationClass, extendedMemory, (uint)extendedSize, out _))
+            {
+                warning = $"Windows Job Object accounting query failed ({Marshal.GetLastWin32Error()}); root-process resource metrics are reported.";
+                return false;
+            }
+            var accounting = Marshal.PtrToStructure<JobObjectBasicAccountingInformation>(accountingMemory);
+            var limits = Marshal.PtrToStructure<JobObjectExtendedLimitInformation>(extendedMemory);
+            cpuTime = TimeSpan.FromTicks(checked(accounting.TotalUserTime + accounting.TotalKernelTime));
+            peakJobMemory = checked((long)limits.PeakJobMemoryUsed);
+            return true;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(accountingMemory);
+            Marshal.FreeHGlobal(extendedMemory);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_handle == 0) return;
+        CloseHandle(_handle);
+        _handle = 0;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JobObjectBasicLimitInformation
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public nuint MinimumWorkingSetSize;
+        public nuint MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public nint Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JobObjectBasicAccountingInformation
+    {
+        public long TotalUserTime;
+        public long TotalKernelTime;
+        public long ThisPeriodTotalUserTime;
+        public long ThisPeriodTotalKernelTime;
+        public uint TotalPageFaultCount;
+        public uint TotalProcesses;
+        public uint ActiveProcesses;
+        public uint TotalTerminatedProcesses;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IoCounters
+    {
+        public ulong ReadOperationCount, WriteOperationCount, OtherOperationCount, ReadTransferCount, WriteTransferCount, OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JobObjectExtendedLimitInformation
+    {
+        public JobObjectBasicLimitInformation BasicLimitInformation;
+        public IoCounters IoInfo;
+        public nuint ProcessMemoryLimit, JobMemoryLimit, PeakProcessMemoryUsed, PeakJobMemoryUsed;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern nint CreateJobObjectW(nint attributes, string? name);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetInformationJobObject(nint job, int informationClass, nint information, uint length);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool AssignProcessToJobObject(nint job, nint process);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool TerminateJobObject(nint job, uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool QueryInformationJobObject(nint job, int informationClass, nint information, uint length, out uint returnLength);
+
+    [DllImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(nint handle);
+}

--- a/tools/SharpEmu.Tools.AgentHarness/DoctorCommand.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/DoctorCommand.cs
@@ -1,0 +1,168 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal static class DoctorCommand
+{
+    public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
+    {
+        var phaseZeroPath = Path.Combine(repository.LocalRoot, "reports", "phase-00-environment.json");
+        JsonDocument? phaseZero = null;
+        if (File.Exists(phaseZeroPath))
+        {
+            await using var stream = File.OpenRead(phaseZeroPath);
+            phaseZero = await JsonDocument.ParseAsync(stream);
+        }
+
+        var dotnet = ProcessUtility.RunCapture("dotnet", ["--version"], repository.Root);
+        var vulkanRuntime = OperatingSystem.IsWindows()
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "vulkan-1.dll")
+            : "vulkan";
+        var configuration = arguments.Value("--configuration") ?? "Debug";
+        var executable = FindEmulator(repository, configuration);
+        var profilePath = arguments.Value("--profile") ?? Path.Combine(repository.LocalRoot, "profiles", "demons-souls-01.004.000.json");
+        ProfileValidation? profile = null;
+        if (File.Exists(profilePath))
+        {
+            (_, profile) = await ProfileLoader.LoadAndValidateAsync(repository, profilePath, verifyHash: false);
+        }
+
+        var gpuNames = ReadGpuNames(phaseZero);
+        var isAmd = gpuNames.Any(name => name.Contains("AMD", StringComparison.OrdinalIgnoreCase) || name.Contains("Radeon", StringComparison.OrdinalIgnoreCase));
+        var isNvidia = gpuNames.Any(name => name.Contains("NVIDIA", StringComparison.OrdinalIgnoreCase));
+        var optionalTools = new[]
+        {
+            Tool("vulkaninfo", "vulkaninfo", true, "Vulkan capability and driver investigation"),
+            Tool("spirv-val", "spirv-val", true, "shader validation"),
+            Tool("spirv-dis", "spirv-dis", true, "SPIR-V inspection"),
+            Tool("glslangValidator", "glslangValidator", true, "shader validation"),
+            Tool("RenderDoc", "renderdoccmd", true, "frame-level Vulkan investigation"),
+            Tool("Radeon GPU Analyzer", "rga", isAmd, "AMD shader investigation"),
+            Tool("Radeon GPU Profiler", "rgp", isAmd, "AMD GPU timing investigation"),
+            Tool("Radeon GPU Detective", "rgd", isAmd, "AMD GPU fault investigation"),
+            Tool("OCAT", "OCAT", isAmd, "AMD frame pacing investigation"),
+            Tool("Nsight Graphics", "ngfx", isNvidia, "NVIDIA frame and shader investigation"),
+            Tool("Nsight Systems", "nsys", isNvidia, "NVIDIA system-wide timing investigation"),
+            Tool("dotnet-trace", "dotnet-trace", true, ".NET runtime trace investigation"),
+            Tool("dotnet-counters", "dotnet-counters", true, ".NET live counter investigation"),
+            Tool("dotnet-dump", "dotnet-dump", true, ".NET crash dump investigation"),
+        };
+        var privateScan = ScanTrackedPrivateData(repository, phaseZero);
+        var outputDirectoryWritable = EnsureWritable(repository.LocalRoot);
+        var vulkanAvailable = !OperatingSystem.IsWindows() || File.Exists(vulkanRuntime);
+        var driveRoot = Path.GetPathRoot(repository.Root)!;
+        var drive = new DriveInfo(driveRoot);
+        var report = new
+        {
+            schemaVersion = "1.0.0",
+            generatedUtc = DateTimeOffset.UtcNow,
+            repository = "<repo>",
+            repository.Branch,
+            commit = repository.Commit,
+            dirty = repository.IsDirty,
+            dotnetSdk = dotnet.ExitCode == 0 ? dotnet.Stdout.Trim() : null,
+            build = new { configuration, executableAvailable = executable is not null, executable = executable is null ? null : "<repo>/" + GitRepository.NormalizeRelativePath(Path.GetRelativePath(repository.Root, executable)) },
+            vulkan = new { available = vulkanAvailable, runtime = OperatingSystem.IsWindows() ? "<windows>/System32/vulkan-1.dll" : vulkanRuntime },
+            gpu = gpuNames,
+            optionalTools,
+            profile,
+            outputDirectoryWritable,
+            disk = new { root = drive.Name, freeBytes = drive.AvailableFreeSpace },
+            privateDataScan = new { passed = privateScan.Count == 0, matches = privateScan },
+            status = dotnet.ExitCode == 0 && executable is not null && vulkanAvailable && outputDirectoryWritable && privateScan.Count == 0 ? "ready" : "attention-required",
+        };
+        var reportDirectory = Path.Combine(repository.LocalRoot, "reports");
+        Directory.CreateDirectory(reportDirectory);
+        var reportPath = Path.Combine(reportDirectory, "agent-harness-doctor.json");
+        await File.WriteAllTextAsync(reportPath, JsonSerializer.Serialize(report, Program.JsonOptions));
+        if (arguments.Has("--json"))
+        {
+            Program.WriteJson(report);
+        }
+        else
+        {
+            Console.WriteLine($"Doctor: {report.status}");
+            Console.WriteLine($"Branch {repository.Branch}, commit {repository.Commit[..12]}, SDK {report.dotnetSdk ?? "missing"}.");
+            Console.WriteLine(executable is null ? "Emulator build: missing" : $"Emulator build: {report.build.executable}");
+            Console.WriteLine($"Vulkan runtime: {(report.vulkan.available ? "available" : "missing")}");
+            Console.WriteLine($"Private-data scan: {(privateScan.Count == 0 ? "passed" : "FAILED")}");
+            Console.WriteLine($"Optional tools: {optionalTools.Count(tool => tool.Status == "available")} available, {optionalTools.Count(tool => tool.Status == "missing")} missing, {optionalTools.Count(tool => tool.Status == "unsupported-on-current-hardware")} unsupported on current hardware.");
+            Console.WriteLine($"Report: {reportPath}");
+        }
+        phaseZero?.Dispose();
+        return report.status == "ready" ? 0 : 2;
+    }
+
+    internal static string? FindEmulator(GitRepository repository, string configuration)
+    {
+        var candidates = new[]
+        {
+            Path.Combine(repository.Root, "artifacts", "bin", configuration, "net10.0", "win-x64", "SharpEmu.exe"),
+            Path.Combine(repository.Root, "artifacts", "publish", "win-x64", "SharpEmu.exe"),
+        };
+        return candidates.FirstOrDefault(File.Exists);
+    }
+
+    private static ToolStatus Tool(string name, string command, bool supported, string recommendation)
+    {
+        if (!supported) return new ToolStatus(name, "unsupported-on-current-hardware", null, recommendation);
+        var result = ProcessUtility.RunCapture("where.exe", [command], Environment.CurrentDirectory, timeoutMilliseconds: 5_000);
+        var path = result.ExitCode == 0 ? result.Stdout.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() : null;
+        return new ToolStatus(name, path is null ? "missing" : "available", path, recommendation);
+    }
+
+    private static IReadOnlyList<string> ReadGpuNames(JsonDocument? phaseZero)
+    {
+        if (phaseZero is null ||
+            !phaseZero.RootElement.TryGetProperty("hardware", out var hardware) ||
+            !hardware.TryGetProperty("gpus", out var gpus)) return [];
+        return gpus.EnumerateArray()
+            .Select(gpu => gpu.TryGetProperty("model", out var model) ? model.GetString() : null)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Cast<string>()
+            .ToArray();
+    }
+
+    private static List<string> ScanTrackedPrivateData(GitRepository repository, JsonDocument? phaseZero)
+    {
+        var needles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(userProfile)) needles.Add(userProfile);
+        if (phaseZero is not null && phaseZero.RootElement.TryGetProperty("archive", out var archive) && archive.TryGetProperty("path", out var archivePath))
+        {
+            var value = archivePath.GetString();
+            if (!string.IsNullOrWhiteSpace(value)) needles.Add(value);
+        }
+        var matches = new List<string>();
+        foreach (var needle in needles)
+        {
+            var result = ProcessUtility.RunCapture("git", ["-C", repository.Root, "grep", "-I", "-l", "-F", needle, "--"], repository.Root);
+            if (result.ExitCode == 0)
+            {
+                matches.AddRange(result.Stdout.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries));
+            }
+        }
+        return matches.Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    private static bool EnsureWritable(string path)
+    {
+        try
+        {
+            Directory.CreateDirectory(path);
+            var probe = Path.Combine(path, $".write-probe-{Environment.ProcessId}");
+            File.WriteAllText(probe, string.Empty);
+            File.Delete(probe);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private sealed record ToolStatus(string Name, string Status, string? Path, string RecommendedFor);
+}

--- a/tools/SharpEmu.Tools.AgentHarness/DoctorCommand.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/DoctorCommand.cs
@@ -9,6 +9,8 @@ internal static class DoctorCommand
 {
     public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
     {
+        var environmentOnly = arguments.Has("--environment-only");
+        var fast = arguments.Has("--fast");
         var phaseZeroPath = Path.Combine(repository.LocalRoot, "reports", "phase-00-environment.json");
         JsonDocument? phaseZero = null;
         if (File.Exists(phaseZeroPath))
@@ -24,10 +26,11 @@ internal static class DoctorCommand
         var configuration = arguments.Value("--configuration") ?? "Debug";
         var executable = FindEmulator(repository, configuration);
         var profilePath = arguments.Value("--profile") ?? Path.Combine(repository.LocalRoot, "profiles", "demons-souls-01.004.000.json");
+        LocalRunProfile? loadedProfile = null;
         ProfileValidation? profile = null;
-        if (File.Exists(profilePath))
+        if (!environmentOnly)
         {
-            (_, profile) = await ProfileLoader.LoadAndValidateAsync(repository, profilePath, verifyHash: false);
+            (loadedProfile, profile) = await ProfileLoader.LoadAndValidateAsync(repository, profilePath, verifyHash: !fast);
         }
 
         var gpuNames = ReadGpuNames(phaseZero);
@@ -50,37 +53,53 @@ internal static class DoctorCommand
             Tool("dotnet-counters", "dotnet-counters", true, ".NET live counter investigation"),
             Tool("dotnet-dump", "dotnet-dump", true, ".NET crash dump investigation"),
         };
-        var privateScan = ScanTrackedPrivateData(repository, phaseZero);
+        var scanRoots = PrivateRoots(phaseZero, loadedProfile);
+        var scanHashes = PrivateHashes(phaseZero, loadedProfile);
+        var privateScan = PrivateDataScanner.Scan(repository, scanRoots, scanHashes);
         var outputDirectoryWritable = EnsureWritable(repository.LocalRoot);
         var vulkanAvailable = !OperatingSystem.IsWindows() || File.Exists(vulkanRuntime);
         var driveRoot = Path.GetPathRoot(repository.Root)!;
         var drive = new DriveInfo(driveRoot);
+        var environmentReady = dotnet.ExitCode == 0 && vulkanAvailable && outputDirectoryWritable;
+        var repositoryReady = executable is not null && privateScan.Passed;
+        var targetReady = IsTargetReady(profile, environmentOnly);
+        var overallReady = environmentReady && (environmentOnly || repositoryReady && targetReady);
+        var redactionMap = RunArtifactRedactor.CreateStandardMap(repository, scanRoots);
         var report = new
         {
-            schemaVersion = "1.0.0",
+            schemaVersion = "1.1.0",
             generatedUtc = DateTimeOffset.UtcNow,
+            mode = environmentOnly ? "environment-only" : "target",
+            fast,
             repository = "<repo>",
             repository.Branch,
             commit = repository.Commit,
             dirty = repository.IsDirty,
             dotnetSdk = dotnet.ExitCode == 0 ? dotnet.Stdout.Trim() : null,
-            build = new { configuration, executableAvailable = executable is not null, executable = executable is null ? null : "<repo>/" + GitRepository.NormalizeRelativePath(Path.GetRelativePath(repository.Root, executable)) },
+            build = new { configuration, executableAvailable = executable is not null, executable = executable is null ? null : RunArtifactRedactor.RedactText(executable, redactionMap) },
             vulkan = new { available = vulkanAvailable, runtime = OperatingSystem.IsWindows() ? "<windows>/System32/vulkan-1.dll" : vulkanRuntime },
             gpu = gpuNames,
             optionalTools,
             profile,
             outputDirectoryWritable,
             disk = new { root = drive.Name, freeBytes = drive.AvailableFreeSpace },
-            privateDataScan = new { passed = privateScan.Count == 0, matches = privateScan },
-            status = dotnet.ExitCode == 0 && executable is not null && vulkanAvailable && outputDirectoryWritable && privateScan.Count == 0 ? "ready" : "attention-required",
+            privateDataScan = privateScan,
+            readiness = new
+            {
+                environment = environmentReady ? "ready" : "attention-required",
+                repositoryBuild = repositoryReady ? "ready" : "attention-required",
+                targetProfile = environmentOnly ? "not-evaluated" : targetReady ? "ready" : "attention-required",
+            },
+            status = overallReady ? "ready" : "attention-required",
         };
         var reportDirectory = Path.Combine(repository.LocalRoot, "reports");
         Directory.CreateDirectory(reportDirectory);
         var reportPath = Path.Combine(reportDirectory, "agent-harness-doctor.json");
-        await File.WriteAllTextAsync(reportPath, JsonSerializer.Serialize(report, Program.JsonOptions));
+        var reportJson = RunArtifactRedactor.RedactText(JsonSerializer.Serialize(report, Program.JsonOptions), redactionMap);
+        await File.WriteAllTextAsync(reportPath, reportJson);
         if (arguments.Has("--json"))
         {
-            Program.WriteJson(report);
+            Console.WriteLine(reportJson);
         }
         else
         {
@@ -88,7 +107,8 @@ internal static class DoctorCommand
             Console.WriteLine($"Branch {repository.Branch}, commit {repository.Commit[..12]}, SDK {report.dotnetSdk ?? "missing"}.");
             Console.WriteLine(executable is null ? "Emulator build: missing" : $"Emulator build: {report.build.executable}");
             Console.WriteLine($"Vulkan runtime: {(report.vulkan.available ? "available" : "missing")}");
-            Console.WriteLine($"Private-data scan: {(privateScan.Count == 0 ? "passed" : "FAILED")}");
+            Console.WriteLine($"Environment readiness: {report.readiness.environment}; repository/build readiness: {report.readiness.repositoryBuild}; target-profile readiness: {report.readiness.targetProfile}.");
+            Console.WriteLine($"Private-data scan: {(privateScan.Passed ? "passed" : "FAILED")}");
             Console.WriteLine($"Optional tools: {optionalTools.Count(tool => tool.Status == "available")} available, {optionalTools.Count(tool => tool.Status == "missing")} missing, {optionalTools.Count(tool => tool.Status == "unsupported-on-current-hardware")} unsupported on current hardware.");
             Console.WriteLine($"Report: {reportPath}");
         }
@@ -105,6 +125,9 @@ internal static class DoctorCommand
         };
         return candidates.FirstOrDefault(File.Exists);
     }
+
+    internal static bool IsTargetReady(ProfileValidation? profile, bool environmentOnly) =>
+        environmentOnly || profile is { Valid: true, HashStatus: "matched" };
 
     private static ToolStatus Tool(string name, string command, bool supported, string recommendation)
     {
@@ -126,26 +149,34 @@ internal static class DoctorCommand
             .ToArray();
     }
 
-    private static List<string> ScanTrackedPrivateData(GitRepository repository, JsonDocument? phaseZero)
+    private static IReadOnlyList<string> PrivateRoots(JsonDocument? phaseZero, LocalRunProfile? profile)
     {
-        var needles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        if (!string.IsNullOrWhiteSpace(userProfile)) needles.Add(userProfile);
+        var roots = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (phaseZero is not null && phaseZero.RootElement.TryGetProperty("archive", out var archive) && archive.TryGetProperty("path", out var archivePath))
         {
             var value = archivePath.GetString();
-            if (!string.IsNullOrWhiteSpace(value)) needles.Add(value);
+            if (!string.IsNullOrWhiteSpace(value)) roots.Add(Path.GetDirectoryName(Path.GetFullPath(value)) ?? value);
         }
-        var matches = new List<string>();
-        foreach (var needle in needles)
+        if (profile is not null)
         {
-            var result = ProcessUtility.RunCapture("git", ["-C", repository.Root, "grep", "-I", "-l", "-F", needle, "--"], repository.Root);
-            if (result.ExitCode == 0)
+            foreach (var root in profile.RedactionRoots) if (!string.IsNullOrWhiteSpace(root)) roots.Add(Path.GetFullPath(root));
+            if (!string.IsNullOrWhiteSpace(profile.EbootPath)) roots.Add(Path.GetDirectoryName(Path.GetFullPath(profile.EbootPath))!);
+        }
+        return roots.ToArray();
+    }
+
+    private static IReadOnlyList<string> PrivateHashes(JsonDocument? phaseZero, LocalRunProfile? profile)
+    {
+        var hashes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(profile?.EbootSha256)) hashes.Add(profile.EbootSha256);
+        if (phaseZero is not null && phaseZero.RootElement.TryGetProperty("archive", out var archive))
+        {
+            foreach (var name in new[] { "sha256", "archiveSha256", "archive_sha256" })
             {
-                matches.AddRange(result.Stdout.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries));
+                if (archive.TryGetProperty(name, out var value) && !string.IsNullOrWhiteSpace(value.GetString())) hashes.Add(value.GetString()!);
             }
         }
-        return matches.Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.OrdinalIgnoreCase).ToList();
+        return hashes.ToArray();
     }
 
     private static bool EnsureWritable(string path)

--- a/tools/SharpEmu.Tools.AgentHarness/GameInputCommand.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/GameInputCommand.cs
@@ -1,0 +1,568 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal sealed record GameInputMetadata(
+    string ArchivePath,
+    long ArchiveSizeBytes,
+    string ArchiveSha256,
+    string ExpectedTitleId,
+    string ExpectedVersion,
+    string ArchiveUtilityPath);
+
+internal sealed record ArchiveInspection(
+    string SchemaVersion,
+    DateTimeOffset GeneratedUtc,
+    long ArchiveSizeBytes,
+    string ArchiveSha256,
+    bool HashMatchesPhaseZero,
+    string Utility,
+    string UtilityVersion,
+    int IntegrityExitCode,
+    string IntegrityStatus,
+    int EntryCount,
+    long ExpectedUncompressedBytes,
+    bool PathsValid,
+    IReadOnlyList<string> Blockers,
+    IReadOnlyList<string> Warnings);
+
+internal sealed record GameBootstrapResult(
+    string SchemaVersion,
+    string ValidationResult,
+    string? ExtractionRoot,
+    string? SelectedEboot,
+    string? EbootSha256,
+    string? TitleId,
+    string? VerifiedVersion,
+    string VersionStatus,
+    bool ArchiveExtracted,
+    IReadOnlyList<string> Blockers,
+    IReadOnlyList<string> Warnings);
+
+internal static class GameInputCommand
+{
+    public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
+    {
+        if (arguments.Count == 0 || arguments[0].ToLowerInvariant() is not ("inspect" or "extract" or "resume")) return Program.Fail("game requires inspect, extract, or resume.");
+        var metadataPath = arguments.Value("--metadata") ?? Path.Combine(repository.LocalRoot, "game-input", "PPSA01341.json");
+        var metadata = await ReadMetadataAsync(repository.ResolvePath(metadataPath));
+        var inspection = arguments[0].Equals("resume", StringComparison.OrdinalIgnoreCase)
+            ? await LoadRecentInspectionAsync(repository, metadata)
+            : await InspectAsync(repository, metadata);
+        if (arguments[0] == "inspect" || inspection.Blockers.Count > 0)
+        {
+            if (arguments.Has("--json")) Program.WriteJson(inspection);
+            else PrintInspection(inspection);
+            return inspection.Blockers.Count == 0 ? 0 : 2;
+        }
+
+        var result = await ExtractAsync(
+            repository,
+            metadata,
+            inspection,
+            allowStagingRecovery: arguments[0].Equals("resume", StringComparison.OrdinalIgnoreCase));
+        if (arguments.Has("--json")) Program.WriteJson(result);
+        else
+        {
+            Console.WriteLine($"Game bootstrap: {result.ValidationResult}");
+            Console.WriteLine($"Title ID: {result.TitleId}; version: {result.VersionStatus}.");
+            Console.WriteLine($"Extraction root: <private-game-root>/{metadata.ExpectedTitleId}/{metadata.ExpectedVersion}");
+            Console.WriteLine($"Profile: .local/profiles/demons-souls-01.004.000.json");
+            foreach (var blocker in result.Blockers) Console.Error.WriteLine($"blocker: {blocker}");
+        }
+        return result.Blockers.Count == 0 ? 0 : 2;
+    }
+
+    private static async Task<ArchiveInspection> LoadRecentInspectionAsync(GitRepository repository, GameInputMetadata metadata)
+    {
+        var path = Path.Combine(repository.LocalRoot, "game-input", "phase-01-archive-inspection.json");
+        if (!File.Exists(path)) throw new InvalidOperationException("No Phase 01 archive inspection is available to resume.");
+        var inspection = JsonSerializer.Deserialize<ArchiveInspection>(await File.ReadAllTextAsync(path), Program.JsonOptions)
+            ?? throw new InvalidDataException("The Phase 01 archive inspection is empty.");
+        var actualSize = File.Exists(metadata.ArchivePath) ? new FileInfo(metadata.ArchivePath).Length : -1;
+        if (inspection.GeneratedUtc < DateTimeOffset.UtcNow.AddHours(-4) ||
+            inspection.Blockers.Count > 0 ||
+            !inspection.HashMatchesPhaseZero ||
+            !inspection.PathsValid ||
+            inspection.IntegrityExitCode != 0 ||
+            !string.Equals(inspection.ArchiveSha256, metadata.ArchiveSha256, StringComparison.OrdinalIgnoreCase) ||
+            inspection.ArchiveSizeBytes != metadata.ArchiveSizeBytes ||
+            actualSize != metadata.ArchiveSizeBytes)
+        {
+            throw new InvalidOperationException("The cached archive inspection is absent, stale, or inconsistent; run game extract for full revalidation.");
+        }
+        return inspection;
+    }
+
+    private static async Task<ArchiveInspection> InspectAsync(GitRepository repository, GameInputMetadata metadata)
+    {
+        var blockers = new List<string>();
+        var warnings = new List<string>();
+        if (!File.Exists(metadata.ArchivePath))
+        {
+            blockers.Add("archive: source archive does not exist");
+            return new ArchiveInspection("1.0.0", DateTimeOffset.UtcNow, 0, string.Empty, false, "7-Zip", "unknown", -1, "not-run", 0, 0, false, blockers, warnings);
+        }
+        if (!File.Exists(metadata.ArchiveUtilityPath))
+        {
+            blockers.Add("environment: recorded official archive utility does not exist");
+            return new ArchiveInspection("1.0.0", DateTimeOffset.UtcNow, new FileInfo(metadata.ArchivePath).Length, string.Empty, false, "7-Zip", "unknown", -1, "not-run", 0, 0, false, blockers, warnings);
+        }
+
+        var archiveSize = new FileInfo(metadata.ArchivePath).Length;
+        if (archiveSize != metadata.ArchiveSizeBytes) blockers.Add("archive: byte size differs from the Phase 00 record");
+        var archiveHash = await HashFileAsync(metadata.ArchivePath);
+        var hashMatches = string.Equals(archiveHash, metadata.ArchiveSha256, StringComparison.OrdinalIgnoreCase);
+        if (!hashMatches) blockers.Add("archive: SHA-256 differs from the Phase 00 record");
+        var versionResult = await RunUtilityAsync(metadata.ArchiveUtilityPath, ["i"], repository.Root, TimeSpan.FromMinutes(1));
+        var utilityVersion = versionResult.Stdout.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(line => line.Contains("7-Zip", StringComparison.OrdinalIgnoreCase))?.Trim() ?? "unknown";
+
+        var listing = await ListAndValidateAsync(metadata.ArchiveUtilityPath, metadata.ArchivePath, repository.Root);
+        blockers.AddRange(listing.Blockers);
+        var drive = new DriveInfo(Path.GetPathRoot(repository.Root)!);
+        var requiredFree = checked((long)Math.Ceiling(listing.TotalUncompressedBytes * 1.10) + 5L * 1024 * 1024 * 1024);
+        if (drive.AvailableFreeSpace < requiredFree) blockers.Add($"archive: insufficient free space; need at least {requiredFree} bytes");
+        var integrity = await RunUtilityAsync(
+            metadata.ArchiveUtilityPath,
+            ["t", "-bb0", "-bd", "-bso0", "-bsp0", "--", metadata.ArchivePath],
+            repository.Root,
+            TimeSpan.FromHours(2));
+        if (integrity.ExitCode != 0)
+        {
+            var classification = (integrity.Stdout + integrity.Stderr).Contains("password", StringComparison.OrdinalIgnoreCase)
+                ? "archive: password-protected or encrypted content cannot be tested without an already-authorized password"
+                : $"archive: integrity test failed with exit {integrity.ExitCode}";
+            blockers.Add(classification);
+        }
+        var inspection = new ArchiveInspection(
+            "1.0.0",
+            DateTimeOffset.UtcNow,
+            archiveSize,
+            archiveHash,
+            hashMatches,
+            "7-Zip",
+            utilityVersion,
+            integrity.ExitCode,
+            integrity.ExitCode == 0 ? "passed" : "failed",
+            listing.EntryCount,
+            listing.TotalUncompressedBytes,
+            listing.Blockers.Count == 0,
+            blockers,
+            warnings);
+        var outputDirectory = Path.Combine(repository.LocalRoot, "game-input");
+        Directory.CreateDirectory(outputDirectory);
+        await File.WriteAllTextAsync(Path.Combine(outputDirectory, "phase-01-archive-inspection.json"), JsonSerializer.Serialize(inspection, Program.JsonOptions));
+        return inspection;
+    }
+
+    private static async Task<GameBootstrapResult> ExtractAsync(
+        GitRepository repository,
+        GameInputMetadata metadata,
+        ArchiveInspection inspection,
+        bool allowStagingRecovery)
+    {
+        var blockers = new List<string>();
+        var warnings = new List<string>();
+        var workspace = Directory.GetParent(repository.Root)?.FullName ?? throw new InvalidOperationException("Repository has no workspace parent.");
+        var finalRoot = Path.Combine(workspace, "private", "games", metadata.ExpectedTitleId, metadata.ExpectedVersion);
+        var privateParent = Path.GetDirectoryName(finalRoot)!;
+        Directory.CreateDirectory(privateParent);
+        if (!string.Equals(Path.GetPathRoot(finalRoot), Path.GetPathRoot(metadata.ArchivePath), StringComparison.OrdinalIgnoreCase))
+        {
+            blockers.Add("archive: staging and source are not on the same fixed local drive");
+        }
+
+        var existingManifestPath = Path.Combine(finalRoot, ".sharpemu-extraction.json");
+        if (Directory.Exists(finalRoot))
+        {
+            if (File.Exists(existingManifestPath))
+            {
+                using var existing = JsonDocument.Parse(await File.ReadAllTextAsync(existingManifestPath));
+                var root = existing.RootElement;
+                var sourceMatches = root.TryGetProperty("sourceArchiveSha256", out var sourceHash) && string.Equals(sourceHash.GetString(), inspection.ArchiveSha256, StringComparison.OrdinalIgnoreCase);
+                var ebootExists = root.TryGetProperty("selectedEbootPath", out var ebootElement) && File.Exists(ebootElement.GetString());
+                if (sourceMatches && ebootExists)
+                {
+                    warnings.Add("Existing extraction was reused after manifest and selected-eboot validation.");
+                    return await CreateProfileFromExistingAsync(repository, metadata, existing.RootElement.Clone(), blockers, warnings);
+                }
+            }
+            blockers.Add("archive: final extraction destination already exists but could not be safely reused");
+        }
+        if (blockers.Count > 0) return Result("blocked", null, null, null, null, null, blockers, warnings);
+
+        var stagingCandidates = Directory.EnumerateDirectories(
+            privateParent,
+            Path.GetFileName(finalRoot) + ".staging-*",
+            SearchOption.TopDirectoryOnly).ToArray();
+        if (stagingCandidates.Length > 1)
+        {
+            blockers.Add("archive: multiple staging directories exist; automatic recovery is ambiguous");
+            return Result("blocked", null, null, null, null, null, blockers, warnings);
+        }
+        if (stagingCandidates.Length == 1 && !allowStagingRecovery)
+        {
+            blockers.Add("archive: an isolated staging tree exists; use the explicit game resume command after reviewing its provenance");
+            return Result("blocked", stagingCandidates[0], null, null, null, null, blockers, warnings);
+        }
+        var staging = stagingCandidates.SingleOrDefault()
+            ?? finalRoot + $".staging-{DateTime.UtcNow:yyyyMMddTHHmmssZ}-{Environment.ProcessId}";
+        var recoveredStaging = stagingCandidates.Length == 1;
+        if (recoveredStaging)
+        {
+            warnings.Add("A single isolated staging tree from the current validated archive was recovered and fully revalidated.");
+        }
+        else
+        {
+            Directory.CreateDirectory(staging);
+            var extraction = await RunUtilityAsync(
+                metadata.ArchiveUtilityPath,
+                ["x", "-bb0", "-bd", "-bso0", "-bsp0", "-y", $"-o{staging}", "--", metadata.ArchivePath],
+                workspace,
+                TimeSpan.FromHours(4));
+            if (extraction.ExitCode != 0)
+            {
+                var combined = extraction.Stdout + extraction.Stderr;
+                blockers.Add(combined.Contains("password", StringComparison.OrdinalIgnoreCase)
+                    ? "archive: extraction requires a password that was not supplied or guessed"
+                    : $"archive: extraction failed with exit {extraction.ExitCode}");
+                return Result("failed", staging, null, null, null, null, blockers, warnings);
+            }
+        }
+
+        foreach (var entry in Directory.EnumerateFileSystemEntries(staging, "*", SearchOption.AllDirectories))
+        {
+            if ((File.GetAttributes(entry) & FileAttributes.ReparsePoint) != 0)
+            {
+                blockers.Add("archive: extracted content contains a symlink, junction, or reparse point");
+                break;
+            }
+            if (!Path.GetFullPath(entry).StartsWith(Path.GetFullPath(staging) + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            {
+                blockers.Add("archive: extracted path escaped staging");
+                break;
+            }
+        }
+        if (blockers.Count > 0) return Result("failed-validation", staging, null, null, null, null, blockers, warnings);
+
+        var candidates = Directory.EnumerateFiles(staging, "eboot.bin", SearchOption.AllDirectories).ToArray();
+        var selections = new List<Candidate>();
+        foreach (var candidate in candidates)
+        {
+            var metadataResult = TryFindMetadata(candidate, staging);
+            if (metadataResult.TitleId is not null)
+            {
+                selections.Add(new Candidate(candidate, metadataResult));
+            }
+        }
+        var matching = selections.Where(candidate => string.Equals(candidate.Metadata.TitleId, metadata.ExpectedTitleId, StringComparison.OrdinalIgnoreCase)).ToArray();
+        if (matching.Length != 1)
+        {
+            blockers.Add(matching.Length == 0
+                ? "archive: no unambiguous eboot with verified target Title ID was found"
+                : "archive: multiple eboot candidates match the target Title ID");
+            return Result("failed-validation", staging, null, null, null, null, blockers, warnings);
+        }
+        var selected = matching[0];
+        var verifiedVersion = selected.Metadata.Version;
+        var versionStatus = string.IsNullOrWhiteSpace(verifiedVersion) ? "unverified" : "verified";
+        if (!string.IsNullOrWhiteSpace(verifiedVersion) && !string.Equals(verifiedVersion, metadata.ExpectedVersion, StringComparison.OrdinalIgnoreCase))
+        {
+            blockers.Add($"target version: metadata proves '{verifiedVersion}', not expected '{metadata.ExpectedVersion}'");
+            return Result("version-mismatch", staging, selected.Path, null, selected.Metadata.TitleId, verifiedVersion, blockers, warnings);
+        }
+        var ebootHash = await HashFileAsync(selected.Path);
+        try
+        {
+            await MoveDirectoryWithRetryAsync(staging, finalRoot);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            blockers.Add($"archive: validated staging could not be promoted to the final root: {exception.Message}");
+            return Result("promotion-failed", staging, selected.Path, ebootHash, selected.Metadata.TitleId, verifiedVersion, blockers, warnings, versionStatus);
+        }
+        var finalEboot = Path.Combine(finalRoot, Path.GetRelativePath(staging, selected.Path));
+        var finalMetadata = selected.Metadata.SourcePath is null ? null : Path.Combine(finalRoot, Path.GetRelativePath(staging, selected.Metadata.SourcePath));
+        var manifest = new
+        {
+            schemaVersion = "1.0.0",
+            sourceArchivePath = metadata.ArchivePath,
+            sourceArchiveSha256 = inspection.ArchiveSha256,
+            extractionUtcTimestamp = DateTimeOffset.UtcNow,
+            extractionUtility = inspection.Utility,
+            extractionUtilityVersion = inspection.UtilityVersion,
+            extractionRoot = finalRoot,
+            selectedEbootPath = finalEboot,
+            ebootSha256 = ebootHash,
+            titleId = selected.Metadata.TitleId,
+            expectedVersion = metadata.ExpectedVersion,
+            verifiedVersion,
+            versionStatus,
+            metadataSource = finalMetadata,
+            validationResult = "passed",
+            archiveExtracted = true,
+            blockers,
+            warnings,
+        };
+        await File.WriteAllTextAsync(existingManifestPath, JsonSerializer.Serialize(manifest, Program.JsonOptions));
+        await WriteProfileAsync(repository, metadata, finalEboot, ebootHash, selected.Metadata.TitleId!, verifiedVersion, versionStatus, finalMetadata);
+        return Result("passed", finalRoot, finalEboot, ebootHash, selected.Metadata.TitleId, verifiedVersion, blockers, warnings, versionStatus);
+    }
+
+    private static async Task MoveDirectoryWithRetryAsync(string source, string destination)
+    {
+        Exception? lastError = null;
+        for (var attempt = 1; attempt <= 15; attempt++)
+        {
+            try
+            {
+                Directory.Move(source, destination);
+                return;
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                lastError = exception;
+                if (Directory.Exists(destination) || attempt == 15) break;
+                await Task.Delay(TimeSpan.FromSeconds(2));
+            }
+        }
+        throw lastError ?? new IOException("Directory promotion failed without diagnostics.");
+    }
+
+    private static async Task<GameBootstrapResult> CreateProfileFromExistingAsync(GitRepository repository, GameInputMetadata metadata, JsonElement manifest, List<string> blockers, List<string> warnings)
+    {
+        var eboot = manifest.GetProperty("selectedEbootPath").GetString()!;
+        var extractionRoot = manifest.TryGetProperty("extractionRoot", out var root)
+            ? root.GetString()!
+            : Path.GetDirectoryName(eboot)!;
+        var expectedEbootHash = manifest.GetProperty("ebootSha256").GetString()!;
+        var ebootHash = await HashFileAsync(eboot);
+        var titleId = manifest.GetProperty("titleId").GetString()!;
+        var verifiedVersion = manifest.TryGetProperty("verifiedVersion", out var version) ? version.GetString() : null;
+        var versionStatus = manifest.TryGetProperty("versionStatus", out var status) ? status.GetString() ?? "unverified" : "unverified";
+        var metadataSource = manifest.TryGetProperty("metadataSource", out var source) ? source.GetString() : null;
+        if (!string.Equals(ebootHash, expectedEbootHash, StringComparison.OrdinalIgnoreCase)) blockers.Add("archive: reusable extraction eboot hash mismatch");
+        if (!string.Equals(titleId, metadata.ExpectedTitleId, StringComparison.OrdinalIgnoreCase)) blockers.Add("archive: reusable extraction Title ID mismatch");
+        if (!string.IsNullOrWhiteSpace(verifiedVersion) && !string.Equals(verifiedVersion, metadata.ExpectedVersion, StringComparison.OrdinalIgnoreCase)) blockers.Add("target version: reusable extraction version mismatch");
+        if (blockers.Count == 0) await WriteProfileAsync(repository, metadata, eboot, ebootHash, titleId, verifiedVersion, versionStatus, metadataSource);
+        return Result(blockers.Count == 0 ? "reused" : "blocked", extractionRoot, eboot, ebootHash, titleId, verifiedVersion, blockers, warnings, versionStatus);
+    }
+
+    private static async Task WriteProfileAsync(GitRepository repository, GameInputMetadata metadata, string eboot, string hash, string titleId, string? verifiedVersion, string versionStatus, string? metadataSource)
+    {
+        var profile = new LocalRunProfile
+        {
+            TargetName = "Demon's Souls 01.004.000",
+            ExpectedTitleId = metadata.ExpectedTitleId,
+            ExpectedVersion = metadata.ExpectedVersion,
+            EbootPath = eboot,
+            EbootSha256 = hash,
+            BuildConfiguration = "Debug",
+            TimeoutSeconds = 180,
+            LogLevel = "debug",
+            ImportTraceLimit = 64,
+            Capture = new CapturePolicy
+            {
+                NativeEnabled = true,
+                WindowFallbackEnabled = true,
+                FirstFrame = true,
+                FrameNumbers = [30, 120],
+                Interval = 300,
+                MaxFrames = 8,
+                WindowSampleSeconds = [15, 45, 90, 150],
+            },
+            RedactionRoots = [Path.GetDirectoryName(eboot)!],
+            Metadata = new TargetMetadata
+            {
+                TitleIdVerified = true,
+                VersionVerified = string.Equals(versionStatus, "verified", StringComparison.OrdinalIgnoreCase),
+                VerifiedVersion = verifiedVersion,
+                MetadataSource = metadataSource,
+                VersionStatus = versionStatus,
+            },
+        };
+        var profileDirectory = Path.Combine(repository.LocalRoot, "profiles");
+        Directory.CreateDirectory(profileDirectory);
+        await File.WriteAllTextAsync(Path.Combine(profileDirectory, "demons-souls-01.004.000.json"), JsonSerializer.Serialize(profile, Program.JsonOptions));
+    }
+
+    private static (string? TitleId, string? Version, string? SourcePath) TryFindMetadata(string eboot, string staging)
+    {
+        var directory = Path.GetDirectoryName(eboot)!;
+        for (var level = 0; level < 4 && directory.StartsWith(staging, StringComparison.OrdinalIgnoreCase); level++)
+        {
+            foreach (var candidate in new[] { Path.Combine(directory, "sce_sys", "param.json"), Path.Combine(directory, "param.json") })
+            {
+                if (!File.Exists(candidate)) continue;
+                try
+                {
+                    using var document = JsonDocument.Parse(File.ReadAllText(candidate));
+                    var root = document.RootElement;
+                    var titleId = StringProperty(root, "titleId") ?? StringProperty(root, "titleID") ?? StringProperty(root, "TITLE_ID");
+                    var version = StringProperty(root, "contentVersion") ?? StringProperty(root, "masterVersion") ?? StringProperty(root, "targetContentVersion") ?? StringProperty(root, "version");
+                    return (titleId, version, candidate);
+                }
+                catch (JsonException)
+                {
+                }
+            }
+            var parent = Directory.GetParent(directory);
+            if (parent is null) break;
+            directory = parent.FullName;
+        }
+        return (null, null, null);
+    }
+
+    private static string? StringProperty(JsonElement root, string name) => root.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String ? value.GetString() : null;
+
+    private static async Task<(int EntryCount, long TotalUncompressedBytes, IReadOnlyList<string> Blockers)> ListAndValidateAsync(string utility, string archive, string workingDirectory)
+    {
+        var blockers = new List<string>();
+        using var process = StartUtility(utility, ["l", "-slt", "-ba", "--", archive], workingDirectory);
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        string? currentPath = null;
+        string? currentAttributes = null;
+        long currentSize = 0;
+        var entryCount = 0;
+        long total = 0;
+        async Task FinishEntry()
+        {
+            if (currentPath is null) return;
+            entryCount++;
+            total = checked(total + Math.Max(0, currentSize));
+            var reason = ValidateArchivePath(currentPath, currentAttributes);
+            if (reason is not null && blockers.Count < 20) blockers.Add($"archive path rejected: {reason}");
+            currentPath = null;
+            currentAttributes = null;
+            currentSize = 0;
+            await Task.CompletedTask;
+        }
+        while (await process.StandardOutput.ReadLineAsync() is { } line)
+        {
+            if (line.Length == 0)
+            {
+                await FinishEntry();
+                continue;
+            }
+            if (line.StartsWith("Path = ", StringComparison.Ordinal)) currentPath = line[7..];
+            else if (line.StartsWith("Size = ", StringComparison.Ordinal) && long.TryParse(line[7..], out var size)) currentSize = size;
+            else if (line.StartsWith("Attributes = ", StringComparison.Ordinal)) currentAttributes = line[13..];
+            else if (HasArchiveLinkTarget(line)) currentAttributes = (currentAttributes ?? string.Empty) + " link";
+        }
+        await FinishEntry();
+        await process.WaitForExitAsync();
+        var stderr = await stderrTask;
+        if (process.ExitCode != 0) blockers.Add($"archive: directory listing failed with exit {process.ExitCode}: {FirstLine(stderr)}");
+        return (entryCount, total, blockers);
+    }
+
+    internal static string? ValidateArchivePath(string path, string? attributes = null)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return "empty entry path";
+        var normalized = path.Replace('/', '\\');
+        if (normalized.StartsWith("\\\\", StringComparison.Ordinal)) return "UNC path";
+        if (normalized.StartsWith('\\')) return "absolute rooted path";
+        if (normalized.Length >= 2 && char.IsLetter(normalized[0]) && normalized[1] == ':') return "drive-qualified path";
+        if (normalized.Split('\\', StringSplitOptions.RemoveEmptyEntries).Any(segment => segment == "..")) return "parent traversal";
+        if (normalized.Contains(':')) return "alternate data stream path";
+        if (attributes?.Contains("link", StringComparison.OrdinalIgnoreCase) == true || attributes?.Contains("reparse", StringComparison.OrdinalIgnoreCase) == true) return "link or reparse entry";
+        var root = Path.Combine(Path.GetTempPath(), "sharpemu-archive-validation-root");
+        var resolved = Path.GetFullPath(Path.Combine(root, normalized));
+        if (!resolved.StartsWith(Path.GetFullPath(root) + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)) return "path escapes staging";
+        return null;
+    }
+
+    internal static bool HasArchiveLinkTarget(string metadataLine)
+    {
+        const string symbolicPrefix = "Symbolic Link = ";
+        const string hardPrefix = "Hard Link = ";
+        var target = metadataLine.StartsWith(symbolicPrefix, StringComparison.Ordinal)
+            ? metadataLine[symbolicPrefix.Length..]
+            : metadataLine.StartsWith(hardPrefix, StringComparison.Ordinal) ? metadataLine[hardPrefix.Length..] : null;
+        return !string.IsNullOrWhiteSpace(target);
+    }
+
+    private static async Task<GameInputMetadata> ReadMetadataAsync(string path)
+    {
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(path));
+        var root = document.RootElement;
+        var archivePath = root.TryGetProperty("archive_path", out var directPath) ? directPath.GetString()! : root.GetProperty("archive").GetProperty("path").GetString()!;
+        var size = root.TryGetProperty("archive_size_bytes", out var directSize) ? directSize.GetInt64() : root.GetProperty("archive").GetProperty("size_bytes").GetInt64();
+        var hash = root.TryGetProperty("archive_sha256", out var directHash) ? directHash.GetString()! : root.GetProperty("archive").GetProperty("sha256").GetString()!;
+        var title = root.TryGetProperty("title_id", out var directTitle) ? directTitle.GetString()! : root.GetProperty("archive").GetProperty("expected_title_id").GetString()!;
+        var version = root.TryGetProperty("expected_game_version", out var directVersion) ? directVersion.GetString()! : root.GetProperty("archive").GetProperty("expected_game_version").GetString()!;
+        string utility;
+        if (root.TryGetProperty("archive_utility", out var utilityObject)) utility = utilityObject.GetProperty("path").GetString()!;
+        else utility = root.GetProperty("tools").EnumerateArray().First(tool => tool.GetProperty("name").GetString() == "7-Zip").GetProperty("path").GetString()!;
+        return new GameInputMetadata(archivePath, size, hash, title, version, utility);
+    }
+
+    private static async Task<string> HashFileAsync(string path)
+    {
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 1024 * 1024, FileOptions.SequentialScan);
+        return Convert.ToHexStringLower(await SHA256.HashDataAsync(stream));
+    }
+
+    private static Process StartUtility(string executable, IReadOnlyList<string> arguments, string workingDirectory)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo(executable)
+            {
+                WorkingDirectory = workingDirectory,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            },
+        };
+        foreach (var argument in arguments) process.StartInfo.ArgumentList.Add(argument);
+        process.Start();
+        return process;
+    }
+
+    private static async Task<CapturedProcess> RunUtilityAsync(string executable, IReadOnlyList<string> arguments, string workingDirectory, TimeSpan timeout)
+    {
+        using var process = StartUtility(executable, arguments, workingDirectory);
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        var exitTask = process.WaitForExitAsync();
+        var completed = await Task.WhenAny(exitTask, Task.Delay(timeout));
+        if (completed != exitTask)
+        {
+            process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync();
+            throw new TimeoutException($"Archive utility exceeded {timeout}.");
+        }
+        return new CapturedProcess(process.ExitCode, await stdout, await stderr);
+    }
+
+    private static string FirstLine(string value) => value.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? "no diagnostics";
+
+    private static void PrintInspection(ArchiveInspection inspection)
+    {
+        Console.WriteLine($"Archive inspection: {inspection.IntegrityStatus}; {inspection.EntryCount} entries; paths {(inspection.PathsValid ? "valid" : "REJECTED")}.");
+        Console.WriteLine($"Archive size: {inspection.ArchiveSizeBytes}; expected uncompressed: {inspection.ExpectedUncompressedBytes} bytes.");
+        foreach (var blocker in inspection.Blockers) Console.Error.WriteLine($"blocker: {blocker}");
+    }
+
+    private static GameBootstrapResult Result(string validationResult, string? extractionRoot, string? selectedEboot, string? ebootSha256, string? titleId, string? verifiedVersion, IReadOnlyList<string> blockers, IReadOnlyList<string> warnings, string versionStatus = "unknown") => new(
+        "1.0.0",
+        validationResult,
+        extractionRoot is null ? null : "<private-game-root>",
+        selectedEboot is null ? null : "<private-game-root>/" + Path.GetFileName(selectedEboot),
+        ebootSha256,
+        titleId,
+        verifiedVersion,
+        versionStatus,
+        validationResult is "passed" or "reused",
+        blockers,
+        warnings);
+
+    private sealed record Candidate(string Path, (string? TitleId, string? Version, string? SourcePath) Metadata);
+}

--- a/tools/SharpEmu.Tools.AgentHarness/GameInputCommand.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/GameInputCommand.cs
@@ -44,6 +44,16 @@ internal sealed record GameBootstrapResult(
     IReadOnlyList<string> Blockers,
     IReadOnlyList<string> Warnings);
 
+internal sealed record ExtractionProvenance(
+    string SchemaVersion,
+    DateTimeOffset CreatedUtc,
+    string ArchiveSha256,
+    long ArchiveSizeBytes,
+    string ExtractionUtility,
+    string ExtractionUtilityPath,
+    string ExtractionUtilityVersion,
+    string IntendedFinalRoot);
+
 internal static class GameInputCommand
 {
     public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
@@ -85,6 +95,10 @@ internal static class GameInputCommand
         var inspection = JsonSerializer.Deserialize<ArchiveInspection>(await File.ReadAllTextAsync(path), Program.JsonOptions)
             ?? throw new InvalidDataException("The Phase 01 archive inspection is empty.");
         var actualSize = File.Exists(metadata.ArchivePath) ? new FileInfo(metadata.ArchivePath).Length : -1;
+        var actualHash = actualSize >= 0 ? await HashFileAsync(metadata.ArchivePath) : null;
+        var utilityVersion = File.Exists(metadata.ArchiveUtilityPath)
+            ? ParseUtilityVersion((await RunUtilityAsync(metadata.ArchiveUtilityPath, ["i"], repository.Root, TimeSpan.FromMinutes(1))).Stdout)
+            : null;
         if (inspection.GeneratedUtc < DateTimeOffset.UtcNow.AddHours(-4) ||
             inspection.Blockers.Count > 0 ||
             !inspection.HashMatchesPhaseZero ||
@@ -92,7 +106,9 @@ internal static class GameInputCommand
             inspection.IntegrityExitCode != 0 ||
             !string.Equals(inspection.ArchiveSha256, metadata.ArchiveSha256, StringComparison.OrdinalIgnoreCase) ||
             inspection.ArchiveSizeBytes != metadata.ArchiveSizeBytes ||
-            actualSize != metadata.ArchiveSizeBytes)
+            actualSize != metadata.ArchiveSizeBytes ||
+            !string.Equals(actualHash, metadata.ArchiveSha256, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(utilityVersion, inspection.UtilityVersion, StringComparison.Ordinal))
         {
             throw new InvalidOperationException("The cached archive inspection is absent, stale, or inconsistent; run game extract for full revalidation.");
         }
@@ -120,7 +136,7 @@ internal static class GameInputCommand
         var hashMatches = string.Equals(archiveHash, metadata.ArchiveSha256, StringComparison.OrdinalIgnoreCase);
         if (!hashMatches) blockers.Add("archive: SHA-256 differs from the Phase 00 record");
         var versionResult = await RunUtilityAsync(metadata.ArchiveUtilityPath, ["i"], repository.Root, TimeSpan.FromMinutes(1));
-        var utilityVersion = versionResult.Stdout.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(line => line.Contains("7-Zip", StringComparison.OrdinalIgnoreCase))?.Trim() ?? "unknown";
+        var utilityVersion = ParseUtilityVersion(versionResult.Stdout);
 
         var listing = await ListAndValidateAsync(metadata.ArchiveUtilityPath, metadata.ArchivePath, repository.Root);
         blockers.AddRange(listing.Blockers);
@@ -169,7 +185,7 @@ internal static class GameInputCommand
         var blockers = new List<string>();
         var warnings = new List<string>();
         var workspace = Directory.GetParent(repository.Root)?.FullName ?? throw new InvalidOperationException("Repository has no workspace parent.");
-        var finalRoot = Path.Combine(workspace, "private", "games", metadata.ExpectedTitleId, metadata.ExpectedVersion);
+        var finalRoot = Path.GetFullPath(Path.Combine(workspace, "private", "games", metadata.ExpectedTitleId, metadata.ExpectedVersion));
         var privateParent = Path.GetDirectoryName(finalRoot)!;
         Directory.CreateDirectory(privateParent);
         if (!string.Equals(Path.GetPathRoot(finalRoot), Path.GetPathRoot(metadata.ArchivePath), StringComparison.OrdinalIgnoreCase))
@@ -184,9 +200,18 @@ internal static class GameInputCommand
             {
                 using var existing = JsonDocument.Parse(await File.ReadAllTextAsync(existingManifestPath));
                 var root = existing.RootElement;
-                var sourceMatches = root.TryGetProperty("sourceArchiveSha256", out var sourceHash) && string.Equals(sourceHash.GetString(), inspection.ArchiveSha256, StringComparison.OrdinalIgnoreCase);
-                var ebootExists = root.TryGetProperty("selectedEbootPath", out var ebootElement) && File.Exists(ebootElement.GetString());
-                if (sourceMatches && ebootExists)
+                var sourceMatches = string.Equals(StringProperty(root, "sourceArchiveSha256"), inspection.ArchiveSha256, StringComparison.OrdinalIgnoreCase);
+                var sizeMatches = root.TryGetProperty("sourceArchiveSizeBytes", out var sourceSize) && sourceSize.TryGetInt64(out var manifestSize) && manifestSize == inspection.ArchiveSizeBytes;
+                var utilityMatches = string.Equals(StringProperty(root, "extractionUtility"), inspection.Utility, StringComparison.Ordinal) &&
+                    StringProperty(root, "extractionUtilityPath") is { } utilityPath && string.Equals(CanonicalPath(utilityPath), CanonicalPath(metadata.ArchiveUtilityPath), StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(StringProperty(root, "extractionUtilityVersion"), inspection.UtilityVersion, StringComparison.Ordinal);
+                var rootMatches = StringProperty(root, "extractionRoot") is { } extractionRoot && string.Equals(CanonicalPath(extractionRoot), finalRoot, StringComparison.OrdinalIgnoreCase);
+                var ebootExists = root.TryGetProperty("selectedEbootPath", out var ebootElement) &&
+                    ebootElement.ValueKind == JsonValueKind.String &&
+                    IsCanonicalDescendant(finalRoot, ebootElement.GetString()!) &&
+                    File.Exists(CanonicalPath(ebootElement.GetString()!)) &&
+                    !HasReparsePoint(finalRoot, ebootElement.GetString()!);
+                if (sourceMatches && sizeMatches && utilityMatches && rootMatches && ebootExists)
                 {
                     warnings.Add("Existing extraction was reused after manifest and selected-eboot validation.");
                     return await CreateProfileFromExistingAsync(repository, metadata, existing.RootElement.Clone(), blockers, warnings);
@@ -212,14 +237,45 @@ internal static class GameInputCommand
         }
         var staging = stagingCandidates.SingleOrDefault()
             ?? finalRoot + $".staging-{DateTime.UtcNow:yyyyMMddTHHmmssZ}-{Environment.ProcessId}";
+        staging = CanonicalPath(staging);
+        var provenancePath = Path.Combine(staging, ".sharpemu-staging-provenance.json");
+        var expectedProvenance = new ExtractionProvenance(
+            "1.0.0",
+            DateTimeOffset.UtcNow,
+            inspection.ArchiveSha256,
+            inspection.ArchiveSizeBytes,
+            inspection.Utility,
+            CanonicalPath(metadata.ArchiveUtilityPath),
+            inspection.UtilityVersion,
+            finalRoot);
         var recoveredStaging = stagingCandidates.Length == 1;
         if (recoveredStaging)
         {
+            if (!File.Exists(provenancePath))
+            {
+                blockers.Add("archive: staging provenance is missing; resume was refused");
+                return Result("blocked", staging, null, null, null, null, blockers, warnings);
+            }
+            ExtractionProvenance? actualProvenance;
+            try
+            {
+                actualProvenance = JsonSerializer.Deserialize<ExtractionProvenance>(await File.ReadAllTextAsync(provenancePath), Program.JsonOptions);
+            }
+            catch (JsonException)
+            {
+                actualProvenance = null;
+            }
+            if (actualProvenance is null || !ProvenanceMatches(expectedProvenance, actualProvenance))
+            {
+                blockers.Add("archive: staging provenance is invalid or does not match the validated archive; resume was refused");
+                return Result("blocked", staging, null, null, null, null, blockers, warnings);
+            }
             warnings.Add("A single isolated staging tree from the current validated archive was recovered and fully revalidated.");
         }
         else
         {
             Directory.CreateDirectory(staging);
+            await File.WriteAllTextAsync(provenancePath, JsonSerializer.Serialize(expectedProvenance, Program.JsonOptions));
             var extraction = await RunUtilityAsync(
                 metadata.ArchiveUtilityPath,
                 ["x", "-bb0", "-bd", "-bso0", "-bsp0", "-y", $"-o{staging}", "--", metadata.ArchivePath],
@@ -242,7 +298,7 @@ internal static class GameInputCommand
                 blockers.Add("archive: extracted content contains a symlink, junction, or reparse point");
                 break;
             }
-            if (!Path.GetFullPath(entry).StartsWith(Path.GetFullPath(staging) + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            if (!IsCanonicalDescendant(staging, entry))
             {
                 blockers.Add("archive: extracted path escaped staging");
                 break;
@@ -250,7 +306,7 @@ internal static class GameInputCommand
         }
         if (blockers.Count > 0) return Result("failed-validation", staging, null, null, null, null, blockers, warnings);
 
-        var candidates = Directory.EnumerateFiles(staging, "eboot.bin", SearchOption.AllDirectories).ToArray();
+        var candidates = Directory.EnumerateFiles(staging, "eboot.bin", SearchOption.AllDirectories).Select(CanonicalPath).Where(path => IsCanonicalDescendant(staging, path)).ToArray();
         var selections = new List<Candidate>();
         foreach (var candidate in candidates)
         {
@@ -283,18 +339,29 @@ internal static class GameInputCommand
         }
         catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
         {
-            blockers.Add($"archive: validated staging could not be promoted to the final root: {exception.Message}");
+            var safeMessage = RunArtifactRedactor.SanitizeMessage(
+                exception.Message,
+                repository,
+                [finalRoot, staging, Path.GetDirectoryName(metadata.ArchivePath)!]);
+            blockers.Add($"archive: validated staging could not be promoted to the final root: {safeMessage}");
             return Result("promotion-failed", staging, selected.Path, ebootHash, selected.Metadata.TitleId, verifiedVersion, blockers, warnings, versionStatus);
         }
-        var finalEboot = Path.Combine(finalRoot, Path.GetRelativePath(staging, selected.Path));
-        var finalMetadata = selected.Metadata.SourcePath is null ? null : Path.Combine(finalRoot, Path.GetRelativePath(staging, selected.Metadata.SourcePath));
+        var finalEboot = CanonicalPath(Path.Combine(finalRoot, Path.GetRelativePath(staging, selected.Path)));
+        var finalMetadata = selected.Metadata.SourcePath is null ? null : CanonicalPath(Path.Combine(finalRoot, Path.GetRelativePath(staging, selected.Metadata.SourcePath)));
+        if (!IsCanonicalDescendant(finalRoot, finalEboot) || finalMetadata is not null && !IsCanonicalDescendant(finalRoot, finalMetadata))
+        {
+            blockers.Add("archive: selected eboot or metadata escaped the canonical final root");
+            return Result("failed-validation", finalRoot, null, null, null, null, blockers, warnings);
+        }
         var manifest = new
         {
             schemaVersion = "1.0.0",
             sourceArchivePath = metadata.ArchivePath,
             sourceArchiveSha256 = inspection.ArchiveSha256,
+            sourceArchiveSizeBytes = inspection.ArchiveSizeBytes,
             extractionUtcTimestamp = DateTimeOffset.UtcNow,
             extractionUtility = inspection.Utility,
+            extractionUtilityPath = CanonicalPath(metadata.ArchiveUtilityPath),
             extractionUtilityVersion = inspection.UtilityVersion,
             extractionRoot = finalRoot,
             selectedEbootPath = finalEboot,
@@ -310,7 +377,7 @@ internal static class GameInputCommand
             warnings,
         };
         await File.WriteAllTextAsync(existingManifestPath, JsonSerializer.Serialize(manifest, Program.JsonOptions));
-        await WriteProfileAsync(repository, metadata, finalEboot, ebootHash, selected.Metadata.TitleId!, verifiedVersion, versionStatus, finalMetadata);
+        await WriteProfileAsync(repository, metadata, finalRoot, finalEboot, ebootHash, selected.Metadata.TitleId!, verifiedVersion, versionStatus, finalMetadata);
         return Result("passed", finalRoot, finalEboot, ebootHash, selected.Metadata.TitleId, verifiedVersion, blockers, warnings, versionStatus);
     }
 
@@ -336,24 +403,32 @@ internal static class GameInputCommand
 
     private static async Task<GameBootstrapResult> CreateProfileFromExistingAsync(GitRepository repository, GameInputMetadata metadata, JsonElement manifest, List<string> blockers, List<string> warnings)
     {
-        var eboot = manifest.GetProperty("selectedEbootPath").GetString()!;
-        var extractionRoot = manifest.TryGetProperty("extractionRoot", out var root)
-            ? root.GetString()!
-            : Path.GetDirectoryName(eboot)!;
+        var eboot = CanonicalPath(manifest.GetProperty("selectedEbootPath").GetString()!);
+        var extractionRoot = CanonicalPath(manifest.GetProperty("extractionRoot").GetString()!);
+        if (!IsCanonicalDescendant(extractionRoot, eboot))
+        {
+            blockers.Add("archive: reusable extraction eboot is outside the canonical extraction root");
+            return Result("blocked", extractionRoot, null, null, null, null, blockers, warnings);
+        }
         var expectedEbootHash = manifest.GetProperty("ebootSha256").GetString()!;
         var ebootHash = await HashFileAsync(eboot);
-        var titleId = manifest.GetProperty("titleId").GetString()!;
-        var verifiedVersion = manifest.TryGetProperty("verifiedVersion", out var version) ? version.GetString() : null;
-        var versionStatus = manifest.TryGetProperty("versionStatus", out var status) ? status.GetString() ?? "unverified" : "unverified";
-        var metadataSource = manifest.TryGetProperty("metadataSource", out var source) ? source.GetString() : null;
+        var reparsed = TryFindMetadata(eboot, extractionRoot);
+        var titleId = reparsed.TitleId;
+        var verifiedVersion = reparsed.Version;
+        var versionStatus = string.IsNullOrWhiteSpace(verifiedVersion) ? "unverified" : "verified";
+        var metadataSource = reparsed.SourcePath;
+        if (metadataSource is null ||
+            !IsCanonicalDescendant(extractionRoot, metadataSource) ||
+            HasReparsePoint(extractionRoot, metadataSource)) blockers.Add("archive: reusable extraction metadata is missing or outside the canonical extraction root");
+        if (HasReparsePoint(extractionRoot, eboot)) blockers.Add("archive: reusable extraction eboot traverses a reparse point");
         if (!string.Equals(ebootHash, expectedEbootHash, StringComparison.OrdinalIgnoreCase)) blockers.Add("archive: reusable extraction eboot hash mismatch");
         if (!string.Equals(titleId, metadata.ExpectedTitleId, StringComparison.OrdinalIgnoreCase)) blockers.Add("archive: reusable extraction Title ID mismatch");
         if (!string.IsNullOrWhiteSpace(verifiedVersion) && !string.Equals(verifiedVersion, metadata.ExpectedVersion, StringComparison.OrdinalIgnoreCase)) blockers.Add("target version: reusable extraction version mismatch");
-        if (blockers.Count == 0) await WriteProfileAsync(repository, metadata, eboot, ebootHash, titleId, verifiedVersion, versionStatus, metadataSource);
+        if (blockers.Count == 0) await WriteProfileAsync(repository, metadata, extractionRoot, eboot, ebootHash, titleId!, verifiedVersion, versionStatus, metadataSource);
         return Result(blockers.Count == 0 ? "reused" : "blocked", extractionRoot, eboot, ebootHash, titleId, verifiedVersion, blockers, warnings, versionStatus);
     }
 
-    private static async Task WriteProfileAsync(GitRepository repository, GameInputMetadata metadata, string eboot, string hash, string titleId, string? verifiedVersion, string versionStatus, string? metadataSource)
+    private static async Task WriteProfileAsync(GitRepository repository, GameInputMetadata metadata, string extractionRoot, string eboot, string hash, string titleId, string? verifiedVersion, string versionStatus, string? metadataSource)
     {
         var profile = new LocalRunProfile
         {
@@ -376,10 +451,11 @@ internal static class GameInputCommand
                 MaxFrames = 8,
                 WindowSampleSeconds = [15, 45, 90, 150],
             },
-            RedactionRoots = [Path.GetDirectoryName(eboot)!],
+            RedactionRoots = [CanonicalPath(extractionRoot)],
             Metadata = new TargetMetadata
             {
                 TitleIdVerified = true,
+                VerifiedTitleId = titleId,
                 VersionVerified = string.Equals(versionStatus, "verified", StringComparison.OrdinalIgnoreCase),
                 VerifiedVersion = verifiedVersion,
                 MetadataSource = metadataSource,
@@ -391,10 +467,11 @@ internal static class GameInputCommand
         await File.WriteAllTextAsync(Path.Combine(profileDirectory, "demons-souls-01.004.000.json"), JsonSerializer.Serialize(profile, Program.JsonOptions));
     }
 
-    private static (string? TitleId, string? Version, string? SourcePath) TryFindMetadata(string eboot, string staging)
+    internal static (string? TitleId, string? Version, string? SourcePath) TryFindMetadata(string eboot, string staging)
     {
-        var directory = Path.GetDirectoryName(eboot)!;
-        for (var level = 0; level < 4 && directory.StartsWith(staging, StringComparison.OrdinalIgnoreCase); level++)
+        staging = CanonicalPath(staging);
+        var directory = Path.GetDirectoryName(CanonicalPath(eboot))!;
+        for (var level = 0; level < 4 && IsCanonicalDescendant(staging, directory, allowRoot: true); level++)
         {
             foreach (var candidate in new[] { Path.Combine(directory, "sce_sys", "param.json"), Path.Combine(directory, "param.json") })
             {
@@ -442,22 +519,34 @@ internal static class GameInputCommand
             currentSize = 0;
             await Task.CompletedTask;
         }
-        while (await process.StandardOutput.ReadLineAsync() is { } line)
+        using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(10));
+        try
         {
-            if (line.Length == 0)
+            while (await process.StandardOutput.ReadLineAsync(timeout.Token) is { } line)
             {
-                await FinishEntry();
-                continue;
+                if (line.Length == 0)
+                {
+                    await FinishEntry();
+                    continue;
+                }
+                if (line.StartsWith("Path = ", StringComparison.Ordinal)) currentPath = line[7..];
+                else if (line.StartsWith("Size = ", StringComparison.Ordinal) && long.TryParse(line[7..], out var size)) currentSize = size;
+                else if (line.StartsWith("Attributes = ", StringComparison.Ordinal)) currentAttributes = line[13..];
+                else if (HasArchiveLinkTarget(line)) currentAttributes = (currentAttributes ?? string.Empty) + " link";
             }
-            if (line.StartsWith("Path = ", StringComparison.Ordinal)) currentPath = line[7..];
-            else if (line.StartsWith("Size = ", StringComparison.Ordinal) && long.TryParse(line[7..], out var size)) currentSize = size;
-            else if (line.StartsWith("Attributes = ", StringComparison.Ordinal)) currentAttributes = line[13..];
-            else if (HasArchiveLinkTarget(line)) currentAttributes = (currentAttributes ?? string.Empty) + " link";
+            await FinishEntry();
+            await process.WaitForExitAsync(timeout.Token);
         }
-        await FinishEntry();
-        await process.WaitForExitAsync();
+        catch (OperationCanceledException)
+        {
+            if (!process.HasExited) process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync(CancellationToken.None);
+            blockers.Add("archive: directory listing exceeded the 10-minute hard timeout");
+            _ = await stderrTask;
+            return (entryCount, total, blockers);
+        }
         var stderr = await stderrTask;
-        if (process.ExitCode != 0) blockers.Add($"archive: directory listing failed with exit {process.ExitCode}: {FirstLine(stderr)}");
+        if (process.ExitCode != 0) blockers.Add($"archive: directory listing failed with exit {process.ExitCode}");
         return (entryCount, total, blockers);
     }
 
@@ -487,6 +576,45 @@ internal static class GameInputCommand
         return !string.IsNullOrWhiteSpace(target);
     }
 
+    internal static bool ProvenanceMatches(ExtractionProvenance expected, ExtractionProvenance actual) =>
+        actual.SchemaVersion == "1.0.0" &&
+        string.Equals(expected.ArchiveSha256, actual.ArchiveSha256, StringComparison.OrdinalIgnoreCase) &&
+        expected.ArchiveSizeBytes == actual.ArchiveSizeBytes &&
+        string.Equals(expected.ExtractionUtility, actual.ExtractionUtility, StringComparison.Ordinal) &&
+        string.Equals(CanonicalPath(expected.ExtractionUtilityPath), CanonicalPath(actual.ExtractionUtilityPath), StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(expected.ExtractionUtilityVersion, actual.ExtractionUtilityVersion, StringComparison.Ordinal) &&
+        string.Equals(CanonicalPath(expected.IntendedFinalRoot), CanonicalPath(actual.IntendedFinalRoot), StringComparison.OrdinalIgnoreCase);
+
+    internal static bool IsCanonicalDescendant(string root, string path, bool allowRoot = false)
+    {
+        var canonicalRoot = CanonicalPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var canonicalPath = CanonicalPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (allowRoot && string.Equals(canonicalRoot, canonicalPath, StringComparison.OrdinalIgnoreCase)) return true;
+        return canonicalPath.StartsWith(canonicalRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static bool HasReparsePoint(string root, string path)
+    {
+        if (!IsCanonicalDescendant(root, path, allowRoot: true)) return true;
+        try
+        {
+            var current = CanonicalPath(root);
+            if (File.GetAttributes(current).HasFlag(FileAttributes.ReparsePoint)) return true;
+            foreach (var segment in Path.GetRelativePath(current, CanonicalPath(path)).Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries))
+            {
+                current = Path.Combine(current, segment);
+                if (File.GetAttributes(current).HasFlag(FileAttributes.ReparsePoint)) return true;
+            }
+            return false;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+
+    private static string CanonicalPath(string path) => Path.GetFullPath(path);
+
     private static async Task<GameInputMetadata> ReadMetadataAsync(string path)
     {
         using var document = JsonDocument.Parse(await File.ReadAllTextAsync(path));
@@ -499,7 +627,7 @@ internal static class GameInputCommand
         string utility;
         if (root.TryGetProperty("archive_utility", out var utilityObject)) utility = utilityObject.GetProperty("path").GetString()!;
         else utility = root.GetProperty("tools").EnumerateArray().First(tool => tool.GetProperty("name").GetString() == "7-Zip").GetProperty("path").GetString()!;
-        return new GameInputMetadata(archivePath, size, hash, title, version, utility);
+        return new GameInputMetadata(CanonicalPath(archivePath), size, hash, title, version, CanonicalPath(utility));
     }
 
     private static async Task<string> HashFileAsync(string path)
@@ -526,7 +654,7 @@ internal static class GameInputCommand
         return process;
     }
 
-    private static async Task<CapturedProcess> RunUtilityAsync(string executable, IReadOnlyList<string> arguments, string workingDirectory, TimeSpan timeout)
+    internal static async Task<CapturedProcess> RunUtilityAsync(string executable, IReadOnlyList<string> arguments, string workingDirectory, TimeSpan timeout)
     {
         using var process = StartUtility(executable, arguments, workingDirectory);
         var stdout = process.StandardOutput.ReadToEndAsync();
@@ -542,7 +670,9 @@ internal static class GameInputCommand
         return new CapturedProcess(process.ExitCode, await stdout, await stderr);
     }
 
-    private static string FirstLine(string value) => value.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? "no diagnostics";
+    private static string ParseUtilityVersion(string output) =>
+        output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(line => line.Contains("7-Zip", StringComparison.OrdinalIgnoreCase))?.Trim() ?? "unknown";
 
     private static void PrintInspection(ArchiveInspection inspection)
     {

--- a/tools/SharpEmu.Tools.AgentHarness/GitRepository.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/GitRepository.cs
@@ -1,0 +1,130 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal sealed class GitRepository
+{
+    private GitRepository(string root)
+    {
+        Root = Path.GetFullPath(root);
+        LocalRoot = Path.Combine(Root, ".local");
+    }
+
+    public string Root { get; }
+
+    public string LocalRoot { get; }
+
+    public string Commit => RunGit("rev-parse", "HEAD").Trim();
+
+    public string Branch => RunGit("branch", "--show-current").Trim();
+
+    public bool IsDirty => RunGit("status", "--porcelain=v1").Length != 0;
+
+    public static GitRepository Discover(string startDirectory)
+    {
+        var result = ProcessUtility.RunCapture(
+            "git",
+            ["-C", Path.GetFullPath(startDirectory), "rev-parse", "--show-toplevel"],
+            startDirectory);
+        if (result.ExitCode != 0 || string.IsNullOrWhiteSpace(result.Stdout))
+        {
+            throw new InvalidOperationException("Run the harness from inside the SharpEmu Git repository.");
+        }
+
+        return new GitRepository(result.Stdout.Trim());
+    }
+
+    public string RunGit(params string[] arguments)
+    {
+        var result = ProcessUtility.RunCapture("git", ["-C", Root, .. arguments], Root);
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"git {string.Join(' ', arguments)} failed: {result.Stderr.Trim()}");
+        }
+
+        return result.Stdout;
+    }
+
+    public IReadOnlyList<string> TrackedFiles()
+    {
+        var output = RunGit("ls-files", "-z");
+        return output.Split('\0', StringSplitOptions.RemoveEmptyEntries)
+            .Select(NormalizeRelativePath)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    public string ResolvePath(string path)
+    {
+        var fullPath = Path.IsPathFullyQualified(path)
+            ? Path.GetFullPath(path)
+            : Path.GetFullPath(path, Root);
+        return fullPath;
+    }
+
+    public static string NormalizeRelativePath(string path) => path.Replace('\\', '/').TrimStart('/');
+
+    public static string Sha256File(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexStringLower(SHA256.HashData(stream));
+    }
+
+    public static string Sha256Bytes(ReadOnlySpan<byte> bytes) =>
+        Convert.ToHexStringLower(SHA256.HashData(bytes));
+}
+
+internal static class ProcessUtility
+{
+    public static CapturedProcess RunCapture(
+        string executable,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string?>? environment = null,
+        int timeoutMilliseconds = 60_000)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo(executable)
+            {
+                WorkingDirectory = workingDirectory,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            },
+        };
+        foreach (var argument in arguments)
+        {
+            process.StartInfo.ArgumentList.Add(argument);
+        }
+
+        if (environment is not null)
+        {
+            foreach (var pair in environment)
+            {
+                process.StartInfo.Environment[pair.Key] = pair.Value;
+            }
+        }
+
+        process.Start();
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(timeoutMilliseconds))
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+            throw new TimeoutException($"{executable} exceeded {timeoutMilliseconds} ms.");
+        }
+
+        Task.WaitAll(stdout, stderr);
+        return new CapturedProcess(process.ExitCode, stdout.Result, stderr.Result);
+    }
+}
+
+internal sealed record CapturedProcess(int ExitCode, string Stdout, string Stderr);

--- a/tools/SharpEmu.Tools.AgentHarness/PngCodec.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/PngCodec.cs
@@ -1,0 +1,184 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.IO.Compression;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal sealed record RgbaImage(int Width, int Height, byte[] Pixels)
+{
+    public int Stride => checked(Width * 4);
+
+    public static RgbaImage FromRaw(int width, int height, ReadOnlySpan<byte> source, string format, int rowPitch = 0, bool flipVertical = false)
+    {
+        if (width <= 0 || height <= 0) throw new ArgumentOutOfRangeException(nameof(width));
+        rowPitch = rowPitch <= 0 ? checked(width * 4) : rowPitch;
+        if (source.Length < checked(rowPitch * height)) throw new ArgumentException("Raw frame is shorter than its dimensions and row pitch.", nameof(source));
+        var rgba = new byte[checked(width * height * 4)];
+        var bgra = format.Contains("B8G8R8A8", StringComparison.OrdinalIgnoreCase) || format.Contains("BGRA", StringComparison.OrdinalIgnoreCase);
+        var rgbaFormat = format.Contains("R8G8B8A8", StringComparison.OrdinalIgnoreCase) || format.Contains("RGBA", StringComparison.OrdinalIgnoreCase);
+        if (!bgra && !rgbaFormat) throw new NotSupportedException($"Unsupported raw pixel format '{format}'.");
+        for (var y = 0; y < height; y++)
+        {
+            var sourceY = flipVertical ? height - 1 - y : y;
+            var sourceRow = source.Slice(sourceY * rowPitch, width * 4);
+            var destinationRow = rgba.AsSpan(y * width * 4, width * 4);
+            for (var x = 0; x < width; x++)
+            {
+                var offset = x * 4;
+                destinationRow[offset] = bgra ? sourceRow[offset + 2] : sourceRow[offset];
+                destinationRow[offset + 1] = sourceRow[offset + 1];
+                destinationRow[offset + 2] = bgra ? sourceRow[offset] : sourceRow[offset + 2];
+                destinationRow[offset + 3] = sourceRow[offset + 3];
+            }
+        }
+        return new RgbaImage(width, height, rgba);
+    }
+}
+
+internal static class PngCodec
+{
+    private static readonly byte[] Signature = [137, 80, 78, 71, 13, 10, 26, 10];
+    private static readonly uint[] CrcTable = BuildCrcTable();
+
+    public static void Write(string path, RgbaImage image)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+        if (image.Pixels.Length != checked(image.Width * image.Height * 4)) throw new ArgumentException("RGBA buffer size is invalid.", nameof(image));
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
+        using var output = File.Create(path);
+        output.Write(Signature);
+        Span<byte> ihdr = stackalloc byte[13];
+        BinaryPrimitives.WriteInt32BigEndian(ihdr, image.Width);
+        BinaryPrimitives.WriteInt32BigEndian(ihdr[4..], image.Height);
+        ihdr[8] = 8;
+        ihdr[9] = 6;
+        WriteChunk(output, "IHDR", ihdr);
+        using var raw = new MemoryStream();
+        for (var y = 0; y < image.Height; y++)
+        {
+            raw.WriteByte(0);
+            raw.Write(image.Pixels, y * image.Stride, image.Stride);
+        }
+        using var compressed = new MemoryStream();
+        using (var zlib = new ZLibStream(compressed, CompressionLevel.Optimal, leaveOpen: true))
+        {
+            raw.Position = 0;
+            raw.CopyTo(zlib);
+        }
+        WriteChunk(output, "IDAT", compressed.ToArray());
+        WriteChunk(output, "IEND", []);
+    }
+
+    public static RgbaImage Read(string path)
+    {
+        using var input = File.OpenRead(path);
+        Span<byte> signature = stackalloc byte[8];
+        input.ReadExactly(signature);
+        if (!signature.SequenceEqual(Signature)) throw new InvalidDataException("Not a PNG file.");
+        var width = 0;
+        var height = 0;
+        using var idat = new MemoryStream();
+        while (input.Position < input.Length)
+        {
+            Span<byte> header = new byte[8];
+            input.ReadExactly(header);
+            var length = BinaryPrimitives.ReadInt32BigEndian(header);
+            if (length < 0) throw new InvalidDataException("Invalid PNG chunk length.");
+            var type = System.Text.Encoding.ASCII.GetString(header[4..]);
+            var data = new byte[length];
+            input.ReadExactly(data);
+            Span<byte> crc = new byte[4];
+            input.ReadExactly(crc);
+            if (type == "IHDR")
+            {
+                if (data.Length != 13 || data[8] != 8 || data[9] != 6 || data[12] != 0) throw new NotSupportedException("Only non-interlaced 8-bit RGBA PNG is supported.");
+                width = BinaryPrimitives.ReadInt32BigEndian(data);
+                height = BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(4));
+            }
+            else if (type == "IDAT") idat.Write(data);
+            else if (type == "IEND") break;
+        }
+        if (width <= 0 || height <= 0) throw new InvalidDataException("PNG has no valid IHDR.");
+        idat.Position = 0;
+        using var decompressed = new MemoryStream();
+        using (var zlib = new ZLibStream(idat, CompressionMode.Decompress)) zlib.CopyTo(decompressed);
+        var filtered = decompressed.ToArray();
+        var stride = checked(width * 4);
+        if (filtered.Length != checked((stride + 1) * height)) throw new InvalidDataException("PNG scanline size is inconsistent.");
+        var pixels = new byte[checked(stride * height)];
+        for (var y = 0; y < height; y++)
+        {
+            var filter = filtered[y * (stride + 1)];
+            var source = filtered.AsSpan(y * (stride + 1) + 1, stride);
+            var destination = pixels.AsSpan(y * stride, stride);
+            var previous = y == 0 ? ReadOnlySpan<byte>.Empty : pixels.AsSpan((y - 1) * stride, stride);
+            Unfilter(filter, source, destination, previous, 4);
+        }
+        return new RgbaImage(width, height, pixels);
+    }
+
+    private static void Unfilter(byte filter, ReadOnlySpan<byte> source, Span<byte> destination, ReadOnlySpan<byte> previous, int bytesPerPixel)
+    {
+        for (var index = 0; index < source.Length; index++)
+        {
+            var left = index >= bytesPerPixel ? destination[index - bytesPerPixel] : 0;
+            var up = previous.IsEmpty ? 0 : previous[index];
+            var upperLeft = previous.IsEmpty || index < bytesPerPixel ? 0 : previous[index - bytesPerPixel];
+            destination[index] = filter switch
+            {
+                0 => source[index],
+                1 => unchecked((byte)(source[index] + left)),
+                2 => unchecked((byte)(source[index] + up)),
+                3 => unchecked((byte)(source[index] + ((left + up) >> 1))),
+                4 => unchecked((byte)(source[index] + Paeth(left, up, upperLeft))),
+                _ => throw new InvalidDataException($"Unsupported PNG filter {filter}."),
+            };
+        }
+    }
+
+    private static int Paeth(int left, int up, int upperLeft)
+    {
+        var estimate = left + up - upperLeft;
+        var leftDistance = Math.Abs(estimate - left);
+        var upDistance = Math.Abs(estimate - up);
+        var upperLeftDistance = Math.Abs(estimate - upperLeft);
+        return leftDistance <= upDistance && leftDistance <= upperLeftDistance ? left : upDistance <= upperLeftDistance ? up : upperLeft;
+    }
+
+    private static void WriteChunk(Stream output, string type, ReadOnlySpan<byte> data)
+    {
+        Span<byte> length = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(length, data.Length);
+        output.Write(length);
+        var typeBytes = System.Text.Encoding.ASCII.GetBytes(type);
+        output.Write(typeBytes);
+        output.Write(data);
+        var crcBytes = new byte[typeBytes.Length + data.Length];
+        typeBytes.CopyTo(crcBytes, 0);
+        data.CopyTo(crcBytes.AsSpan(typeBytes.Length));
+        Span<byte> crc = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(crc, ComputeCrc(crcBytes));
+        output.Write(crc);
+    }
+
+    private static uint ComputeCrc(ReadOnlySpan<byte> data)
+    {
+        var crc = uint.MaxValue;
+        foreach (var value in data) crc = CrcTable[(crc ^ value) & 0xFF] ^ (crc >> 8);
+        return crc ^ uint.MaxValue;
+    }
+
+    private static uint[] BuildCrcTable()
+    {
+        var table = new uint[256];
+        for (uint value = 0; value < table.Length; value++)
+        {
+            var crc = value;
+            for (var bit = 0; bit < 8; bit++) crc = (crc & 1) != 0 ? 0xEDB88320u ^ (crc >> 1) : crc >> 1;
+            table[value] = crc;
+        }
+        return table;
+    }
+}

--- a/tools/SharpEmu.Tools.AgentHarness/PrivateDataScanner.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/PrivateDataScanner.cs
@@ -1,0 +1,137 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.RegularExpressions;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal sealed record PrivateScanFinding(string Category, string Path);
+
+internal sealed record PrivateDataScanResult(
+    string Scope,
+    bool Passed,
+    int FindingCount,
+    IReadOnlyList<PrivateScanFinding> Findings,
+    IReadOnlyList<string> ExecutionFailures);
+
+internal static partial class PrivateDataScanner
+{
+    private const int DetailLimit = 100;
+    private const long ContentScanLimitBytes = 5 * 1024 * 1024;
+    private static readonly HashSet<string> AllowedRepositoryImages = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".github/images/614291356-95dc2b2a-4ed2-46b8-8875-2e0251529a35.jpg",
+        ".github/images/dead-cells.jpg",
+        ".github/images/demons-souls.jpg",
+        ".github/images/dreaming-sarah.jpg",
+        ".github/images/void-terrarium.jpg",
+        "assets/images/commit-icon.png",
+        "assets/images/discord.png",
+        "assets/images/github.png",
+        "assets/images/logo.png",
+        "assets/images/pic0.png",
+        "assets/images/update-icon.png",
+        "tools/SharpEmu.DebuggerFrontend/web/sharpemu-logo.webp",
+    };
+    private static readonly HashSet<string> ProhibitedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".7z", ".bin", ".cap", ".dmp", ".dump", ".elf", ".etl", ".gz", ".iso", ".pcap", ".pkg", ".prx", ".pup", ".rar", ".raw", ".self", ".sprx", ".tar", ".tgz", ".trace", ".xz", ".zip", ".zst",
+    };
+    private static readonly HashSet<string> ImageExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".bmp", ".gif", ".jpeg", ".jpg", ".png", ".tif", ".tiff", ".webp",
+    };
+
+    public static PrivateDataScanResult Scan(
+        GitRepository repository,
+        IEnumerable<string> privateRoots,
+        IEnumerable<string> privateHashes)
+    {
+        var findings = new List<PrivateScanFinding>();
+        var failures = new List<string>();
+        var tracked = repository.TrackedFiles();
+        foreach (var path in tracked)
+        {
+            if (path.Equals(".local", StringComparison.OrdinalIgnoreCase) || path.StartsWith(".local/", StringComparison.OrdinalIgnoreCase))
+            {
+                findings.Add(new PrivateScanFinding("tracked-local-path", path));
+            }
+            if (ProhibitedExtensions.Contains(Path.GetExtension(path)))
+            {
+                findings.Add(new PrivateScanFinding("prohibited-artifact-extension", path));
+            }
+            if (ImageExtensions.Contains(Path.GetExtension(path)) && !AllowedRepositoryImages.Contains(path))
+            {
+                findings.Add(new PrivateScanFinding("unapproved-tracked-image", path));
+            }
+        }
+
+        var needles = privateRoots.Concat(privateHashes)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        foreach (var needle in needles)
+        {
+            try
+            {
+                var result = ProcessUtility.RunCapture(
+                    "git",
+                    ["-C", repository.Root, "grep", "-I", "-l", "-F", needle, "--"],
+                    repository.Root);
+                if (ClassifyGitGrepExitCode(result.ExitCode) == "matches")
+                {
+                    foreach (var path in result.Stdout.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        findings.Add(new PrivateScanFinding("configured-private-value", GitRepository.NormalizeRelativePath(path)));
+                    }
+                }
+                else if (ClassifyGitGrepExitCode(result.ExitCode) == "failure")
+                {
+                    failures.Add($"git-grep-fixed-string-exit-{result.ExitCode}");
+                }
+            }
+            catch (Exception exception)
+            {
+                failures.Add("git-grep-fixed-string-failed-" + exception.GetType().Name);
+            }
+        }
+
+        foreach (var path in tracked)
+        {
+            try
+            {
+                var fullPath = repository.ResolvePath(path);
+                if (!File.Exists(fullPath) || new FileInfo(fullPath).Length > ContentScanLimitBytes) continue;
+                var bytes = File.ReadAllBytes(fullPath);
+                if (SourceIndexStore.IsBinary(bytes)) continue;
+                var text = System.Text.Encoding.UTF8.GetString(bytes);
+                if (CredentialPattern().IsMatch(text))
+                {
+                    findings.Add(new PrivateScanFinding("credential-pattern", path));
+                }
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                failures.Add($"tracked-content-read-failed:{path}:{exception.GetType().Name}");
+            }
+        }
+
+        var distinct = findings.Distinct().OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase).ThenBy(item => item.Category, StringComparer.Ordinal).ToArray();
+        return new PrivateDataScanResult(
+            "tracked paths plus non-binary current working-tree contents up to 5242880 bytes per Git-indexed file",
+            distinct.Length == 0 && failures.Count == 0,
+            distinct.Length,
+            distinct.Take(DetailLimit).ToArray(),
+            failures.Take(DetailLimit).ToArray());
+    }
+
+    internal static string ClassifyGitGrepExitCode(int exitCode) => exitCode switch
+    {
+        0 => "matches",
+        1 => "no-match",
+        _ => "failure",
+    };
+
+    [GeneratedRegex("(?:gh[pousr]_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN (?:RSA |OPENSSH |EC )?PRIVATE KEY-----|(?:api[_-]?key|access[_-]?token|client[_-]?secret|password)\\s*[:=]\\s*[\\\"'][A-Za-z0-9_./+=-]{16,})", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex CredentialPattern();
+}

--- a/tools/SharpEmu.Tools.AgentHarness/Profiles.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/Profiles.cs
@@ -1,0 +1,209 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal sealed record LocalRunProfile
+{
+    public string SchemaVersion { get; init; } = "1.0.0";
+
+    public string TargetName { get; init; } = string.Empty;
+
+    public string ExpectedTitleId { get; init; } = string.Empty;
+
+    public string ExpectedVersion { get; init; } = string.Empty;
+
+    public string EbootPath { get; init; } = string.Empty;
+
+    public string EbootSha256 { get; init; } = string.Empty;
+
+    public string BuildConfiguration { get; init; } = "Debug";
+
+    public string? EmulatorExecutable { get; init; }
+
+    public IReadOnlyList<string> EmulatorArguments { get; init; } = [];
+
+    public int TimeoutSeconds { get; init; } = 180;
+
+    public string LogLevel { get; init; } = "debug";
+
+    public int ImportTraceLimit { get; init; } = 64;
+
+    public CapturePolicy Capture { get; init; } = new();
+
+    public IReadOnlyDictionary<string, string?> Environment { get; init; } = new Dictionary<string, string?>();
+
+    public IReadOnlyList<string> RedactionRoots { get; init; } = [];
+
+    public TargetMetadata Metadata { get; init; } = new();
+}
+
+internal sealed record CapturePolicy
+{
+    public bool NativeEnabled { get; init; } = true;
+
+    public bool WindowFallbackEnabled { get; init; }
+
+    public bool FirstFrame { get; init; } = true;
+
+    public IReadOnlyList<long> FrameNumbers { get; init; } = [];
+
+    public int Interval { get; init; }
+
+    public int MaxFrames { get; init; } = 8;
+
+    public IReadOnlyList<int> WindowSampleSeconds { get; init; } = [];
+}
+
+internal sealed record TargetMetadata
+{
+    public bool TitleIdVerified { get; init; }
+
+    public bool VersionVerified { get; init; }
+
+    public string? VerifiedVersion { get; init; }
+
+    public string? MetadataSource { get; init; }
+
+    public string VersionStatus { get; init; } = "unverified";
+}
+
+internal sealed record ProfileValidation(
+    bool Valid,
+    string ProfilePath,
+    string? TargetName,
+    string? ExpectedTitleId,
+    string? ExpectedVersion,
+    bool EbootExists,
+    bool EbootHashMatches,
+    bool TitleIdVerified,
+    string VersionStatus,
+    IReadOnlyList<string> Errors,
+    IReadOnlyList<string> Warnings);
+
+internal static class ProfileLoader
+{
+    public static async Task<(LocalRunProfile? Profile, ProfileValidation Validation)> LoadAndValidateAsync(
+        GitRepository repository,
+        string path,
+        bool verifyHash = true,
+        CancellationToken cancellationToken = default)
+    {
+        var fullPath = repository.ResolvePath(path);
+        var errors = new List<string>();
+        var warnings = new List<string>();
+        if (!File.Exists(fullPath))
+        {
+            errors.Add("Profile file does not exist.");
+            return (null, new ProfileValidation(false, Redact(repository, fullPath), null, null, null, false, false, false, "unknown", errors, warnings));
+        }
+
+        LocalRunProfile? profile;
+        try
+        {
+            await using var stream = File.OpenRead(fullPath);
+            profile = await JsonSerializer.DeserializeAsync<LocalRunProfile>(stream, Program.JsonOptions, cancellationToken);
+        }
+        catch (Exception exception) when (exception is JsonException or IOException)
+        {
+            errors.Add($"Profile JSON is invalid: {exception.Message}");
+            return (null, new ProfileValidation(false, Redact(repository, fullPath), null, null, null, false, false, false, "unknown", errors, warnings));
+        }
+
+        if (profile is null)
+        {
+            errors.Add("Profile JSON was empty.");
+            return (null, new ProfileValidation(false, Redact(repository, fullPath), null, null, null, false, false, false, "unknown", errors, warnings));
+        }
+
+        if (profile.SchemaVersion != "1.0.0") errors.Add($"Unsupported profile schema '{profile.SchemaVersion}'.");
+        if (string.IsNullOrWhiteSpace(profile.TargetName)) errors.Add("targetName is required.");
+        if (string.IsNullOrWhiteSpace(profile.ExpectedTitleId)) errors.Add("expectedTitleId is required.");
+        if (string.IsNullOrWhiteSpace(profile.ExpectedVersion)) errors.Add("expectedVersion is required.");
+        if (profile.TimeoutSeconds is <= 0 or > 180) errors.Add("timeoutSeconds must be between 1 and 180.");
+        if (profile.ImportTraceLimit is < 0 or > 10_000) errors.Add("importTraceLimit must be between 0 and 10000.");
+        if (profile.Capture.MaxFrames is < 0 or > 8) errors.Add("capture.maxFrames must be between 0 and 8.");
+
+        var ebootPath = Path.IsPathFullyQualified(profile.EbootPath)
+            ? Path.GetFullPath(profile.EbootPath)
+            : repository.ResolvePath(profile.EbootPath);
+        var ebootExists = File.Exists(ebootPath);
+        if (!ebootExists)
+        {
+            errors.Add("Selected eboot does not exist.");
+        }
+        var hashMatches = false;
+        if (ebootExists && verifyHash)
+        {
+            hashMatches = string.Equals(
+                GitRepository.Sha256File(ebootPath),
+                profile.EbootSha256,
+                StringComparison.OrdinalIgnoreCase);
+            if (!hashMatches) errors.Add("Selected eboot SHA-256 does not match the profile.");
+        }
+        else if (ebootExists)
+        {
+            hashMatches = !string.IsNullOrWhiteSpace(profile.EbootSha256);
+        }
+
+        if (!profile.Metadata.TitleIdVerified)
+        {
+            errors.Add("The target Title ID is not independently verified.");
+        }
+        if (!profile.Metadata.VersionVerified)
+        {
+            warnings.Add("Target version is unverified; the run may proceed only because no contradictory version was found.");
+        }
+        if (profile.Metadata.VersionVerified &&
+            !string.Equals(profile.Metadata.VerifiedVersion, profile.ExpectedVersion, StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add("Verified target version contradicts expectedVersion.");
+        }
+        if (profile.EmulatorArguments.Any(argument => string.Equals(argument, "--strict", StringComparison.OrdinalIgnoreCase)))
+        {
+            warnings.Add("Strict dynamic-library resolution is enabled by the profile; confirm this is intentional evidence, not a faster-failure shortcut.");
+        }
+
+        return (profile, new ProfileValidation(
+            errors.Count == 0,
+            Redact(repository, fullPath),
+            profile.TargetName,
+            profile.ExpectedTitleId,
+            profile.ExpectedVersion,
+            ebootExists,
+            hashMatches,
+            profile.Metadata.TitleIdVerified,
+            profile.Metadata.VersionStatus,
+            errors,
+            warnings));
+    }
+
+    private static string Redact(GitRepository repository, string path) =>
+        path.StartsWith(repository.Root, StringComparison.OrdinalIgnoreCase)
+            ? "<repo>/" + GitRepository.NormalizeRelativePath(Path.GetRelativePath(repository.Root, path))
+            : "<private>/" + Path.GetFileName(path);
+}
+
+internal static class ProfileCommand
+{
+    public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
+    {
+        if (!arguments.Is("validate")) return Program.Fail("profile requires validate.");
+        var path = arguments.Value("--profile");
+        if (string.IsNullOrWhiteSpace(path)) return Program.Fail("profile validate requires --profile.");
+        var (_, validation) = await ProfileLoader.LoadAndValidateAsync(repository, path);
+        if (arguments.Has("--json"))
+        {
+            Program.WriteJson(validation);
+        }
+        else
+        {
+            Console.WriteLine(validation.Valid ? "Profile is valid." : "Profile is invalid.");
+            foreach (var warning in validation.Warnings) Console.WriteLine($"warning: {warning}");
+            foreach (var error in validation.Errors) Console.Error.WriteLine($"error: {error}");
+        }
+        return validation.Valid ? 0 : 2;
+    }
+}

--- a/tools/SharpEmu.Tools.AgentHarness/Profiles.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/Profiles.cs
@@ -61,6 +61,8 @@ internal sealed record TargetMetadata
 {
     public bool TitleIdVerified { get; init; }
 
+    public string? VerifiedTitleId { get; init; }
+
     public bool VersionVerified { get; init; }
 
     public string? VerifiedVersion { get; init; }
@@ -78,7 +80,9 @@ internal sealed record ProfileValidation(
     string? ExpectedVersion,
     bool EbootExists,
     bool EbootHashMatches,
+    string HashStatus,
     bool TitleIdVerified,
+    string? VerifiedTitleId,
     string VersionStatus,
     IReadOnlyList<string> Errors,
     IReadOnlyList<string> Warnings);
@@ -97,7 +101,7 @@ internal static class ProfileLoader
         if (!File.Exists(fullPath))
         {
             errors.Add("Profile file does not exist.");
-            return (null, new ProfileValidation(false, Redact(repository, fullPath), null, null, null, false, false, false, "unknown", errors, warnings));
+            return (null, InvalidProfile(repository, fullPath, errors, warnings));
         }
 
         LocalRunProfile? profile;
@@ -108,14 +112,14 @@ internal static class ProfileLoader
         }
         catch (Exception exception) when (exception is JsonException or IOException)
         {
-            errors.Add($"Profile JSON is invalid: {exception.Message}");
-            return (null, new ProfileValidation(false, Redact(repository, fullPath), null, null, null, false, false, false, "unknown", errors, warnings));
+            errors.Add($"Profile JSON is invalid: {RunArtifactRedactor.SanitizeMessage(exception.Message, repository)}");
+            return (null, InvalidProfile(repository, fullPath, errors, warnings));
         }
 
         if (profile is null)
         {
             errors.Add("Profile JSON was empty.");
-            return (null, new ProfileValidation(false, Redact(repository, fullPath), null, null, null, false, false, false, "unknown", errors, warnings));
+            return (null, InvalidProfile(repository, fullPath, errors, warnings));
         }
 
         if (profile.SchemaVersion != "1.0.0") errors.Add($"Unsupported profile schema '{profile.SchemaVersion}'.");
@@ -135,29 +139,46 @@ internal static class ProfileLoader
             errors.Add("Selected eboot does not exist.");
         }
         var hashMatches = false;
+        var hashStatus = "not-verified";
         if (ebootExists && verifyHash)
         {
             hashMatches = string.Equals(
                 GitRepository.Sha256File(ebootPath),
                 profile.EbootSha256,
                 StringComparison.OrdinalIgnoreCase);
+            hashStatus = hashMatches ? "matched" : "mismatched";
             if (!hashMatches) errors.Add("Selected eboot SHA-256 does not match the profile.");
         }
-        else if (ebootExists)
-        {
-            hashMatches = !string.IsNullOrWhiteSpace(profile.EbootSha256);
-        }
 
-        if (!profile.Metadata.TitleIdVerified)
+        var (metadataTitleId, metadataVersion) = ReadMetadataIdentity(repository, profile.Metadata.MetadataSource);
+        if (!string.IsNullOrWhiteSpace(metadataTitleId) &&
+            !string.IsNullOrWhiteSpace(profile.Metadata.VerifiedTitleId) &&
+            !string.Equals(metadataTitleId, profile.Metadata.VerifiedTitleId, StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add("Actual target metadata Title ID contradicts the profile verification record.");
+        }
+        if (!string.IsNullOrWhiteSpace(metadataVersion) &&
+            !string.IsNullOrWhiteSpace(profile.Metadata.VerifiedVersion) &&
+            !string.Equals(metadataVersion, profile.Metadata.VerifiedVersion, StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add("Actual target metadata version contradicts the profile verification record.");
+        }
+        var verifiedTitleId = metadataTitleId ?? profile.Metadata.VerifiedTitleId;
+        var verifiedVersion = metadataVersion ?? profile.Metadata.VerifiedVersion;
+        if (!profile.Metadata.TitleIdVerified || string.IsNullOrWhiteSpace(verifiedTitleId))
         {
             errors.Add("The target Title ID is not independently verified.");
         }
-        if (!profile.Metadata.VersionVerified)
+        else if (!string.Equals(verifiedTitleId, profile.ExpectedTitleId, StringComparison.OrdinalIgnoreCase))
         {
-            warnings.Add("Target version is unverified; the run may proceed only because no contradictory version was found.");
+            errors.Add("Verified target Title ID contradicts expectedTitleId.");
+        }
+        if (!profile.Metadata.VersionVerified || string.IsNullOrWhiteSpace(verifiedVersion))
+        {
+            errors.Add("The target version is not independently verified.");
         }
         if (profile.Metadata.VersionVerified &&
-            !string.Equals(profile.Metadata.VerifiedVersion, profile.ExpectedVersion, StringComparison.OrdinalIgnoreCase))
+            !string.Equals(verifiedVersion, profile.ExpectedVersion, StringComparison.OrdinalIgnoreCase))
         {
             errors.Add("Verified target version contradicts expectedVersion.");
         }
@@ -165,6 +186,14 @@ internal static class ProfileLoader
         {
             warnings.Add("Strict dynamic-library resolution is enabled by the profile; confirm this is intentional evidence, not a faster-failure shortcut.");
         }
+        profile = profile with
+        {
+            Metadata = profile.Metadata with
+            {
+                VerifiedTitleId = verifiedTitleId,
+                VerifiedVersion = verifiedVersion,
+            },
+        };
 
         return (profile, new ProfileValidation(
             errors.Count == 0,
@@ -174,7 +203,9 @@ internal static class ProfileLoader
             profile.ExpectedVersion,
             ebootExists,
             hashMatches,
-            profile.Metadata.TitleIdVerified,
+            hashStatus,
+            profile.Metadata.TitleIdVerified && !string.IsNullOrWhiteSpace(verifiedTitleId),
+            verifiedTitleId,
             profile.Metadata.VersionStatus,
             errors,
             warnings));
@@ -184,6 +215,35 @@ internal static class ProfileLoader
         path.StartsWith(repository.Root, StringComparison.OrdinalIgnoreCase)
             ? "<repo>/" + GitRepository.NormalizeRelativePath(Path.GetRelativePath(repository.Root, path))
             : "<private>/" + Path.GetFileName(path);
+
+    private static ProfileValidation InvalidProfile(
+        GitRepository repository,
+        string path,
+        IReadOnlyList<string> errors,
+        IReadOnlyList<string> warnings) =>
+        new(false, Redact(repository, path), null, null, null, false, false, "not-verified", false, null, "unknown", errors, warnings);
+
+    private static (string? TitleId, string? Version) ReadMetadataIdentity(GitRepository repository, string? source)
+    {
+        if (string.IsNullOrWhiteSpace(source)) return (null, null);
+        try
+        {
+            var path = Path.IsPathFullyQualified(source) ? Path.GetFullPath(source) : repository.ResolvePath(source);
+            if (!File.Exists(path)) return (null, null);
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            var root = document.RootElement;
+            return (
+                StringProperty(root, "titleId") ?? StringProperty(root, "titleID") ?? StringProperty(root, "TITLE_ID"),
+                StringProperty(root, "contentVersion") ?? StringProperty(root, "masterVersion") ?? StringProperty(root, "targetContentVersion") ?? StringProperty(root, "version"));
+        }
+        catch (Exception exception) when (exception is JsonException or IOException or UnauthorizedAccessException)
+        {
+            return (null, null);
+        }
+    }
+
+    private static string? StringProperty(JsonElement root, string name) =>
+        root.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String ? value.GetString() : null;
 }
 
 internal static class ProfileCommand
@@ -193,7 +253,7 @@ internal static class ProfileCommand
         if (!arguments.Is("validate")) return Program.Fail("profile requires validate.");
         var path = arguments.Value("--profile");
         if (string.IsNullOrWhiteSpace(path)) return Program.Fail("profile validate requires --profile.");
-        var (_, validation) = await ProfileLoader.LoadAndValidateAsync(repository, path);
+        var (_, validation) = await ProfileLoader.LoadAndValidateAsync(repository, path, verifyHash: !arguments.Has("--fast"));
         if (arguments.Has("--json"))
         {
             Program.WriteJson(validation);

--- a/tools/SharpEmu.Tools.AgentHarness/Program.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/Program.cs
@@ -1,0 +1,133 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal static class Program
+{
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private static async Task<int> Main(string[] args)
+    {
+        try
+        {
+            var repository = GitRepository.Discover(Environment.CurrentDirectory);
+            var arguments = new CommandArguments(args);
+            if (arguments.Count == 0 || arguments.Is("help") || arguments.Has("--help") || arguments.Has("-h"))
+            {
+                PrintHelp();
+                return 0;
+            }
+
+            return arguments[0].ToLowerInvariant() switch
+            {
+                "doctor" => await DoctorCommand.RunAsync(repository, arguments.Slice(1)),
+                "index" => await SourceIndexCommand.RunAsync(repository, arguments.Slice(1)),
+                "profile" => await ProfileCommand.RunAsync(repository, arguments.Slice(1)),
+                "run" => await RunCommand.RunAsync(repository, arguments.Slice(1)),
+                "visual" => await VisualCommand.RunAsync(repository, arguments.Slice(1)),
+                "synthetic" => await SyntheticCommand.RunAsync(repository, arguments.Slice(1)),
+                "game" => await GameInputCommand.RunAsync(repository, arguments.Slice(1)),
+                "skills" => SkillCommand.Run(repository, arguments.Slice(1)),
+                "redact" => await RunArtifactRedactor.RunAsync(repository, arguments.Slice(1)),
+                _ => Fail($"Unknown command '{arguments[0]}'. Run with --help for usage."),
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            Console.Error.WriteLine("Operation canceled.");
+            return 130;
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine($"agent-harness: {exception.Message}");
+            return 1;
+        }
+    }
+
+    internal static int Fail(string message)
+    {
+        Console.Error.WriteLine(message);
+        return 1;
+    }
+
+    internal static void WriteJson<T>(T value) =>
+        Console.WriteLine(JsonSerializer.Serialize(value, JsonOptions));
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine(
+            """
+            SharpEmu agent harness
+
+              agent-harness doctor [--json]
+              agent-harness index build|status [--json]
+              agent-harness index query --symbol <name> [--namespace <name>] [--kind <kind>] [--limit 20] [--json]
+              agent-harness index outline (--path <tracked-path> | --symbol <name>) [--limit 20] [--json]
+              agent-harness index text --pattern <text> [--limit 20] [--json]
+              agent-harness index map --project <name> [--json]
+              agent-harness profile validate --profile <local-profile.json> [--json]
+              agent-harness run --profile <local-profile.json>
+              agent-harness visual analyze --run <run-id-or-path> [--json]
+              agent-harness visual compare --before <run-id-or-path> --after <run-id-or-path> [--json]
+              agent-harness synthetic visual [--output <directory>] [--json]
+              agent-harness game inspect|extract|resume --metadata <phase-00-json> [--json]
+              agent-harness skills validate [--json]
+              agent-harness redact run --run <run-id-or-path> [--json]
+
+            Output is bounded to 20 results by default. Add --json for machine-readable query output.
+            Generated indexes, reports, runs, and images stay under .local/.
+            """);
+    }
+}
+
+internal sealed class CommandArguments
+{
+    private readonly string[] _values;
+
+    public CommandArguments(IEnumerable<string> values) => _values = values.ToArray();
+
+    public int Count => _values.Length;
+
+    public string this[int index] => _values[index];
+
+    public bool Is(string value) => Count > 0 && string.Equals(_values[0], value, StringComparison.OrdinalIgnoreCase);
+
+    public bool Has(string option) => _values.Any(value => string.Equals(value, option, StringComparison.OrdinalIgnoreCase));
+
+    public string? Value(string option)
+    {
+        for (var index = 0; index < _values.Length; index++)
+        {
+            var value = _values[index];
+            if (string.Equals(value, option, StringComparison.OrdinalIgnoreCase))
+            {
+                return index + 1 < _values.Length ? _values[index + 1] : null;
+            }
+
+            var prefix = option + "=";
+            if (value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return value[prefix.Length..];
+            }
+        }
+
+        return null;
+    }
+
+    public int IntValue(string option, int fallback, int minimum = 1, int maximum = 10_000)
+    {
+        var text = Value(option);
+        return int.TryParse(text, out var value) ? Math.Clamp(value, minimum, maximum) : fallback;
+    }
+
+    public CommandArguments Slice(int start) => new(_values.Skip(start));
+
+    public IReadOnlyList<string> Values => _values;
+}

--- a/tools/SharpEmu.Tools.AgentHarness/Program.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/Program.cs
@@ -15,9 +15,10 @@ internal static class Program
 
     private static async Task<int> Main(string[] args)
     {
+        GitRepository? repository = null;
         try
         {
-            var repository = GitRepository.Discover(Environment.CurrentDirectory);
+            repository = GitRepository.Discover(Environment.CurrentDirectory);
             var arguments = new CommandArguments(args);
             if (arguments.Count == 0 || arguments.Is("help") || arguments.Has("--help") || arguments.Has("-h"))
             {
@@ -46,7 +47,10 @@ internal static class Program
         }
         catch (Exception exception)
         {
-            Console.Error.WriteLine($"agent-harness: {exception.Message}");
+            var message = repository is null
+                ? exception.GetType().Name
+                : RunArtifactRedactor.SanitizeMessage(exception.Message, repository);
+            Console.Error.WriteLine($"agent-harness: {message}");
             return 1;
         }
     }
@@ -66,16 +70,16 @@ internal static class Program
             """
             SharpEmu agent harness
 
-              agent-harness doctor [--json]
+              agent-harness doctor [--profile <local-profile.json>] [--fast] [--environment-only] [--json]
               agent-harness index build|status [--json]
               agent-harness index query --symbol <name> [--namespace <name>] [--kind <kind>] [--limit 20] [--json]
               agent-harness index outline (--path <tracked-path> | --symbol <name>) [--limit 20] [--json]
               agent-harness index text --pattern <text> [--limit 20] [--json]
               agent-harness index map --project <name> [--json]
-              agent-harness profile validate --profile <local-profile.json> [--json]
+              agent-harness profile validate --profile <local-profile.json> [--fast] [--json]
               agent-harness run --profile <local-profile.json>
               agent-harness visual analyze --run <run-id-or-path> [--json]
-              agent-harness visual compare --before <run-id-or-path> --after <run-id-or-path> [--json]
+              agent-harness visual compare --before <run-id-or-path> --after <run-id-or-path> [--frame <number>] [--exploratory] [--json]
               agent-harness synthetic visual [--output <directory>] [--json]
               agent-harness game inspect|extract|resume --metadata <phase-00-json> [--json]
               agent-harness skills validate [--json]

--- a/tools/SharpEmu.Tools.AgentHarness/RunArtifactRedactor.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/RunArtifactRedactor.cs
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal static class RunArtifactRedactor
+{
+    private static readonly string[] TextArtifactNames =
+    [
+        "stdout.log",
+        "stderr.log",
+        "emulator.log",
+        "events.jsonl",
+        "run.json",
+        "environment.json",
+        "harness-config.json",
+    ];
+
+    public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
+    {
+        if (!arguments.Is("run")) return Program.Fail("redact requires run.");
+        var value = arguments.Value("--run");
+        if (string.IsNullOrWhiteSpace(value)) return Program.Fail("redact run requires --run.");
+        var runDirectory = Path.IsPathFullyQualified(value)
+            ? Path.GetFullPath(value)
+            : Directory.Exists(repository.ResolvePath(value))
+                ? repository.ResolvePath(value)
+                : Path.Combine(repository.LocalRoot, "runs", value);
+        if (!Directory.Exists(runDirectory)) return Program.Fail($"Run '{value}' was not found.");
+        var roots = await ReadRootsAsync(runDirectory);
+        if (roots.Count == 0) return Program.Fail("Run has no readable configured redaction roots.");
+        var redacted = await RedactAsync(runDirectory, roots);
+        var result = new { runId = Path.GetFileName(runDirectory), redactedFiles = redacted, rootCount = roots.Count };
+        if (arguments.Has("--json")) Program.WriteJson(result); else Console.WriteLine($"Redacted {redacted.Count} artifact(s) for {result.runId}.");
+        return 0;
+    }
+
+    public static async Task<IReadOnlyList<string>> RedactAsync(string runDirectory, IReadOnlyList<string> roots)
+    {
+        var redacted = new List<string>();
+        foreach (var name in TextArtifactNames)
+        {
+            var path = Path.Combine(runDirectory, name);
+            if (!File.Exists(path)) continue;
+            var text = await File.ReadAllTextAsync(path);
+            var updated = RedactText(text, roots);
+            if (string.Equals(text, updated, StringComparison.Ordinal)) continue;
+            await File.WriteAllTextAsync(path, updated);
+            redacted.Add(name);
+        }
+        return redacted;
+    }
+
+    internal static string RedactText(string value, IReadOnlyList<string> roots)
+    {
+        var redacted = value;
+        for (var index = 0; index < roots.Count; index++)
+        {
+            var replacement = $"<private-root-{index + 1}>";
+            var root = Path.GetFullPath(roots[index]);
+            redacted = redacted.Replace(root, replacement, StringComparison.OrdinalIgnoreCase);
+            redacted = redacted.Replace(JsonEncodedText.Encode(root).ToString(), replacement, StringComparison.OrdinalIgnoreCase);
+        }
+        return redacted;
+    }
+
+    private static async Task<IReadOnlyList<string>> ReadRootsAsync(string runDirectory)
+    {
+        var path = Path.Combine(runDirectory, "harness-config.json");
+        if (!File.Exists(path)) return [];
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(path));
+        return document.RootElement.TryGetProperty("redactionRoots", out var roots)
+            ? roots.EnumerateArray().Select(root => root.GetString()).Where(root => !string.IsNullOrWhiteSpace(root)).Cast<string>().ToArray()
+            : [];
+    }
+}

--- a/tools/SharpEmu.Tools.AgentHarness/RunArtifactRedactor.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/RunArtifactRedactor.cs
@@ -5,6 +5,8 @@ using System.Text.Json;
 
 namespace SharpEmu.Tools.AgentHarness;
 
+internal sealed record RedactionRoot(string Path, string Token);
+
 internal static class RunArtifactRedactor
 {
     private static readonly string[] TextArtifactNames =
@@ -16,6 +18,7 @@ internal static class RunArtifactRedactor
         "run.json",
         "environment.json",
         "harness-config.json",
+        "vulkan-validation.json",
     ];
 
     public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
@@ -31,13 +34,16 @@ internal static class RunArtifactRedactor
         if (!Directory.Exists(runDirectory)) return Program.Fail($"Run '{value}' was not found.");
         var roots = await ReadRootsAsync(runDirectory);
         if (roots.Count == 0) return Program.Fail("Run has no readable configured redaction roots.");
-        var redacted = await RedactAsync(runDirectory, roots);
+        var redacted = await RedactAsync(runDirectory, CreatePrivateMap(roots));
         var result = new { runId = Path.GetFileName(runDirectory), redactedFiles = redacted, rootCount = roots.Count };
         if (arguments.Has("--json")) Program.WriteJson(result); else Console.WriteLine($"Redacted {redacted.Count} artifact(s) for {result.runId}.");
         return 0;
     }
 
     public static async Task<IReadOnlyList<string>> RedactAsync(string runDirectory, IReadOnlyList<string> roots)
+        => await RedactAsync(runDirectory, CreatePrivateMap(roots));
+
+    public static async Task<IReadOnlyList<string>> RedactAsync(string runDirectory, IReadOnlyList<RedactionRoot> roots)
     {
         var redacted = new List<string>();
         foreach (var name in TextArtifactNames)
@@ -53,17 +59,61 @@ internal static class RunArtifactRedactor
         return redacted;
     }
 
-    internal static string RedactText(string value, IReadOnlyList<string> roots)
+    internal static string RedactText(string value, IReadOnlyList<string> roots) =>
+        RedactText(value, CreatePrivateMap(roots));
+
+    internal static string RedactText(string value, IReadOnlyList<RedactionRoot> roots)
     {
         var redacted = value;
-        for (var index = 0; index < roots.Count; index++)
+        foreach (var item in roots.OrderByDescending(item => item.Path.Length))
         {
-            var replacement = $"<private-root-{index + 1}>";
-            var root = Path.GetFullPath(roots[index]);
-            redacted = redacted.Replace(root, replacement, StringComparison.OrdinalIgnoreCase);
-            redacted = redacted.Replace(JsonEncodedText.Encode(root).ToString(), replacement, StringComparison.OrdinalIgnoreCase);
+            foreach (var root in PathForms(item.Path))
+            {
+                redacted = redacted.Replace(root, item.Token, StringComparison.OrdinalIgnoreCase);
+                redacted = redacted.Replace(JsonEncodedText.Encode(root).ToString(), item.Token, StringComparison.OrdinalIgnoreCase);
+            }
         }
         return redacted;
+    }
+
+    internal static IReadOnlyList<RedactionRoot> CreateStandardMap(
+        GitRepository repository,
+        IEnumerable<string> privateRoots)
+    {
+        var result = new List<RedactionRoot>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var privateIndex = 0;
+        foreach (var value in privateRoots.Where(value => !string.IsNullOrWhiteSpace(value)))
+        {
+            var root = Path.GetFullPath(value);
+            if (!seen.Add(root)) continue;
+            result.Add(new RedactionRoot(root, privateIndex++ == 0 ? "<private-game-root>" : $"<private-root-{privateIndex}>"));
+        }
+
+        if (seen.Add(repository.Root)) result.Add(new RedactionRoot(repository.Root, "<repo>"));
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(home) && seen.Add(Path.GetFullPath(home)))
+        {
+            result.Add(new RedactionRoot(home, "<user-home>"));
+        }
+        return result;
+    }
+
+    internal static string SanitizeMessage(
+        string message,
+        GitRepository repository,
+        IEnumerable<string>? privateRoots = null) =>
+        RedactText(message, CreateStandardMap(repository, privateRoots ?? []));
+
+    private static IReadOnlyList<RedactionRoot> CreatePrivateMap(IReadOnlyList<string> roots) =>
+        roots.Select((root, index) => new RedactionRoot(Path.GetFullPath(root), $"<private-root-{index + 1}>")).ToArray();
+
+    private static IEnumerable<string> PathForms(string path)
+    {
+        var full = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        yield return full;
+        var forward = full.Replace('\\', '/');
+        if (!string.Equals(forward, full, StringComparison.Ordinal)) yield return forward;
     }
 
     private static async Task<IReadOnlyList<string>> ReadRootsAsync(string runDirectory)

--- a/tools/SharpEmu.Tools.AgentHarness/RunCommand.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/RunCommand.cs
@@ -1,0 +1,310 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal static class RunCommand
+{
+    public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
+    {
+        var profileValue = arguments.Value("--profile");
+        if (string.IsNullOrWhiteSpace(profileValue)) return Program.Fail("run requires --profile.");
+        var (profile, validation) = await ProfileLoader.LoadAndValidateAsync(repository, profileValue);
+        if (profile is null || !validation.Valid)
+        {
+            foreach (var error in validation.Errors) Console.Error.WriteLine($"profile: {error}");
+            return 2;
+        }
+
+        var executable = !string.IsNullOrWhiteSpace(profile.EmulatorExecutable)
+            ? (Path.IsPathFullyQualified(profile.EmulatorExecutable) ? Path.GetFullPath(profile.EmulatorExecutable) : repository.ResolvePath(profile.EmulatorExecutable))
+            : DoctorCommand.FindEmulator(repository, profile.BuildConfiguration);
+        if (executable is null || !File.Exists(executable)) return Program.Fail($"SharpEmu {profile.BuildConfiguration} executable is missing; build the solution first.");
+
+        var shortCommit = repository.Commit[..12];
+        var runId = $"{DateTime.UtcNow:yyyyMMddTHHmmss.fffZ}-{shortCommit}-{Sanitize(profile.ExpectedTitleId)}";
+        var runDirectory = Path.Combine(repository.LocalRoot, "runs", runId);
+        var frameDirectory = Path.Combine(runDirectory, "frames");
+        Directory.CreateDirectory(frameDirectory);
+        Directory.CreateDirectory(Path.Combine(runDirectory, "diffs"));
+        var eventsPath = Path.Combine(runDirectory, "events.jsonl");
+        var stdoutPath = Path.Combine(runDirectory, "stdout.log");
+        var stderrPath = Path.Combine(runDirectory, "stderr.log");
+        var emulatorLogPath = Path.Combine(runDirectory, "emulator.log");
+        var harnessConfigPath = Path.Combine(runDirectory, "harness-config.json");
+        await File.WriteAllTextAsync(eventsPath, string.Empty);
+
+        var ebootPath = Path.GetFullPath(profile.EbootPath);
+        var redactionRoots = profile.RedactionRoots
+            .Append(Path.GetDirectoryName(ebootPath)!)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var harnessConfig = new
+        {
+            schemaVersion = "1.0.0",
+            eventsPath,
+            rawFrameDirectory = frameDirectory,
+            redactionRoots,
+            capture = new
+            {
+                enabled = profile.Capture.NativeEnabled,
+                profile.Capture.FirstFrame,
+                profile.Capture.FrameNumbers,
+                profile.Capture.Interval,
+                profile.Capture.MaxFrames,
+            },
+        };
+        await File.WriteAllTextAsync(harnessConfigPath, JsonSerializer.Serialize(harnessConfig, Program.JsonOptions));
+
+        var emulatorArguments = new List<string>(profile.EmulatorArguments);
+        if (profile.ImportTraceLimit > 0 && !ContainsOption(emulatorArguments, "--trace-imports")) emulatorArguments.Add($"--trace-imports={profile.ImportTraceLimit}");
+        if (!ContainsOption(emulatorArguments, "--log-level")) emulatorArguments.Add($"--log-level={profile.LogLevel}");
+        if (!ContainsOption(emulatorArguments, "--log-file")) emulatorArguments.Add($"--log-file={emulatorLogPath}");
+        emulatorArguments.Add($"--harness-config={harnessConfigPath}");
+        emulatorArguments.Add(ebootPath);
+
+        var environment = new Dictionary<string, string?>(profile.Environment, StringComparer.OrdinalIgnoreCase);
+        var environmentReport = await WriteEnvironmentAsync(repository, runDirectory, profile.BuildConfiguration);
+        var preliminary = new
+        {
+            schemaVersion = "1.0.0",
+            runId,
+            status = "running",
+            profile = $"<local-profile>/{Path.GetFileName(profileValue)}",
+            repositorySha = repository.Commit,
+            dirty = repository.IsDirty,
+            buildConfiguration = profile.BuildConfiguration,
+            executableSha256 = GitRepository.Sha256File(executable),
+            targetId = profile.ExpectedTitleId,
+            expectedVersion = profile.ExpectedVersion,
+            verifiedVersion = profile.Metadata.VerifiedVersion,
+            versionStatus = profile.Metadata.VersionStatus,
+            commandArguments = RedactArguments(emulatorArguments, redactionRoots),
+            startUtc = DateTimeOffset.UtcNow,
+        };
+        await File.WriteAllTextAsync(Path.Combine(runDirectory, "run.json"), JsonSerializer.Serialize(preliminary, Program.JsonOptions));
+
+        var sampledWindowSeconds = new HashSet<int>();
+        var windowStatuses = new List<string>();
+        async Task Sample(Process process, TimeSpan elapsed)
+        {
+            if (!profile.Capture.WindowFallbackEnabled || profile.Capture.WindowSampleSeconds.Count == 0) return;
+            foreach (var second in profile.Capture.WindowSampleSeconds.Where(second => second >= 0 && elapsed.TotalSeconds >= second))
+            {
+                if (!sampledWindowSeconds.Add(second)) continue;
+                if (Directory.EnumerateFiles(frameDirectory, "native-*.raw.json").Any()) continue;
+                var existing = Directory.EnumerateFiles(frameDirectory, "*.raw.json").Count();
+                if (existing >= profile.Capture.MaxFrames) continue;
+                var captured = WindowCapture.TryCaptureClientArea(process, frameDirectory, existing + 1, elapsed.TotalSeconds, out var status);
+                windowStatuses.Add($"t={second}s:{status}");
+                if (!captured) await Task.CompletedTask;
+            }
+        }
+
+        BoundedProcessResult processResult;
+        try
+        {
+            processResult = await BoundedProcessRunner.RunAsync(
+                executable,
+                emulatorArguments,
+                Path.GetDirectoryName(executable)!,
+                environment,
+                TimeSpan.FromSeconds(profile.TimeoutSeconds),
+                stdoutPath,
+                stderrPath,
+                Sample);
+        }
+        catch (Exception exception)
+        {
+            await RunArtifactRedactor.RedactAsync(runDirectory, redactionRoots);
+            var failed = new
+            {
+                schemaVersion = "1.0.0",
+                runId,
+                status = "launch-failed",
+                error = exception.Message,
+                repositorySha = repository.Commit,
+                dirty = repository.IsDirty,
+                targetId = profile.ExpectedTitleId,
+                warnings = validation.Warnings,
+                blockers = new[] { "environment: emulator process could not be launched" },
+            };
+            await File.WriteAllTextAsync(Path.Combine(runDirectory, "run.json"), JsonSerializer.Serialize(failed, Program.JsonOptions));
+            Console.Error.WriteLine($"Run {runId} failed to launch: {exception.Message}");
+            return 3;
+        }
+
+        await RunArtifactRedactor.RedactAsync(runDirectory, redactionRoots);
+        var visual = await VisualCommand.AnalyzeRunAsync(runDirectory);
+        var events = await ReadEventsAsync(eventsPath);
+        var milestoneValues = events.Select(item => item.Milestone).Where(value => value.HasValue).Select(value => value!.Value).ToArray();
+        var firstMilestone = milestoneValues.Length == 0 ? 0 : milestoneValues.Min();
+        var highestMilestone = milestoneValues.Length == 0 ? 0 : milestoneValues.Max();
+        var hasHostException = events.Any(item => string.Equals(item.Kind, "host.exception", StringComparison.OrdinalIgnoreCase));
+        var exitStatus = processResult.TimedOut
+            ? "timeout"
+            : hasHostException || processResult.Crash
+                ? "emulator-crash"
+                : processResult.ExitCode == 0 ? "clean-exit" : "guest-failure";
+        var blocker = ClassifyBlocker(events, processResult, visual, highestMilestone);
+        var metrics = new
+        {
+            schemaVersion = "1.0.0",
+            wallSeconds = processResult.ElapsedSeconds,
+            processCpuSeconds = processResult.CpuSeconds,
+            peakWorkingSetBytes = processResult.PeakWorkingSetBytes,
+            resourceMeasurementScope = processResult.ResourceMeasurementScope,
+        };
+        await File.WriteAllTextAsync(Path.Combine(runDirectory, "metrics.json"), JsonSerializer.Serialize(metrics, Program.JsonOptions));
+        var warnings = validation.Warnings
+            .Concat(processResult.Warnings)
+            .Concat(windowStatuses.Select(value => "window-fallback: " + value))
+            .ToArray();
+        var result = new
+        {
+            schemaVersion = "1.0.0",
+            runId,
+            profile = $"<local-profile>/{Path.GetFileName(profileValue)}",
+            repositorySha = repository.Commit,
+            dirty = repository.IsDirty,
+            buildConfiguration = profile.BuildConfiguration,
+            executableSha256 = preliminary.executableSha256,
+            targetId = profile.ExpectedTitleId,
+            expectedVersion = profile.ExpectedVersion,
+            verifiedVersion = profile.Metadata.VerifiedVersion,
+            versionStatus = profile.Metadata.VersionStatus,
+            commandArguments = preliminary.commandArguments,
+            processResult.StartUtc,
+            processResult.EndUtc,
+            elapsedSeconds = processResult.ElapsedSeconds,
+            exitCode = processResult.ExitCode,
+            exitStatus,
+            timedOut = processResult.TimedOut,
+            crash = hasHostException || processResult.Crash,
+            processTree = new { processResult.JobObjectOwned, processResult.ProcessTreeCleaned },
+            firstObservedMilestone = firstMilestone,
+            highestObservedMilestone = highestMilestone,
+            firstFrameStatus = visual.FirstFrameStatus,
+            captureStatus = visual.CaptureStatus,
+            artifacts = new
+            {
+                run = "run.json",
+                environment = "environment.json",
+                events = "events.jsonl",
+                stdout = "stdout.log",
+                stderr = "stderr.log",
+                emulatorLog = File.Exists(emulatorLogPath) ? "emulator.log" : null,
+                metrics = "metrics.json",
+                frames = "frames/",
+                visual = "visual.json",
+                contactSheet = visual.ContactSheet,
+            },
+            environmentFingerprint = environmentReport.Fingerprint,
+            warnings,
+            blockers = new[] { blocker },
+            nextRunCommand = $".\\scripts\\agent-harness.ps1 run --profile .local\\profiles\\{Path.GetFileName(profileValue)}",
+        };
+        await File.WriteAllTextAsync(Path.Combine(runDirectory, "run.json"), JsonSerializer.Serialize(result, Program.JsonOptions));
+        Console.WriteLine($"Run ID: {runId}");
+        Console.WriteLine($"Exit: {exitStatus}; elapsed {processResult.ElapsedSeconds:F1}s; highest milestone {highestMilestone}.");
+        Console.WriteLine($"Frames: {visual.Frames.Count}; capture {visual.CaptureStatus}.");
+        Console.WriteLine($"Blocker: {blocker}");
+        Console.WriteLine(runDirectory);
+        return processResult.TimedOut ? 124 : processResult.ExitCode ?? 3;
+    }
+
+    private static bool ContainsOption(IReadOnlyList<string> arguments, string option) =>
+        arguments.Any(argument => string.Equals(argument, option, StringComparison.OrdinalIgnoreCase) || argument.StartsWith(option + "=", StringComparison.OrdinalIgnoreCase));
+
+    private static string[] RedactArguments(IEnumerable<string> arguments, IReadOnlyList<string> roots) =>
+        arguments.Select(argument => Redact(argument, roots)).ToArray();
+
+    private static string Redact(string value, IReadOnlyList<string> roots)
+    {
+        var redacted = value;
+        for (var index = 0; index < roots.Count; index++) redacted = redacted.Replace(roots[index], $"<private-root-{index + 1}>", StringComparison.OrdinalIgnoreCase);
+        return redacted;
+    }
+
+    private static string Sanitize(string value) => new(value.Select(character => char.IsLetterOrDigit(character) || character is '-' or '_' ? character : '-').ToArray());
+
+    private static async Task<(string Fingerprint, object Report)> WriteEnvironmentAsync(GitRepository repository, string runDirectory, string configuration)
+    {
+        var phaseZeroPath = Path.Combine(repository.LocalRoot, "reports", "phase-00-environment.json");
+        JsonElement? phaseZeroWindows = null;
+        JsonElement? phaseZeroHardware = null;
+        JsonDocument? document = null;
+        if (File.Exists(phaseZeroPath))
+        {
+            document = JsonDocument.Parse(await File.ReadAllTextAsync(phaseZeroPath));
+            if (document.RootElement.TryGetProperty("windows", out var windows)) phaseZeroWindows = windows.Clone();
+            if (document.RootElement.TryGetProperty("hardware", out var hardware)) phaseZeroHardware = hardware.Clone();
+        }
+        var fingerprintBasis = new
+        {
+            os = Environment.OSVersion.ToString(),
+            architecture = RuntimeInformation.ProcessArchitecture.ToString(),
+            framework = RuntimeInformation.FrameworkDescription,
+            configuration,
+            phaseZeroWindows,
+            phaseZeroHardware,
+        };
+        var fingerprintJson = JsonSerializer.Serialize(fingerprintBasis, Program.JsonOptions);
+        var fingerprint = GitRepository.Sha256Bytes(System.Text.Encoding.UTF8.GetBytes(fingerprintJson));
+        var report = new
+        {
+            schemaVersion = "1.0.0",
+            generatedUtc = DateTimeOffset.UtcNow,
+            fingerprintBasis.os,
+            fingerprintBasis.architecture,
+            fingerprintBasis.framework,
+            fingerprintBasis.configuration,
+            hardwareFingerprint = fingerprint,
+            fingerprintBasis.phaseZeroWindows,
+            fingerprintBasis.phaseZeroHardware,
+        };
+        await File.WriteAllTextAsync(Path.Combine(runDirectory, "environment.json"), JsonSerializer.Serialize(report, Program.JsonOptions));
+        document?.Dispose();
+        return (fingerprint, report);
+    }
+
+    private static async Task<IReadOnlyList<HarnessEvent>> ReadEventsAsync(string path)
+    {
+        var events = new List<HarnessEvent>();
+        foreach (var line in await File.ReadAllLinesAsync(path))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            try
+            {
+                using var document = JsonDocument.Parse(line);
+                var root = document.RootElement;
+                events.Add(new HarnessEvent(
+                    root.TryGetProperty("kind", out var kind) ? kind.GetString() ?? "unknown" : "unknown",
+                    root.TryGetProperty("milestone", out var milestone) && milestone.TryGetInt32(out var value) ? value : null));
+            }
+            catch (JsonException)
+            {
+            }
+        }
+        return events;
+    }
+
+    private static string ClassifyBlocker(IReadOnlyList<HarnessEvent> events, BoundedProcessResult process, VisualReport visual, int milestone)
+    {
+        if (process.TimedOut) return "loader/runtime: hard timeout reached; inspect the last structured event";
+        if (events.Any(item => item.Kind == "import.resolution-failed")) return "loader/runtime: unresolved import";
+        if (events.Any(item => item.Kind == "shader.translation-failed")) return "graphics: shader translation failed";
+        if (events.Any(item => item.Kind == "host.exception") || process.Crash) return "loader/runtime: unhandled host exception or abnormal emulator exit";
+        if (visual.Frames.Count == 0 && milestone < 10) return "no-frame: no host frame was observed before execution ended";
+        if (visual.Frames.Count > 0 && visual.Frames.All(frame => frame.Metrics.LikelyBlank)) return "graphics: captured frames are likely blank";
+        return process.ExitCode == 0 ? "none: clean exit" : "loader/runtime: guest execution returned failure";
+    }
+
+    private sealed record HarnessEvent(string Kind, int? Milestone);
+}

--- a/tools/SharpEmu.Tools.AgentHarness/RunCommand.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/RunCommand.cs
@@ -7,6 +7,13 @@ using System.Text.Json;
 
 namespace SharpEmu.Tools.AgentHarness;
 
+internal sealed record VulkanValidationEvidence(
+    bool Requested,
+    string Status,
+    int MessageCount,
+    IReadOnlyList<string> Messages,
+    bool Truncated);
+
 internal static class RunCommand
 {
     public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
@@ -45,6 +52,7 @@ internal static class RunCommand
             .Select(Path.GetFullPath)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
+        var redactionMap = RunArtifactRedactor.CreateStandardMap(repository, redactionRoots);
         var harnessConfig = new
         {
             schemaVersion = "1.0.0",
@@ -85,7 +93,8 @@ internal static class RunCommand
             expectedVersion = profile.ExpectedVersion,
             verifiedVersion = profile.Metadata.VerifiedVersion,
             versionStatus = profile.Metadata.VersionStatus,
-            commandArguments = RedactArguments(emulatorArguments, redactionRoots),
+            ebootHashStatus = validation.HashStatus,
+            commandArguments = RedactArguments(emulatorArguments, redactionMap),
             startUtc = DateTimeOffset.UtcNow,
         };
         await File.WriteAllTextAsync(Path.Combine(runDirectory, "run.json"), JsonSerializer.Serialize(preliminary, Program.JsonOptions));
@@ -108,6 +117,13 @@ internal static class RunCommand
         }
 
         BoundedProcessResult processResult;
+        using var externalCancellation = new CancellationTokenSource();
+        ConsoleCancelEventHandler cancellationHandler = (_, eventArgs) =>
+        {
+            eventArgs.Cancel = true;
+            externalCancellation.Cancel();
+        };
+        Console.CancelKeyPress += cancellationHandler;
         try
         {
             processResult = await BoundedProcessRunner.RunAsync(
@@ -118,17 +134,18 @@ internal static class RunCommand
                 TimeSpan.FromSeconds(profile.TimeoutSeconds),
                 stdoutPath,
                 stderrPath,
-                Sample);
+                Sample,
+                externalCancellation.Token);
         }
         catch (Exception exception)
         {
-            await RunArtifactRedactor.RedactAsync(runDirectory, redactionRoots);
+            var safeMessage = RunArtifactRedactor.RedactText(exception.Message, redactionMap);
             var failed = new
             {
                 schemaVersion = "1.0.0",
                 runId,
                 status = "launch-failed",
-                error = exception.Message,
+                error = safeMessage,
                 repositorySha = repository.Commit,
                 dirty = repository.IsDirty,
                 targetId = profile.ExpectedTitleId,
@@ -136,18 +153,28 @@ internal static class RunCommand
                 blockers = new[] { "environment: emulator process could not be launched" },
             };
             await File.WriteAllTextAsync(Path.Combine(runDirectory, "run.json"), JsonSerializer.Serialize(failed, Program.JsonOptions));
-            Console.Error.WriteLine($"Run {runId} failed to launch: {exception.Message}");
+            await RunArtifactRedactor.RedactAsync(runDirectory, redactionMap);
+            Console.Error.WriteLine($"Run {runId} failed to launch: {safeMessage}");
             return 3;
         }
+        finally
+        {
+            Console.CancelKeyPress -= cancellationHandler;
+        }
 
-        await RunArtifactRedactor.RedactAsync(runDirectory, redactionRoots);
+        await RunArtifactRedactor.RedactAsync(runDirectory, redactionMap);
         var visual = await VisualCommand.AnalyzeRunAsync(runDirectory);
-        var events = await ReadEventsAsync(eventsPath);
+        var eventEvidence = await ReadEventsAsync(eventsPath);
+        var events = eventEvidence.Events;
         var milestoneValues = events.Select(item => item.Milestone).Where(value => value.HasValue).Select(value => value!.Value).ToArray();
         var firstMilestone = milestoneValues.Length == 0 ? 0 : milestoneValues.Min();
         var highestMilestone = milestoneValues.Length == 0 ? 0 : milestoneValues.Max();
         var hasHostException = events.Any(item => string.Equals(item.Kind, "host.exception", StringComparison.OrdinalIgnoreCase));
-        var exitStatus = processResult.TimedOut
+        var hostMilestone = events.Where(item => item.Kind is "frame.presented" or "capture.frame-written").Select(item => item.Milestone ?? 0).DefaultIfEmpty(0).Max();
+        var guestMilestone = events.Where(item => item.Kind is not ("session.started" or "frame.presented" or "capture.frame-written" or "host.exception")).Select(item => item.Milestone ?? 0).DefaultIfEmpty(0).Max();
+        var exitStatus = processResult.Canceled
+            ? "canceled"
+            : processResult.TimedOut
             ? "timeout"
             : hasHostException || processResult.Crash
                 ? "emulator-crash"
@@ -165,7 +192,10 @@ internal static class RunCommand
         var warnings = validation.Warnings
             .Concat(processResult.Warnings)
             .Concat(windowStatuses.Select(value => "window-fallback: " + value))
+            .Concat(eventEvidence.ParseErrorCount > 0 ? ["Structured-event evidence is incomplete because one or more JSONL lines could not be parsed."] : [])
             .ToArray();
+        var vulkanValidation = await CollectVulkanValidationAsync(stderrPath, environment);
+        await File.WriteAllTextAsync(Path.Combine(runDirectory, "vulkan-validation.json"), JsonSerializer.Serialize(vulkanValidation, Program.JsonOptions));
         var result = new
         {
             schemaVersion = "1.0.0",
@@ -179,6 +209,7 @@ internal static class RunCommand
             expectedVersion = profile.ExpectedVersion,
             verifiedVersion = profile.Metadata.VerifiedVersion,
             versionStatus = profile.Metadata.VersionStatus,
+            ebootHashStatus = validation.HashStatus,
             commandArguments = preliminary.commandArguments,
             processResult.StartUtc,
             processResult.EndUtc,
@@ -186,10 +217,20 @@ internal static class RunCommand
             exitCode = processResult.ExitCode,
             exitStatus,
             timedOut = processResult.TimedOut,
+            canceled = processResult.Canceled,
             crash = hasHostException || processResult.Crash,
-            processTree = new { processResult.JobObjectOwned, processResult.ProcessTreeCleaned },
+            processTree = new { processResult.JobObjectOwned, processResult.ProcessTreeCleaned, processResult.ActiveProcessCountAfterCleanup },
             firstObservedMilestone = firstMilestone,
             highestObservedMilestone = highestMilestone,
+            highestProvenHostMilestone = hostMilestone,
+            highestProvenGuestMilestone = guestMilestone,
+            structuredEvents = new
+            {
+                parsedCount = events.Count,
+                parseErrorCount = eventEvidence.ParseErrorCount,
+                parseErrors = eventEvidence.ParseErrors,
+                milestoneEvidenceComplete = eventEvidence.ParseErrorCount == 0,
+            },
             firstFrameStatus = visual.FirstFrameStatus,
             captureStatus = visual.CaptureStatus,
             artifacts = new
@@ -203,6 +244,7 @@ internal static class RunCommand
                 metrics = "metrics.json",
                 frames = "frames/",
                 visual = "visual.json",
+                vulkanValidation = "vulkan-validation.json",
                 contactSheet = visual.ContactSheet,
             },
             environmentFingerprint = environmentReport.Fingerprint,
@@ -211,26 +253,20 @@ internal static class RunCommand
             nextRunCommand = $".\\scripts\\agent-harness.ps1 run --profile .local\\profiles\\{Path.GetFileName(profileValue)}",
         };
         await File.WriteAllTextAsync(Path.Combine(runDirectory, "run.json"), JsonSerializer.Serialize(result, Program.JsonOptions));
+        await RunArtifactRedactor.RedactAsync(runDirectory, redactionMap);
         Console.WriteLine($"Run ID: {runId}");
         Console.WriteLine($"Exit: {exitStatus}; elapsed {processResult.ElapsedSeconds:F1}s; highest milestone {highestMilestone}.");
         Console.WriteLine($"Frames: {visual.Frames.Count}; capture {visual.CaptureStatus}.");
         Console.WriteLine($"Blocker: {blocker}");
         Console.WriteLine(runDirectory);
-        return processResult.TimedOut ? 124 : processResult.ExitCode ?? 3;
+        return processResult.Canceled ? 130 : processResult.TimedOut ? 124 : processResult.ExitCode ?? 3;
     }
 
     private static bool ContainsOption(IReadOnlyList<string> arguments, string option) =>
         arguments.Any(argument => string.Equals(argument, option, StringComparison.OrdinalIgnoreCase) || argument.StartsWith(option + "=", StringComparison.OrdinalIgnoreCase));
 
-    private static string[] RedactArguments(IEnumerable<string> arguments, IReadOnlyList<string> roots) =>
-        arguments.Select(argument => Redact(argument, roots)).ToArray();
-
-    private static string Redact(string value, IReadOnlyList<string> roots)
-    {
-        var redacted = value;
-        for (var index = 0; index < roots.Count; index++) redacted = redacted.Replace(roots[index], $"<private-root-{index + 1}>", StringComparison.OrdinalIgnoreCase);
-        return redacted;
-    }
+    private static string[] RedactArguments(IEnumerable<string> arguments, IReadOnlyList<RedactionRoot> roots) =>
+        arguments.Select(argument => RunArtifactRedactor.RedactText(argument, roots)).ToArray();
 
     private static string Sanitize(string value) => new(value.Select(character => char.IsLetterOrDigit(character) || character is '-' or '_' ? character : '-').ToArray());
 
@@ -274,25 +310,72 @@ internal static class RunCommand
         return (fingerprint, report);
     }
 
-    private static async Task<IReadOnlyList<HarnessEvent>> ReadEventsAsync(string path)
+    internal static async Task<EventEvidence> ReadEventsAsync(string path)
     {
         var events = new List<HarnessEvent>();
+        var errors = new List<EventParseError>();
+        var parseErrorCount = 0;
+        var lineNumber = 0;
         foreach (var line in await File.ReadAllLinesAsync(path))
         {
+            lineNumber++;
             if (string.IsNullOrWhiteSpace(line)) continue;
             try
             {
                 using var document = JsonDocument.Parse(line);
                 var root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Object)
+                {
+                    AddParseError(errors, ref parseErrorCount, lineNumber, "non-object-json");
+                    continue;
+                }
+                if (!root.TryGetProperty("kind", out var kind) || kind.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(kind.GetString()))
+                {
+                    AddParseError(errors, ref parseErrorCount, lineNumber, "missing-or-invalid-kind");
+                    continue;
+                }
+                int? milestoneValue = null;
+                if (root.TryGetProperty("milestone", out var milestone) && milestone.ValueKind != JsonValueKind.Null)
+                {
+                    if (milestone.ValueKind != JsonValueKind.Number || !milestone.TryGetInt32(out var value))
+                    {
+                        AddParseError(errors, ref parseErrorCount, lineNumber, "invalid-milestone");
+                        continue;
+                    }
+                    milestoneValue = value;
+                }
                 events.Add(new HarnessEvent(
-                    root.TryGetProperty("kind", out var kind) ? kind.GetString() ?? "unknown" : "unknown",
-                    root.TryGetProperty("milestone", out var milestone) && milestone.TryGetInt32(out var value) ? value : null));
+                    kind.GetString()!,
+                    milestoneValue));
             }
             catch (JsonException)
             {
+                AddParseError(errors, ref parseErrorCount, lineNumber, "invalid-json");
             }
         }
-        return events;
+        return new EventEvidence(events, parseErrorCount, errors);
+    }
+
+    private static void AddParseError(List<EventParseError> errors, ref int total, int lineNumber, string category)
+    {
+        total++;
+        if (errors.Count < 20) errors.Add(new EventParseError(lineNumber, category));
+    }
+
+    internal static async Task<VulkanValidationEvidence> CollectVulkanValidationAsync(string stderrPath, IReadOnlyDictionary<string, string?> environment)
+    {
+        var requested = environment.TryGetValue("SHARPEMU_VK_VALIDATION", out var value) && string.Equals(value, "1", StringComparison.Ordinal);
+        var lines = File.Exists(stderrPath) ? await File.ReadAllLinesAsync(stderrPath) : [];
+        var active = lines.Any(line => line.Contains("Vulkan Validation Layers active", StringComparison.OrdinalIgnoreCase));
+        var unavailable = lines.Any(line => line.Contains("validation", StringComparison.OrdinalIgnoreCase) && line.Contains("not found", StringComparison.OrdinalIgnoreCase));
+        var messages = lines.Where(line => line.StartsWith("[VULKAN]", StringComparison.OrdinalIgnoreCase)).Take(100).ToArray();
+        var messageCount = lines.Count(line => line.StartsWith("[VULKAN]", StringComparison.OrdinalIgnoreCase));
+        return new VulkanValidationEvidence(
+            requested,
+            !requested ? "not-requested" : active ? "active" : unavailable ? "unavailable" : "requested-not-confirmed",
+            messageCount,
+            messages,
+            messageCount > messages.Length);
     }
 
     private static string ClassifyBlocker(IReadOnlyList<HarnessEvent> events, BoundedProcessResult process, VisualReport visual, int milestone)
@@ -306,5 +389,9 @@ internal static class RunCommand
         return process.ExitCode == 0 ? "none: clean exit" : "loader/runtime: guest execution returned failure";
     }
 
-    private sealed record HarnessEvent(string Kind, int? Milestone);
+    internal sealed record HarnessEvent(string Kind, int? Milestone);
+
+    internal sealed record EventParseError(int Line, string Category);
+
+    internal sealed record EventEvidence(IReadOnlyList<HarnessEvent> Events, int ParseErrorCount, IReadOnlyList<EventParseError> ParseErrors);
 }

--- a/tools/SharpEmu.Tools.AgentHarness/SharpEmu.Tools.AgentHarness.csproj
+++ b/tools/SharpEmu.Tools.AgentHarness/SharpEmu.Tools.AgentHarness.csproj
@@ -1,0 +1,20 @@
+<!--
+Copyright (C) 2026 SharpEmu Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="SharpEmu.Tools.AgentHarness.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+</Project>

--- a/tools/SharpEmu.Tools.AgentHarness/SkillCommand.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/SkillCommand.cs
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal sealed record SkillValidation(string Name, string Path, bool Valid, IReadOnlyList<string> Errors);
+
+internal static class SkillCommand
+{
+    private static readonly string[] RequiredNames =
+    [
+        "sharpemu-boot-triage",
+        "sharpemu-clean-room-research",
+        "sharpemu-code-navigation",
+        "sharpemu-performance-investigation",
+        "sharpemu-visual-regression",
+    ];
+
+    public static int Run(GitRepository repository, CommandArguments arguments)
+    {
+        if (!arguments.Is("validate")) return Program.Fail("skills requires validate.");
+        var root = Path.Combine(repository.Root, ".agents", "skills");
+        var results = new List<SkillValidation>();
+        foreach (var requiredName in RequiredNames)
+        {
+            var directory = Path.Combine(root, requiredName);
+            var errors = new List<string>();
+            if (!Directory.Exists(directory))
+            {
+                errors.Add("Required skill directory is missing.");
+            }
+            else
+            {
+                var files = Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories).ToArray();
+                if (files.Length != 1 || !string.Equals(Path.GetFileName(files.SingleOrDefault()), "SKILL.md", StringComparison.Ordinal))
+                {
+                    errors.Add("A repository skill must contain exactly one SKILL.md file.");
+                }
+                var skillPath = Path.Combine(directory, "SKILL.md");
+                if (File.Exists(skillPath)) ValidateFrontmatter(requiredName, File.ReadAllText(skillPath), errors);
+            }
+            results.Add(new SkillValidation(requiredName, $".agents/skills/{requiredName}/SKILL.md", errors.Count == 0, errors));
+        }
+        if (Directory.Exists(root))
+        {
+            foreach (var unexpected in Directory.EnumerateDirectories(root).Select(Path.GetFileName).Where(name => !RequiredNames.Contains(name, StringComparer.Ordinal)))
+            {
+                results.Add(new SkillValidation(unexpected!, $".agents/skills/{unexpected}", false, ["Unexpected repository skill directory."]));
+            }
+        }
+        var valid = results.Count == RequiredNames.Length && results.All(result => result.Valid);
+        if (arguments.Has("--json")) Program.WriteJson(new { valid, skills = results });
+        else
+        {
+            foreach (var result in results) Console.WriteLine($"{(result.Valid ? "PASS" : "FAIL")} {result.Name}");
+            foreach (var result in results) foreach (var error in result.Errors) Console.Error.WriteLine($"{result.Name}: {error}");
+        }
+        return valid ? 0 : 2;
+    }
+
+    internal static void ValidateFrontmatter(string expectedName, string contents, List<string> errors)
+    {
+        using var reader = new StringReader(contents);
+        if (!string.Equals(reader.ReadLine(), "---", StringComparison.Ordinal))
+        {
+            errors.Add("YAML frontmatter must begin on the first line.");
+            return;
+        }
+        string? name = null;
+        string? description = null;
+        var closed = false;
+        while (reader.ReadLine() is { } line)
+        {
+            if (line == "---")
+            {
+                closed = true;
+                break;
+            }
+            var separator = line.IndexOf(':');
+            if (separator <= 0) continue;
+            var key = line[..separator].Trim();
+            var value = line[(separator + 1)..].Trim();
+            if (key == "name") name = value;
+            if (key == "description") description = value;
+        }
+        if (!closed) errors.Add("YAML frontmatter is not closed.");
+        if (!string.Equals(name, expectedName, StringComparison.Ordinal)) errors.Add($"Frontmatter name must be '{expectedName}'.");
+        if (string.IsNullOrWhiteSpace(description) || description.Length < 40) errors.Add("Frontmatter description must precisely describe triggers and exclusions.");
+    }
+}

--- a/tools/SharpEmu.Tools.AgentHarness/SourceIndex.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/SourceIndex.cs
@@ -40,6 +40,30 @@ internal sealed record IndexedSymbol(
     int EndLine,
     string Path);
 
+internal sealed record SourceIndexStatus(
+    bool Exists,
+    string Path,
+    string CurrentCommit,
+    SourceIndexDocument? Index,
+    IReadOnlyList<string> AddedTrackedTextFiles,
+    IReadOnlyList<string> RemovedTrackedFiles,
+    IReadOnlyList<string> ContentModifiedTrackedFiles)
+{
+    public bool Current =>
+        Exists &&
+        Index is { SchemaVersion: SourceIndexStore.SchemaVersion } &&
+        Index.Commit == CurrentCommit &&
+        AddedTrackedTextFiles.Count == 0 &&
+        RemovedTrackedFiles.Count == 0 &&
+        ContentModifiedTrackedFiles.Count == 0;
+}
+
+internal sealed class SourceIndexStaleException(SourceIndexStatus status)
+    : InvalidOperationException("The source index is stale; run index build before querying.")
+{
+    public SourceIndexStatus Status { get; } = status;
+}
+
 internal sealed class SourceIndexStore
 {
     public const string SchemaVersion = "1.0.0";
@@ -167,6 +191,84 @@ internal sealed class SourceIndexStore
         return document is { SchemaVersion: SchemaVersion }
             ? document
             : await BuildAsync(cancellationToken);
+    }
+
+    public async Task<SourceIndexDocument> LoadCurrentAsync(CancellationToken cancellationToken = default)
+    {
+        var status = await GetStatusAsync(cancellationToken);
+        if (!status.Current || status.Index is null)
+        {
+            throw new SourceIndexStaleException(status);
+        }
+
+        return status.Index;
+    }
+
+    public async Task<SourceIndexStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(IndexPath))
+        {
+            return new SourceIndexStatus(false, IndexPath, _repository.Commit, null, [], [], []);
+        }
+
+        SourceIndexDocument? index;
+        try
+        {
+            await using var stream = File.OpenRead(IndexPath);
+            index = await JsonSerializer.DeserializeAsync<SourceIndexDocument>(stream, Program.JsonOptions, cancellationToken);
+        }
+        catch (JsonException)
+        {
+            index = null;
+        }
+
+        if (index is null || index.SchemaVersion != SchemaVersion)
+        {
+            return new SourceIndexStatus(true, IndexPath, _repository.Commit, index, [], [], []);
+        }
+
+        var tracked = _repository.TrackedFiles().ToHashSet(StringComparer.Ordinal);
+        var indexed = index.Files.ToDictionary(file => file.Path, StringComparer.Ordinal);
+        var added = new List<string>();
+        var modified = new List<string>();
+        foreach (var relativePath in tracked)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var fullPath = _repository.ResolvePath(relativePath);
+            if (!File.Exists(fullPath))
+            {
+                continue;
+            }
+
+            var bytes = await File.ReadAllBytesAsync(fullPath, cancellationToken);
+            if (IsBinary(bytes))
+            {
+                if (indexed.ContainsKey(relativePath))
+                {
+                    modified.Add(relativePath);
+                }
+                continue;
+            }
+
+            if (!indexed.TryGetValue(relativePath, out var indexedFile))
+            {
+                added.Add(relativePath);
+            }
+            else if (!string.Equals(GitRepository.Sha256Bytes(bytes), indexedFile.Sha256, StringComparison.OrdinalIgnoreCase))
+            {
+                modified.Add(relativePath);
+            }
+        }
+
+        var removed = indexed.Keys.Where(path => !tracked.Contains(path) || !File.Exists(_repository.ResolvePath(path))).ToArray();
+        return new SourceIndexStatus(
+            true,
+            IndexPath,
+            _repository.Commit,
+            index,
+            added.Order(StringComparer.Ordinal).ToArray(),
+            removed.Order(StringComparer.Ordinal).ToArray(),
+            modified.Order(StringComparer.Ordinal).ToArray());
     }
 
     internal static bool IsBinary(ReadOnlySpan<byte> bytes)

--- a/tools/SharpEmu.Tools.AgentHarness/SourceIndex.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/SourceIndex.cs
@@ -1,0 +1,414 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text;
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal sealed record SourceIndexDocument(
+    string SchemaVersion,
+    string Commit,
+    DateTimeOffset GeneratedUtc,
+    IReadOnlyList<IndexedFile> Files,
+    IReadOnlyList<IndexedSymbol> Symbols);
+
+internal sealed record IndexedFile(
+    string Path,
+    string? Project,
+    string Language,
+    string Sha256,
+    int LineCount,
+    IReadOnlyList<string> Namespaces,
+    IReadOnlyList<string> TopLevelDeclarations,
+    bool Generated,
+    IReadOnlyList<string> Imports);
+
+internal sealed record IndexedSymbol(
+    string FullyQualifiedName,
+    string Name,
+    string Kind,
+    string Accessibility,
+    string? Namespace,
+    string? ContainingType,
+    string? Project,
+    string Signature,
+    int StartLine,
+    int EndLine,
+    string Path);
+
+internal sealed class SourceIndexStore
+{
+    public const string SchemaVersion = "1.0.0";
+
+    private readonly GitRepository _repository;
+
+    public SourceIndexStore(GitRepository repository) => _repository = repository;
+
+    public string IndexDirectory => Path.Combine(_repository.LocalRoot, "index", _repository.Commit);
+
+    public string IndexPath => Path.Combine(IndexDirectory, "index.json");
+
+    public async Task<SourceIndexDocument> BuildAsync(CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(IndexDirectory);
+        var tracked = _repository.TrackedFiles();
+        var projects = tracked
+            .Where(path => path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            .Select(path => new ProjectLocation(
+                Path.GetFileNameWithoutExtension(path),
+                GitRepository.NormalizeRelativePath(Path.GetDirectoryName(path) ?? string.Empty)))
+            .OrderByDescending(project => project.Directory.Length)
+            .ToArray();
+
+        SourceIndexDocument? previous = null;
+        if (File.Exists(IndexPath))
+        {
+            await using var oldStream = File.OpenRead(IndexPath);
+            previous = await JsonSerializer.DeserializeAsync<SourceIndexDocument>(
+                oldStream,
+                Program.JsonOptions,
+                cancellationToken);
+            if (previous?.SchemaVersion != SchemaVersion)
+            {
+                previous = null;
+            }
+        }
+
+        var previousFiles = previous?.Files.ToDictionary(file => file.Path, StringComparer.Ordinal)
+            ?? new Dictionary<string, IndexedFile>(StringComparer.Ordinal);
+        var previousSymbols = previous?.Symbols
+            .GroupBy(symbol => symbol.Path, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal)
+            ?? new Dictionary<string, IndexedSymbol[]>(StringComparer.Ordinal);
+
+        var files = new List<IndexedFile>(tracked.Count);
+        var symbols = new List<IndexedSymbol>();
+        foreach (var relativePath in tracked)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var fullPath = _repository.ResolvePath(relativePath);
+            if (!File.Exists(fullPath))
+            {
+                continue;
+            }
+
+            var bytes = await File.ReadAllBytesAsync(fullPath, cancellationToken);
+            if (IsBinary(bytes))
+            {
+                continue;
+            }
+
+            var hash = GitRepository.Sha256Bytes(bytes);
+            if (previousFiles.TryGetValue(relativePath, out var cached) && cached.Sha256 == hash)
+            {
+                files.Add(cached);
+                if (previousSymbols.TryGetValue(relativePath, out var cachedSymbols))
+                {
+                    symbols.AddRange(cachedSymbols);
+                }
+                continue;
+            }
+
+            var text = DecodeText(bytes);
+            var project = FindProject(relativePath, projects);
+            if (relativePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            {
+                var parsed = CSharpFileIndexer.Index(relativePath, project, hash, text);
+                files.Add(parsed.File);
+                symbols.AddRange(parsed.Symbols);
+            }
+            else
+            {
+                files.Add(new IndexedFile(
+                    relativePath,
+                    project,
+                    LanguageFromPath(relativePath),
+                    hash,
+                    CountLines(text),
+                    [],
+                    [],
+                    IsGenerated(relativePath, text),
+                    []));
+            }
+        }
+
+        var document = new SourceIndexDocument(
+            SchemaVersion,
+            _repository.Commit,
+            DateTimeOffset.UtcNow,
+            files.OrderBy(file => file.Path, StringComparer.Ordinal).ToArray(),
+            symbols
+                .OrderBy(symbol => symbol.Path, StringComparer.Ordinal)
+                .ThenBy(symbol => symbol.StartLine)
+                .ThenBy(symbol => symbol.Name, StringComparer.Ordinal)
+                .ToArray());
+        var temporaryPath = IndexPath + $".{Environment.ProcessId}.tmp";
+        await using (var stream = File.Create(temporaryPath))
+        {
+            await JsonSerializer.SerializeAsync(stream, document, Program.JsonOptions, cancellationToken);
+        }
+        File.Move(temporaryPath, IndexPath, overwrite: true);
+        return document;
+    }
+
+    public async Task<SourceIndexDocument> LoadOrBuildAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(IndexPath))
+        {
+            return await BuildAsync(cancellationToken);
+        }
+
+        await using var stream = File.OpenRead(IndexPath);
+        var document = await JsonSerializer.DeserializeAsync<SourceIndexDocument>(stream, Program.JsonOptions, cancellationToken);
+        return document is { SchemaVersion: SchemaVersion }
+            ? document
+            : await BuildAsync(cancellationToken);
+    }
+
+    internal static bool IsBinary(ReadOnlySpan<byte> bytes)
+    {
+        var sampleLength = Math.Min(bytes.Length, 8192);
+        for (var index = 0; index < sampleLength; index++)
+        {
+            if (bytes[index] == 0)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    internal static int CountLines(string text)
+    {
+        if (text.Length == 0)
+        {
+            return 0;
+        }
+        return text.Count(character => character == '\n') + (text[^1] == '\n' ? 0 : 1);
+    }
+
+    private static string DecodeText(byte[] bytes)
+    {
+        using var reader = new StreamReader(new MemoryStream(bytes), Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        return reader.ReadToEnd();
+    }
+
+    private static string? FindProject(string path, IReadOnlyList<ProjectLocation> projects)
+    {
+        foreach (var project in projects)
+        {
+            if (path.StartsWith(project.Directory + "/", StringComparison.Ordinal) ||
+                string.Equals(path, project.Directory, StringComparison.Ordinal))
+            {
+                return project.Name;
+            }
+        }
+        return null;
+    }
+
+    private static bool IsGenerated(string path, string text) =>
+        path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase) ||
+        path.EndsWith(".generated.cs", StringComparison.OrdinalIgnoreCase) ||
+        text.AsSpan(0, Math.Min(text.Length, 512)).Contains("<auto-generated", StringComparison.OrdinalIgnoreCase);
+
+    private static string LanguageFromPath(string path) => Path.GetExtension(path).ToLowerInvariant() switch
+    {
+        ".cs" => "C#",
+        ".ps1" => "PowerShell",
+        ".py" => "Python",
+        ".sh" => "Shell",
+        ".json" => "JSON",
+        ".yml" or ".yaml" => "YAML",
+        ".xml" or ".props" or ".csproj" or ".slnx" => "XML",
+        ".md" => "Markdown",
+        _ => "text",
+    };
+
+    private sealed record ProjectLocation(string Name, string Directory);
+}
+
+internal static class CSharpFileIndexer
+{
+    public static (IndexedFile File, IReadOnlyList<IndexedSymbol> Symbols) Index(
+        string path,
+        string? project,
+        string hash,
+        string text)
+    {
+        var tree = CSharpSyntaxTree.ParseText(text, new CSharpParseOptions(LanguageVersion.Latest));
+        var root = tree.GetCompilationUnitRoot();
+        var namespaces = root.DescendantNodes()
+            .OfType<BaseNamespaceDeclarationSyntax>()
+            .Select(node => node.Name.ToString())
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        var imports = root.DescendantNodes()
+            .OfType<UsingDirectiveSyntax>()
+            .Select(node => node.Name?.ToString() ?? node.ToString())
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        var collector = new SymbolCollector(path, project, tree);
+        collector.Visit(root);
+        var topLevel = collector.Symbols
+            .Where(symbol => symbol.ContainingType is null &&
+                symbol.Kind is "class" or "record" or "struct" or "interface" or "enum" or "delegate")
+            .Select(symbol => symbol.Name)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        var file = new IndexedFile(
+            path,
+            project,
+            "C#",
+            hash,
+            SourceIndexStore.CountLines(text),
+            namespaces,
+            topLevel,
+            path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase) ||
+                text.AsSpan(0, Math.Min(text.Length, 512)).Contains("<auto-generated", StringComparison.OrdinalIgnoreCase),
+            imports);
+        return (file, collector.Symbols);
+    }
+
+    private sealed class SymbolCollector : CSharpSyntaxWalker
+    {
+        private readonly string _path;
+        private readonly string? _project;
+        private readonly SyntaxTree _tree;
+        private readonly Stack<string> _types = new();
+
+        public SymbolCollector(string path, string? project, SyntaxTree tree)
+            : base(SyntaxWalkerDepth.Node)
+        {
+            _path = path;
+            _project = project;
+            _tree = tree;
+        }
+
+        public List<IndexedSymbol> Symbols { get; } = [];
+
+        public override void VisitClassDeclaration(ClassDeclarationSyntax node) => VisitType(node, "class", node.Identifier.Text, () => base.VisitClassDeclaration(node));
+
+        public override void VisitStructDeclaration(StructDeclarationSyntax node) => VisitType(node, "struct", node.Identifier.Text, () => base.VisitStructDeclaration(node));
+
+        public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node) => VisitType(node, "interface", node.Identifier.Text, () => base.VisitInterfaceDeclaration(node));
+
+        public override void VisitEnumDeclaration(EnumDeclarationSyntax node) => VisitType(node, "enum", node.Identifier.Text, () => base.VisitEnumDeclaration(node));
+
+        public override void VisitRecordDeclaration(RecordDeclarationSyntax node) => VisitType(node, "record", node.Identifier.Text, () => base.VisitRecordDeclaration(node));
+
+        public override void VisitDelegateDeclaration(DelegateDeclarationSyntax node)
+        {
+            Add(node, node.Identifier.Text, "delegate", $"{Modifiers(node.Modifiers)}delegate {node.ReturnType} {node.Identifier}{node.TypeParameterList}{node.ParameterList}");
+            base.VisitDelegateDeclaration(node);
+        }
+
+        public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            Add(node, node.Identifier.Text, "method", $"{Modifiers(node.Modifiers)}{node.ReturnType} {node.Identifier}{node.TypeParameterList}{node.ParameterList}");
+            base.VisitMethodDeclaration(node);
+        }
+
+        public override void VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+        {
+            Add(node, node.Identifier.Text, "constructor", $"{Modifiers(node.Modifiers)}{node.Identifier}{node.ParameterList}");
+            base.VisitConstructorDeclaration(node);
+        }
+
+        public override void VisitDestructorDeclaration(DestructorDeclarationSyntax node)
+        {
+            Add(node, "~" + node.Identifier.Text, "destructor", $"~{node.Identifier}{node.ParameterList}");
+            base.VisitDestructorDeclaration(node);
+        }
+
+        public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            Add(node, node.Identifier.Text, "property", $"{Modifiers(node.Modifiers)}{node.Type} {node.Identifier}");
+            base.VisitPropertyDeclaration(node);
+        }
+
+        public override void VisitIndexerDeclaration(IndexerDeclarationSyntax node)
+        {
+            Add(node, "this", "indexer", $"{Modifiers(node.Modifiers)}{node.Type} this{node.ParameterList}");
+            base.VisitIndexerDeclaration(node);
+        }
+
+        public override void VisitOperatorDeclaration(OperatorDeclarationSyntax node)
+        {
+            Add(node, "operator " + node.OperatorToken.Text, "operator", $"{Modifiers(node.Modifiers)}{node.ReturnType} operator {node.OperatorToken}{node.ParameterList}");
+            base.VisitOperatorDeclaration(node);
+        }
+
+        public override void VisitConversionOperatorDeclaration(ConversionOperatorDeclarationSyntax node)
+        {
+            Add(node, "operator " + node.Type, "conversion", $"{Modifiers(node.Modifiers)}{node.ImplicitOrExplicitKeyword} operator {node.Type}{node.ParameterList}");
+            base.VisitConversionOperatorDeclaration(node);
+        }
+
+        public override void VisitEventDeclaration(EventDeclarationSyntax node)
+        {
+            Add(node, node.Identifier.Text, "event", $"{Modifiers(node.Modifiers)}event {node.Type} {node.Identifier}");
+            base.VisitEventDeclaration(node);
+        }
+
+        private void VisitType(MemberDeclarationSyntax node, string kind, string name, Action visitChildren)
+        {
+            var signature = node switch
+            {
+                TypeDeclarationSyntax type => $"{Modifiers(type.Modifiers)}{kind} {type.Identifier}{type.TypeParameterList}{type.BaseList}",
+                EnumDeclarationSyntax enumeration => $"{Modifiers(enumeration.Modifiers)}enum {enumeration.Identifier}{enumeration.BaseList}",
+                _ => $"{kind} {name}",
+            };
+            Add(node, name, kind, signature);
+            _types.Push(name);
+            visitChildren();
+            _types.Pop();
+        }
+
+        private void Add(SyntaxNode node, string name, string kind, string signature)
+        {
+            var namespaceName = node.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().FirstOrDefault()?.Name.ToString();
+            var containingType = _types.Count == 0 ? null : string.Join('.', _types.Reverse());
+            var fullName = string.Join('.', new[] { namespaceName, containingType, name }.Where(value => !string.IsNullOrWhiteSpace(value)));
+            var span = _tree.GetLineSpan(node.Span);
+            var modifiers = node switch
+            {
+                MemberDeclarationSyntax member => member.Modifiers,
+                _ => default,
+            };
+            Symbols.Add(new IndexedSymbol(
+                fullName,
+                name,
+                kind,
+                Accessibility(modifiers),
+                namespaceName,
+                containingType,
+                _project,
+                Compact(signature),
+                span.StartLinePosition.Line + 1,
+                span.EndLinePosition.Line + 1,
+                _path));
+        }
+
+        private static string Modifiers(SyntaxTokenList modifiers) => modifiers.Count == 0 ? string.Empty : string.Join(' ', modifiers.Select(token => token.Text)) + " ";
+
+        private static string Accessibility(SyntaxTokenList modifiers)
+        {
+            var values = modifiers.Select(token => token.Text).ToHashSet(StringComparer.Ordinal);
+            if (values.Contains("public")) return "public";
+            if (values.Contains("private") && values.Contains("protected")) return "private protected";
+            if (values.Contains("protected") && values.Contains("internal")) return "protected internal";
+            if (values.Contains("protected")) return "protected";
+            if (values.Contains("internal")) return "internal";
+            if (values.Contains("private")) return "private";
+            return "default";
+        }
+
+        private static string Compact(string value) => string.Join(' ', value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+    }
+}

--- a/tools/SharpEmu.Tools.AgentHarness/SourceIndexCommand.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/SourceIndexCommand.cs
@@ -1,0 +1,270 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal static class SourceIndexCommand
+{
+    public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
+    {
+        if (arguments.Count == 0)
+        {
+            return Program.Fail("index requires build, status, query, outline, text, or map.");
+        }
+
+        var store = new SourceIndexStore(repository);
+        return arguments[0].ToLowerInvariant() switch
+        {
+            "build" => await BuildAsync(store, arguments.Slice(1)),
+            "status" => await StatusAsync(repository, store, arguments.Slice(1)),
+            "query" => await QueryAsync(store, arguments.Slice(1)),
+            "outline" => await OutlineAsync(store, arguments.Slice(1)),
+            "text" => await TextAsync(repository, store, arguments.Slice(1)),
+            "map" => await MapAsync(repository, store, arguments.Slice(1)),
+            _ => Program.Fail($"Unknown index command '{arguments[0]}'."),
+        };
+    }
+
+    private static async Task<int> BuildAsync(SourceIndexStore store, CommandArguments arguments)
+    {
+        var index = await store.BuildAsync();
+        var result = new
+        {
+            index.SchemaVersion,
+            index.Commit,
+            index.GeneratedUtc,
+            path = store.IndexPath,
+            fileCount = index.Files.Count,
+            symbolCount = index.Symbols.Count,
+        };
+        if (arguments.Has("--json"))
+        {
+            Program.WriteJson(result);
+        }
+        else
+        {
+            Console.WriteLine($"Index built: {index.Files.Count} text files, {index.Symbols.Count} C# symbols.");
+            Console.WriteLine(store.IndexPath);
+        }
+        return 0;
+    }
+
+    private static async Task<int> StatusAsync(GitRepository repository, SourceIndexStore store, CommandArguments arguments)
+    {
+        if (!File.Exists(store.IndexPath))
+        {
+            var missing = new { exists = false, path = store.IndexPath, commit = repository.Commit };
+            if (arguments.Has("--json")) Program.WriteJson(missing); else Console.WriteLine("Index is missing; run index build.");
+            return 2;
+        }
+
+        var index = await store.LoadOrBuildAsync();
+        var tracked = repository.TrackedFiles().ToHashSet(StringComparer.Ordinal);
+        var indexed = index.Files.Select(file => file.Path).ToHashSet(StringComparer.Ordinal);
+        var missingFiles = tracked.Where(path => IsLikelyText(repository.ResolvePath(path)) && !indexed.Contains(path)).Take(20).ToArray();
+        var removedFiles = indexed.Where(path => !tracked.Contains(path)).Take(20).ToArray();
+        var result = new
+        {
+            exists = true,
+            path = store.IndexPath,
+            index.Commit,
+            currentCommit = repository.Commit,
+            fileCount = index.Files.Count,
+            symbolCount = index.Symbols.Count,
+            missingTrackedTextFiles = missingFiles,
+            removedTrackedFiles = removedFiles,
+            current = index.Commit == repository.Commit && missingFiles.Length == 0 && removedFiles.Length == 0,
+        };
+        if (arguments.Has("--json"))
+        {
+            Program.WriteJson(result);
+        }
+        else
+        {
+            Console.WriteLine($"Index: {index.Files.Count} files, {index.Symbols.Count} symbols, commit {index.Commit[..12]}.");
+            Console.WriteLine(result.current ? "Status: current" : "Status: refresh recommended");
+        }
+        return result.current ? 0 : 2;
+    }
+
+    private static async Task<int> QueryAsync(SourceIndexStore store, CommandArguments arguments)
+    {
+        var index = await store.LoadOrBuildAsync();
+        var symbol = arguments.Value("--symbol");
+        var namespaceName = arguments.Value("--namespace");
+        var kind = arguments.Value("--kind");
+        var limit = arguments.IntValue("--limit", 20, 1, 160);
+        IEnumerable<IndexedSymbol> query = index.Symbols;
+        if (!string.IsNullOrWhiteSpace(symbol))
+        {
+            query = query.Where(item =>
+                item.Name.Contains(symbol, StringComparison.OrdinalIgnoreCase) ||
+                item.FullyQualifiedName.Contains(symbol, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrWhiteSpace(namespaceName))
+        {
+            query = query.Where(item => item.Namespace?.Contains(namespaceName, StringComparison.OrdinalIgnoreCase) == true);
+        }
+        if (!string.IsNullOrWhiteSpace(kind))
+        {
+            var normalizedKind = string.Equals(kind, "type", StringComparison.OrdinalIgnoreCase) ? null : kind;
+            query = normalizedKind is null
+                ? query.Where(item => item.Kind is "class" or "record" or "struct" or "interface" or "enum" or "delegate")
+                : query.Where(item => string.Equals(item.Kind, normalizedKind, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var ordered = query
+            .OrderBy(item => ExactRank(item, symbol))
+            .ThenBy(item => item.FullyQualifiedName, StringComparer.Ordinal)
+            .ToArray();
+        return WriteBounded(ordered, limit, arguments.Has("--json"), item =>
+            $"{item.Path}:{item.StartLine}-{item.EndLine} [{item.Project ?? "no-project"}] {item.FullyQualifiedName} — {item.Signature}");
+    }
+
+    private static async Task<int> OutlineAsync(SourceIndexStore store, CommandArguments arguments)
+    {
+        var index = await store.LoadOrBuildAsync();
+        var path = arguments.Value("--path");
+        var symbol = arguments.Value("--symbol");
+        if (string.IsNullOrWhiteSpace(path) == string.IsNullOrWhiteSpace(symbol))
+        {
+            return Program.Fail("index outline requires exactly one of --path or --symbol.");
+        }
+
+        IEnumerable<IndexedSymbol> query = index.Symbols;
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            var normalized = GitRepository.NormalizeRelativePath(path);
+            query = query.Where(item => string.Equals(item.Path, normalized, StringComparison.OrdinalIgnoreCase));
+        }
+        else
+        {
+            query = query.Where(item =>
+                item.Name.Contains(symbol!, StringComparison.OrdinalIgnoreCase) ||
+                item.FullyQualifiedName.Contains(symbol!, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var values = query.OrderBy(item => item.Path, StringComparer.Ordinal).ThenBy(item => item.StartLine).ToArray();
+        var limit = arguments.IntValue("--limit", 20, 1, 160);
+        return WriteBounded(values, limit, arguments.Has("--json"), item =>
+            $"{item.Path}:{item.StartLine}-{item.EndLine} {item.Kind} {item.FullyQualifiedName} — {item.Signature}");
+    }
+
+    private static async Task<int> TextAsync(GitRepository repository, SourceIndexStore store, CommandArguments arguments)
+    {
+        var pattern = arguments.Value("--pattern");
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            return Program.Fail("index text requires --pattern.");
+        }
+        var index = await store.LoadOrBuildAsync();
+        var limit = arguments.IntValue("--limit", 20, 1, 160);
+        var matches = new List<TextMatch>();
+        var total = 0;
+        foreach (var file in index.Files)
+        {
+            var lines = await File.ReadAllLinesAsync(repository.ResolvePath(file.Path));
+            for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+            {
+                var column = lines[lineIndex].IndexOf(pattern, StringComparison.OrdinalIgnoreCase);
+                if (column < 0)
+                {
+                    continue;
+                }
+                total++;
+                if (matches.Count < limit)
+                {
+                    var excerpt = lines[lineIndex].Trim();
+                    if (excerpt.Length > 180) excerpt = excerpt[..177] + "...";
+                    matches.Add(new TextMatch(file.Path, lineIndex + 1, column + 1, excerpt));
+                }
+            }
+        }
+        return WriteBounded(matches.ToArray(), limit, arguments.Has("--json"), item =>
+            $"{item.Path}:{item.Line}:{item.Column} {item.Excerpt}", total);
+    }
+
+    private static async Task<int> MapAsync(GitRepository repository, SourceIndexStore store, CommandArguments arguments)
+    {
+        _ = await store.LoadOrBuildAsync();
+        var requested = arguments.Value("--project");
+        if (string.IsNullOrWhiteSpace(requested))
+        {
+            return Program.Fail("index map requires --project.");
+        }
+        var projects = new List<ProjectMap>();
+        foreach (var path in repository.TrackedFiles().Where(path => path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)))
+        {
+            var document = XDocument.Load(repository.ResolvePath(path));
+            var references = document.Descendants("ProjectReference")
+                .Select(element => element.Attribute("Include")?.Value)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Select(value => Path.GetFileNameWithoutExtension(value!))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            projects.Add(new ProjectMap(Path.GetFileNameWithoutExtension(path), path, references));
+        }
+        var selected = projects.Where(project => project.Name.Contains(requested, StringComparison.OrdinalIgnoreCase)).ToArray();
+        if (arguments.Has("--json"))
+        {
+            Program.WriteJson(new { results = selected, total = selected.Length, relationship = "MSBuild ProjectReference (declared)" });
+        }
+        else
+        {
+            foreach (var project in selected)
+            {
+                Console.WriteLine($"{project.Name} ({project.Path})");
+                Console.WriteLine(project.References.Count == 0
+                    ? "  references: none"
+                    : $"  references: {string.Join(", ", project.References)}");
+            }
+            Console.WriteLine("Relationship: declared MSBuild ProjectReference; this is not a semantic runtime call graph.");
+        }
+        return selected.Length == 0 ? 2 : 0;
+    }
+
+    private static int WriteBounded<T>(
+        IReadOnlyList<T> values,
+        int limit,
+        bool json,
+        Func<T, string> render,
+        int? knownTotal = null)
+    {
+        var total = knownTotal ?? values.Count;
+        var selected = values.Take(limit).ToArray();
+        if (json)
+        {
+            Program.WriteJson(new { results = selected, total, returned = selected.Length, truncated = total > selected.Length, limit });
+        }
+        else
+        {
+            foreach (var value in selected) Console.WriteLine(render(value));
+            Console.WriteLine(total > selected.Length
+                ? $"Showing {selected.Length} of {total}; use --limit to expand (maximum 160)."
+                : $"{selected.Length} result(s).");
+        }
+        return selected.Length == 0 ? 2 : 0;
+    }
+
+    private static int ExactRank(IndexedSymbol item, string? requested) =>
+        !string.IsNullOrWhiteSpace(requested) &&
+        (string.Equals(item.Name, requested, StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(item.FullyQualifiedName, requested, StringComparison.OrdinalIgnoreCase)) ? 0 : 1;
+
+    private static bool IsLikelyText(string path)
+    {
+        if (!File.Exists(path)) return false;
+        using var stream = File.OpenRead(path);
+        Span<byte> bytes = stackalloc byte[8192];
+        var read = stream.Read(bytes);
+        return !SourceIndexStore.IsBinary(bytes[..read]);
+    }
+
+    private sealed record TextMatch(string Path, int Line, int Column, string Excerpt);
+
+    private sealed record ProjectMap(string Name, string Path, IReadOnlyList<string> References);
+}

--- a/tools/SharpEmu.Tools.AgentHarness/SourceIndexCommand.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/SourceIndexCommand.cs
@@ -54,18 +54,23 @@ internal static class SourceIndexCommand
 
     private static async Task<int> StatusAsync(GitRepository repository, SourceIndexStore store, CommandArguments arguments)
     {
-        if (!File.Exists(store.IndexPath))
+        var status = await store.GetStatusAsync();
+        if (!status.Exists)
         {
             var missing = new { exists = false, path = store.IndexPath, commit = repository.Commit };
             if (arguments.Has("--json")) Program.WriteJson(missing); else Console.WriteLine("Index is missing; run index build.");
             return 2;
         }
 
-        var index = await store.LoadOrBuildAsync();
-        var tracked = repository.TrackedFiles().ToHashSet(StringComparer.Ordinal);
-        var indexed = index.Files.Select(file => file.Path).ToHashSet(StringComparer.Ordinal);
-        var missingFiles = tracked.Where(path => IsLikelyText(repository.ResolvePath(path)) && !indexed.Contains(path)).Take(20).ToArray();
-        var removedFiles = indexed.Where(path => !tracked.Contains(path)).Take(20).ToArray();
+        var index = status.Index;
+        if (index is null || index.SchemaVersion != SourceIndexStore.SchemaVersion)
+        {
+            var invalid = new { exists = true, path = store.IndexPath, current = false, reason = "unsupported-or-invalid-schema" };
+            if (arguments.Has("--json")) Program.WriteJson(invalid); else Console.WriteLine("Index schema is invalid; run index build.");
+            return 2;
+        }
+
+        const int detailLimit = 20;
         var result = new
         {
             exists = true,
@@ -74,9 +79,14 @@ internal static class SourceIndexCommand
             currentCommit = repository.Commit,
             fileCount = index.Files.Count,
             symbolCount = index.Symbols.Count,
-            missingTrackedTextFiles = missingFiles,
-            removedTrackedFiles = removedFiles,
-            current = index.Commit == repository.Commit && missingFiles.Length == 0 && removedFiles.Length == 0,
+            addedTrackedTextFileCount = status.AddedTrackedTextFiles.Count,
+            removedTrackedFileCount = status.RemovedTrackedFiles.Count,
+            contentModifiedTrackedFileCount = status.ContentModifiedTrackedFiles.Count,
+            addedTrackedTextFiles = status.AddedTrackedTextFiles.Take(detailLimit).ToArray(),
+            removedTrackedFiles = status.RemovedTrackedFiles.Take(detailLimit).ToArray(),
+            contentModifiedTrackedFiles = status.ContentModifiedTrackedFiles.Take(detailLimit).ToArray(),
+            truncated = status.AddedTrackedTextFiles.Count > detailLimit || status.RemovedTrackedFiles.Count > detailLimit || status.ContentModifiedTrackedFiles.Count > detailLimit,
+            current = status.Current,
         };
         if (arguments.Has("--json"))
         {
@@ -92,7 +102,8 @@ internal static class SourceIndexCommand
 
     private static async Task<int> QueryAsync(SourceIndexStore store, CommandArguments arguments)
     {
-        var index = await store.LoadOrBuildAsync();
+        var index = await LoadForQueryAsync(store);
+        if (index is null) return 2;
         var symbol = arguments.Value("--symbol");
         var namespaceName = arguments.Value("--namespace");
         var kind = arguments.Value("--kind");
@@ -126,7 +137,8 @@ internal static class SourceIndexCommand
 
     private static async Task<int> OutlineAsync(SourceIndexStore store, CommandArguments arguments)
     {
-        var index = await store.LoadOrBuildAsync();
+        var index = await LoadForQueryAsync(store);
+        if (index is null) return 2;
         var path = arguments.Value("--path");
         var symbol = arguments.Value("--symbol");
         if (string.IsNullOrWhiteSpace(path) == string.IsNullOrWhiteSpace(symbol))
@@ -160,7 +172,8 @@ internal static class SourceIndexCommand
         {
             return Program.Fail("index text requires --pattern.");
         }
-        var index = await store.LoadOrBuildAsync();
+        var index = await LoadForQueryAsync(store);
+        if (index is null) return 2;
         var limit = arguments.IntValue("--limit", 20, 1, 160);
         var matches = new List<TextMatch>();
         var total = 0;
@@ -189,7 +202,7 @@ internal static class SourceIndexCommand
 
     private static async Task<int> MapAsync(GitRepository repository, SourceIndexStore store, CommandArguments arguments)
     {
-        _ = await store.LoadOrBuildAsync();
+        if (await LoadForQueryAsync(store) is null) return 2;
         var requested = arguments.Value("--project");
         if (string.IsNullOrWhiteSpace(requested))
         {
@@ -255,13 +268,17 @@ internal static class SourceIndexCommand
         (string.Equals(item.Name, requested, StringComparison.OrdinalIgnoreCase) ||
          string.Equals(item.FullyQualifiedName, requested, StringComparison.OrdinalIgnoreCase)) ? 0 : 1;
 
-    private static bool IsLikelyText(string path)
+    private static async Task<SourceIndexDocument?> LoadForQueryAsync(SourceIndexStore store)
     {
-        if (!File.Exists(path)) return false;
-        using var stream = File.OpenRead(path);
-        Span<byte> bytes = stackalloc byte[8192];
-        var read = stream.Read(bytes);
-        return !SourceIndexStore.IsBinary(bytes[..read]);
+        try
+        {
+            return await store.LoadCurrentAsync();
+        }
+        catch (SourceIndexStaleException)
+        {
+            Console.Error.WriteLine("The source index is stale; run index build before querying.");
+            return null;
+        }
     }
 
     private sealed record TextMatch(string Path, int Line, int Column, string Excerpt);

--- a/tools/SharpEmu.Tools.AgentHarness/VisualAnalysis.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/VisualAnalysis.cs
@@ -1,0 +1,226 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal sealed record ImageMetrics(
+    int Width,
+    int Height,
+    string Sha256,
+    double MeanLuminance,
+    double LuminanceStandardDeviation,
+    double NearBlackPercent,
+    double NearWhitePercent,
+    long AlphaAnomalyPixels,
+    string DifferenceHash,
+    bool LikelyBlank);
+
+internal sealed record ImageDifference(double ChangedPixelRatio, double NormalizedMeanAbsoluteDifference);
+
+internal sealed record VisualFrame(
+    string File,
+    string CaptureSource,
+    long? FrameNumber,
+    double? ElapsedSeconds,
+    string SourcePixelFormat,
+    string CanonicalFormat,
+    string? ColorSpace,
+    bool VerticalFlipApplied,
+    string EncoderStatus,
+    ImageMetrics Metrics,
+    ImageDifference? DifferenceFromPrevious);
+
+internal static class VisualAnalyzer
+{
+    public static ImageMetrics Analyze(RgbaImage image, string sha256)
+    {
+        var count = checked(image.Width * image.Height);
+        if (count == 0) throw new ArgumentException("Image is empty.", nameof(image));
+        double sum = 0;
+        double squared = 0;
+        var black = 0L;
+        var white = 0L;
+        var alpha = 0L;
+        for (var offset = 0; offset < image.Pixels.Length; offset += 4)
+        {
+            var luminance = 0.2126 * image.Pixels[offset] + 0.7152 * image.Pixels[offset + 1] + 0.0722 * image.Pixels[offset + 2];
+            sum += luminance;
+            squared += luminance * luminance;
+            if (luminance <= 10) black++;
+            if (luminance >= 245) white++;
+            if (image.Pixels[offset + 3] != 255) alpha++;
+        }
+        var mean = sum / count;
+        var variance = Math.Max(0, squared / count - mean * mean);
+        var blackPercent = black * 100.0 / count;
+        var whitePercent = white * 100.0 / count;
+        var standardDeviation = Math.Sqrt(variance);
+        return new ImageMetrics(
+            image.Width,
+            image.Height,
+            sha256,
+            mean,
+            standardDeviation,
+            blackPercent,
+            whitePercent,
+            alpha,
+            DifferenceHash(image),
+            standardDeviation < 1.5 || blackPercent > 99.5 || whitePercent > 99.5);
+    }
+
+    public static ImageDifference Compare(RgbaImage before, RgbaImage after)
+    {
+        if (before.Width != after.Width || before.Height != after.Height) throw new ArgumentException("Image dimensions do not match.");
+        var pixels = before.Width * before.Height;
+        var changed = 0L;
+        double absolute = 0;
+        for (var offset = 0; offset < before.Pixels.Length; offset += 4)
+        {
+            var pixelChanged = false;
+            for (var channel = 0; channel < 4; channel++)
+            {
+                var difference = Math.Abs(before.Pixels[offset + channel] - after.Pixels[offset + channel]);
+                absolute += difference;
+                pixelChanged |= difference != 0;
+            }
+            if (pixelChanged) changed++;
+        }
+        return new ImageDifference(changed / (double)pixels, absolute / (pixels * 4.0 * 255.0));
+    }
+
+    public static RgbaImage AbsoluteDifference(RgbaImage before, RgbaImage after)
+    {
+        if (before.Width != after.Width || before.Height != after.Height) throw new ArgumentException("Image dimensions do not match.");
+        var pixels = new byte[before.Pixels.Length];
+        for (var index = 0; index < pixels.Length; index += 4)
+        {
+            pixels[index] = (byte)Math.Abs(before.Pixels[index] - after.Pixels[index]);
+            pixels[index + 1] = (byte)Math.Abs(before.Pixels[index + 1] - after.Pixels[index + 1]);
+            pixels[index + 2] = (byte)Math.Abs(before.Pixels[index + 2] - after.Pixels[index + 2]);
+            pixels[index + 3] = 255;
+        }
+        return new RgbaImage(before.Width, before.Height, pixels);
+    }
+
+    public static bool IsFrozen(IReadOnlyList<RgbaImage> images)
+    {
+        if (images.Count < 2) return false;
+        return images.Skip(1).All(image => Compare(images[0], image).ChangedPixelRatio < 0.0001);
+    }
+
+    private static string DifferenceHash(RgbaImage image)
+    {
+        Span<double> values = stackalloc double[64];
+        for (var y = 0; y < 8; y++)
+        {
+            for (var x = 0; x < 8; x++)
+            {
+                var sourceX = Math.Min(image.Width - 1, x * image.Width / 8);
+                var sourceY = Math.Min(image.Height - 1, y * image.Height / 8);
+                var offset = (sourceY * image.Width + sourceX) * 4;
+                values[y * 8 + x] = 0.2126 * image.Pixels[offset] + 0.7152 * image.Pixels[offset + 1] + 0.0722 * image.Pixels[offset + 2];
+            }
+        }
+        var mean = values.ToArray().Average();
+        ulong hash = 0;
+        for (var index = 0; index < values.Length; index++) if (values[index] >= mean) hash |= 1UL << index;
+        return hash.ToString("X16");
+    }
+}
+
+internal static class ContactSheet
+{
+    private const int PanelWidth = 320;
+    private const int ImageHeight = 180;
+    private const int TextHeight = 48;
+    private const int HeaderHeight = 18;
+
+    public static RgbaImage Create(string title, IReadOnlyList<(RgbaImage Image, string Label)> frames)
+    {
+        var columns = Math.Min(3, Math.Max(1, frames.Count));
+        var rows = Math.Max(1, (frames.Count + columns - 1) / columns);
+        var width = columns * PanelWidth;
+        var height = HeaderHeight + rows * (ImageHeight + TextHeight);
+        var pixels = Enumerable.Repeat((byte)18, width * height * 4).ToArray();
+        for (var index = 3; index < pixels.Length; index += 4) pixels[index] = 255;
+        var canvas = new RasterCanvas(new RgbaImage(width, height, pixels));
+        canvas.DrawText(4, 4, title, 220, 220, 220);
+        for (var index = 0; index < frames.Count; index++)
+        {
+            var x = index % columns * PanelWidth;
+            var y = HeaderHeight + index / columns * (ImageHeight + TextHeight);
+            canvas.BlitScaled(frames[index].Image, x, y, PanelWidth, ImageHeight);
+            var lines = Wrap(frames[index].Label.ToUpperInvariant(), 50).Take(3).ToArray();
+            for (var line = 0; line < lines.Length; line++) canvas.DrawText(x + 3, y + ImageHeight + 5 + line * 12, lines[line], 240, 240, 240);
+        }
+        return canvas.Image;
+    }
+
+    private static IEnumerable<string> Wrap(string value, int width)
+    {
+        for (var offset = 0; offset < value.Length; offset += width) yield return value.Substring(offset, Math.Min(width, value.Length - offset));
+    }
+}
+
+internal sealed class RasterCanvas
+{
+    private static readonly IReadOnlyDictionary<char, string[]> Font = CreateFont();
+
+    public RasterCanvas(RgbaImage image) => Image = image;
+
+    public RgbaImage Image { get; }
+
+    public void BlitScaled(RgbaImage source, int x, int y, int width, int height)
+    {
+        for (var destinationY = 0; destinationY < height; destinationY++)
+        {
+            var sourceY = destinationY * source.Height / height;
+            for (var destinationX = 0; destinationX < width; destinationX++)
+            {
+                var sourceX = destinationX * source.Width / width;
+                var sourceOffset = (sourceY * source.Width + sourceX) * 4;
+                var destinationOffset = ((y + destinationY) * Image.Width + x + destinationX) * 4;
+                source.Pixels.AsSpan(sourceOffset, 4).CopyTo(Image.Pixels.AsSpan(destinationOffset, 4));
+            }
+        }
+    }
+
+    public void DrawText(int x, int y, string text, byte red, byte green, byte blue)
+    {
+        var cursor = x;
+        foreach (var character in text)
+        {
+            if (!Font.TryGetValue(character, out var glyph)) glyph = Font['?'];
+            for (var row = 0; row < glyph.Length; row++)
+            {
+                for (var column = 0; column < glyph[row].Length; column++)
+                {
+                    if (glyph[row][column] != '#') continue;
+                    var px = cursor + column;
+                    var py = y + row;
+                    if (px < 0 || py < 0 || px >= Image.Width || py >= Image.Height) continue;
+                    var offset = (py * Image.Width + px) * 4;
+                    Image.Pixels[offset] = red;
+                    Image.Pixels[offset + 1] = green;
+                    Image.Pixels[offset + 2] = blue;
+                    Image.Pixels[offset + 3] = 255;
+                }
+            }
+            cursor += 4;
+        }
+    }
+
+    private static IReadOnlyDictionary<char, string[]> CreateFont()
+    {
+        var patterns = new Dictionary<char, string[]>(64);
+        void Add(char value, params string[] rows) => patterns[value] = rows;
+        Add(' ', "...", "...", "...", "...", "..."); Add('?', "##.", "..#", ".#.", "...", ".#.");
+        Add('-', "...", "...", "###", "...", "..."); Add('.', "...", "...", "...", "...", ".#."); Add(':', "...", ".#.", "...", ".#.", "...");
+        Add('/', "..#", "..#", ".#.", "#..", "#.."); Add('_', "...", "...", "...", "...", "###"); Add('%', "#.#", "..#", ".#.", "#..", "#.#"); Add('=', "...", "###", "...", "###", "...");
+        Add('0', "###", "#.#", "#.#", "#.#", "###"); Add('1', ".#.", "##.", ".#.", ".#.", "###"); Add('2', "##.", "..#", ".#.", "#..", "###"); Add('3', "##.", "..#", ".#.", "..#", "##."); Add('4', "#.#", "#.#", "###", "..#", "..#"); Add('5', "###", "#..", "##.", "..#", "##."); Add('6', ".##", "#..", "###", "#.#", "###"); Add('7', "###", "..#", ".#.", ".#.", ".#."); Add('8', "###", "#.#", "###", "#.#", "###"); Add('9', "###", "#.#", "###", "..#", "##.");
+        Add('A', ".#.", "#.#", "###", "#.#", "#.#"); Add('B', "##.", "#.#", "##.", "#.#", "##."); Add('C', ".##", "#..", "#..", "#..", ".##"); Add('D', "##.", "#.#", "#.#", "#.#", "##."); Add('E', "###", "#..", "##.", "#..", "###"); Add('F', "###", "#..", "##.", "#..", "#.."); Add('G', ".##", "#..", "#.#", "#.#", ".##"); Add('H', "#.#", "#.#", "###", "#.#", "#.#"); Add('I', "###", ".#.", ".#.", ".#.", "###"); Add('J', "..#", "..#", "..#", "#.#", ".#."); Add('K', "#.#", "#.#", "##.", "#.#", "#.#"); Add('L', "#..", "#..", "#..", "#..", "###"); Add('M', "#.#", "###", "###", "#.#", "#.#"); Add('N', "#.#", "###", "###", "###", "#.#"); Add('O', ".#.", "#.#", "#.#", "#.#", ".#."); Add('P', "##.", "#.#", "##.", "#..", "#.."); Add('Q', ".#.", "#.#", "#.#", ".#.", "..#"); Add('R', "##.", "#.#", "##.", "#.#", "#.#"); Add('S', ".##", "#..", ".#.", "..#", "##."); Add('T', "###", ".#.", ".#.", ".#.", ".#."); Add('U', "#.#", "#.#", "#.#", "#.#", "###"); Add('V', "#.#", "#.#", "#.#", "#.#", ".#."); Add('W', "#.#", "#.#", "###", "###", "#.#"); Add('X', "#.#", "#.#", ".#.", "#.#", "#.#"); Add('Y', "#.#", "#.#", ".#.", ".#.", ".#."); Add('Z', "###", "..#", ".#.", "#..", "###");
+        return patterns;
+    }
+}

--- a/tools/SharpEmu.Tools.AgentHarness/VisualAnalysis.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/VisualAnalysis.cs
@@ -27,6 +27,7 @@ internal sealed record VisualFrame(
     string SourcePixelFormat,
     string CanonicalFormat,
     string? ColorSpace,
+    string? NearestMilestone,
     bool VerticalFlipApplied,
     string EncoderStatus,
     ImageMetrics Metrics,

--- a/tools/SharpEmu.Tools.AgentHarness/VisualCommand.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/VisualCommand.cs
@@ -1,0 +1,259 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text.Json;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal sealed record RawFrameDescriptor(
+    string RawFile,
+    int Width,
+    int Height,
+    int RowPitch,
+    string Format,
+    string CaptureSource,
+    long? FrameNumber,
+    double? ElapsedSeconds,
+    DateTimeOffset UtcTimestamp,
+    string? ColorSpace,
+    bool FlipVertical,
+    string? NearestMilestone);
+
+internal sealed record VisualReport(
+    string SchemaVersion,
+    string RunId,
+    DateTimeOffset GeneratedUtc,
+    string FirstFrameStatus,
+    string CaptureStatus,
+    bool LikelyFrozenSequence,
+    IReadOnlyList<VisualFrame> Frames,
+    string? ContactSheet,
+    IReadOnlyList<string> Warnings);
+
+internal static class VisualCommand
+{
+    public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
+    {
+        if (arguments.Count == 0) return Program.Fail("visual requires analyze or compare.");
+        return arguments[0].ToLowerInvariant() switch
+        {
+            "analyze" => await AnalyzeCommandAsync(repository, arguments.Slice(1)),
+            "compare" => await CompareCommandAsync(repository, arguments.Slice(1)),
+            _ => Program.Fail($"Unknown visual command '{arguments[0]}'."),
+        };
+    }
+
+    internal static async Task<VisualReport> AnalyzeRunAsync(string runDirectory)
+    {
+        Directory.CreateDirectory(runDirectory);
+        var frameDirectory = Path.Combine(runDirectory, "frames");
+        Directory.CreateDirectory(frameDirectory);
+        var warnings = new List<string>();
+        foreach (var descriptorPath in Directory.EnumerateFiles(frameDirectory, "*.raw.json").Order(StringComparer.Ordinal))
+        {
+            try
+            {
+                var descriptor = JsonSerializer.Deserialize<RawFrameDescriptor>(await File.ReadAllTextAsync(descriptorPath), Program.JsonOptions)
+                    ?? throw new InvalidDataException("Raw descriptor is empty.");
+                var rawPath = Path.Combine(frameDirectory, descriptor.RawFile);
+                var image = RgbaImage.FromRaw(
+                    descriptor.Width,
+                    descriptor.Height,
+                    await File.ReadAllBytesAsync(rawPath),
+                    descriptor.Format,
+                    descriptor.RowPitch,
+                    descriptor.FlipVertical);
+                PngCodec.Write(Path.ChangeExtension(descriptorPath, ".png"), image);
+            }
+            catch (Exception exception)
+            {
+                warnings.Add($"Failed to encode {Path.GetFileName(descriptorPath)}: {exception.Message}");
+            }
+        }
+
+        var pngPaths = Directory.EnumerateFiles(frameDirectory, "*.png").Order(StringComparer.Ordinal).ToArray();
+        var images = new List<RgbaImage>(pngPaths.Length);
+        var frames = new List<VisualFrame>(pngPaths.Length);
+        for (var index = 0; index < pngPaths.Length; index++)
+        {
+            var pngPath = pngPaths[index];
+            var image = PngCodec.Read(pngPath);
+            images.Add(image);
+            var descriptorPath = Path.ChangeExtension(pngPath, ".json");
+            RawFrameDescriptor? descriptor = null;
+            if (File.Exists(descriptorPath))
+            {
+                descriptor = JsonSerializer.Deserialize<RawFrameDescriptor>(await File.ReadAllTextAsync(descriptorPath), Program.JsonOptions);
+            }
+            var metrics = VisualAnalyzer.Analyze(image, GitRepository.Sha256File(pngPath));
+            var difference = index == 0 ? null : VisualAnalyzer.Compare(images[index - 1], image);
+            var inferredSource = Path.GetFileName(pngPath).StartsWith("window-", StringComparison.OrdinalIgnoreCase)
+                ? "window-fallback"
+                : Path.GetFileName(pngPath).StartsWith("synthetic-", StringComparison.OrdinalIgnoreCase) ? "synthetic" : "unknown";
+            frames.Add(new VisualFrame(
+                Path.GetRelativePath(runDirectory, pngPath).Replace('\\', '/'),
+                descriptor?.CaptureSource ?? inferredSource,
+                descriptor?.FrameNumber,
+                descriptor?.ElapsedSeconds,
+                descriptor?.Format ?? (inferredSource == "synthetic" ? "generated RGBA8" : "unknown"),
+                "RGBA8 PNG",
+                descriptor?.ColorSpace,
+                descriptor?.FlipVertical ?? false,
+                "success",
+                metrics,
+                difference));
+        }
+
+        var runId = Path.GetFileName(Path.TrimEndingDirectorySeparator(runDirectory));
+        string? contactSheetRelative = null;
+        if (frames.Count > 0)
+        {
+            var sheetFrames = frames.Select((frame, index) =>
+            {
+                var label = $"{Path.GetFileName(frame.File)} {frame.CaptureSource} F={frame.FrameNumber?.ToString() ?? "?"} " +
+                    $"L={frame.Metrics.MeanLuminance:F1} SD={frame.Metrics.LuminanceStandardDeviation:F1} BLACK={frame.Metrics.NearBlackPercent:F1}%";
+                return (images[index], label);
+            }).ToArray();
+            var contactSheetPath = Path.Combine(runDirectory, "contact-sheet.png");
+            PngCodec.Write(contactSheetPath, ContactSheet.Create(runId, sheetFrames));
+            contactSheetRelative = "contact-sheet.png";
+        }
+        var sources = frames.Select(frame => frame.CaptureSource).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        var report = new VisualReport(
+            "1.0.0",
+            runId,
+            DateTimeOffset.UtcNow,
+            frames.Count == 0 ? "not-observed" : "observed",
+            frames.Count == 0 ? "no-frame-produced" : string.Join('+', sources),
+            VisualAnalyzer.IsFrozen(images),
+            frames,
+            contactSheetRelative,
+            warnings);
+        await File.WriteAllTextAsync(Path.Combine(runDirectory, "visual.json"), JsonSerializer.Serialize(report, Program.JsonOptions));
+        return report;
+    }
+
+    private static async Task<int> AnalyzeCommandAsync(GitRepository repository, CommandArguments arguments)
+    {
+        var run = arguments.Value("--run");
+        if (string.IsNullOrWhiteSpace(run)) return Program.Fail("visual analyze requires --run.");
+        var directory = ResolveRun(repository, run);
+        if (!Directory.Exists(directory)) return Program.Fail($"Run '{run}' was not found.");
+        var report = await AnalyzeRunAsync(directory);
+        if (arguments.Has("--json")) Program.WriteJson(report);
+        else
+        {
+            Console.WriteLine($"Visual analysis: {report.Frames.Count} frame(s), status {report.CaptureStatus}.");
+            if (report.ContactSheet is not null) Console.WriteLine(Path.Combine(directory, report.ContactSheet));
+            foreach (var warning in report.Warnings) Console.WriteLine($"warning: {warning}");
+        }
+        return 0;
+    }
+
+    private static async Task<int> CompareCommandAsync(GitRepository repository, CommandArguments arguments)
+    {
+        var beforeValue = arguments.Value("--before");
+        var afterValue = arguments.Value("--after");
+        if (string.IsNullOrWhiteSpace(beforeValue) || string.IsNullOrWhiteSpace(afterValue)) return Program.Fail("visual compare requires --before and --after.");
+        var beforeDirectory = ResolveRun(repository, beforeValue);
+        var afterDirectory = ResolveRun(repository, afterValue);
+        var before = await AnalyzeRunAsync(beforeDirectory);
+        var after = await AnalyzeRunAsync(afterDirectory);
+        if (before.Frames.Count == 0 || after.Frames.Count == 0) return Program.Fail("Both runs must contain at least one frame.");
+        var beforeFrame = before.Frames[0];
+        var afterFrame = after.Frames[0];
+        var beforeImage = PngCodec.Read(Path.Combine(beforeDirectory, beforeFrame.File));
+        var afterImage = PngCodec.Read(Path.Combine(afterDirectory, afterFrame.File));
+        var sourceMatches = string.Equals(beforeFrame.CaptureSource, afterFrame.CaptureSource, StringComparison.OrdinalIgnoreCase);
+        var resolutionMatches = beforeImage.Width == afterImage.Width && beforeImage.Height == afterImage.Height;
+        var compatible = sourceMatches && resolutionMatches;
+        ImageDifference? difference = null;
+        string? differencePath = null;
+        string? sheetPath = null;
+        var outputDirectory = Path.Combine(afterDirectory, "diffs", $"vs-{before.RunId}");
+        Directory.CreateDirectory(outputDirectory);
+        if (resolutionMatches)
+        {
+            difference = VisualAnalyzer.Compare(beforeImage, afterImage);
+            differencePath = Path.Combine(outputDirectory, "absolute-difference.png");
+            PngCodec.Write(differencePath, VisualAnalyzer.AbsoluteDifference(beforeImage, afterImage));
+            sheetPath = Path.Combine(outputDirectory, "comparison.png");
+            PngCodec.Write(sheetPath, ContactSheet.Create(
+                $"{before.RunId} VS {after.RunId}",
+                [(beforeImage, $"BEFORE {beforeFrame.CaptureSource}"), (afterImage, $"AFTER {afterFrame.CaptureSource}"), (VisualAnalyzer.AbsoluteDifference(beforeImage, afterImage), $"DIFF CHANGED={difference.ChangedPixelRatio:P2} MAD={difference.NormalizedMeanAbsoluteDifference:F4}")]));
+        }
+        var result = new
+        {
+            schemaVersion = "1.0.0",
+            beforeRun = before.RunId,
+            afterRun = after.RunId,
+            sourceMatches,
+            resolutionMatches,
+            hardwareAndBuildProfileCheck = "not-proven-by-image-data",
+            compatible,
+            warning = compatible ? null : "Runs are not directly comparable; capture source or resolution differs.",
+            difference,
+            absoluteDifference = differencePath,
+            contactSheet = sheetPath,
+            metricDeltas = new
+            {
+                meanLuminance = afterFrame.Metrics.MeanLuminance - beforeFrame.Metrics.MeanLuminance,
+                luminanceStandardDeviation = afterFrame.Metrics.LuminanceStandardDeviation - beforeFrame.Metrics.LuminanceStandardDeviation,
+                nearBlackPercent = afterFrame.Metrics.NearBlackPercent - beforeFrame.Metrics.NearBlackPercent,
+            },
+        };
+        await File.WriteAllTextAsync(Path.Combine(outputDirectory, "comparison.json"), JsonSerializer.Serialize(result, Program.JsonOptions));
+        if (arguments.Has("--json")) Program.WriteJson(result); else Console.WriteLine(sheetPath ?? result.warning);
+        return compatible ? 0 : 2;
+    }
+
+    private static string ResolveRun(GitRepository repository, string value)
+    {
+        if (Path.IsPathFullyQualified(value)) return Path.GetFullPath(value);
+        var direct = repository.ResolvePath(value);
+        if (Directory.Exists(direct)) return direct;
+        return Path.Combine(repository.LocalRoot, "runs", value);
+    }
+}
+
+internal static class SyntheticCommand
+{
+    public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
+    {
+        if (!arguments.Is("visual")) return Program.Fail("synthetic requires visual.");
+        var output = arguments.Value("--output") ?? Path.Combine(repository.LocalRoot, "runs", $"synthetic-{DateTime.UtcNow:yyyyMMddTHHmmssZ}");
+        output = Path.IsPathFullyQualified(output) ? Path.GetFullPath(output) : repository.ResolvePath(output);
+        var frames = Path.Combine(output, "frames");
+        Directory.CreateDirectory(frames);
+        var first = Checkerboard(128, 72, shift: 0);
+        var second = Checkerboard(128, 72, shift: 1);
+        PngCodec.Write(Path.Combine(frames, "synthetic-0001.png"), first);
+        PngCodec.Write(Path.Combine(frames, "synthetic-0002.png"), second);
+        var report = await VisualCommand.AnalyzeRunAsync(output);
+        if (arguments.Has("--json")) Program.WriteJson(report);
+        else
+        {
+            Console.WriteLine($"Synthetic visual validation passed: {report.Frames.Count} frames, frozen={report.LikelyFrozenSequence}.");
+            Console.WriteLine(Path.Combine(output, report.ContactSheet!));
+        }
+        return report.Frames.Count == 2 && !report.LikelyFrozenSequence ? 0 : 2;
+    }
+
+    internal static RgbaImage Checkerboard(int width, int height, int shift)
+    {
+        var pixels = new byte[width * height * 4];
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var offset = (y * width + x) * 4;
+                var checker = ((x / 8 + y / 8 + shift) & 1) == 0;
+                pixels[offset] = checker ? (byte)240 : (byte)(x * 255 / Math.Max(1, width - 1));
+                pixels[offset + 1] = checker ? (byte)(y * 255 / Math.Max(1, height - 1)) : (byte)32;
+                pixels[offset + 2] = checker ? (byte)40 : (byte)220;
+                pixels[offset + 3] = 255;
+            }
+        }
+        return new RgbaImage(width, height, pixels);
+    }
+}

--- a/tools/SharpEmu.Tools.AgentHarness/VisualCommand.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/VisualCommand.cs
@@ -30,6 +30,24 @@ internal sealed record VisualReport(
     string? ContactSheet,
     IReadOnlyList<string> Warnings);
 
+internal sealed record ComparisonField(string Name, string? Before, string? After, string Status);
+
+internal sealed record VisualComparisonReport(
+    string SchemaVersion,
+    string BeforeRun,
+    string AfterRun,
+    string Classification,
+    bool StrictComparabilityProven,
+    bool ExploratoryOverride,
+    long? SelectedFrame,
+    IReadOnlyList<ComparisonField> Fields,
+    ImageDifference? PixelDifference,
+    string PixelConclusion,
+    string? AbsoluteDifference,
+    string? ContactSheet,
+    object? MetricDeltas,
+    IReadOnlyList<string> Warnings);
+
 internal static class VisualCommand
 {
     public static async Task<int> RunAsync(GitRepository repository, CommandArguments arguments)
@@ -67,7 +85,7 @@ internal static class VisualCommand
             }
             catch (Exception exception)
             {
-                warnings.Add($"Failed to encode {Path.GetFileName(descriptorPath)}: {exception.Message}");
+                warnings.Add($"Failed to encode {Path.GetFileName(descriptorPath)}: {exception.GetType().Name}.");
             }
         }
 
@@ -98,6 +116,7 @@ internal static class VisualCommand
                 descriptor?.Format ?? (inferredSource == "synthetic" ? "generated RGBA8" : "unknown"),
                 "RGBA8 PNG",
                 descriptor?.ColorSpace,
+                descriptor?.NearestMilestone,
                 descriptor?.FlipVertical ?? false,
                 "success",
                 metrics,
@@ -119,12 +138,13 @@ internal static class VisualCommand
             contactSheetRelative = "contact-sheet.png";
         }
         var sources = frames.Select(frame => frame.CaptureSource).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        var captureFailed = frames.Count == 0 && warnings.Count > 0;
         var report = new VisualReport(
             "1.0.0",
             runId,
             DateTimeOffset.UtcNow,
-            frames.Count == 0 ? "not-observed" : "observed",
-            frames.Count == 0 ? "no-frame-produced" : string.Join('+', sources),
+            frames.Count == 0 ? captureFailed ? "capture-failed" : "not-observed" : "observed",
+            frames.Count == 0 ? captureFailed ? "capture-failed" : "no-frame-produced" : string.Join('+', sources),
             VisualAnalyzer.IsFrozen(images),
             frames,
             contactSheetRelative,
@@ -157,55 +177,168 @@ internal static class VisualCommand
         if (string.IsNullOrWhiteSpace(beforeValue) || string.IsNullOrWhiteSpace(afterValue)) return Program.Fail("visual compare requires --before and --after.");
         var beforeDirectory = ResolveRun(repository, beforeValue);
         var afterDirectory = ResolveRun(repository, afterValue);
+        var selectedFrame = arguments.Value("--frame");
+        if (selectedFrame is not null && !long.TryParse(selectedFrame, out _)) return Program.Fail("visual compare --frame requires an integer frame number.");
+        var frameNumber = long.TryParse(selectedFrame, out var parsedFrame) ? parsedFrame : (long?)null;
+        var (result, exitCode) = await CompareRunsAsync(beforeDirectory, afterDirectory, frameNumber, arguments.Has("--exploratory"));
+        if (arguments.Has("--json")) Program.WriteJson(result);
+        else Console.WriteLine($"Visual comparison: {result.Classification}; pixels {(result.PixelDifference is null ? "not compared" : "compared for exploration/evidence only")}.");
+        return exitCode;
+    }
+
+    internal static async Task<(VisualComparisonReport Report, int ExitCode)> CompareRunsAsync(
+        string beforeDirectory,
+        string afterDirectory,
+        long? requestedFrame,
+        bool exploratory)
+    {
         var before = await AnalyzeRunAsync(beforeDirectory);
         var after = await AnalyzeRunAsync(afterDirectory);
-        if (before.Frames.Count == 0 || after.Frames.Count == 0) return Program.Fail("Both runs must contain at least one frame.");
-        var beforeFrame = before.Frames[0];
-        var afterFrame = after.Frames[0];
+        var fields = new List<ComparisonField>();
+        var warnings = new List<string>();
+        var pair = SelectFramePair(before.Frames, after.Frames, requestedFrame);
+        if (pair is null)
+        {
+            warnings.Add(requestedFrame.HasValue
+                ? $"Frame {requestedFrame.Value} with a matching capture source is not present in both runs."
+                : "No common capture-source/frame-number pair exists; unlike first frames were not compared.");
+            return (new VisualComparisonReport(
+                "1.1.0", before.RunId, after.RunId, "not-comparable", false, exploratory, requestedFrame,
+                fields, null, "No pixel comparison was performed and no correctness conclusion is available.", null, null, null, warnings), 2);
+        }
+
+        var (beforeFrame, afterFrame) = pair.Value;
         var beforeImage = PngCodec.Read(Path.Combine(beforeDirectory, beforeFrame.File));
         var afterImage = PngCodec.Read(Path.Combine(afterDirectory, afterFrame.File));
-        var sourceMatches = string.Equals(beforeFrame.CaptureSource, afterFrame.CaptureSource, StringComparison.OrdinalIgnoreCase);
-        var resolutionMatches = beforeImage.Width == afterImage.Width && beforeImage.Height == afterImage.Height;
-        var compatible = sourceMatches && resolutionMatches;
+        var beforeMetadata = await ReadRunMetadataAsync(beforeDirectory);
+        var afterMetadata = await ReadRunMetadataAsync(afterDirectory);
+        AddField(fields, "target/profile identity", beforeMetadata.ProfileIdentity, afterMetadata.ProfileIdentity);
+        AddField(fields, "capture source", beforeFrame.CaptureSource, afterFrame.CaptureSource);
+        AddField(fields, "frame number", beforeFrame.FrameNumber?.ToString(), afterFrame.FrameNumber?.ToString());
+        AddField(fields, "width", beforeImage.Width.ToString(), afterImage.Width.ToString());
+        AddField(fields, "height", beforeImage.Height.ToString(), afterImage.Height.ToString());
+        AddField(fields, "canonical pixel format", beforeFrame.CanonicalFormat, afterFrame.CanonicalFormat);
+        AddField(fields, "capture policy", beforeMetadata.CapturePolicy, afterMetadata.CapturePolicy);
+        var pixelFields = fields.Count;
+        AddField(fields, "build configuration", beforeMetadata.BuildConfiguration, afterMetadata.BuildConfiguration);
+        AddField(fields, "repository commit", beforeMetadata.RepositoryCommit, afterMetadata.RepositoryCommit);
+        AddField(fields, "executable SHA-256", beforeMetadata.ExecutableSha256, afterMetadata.ExecutableSha256);
+        AddField(fields, "hardware fingerprint", beforeMetadata.HardwareFingerprint, afterMetadata.HardwareFingerprint);
+        AddField(fields, "GPU and driver", beforeMetadata.GpuAndDriver, afterMetadata.GpuAndDriver);
+
+        var pixelComparable = fields.Take(pixelFields).All(field => field.Status == "matched");
+        var strict = pixelComparable && fields.Skip(pixelFields).All(field => field.Status == "matched");
+        var classification = strict
+            ? "strictly-comparable"
+            : pixelComparable ? "pixel-comparable-environment-unverified" : "not-comparable";
         ImageDifference? difference = null;
         string? differencePath = null;
         string? sheetPath = null;
+        object? metricDeltas = null;
         var outputDirectory = Path.Combine(afterDirectory, "diffs", $"vs-{before.RunId}");
         Directory.CreateDirectory(outputDirectory);
-        if (resolutionMatches)
+        if (strict || exploratory && pixelComparable)
         {
             difference = VisualAnalyzer.Compare(beforeImage, afterImage);
-            differencePath = Path.Combine(outputDirectory, "absolute-difference.png");
-            PngCodec.Write(differencePath, VisualAnalyzer.AbsoluteDifference(beforeImage, afterImage));
-            sheetPath = Path.Combine(outputDirectory, "comparison.png");
-            PngCodec.Write(sheetPath, ContactSheet.Create(
+            var absolute = VisualAnalyzer.AbsoluteDifference(beforeImage, afterImage);
+            var differenceFullPath = Path.Combine(outputDirectory, $"frame-{beforeFrame.FrameNumber:D8}-absolute-difference.png");
+            PngCodec.Write(differenceFullPath, absolute);
+            differencePath = Path.GetRelativePath(afterDirectory, differenceFullPath).Replace('\\', '/');
+            var sheetFullPath = Path.Combine(outputDirectory, $"frame-{beforeFrame.FrameNumber:D8}-comparison.png");
+            PngCodec.Write(sheetFullPath, ContactSheet.Create(
                 $"{before.RunId} VS {after.RunId}",
-                [(beforeImage, $"BEFORE {beforeFrame.CaptureSource}"), (afterImage, $"AFTER {afterFrame.CaptureSource}"), (VisualAnalyzer.AbsoluteDifference(beforeImage, afterImage), $"DIFF CHANGED={difference.ChangedPixelRatio:P2} MAD={difference.NormalizedMeanAbsoluteDifference:F4}")]));
-        }
-        var result = new
-        {
-            schemaVersion = "1.0.0",
-            beforeRun = before.RunId,
-            afterRun = after.RunId,
-            sourceMatches,
-            resolutionMatches,
-            hardwareAndBuildProfileCheck = "not-proven-by-image-data",
-            compatible,
-            warning = compatible ? null : "Runs are not directly comparable; capture source or resolution differs.",
-            difference,
-            absoluteDifference = differencePath,
-            contactSheet = sheetPath,
+                [(beforeImage, $"BEFORE {beforeFrame.CaptureSource} F={beforeFrame.FrameNumber}"), (afterImage, $"AFTER {afterFrame.CaptureSource} F={afterFrame.FrameNumber}"), (absolute, $"PIXEL DIFF CHANGED={difference.ChangedPixelRatio:P2} MAD={difference.NormalizedMeanAbsoluteDifference:F4}")]));
+            sheetPath = Path.GetRelativePath(afterDirectory, sheetFullPath).Replace('\\', '/');
             metricDeltas = new
             {
                 meanLuminance = afterFrame.Metrics.MeanLuminance - beforeFrame.Metrics.MeanLuminance,
                 luminanceStandardDeviation = afterFrame.Metrics.LuminanceStandardDeviation - beforeFrame.Metrics.LuminanceStandardDeviation,
                 nearBlackPercent = afterFrame.Metrics.NearBlackPercent - beforeFrame.Metrics.NearBlackPercent,
-            },
-        };
-        await File.WriteAllTextAsync(Path.Combine(outputDirectory, "comparison.json"), JsonSerializer.Serialize(result, Program.JsonOptions));
-        if (arguments.Has("--json")) Program.WriteJson(result); else Console.WriteLine(sheetPath ?? result.warning);
-        return compatible ? 0 : 2;
+            };
+        }
+        else if (pixelComparable)
+        {
+            warnings.Add("Pixel inputs align, but strict environment/build identity is not proven; use --exploratory to generate a non-correctness pixel comparison.");
+        }
+
+        var report = new VisualComparisonReport(
+            "1.1.0", before.RunId, after.RunId, classification, strict, exploratory, beforeFrame.FrameNumber,
+            fields, difference, "Pixel differences are evidence only and do not establish rendering correctness or compatibility.",
+            differencePath, sheetPath, metricDeltas, warnings);
+        await File.WriteAllTextAsync(Path.Combine(outputDirectory, "comparison.json"), JsonSerializer.Serialize(report, Program.JsonOptions));
+        return (report, strict || exploratory && pixelComparable ? 0 : 2);
     }
+
+    private static (VisualFrame Before, VisualFrame After)? SelectFramePair(
+        IReadOnlyList<VisualFrame> before,
+        IReadOnlyList<VisualFrame> after,
+        long? requestedFrame)
+    {
+        var pairs = from left in before
+                    where left.FrameNumber.HasValue && (!requestedFrame.HasValue || left.FrameNumber == requestedFrame)
+                    join right in after on new { Source = left.CaptureSource.ToUpperInvariant(), Frame = left.FrameNumber }
+                        equals new { Source = right.CaptureSource.ToUpperInvariant(), Frame = right.FrameNumber }
+                    orderby left.FrameNumber
+                    select (left, right);
+        foreach (var pair in pairs) return pair;
+        return null;
+    }
+
+    private static void AddField(List<ComparisonField> fields, string name, string? before, string? after)
+    {
+        var status = string.IsNullOrWhiteSpace(before) || string.IsNullOrWhiteSpace(after)
+            ? "missing"
+            : string.Equals(before, after, StringComparison.OrdinalIgnoreCase) ? "matched" : "different";
+        fields.Add(new ComparisonField(name, before, after, status));
+    }
+
+    private static async Task<RunComparisonMetadata> ReadRunMetadataAsync(string runDirectory)
+    {
+        using var run = await ReadJsonIfPresentAsync(Path.Combine(runDirectory, "run.json"));
+        using var environment = await ReadJsonIfPresentAsync(Path.Combine(runDirectory, "environment.json"));
+        using var config = await ReadJsonIfPresentAsync(Path.Combine(runDirectory, "harness-config.json"));
+        var runRoot = run?.RootElement;
+        var environmentRoot = environment?.RootElement;
+        var profileIdentity = JoinIdentity(runRoot, "profile", "targetId", "expectedVersion", "verifiedVersion");
+        var capturePolicy = config is not null && config.RootElement.TryGetProperty("capture", out var capture)
+            ? CanonicalJson(capture)
+            : null;
+        var gpu = environmentRoot.HasValue && environmentRoot.Value.TryGetProperty("phaseZeroHardware", out var hardware) && hardware.TryGetProperty("gpus", out var gpus)
+            ? CanonicalJson(gpus)
+            : null;
+        return new RunComparisonMetadata(
+            profileIdentity,
+            Property(runRoot, "buildConfiguration"),
+            Property(runRoot, "repositorySha"),
+            Property(runRoot, "executableSha256"),
+            capturePolicy,
+            Property(environmentRoot, "hardwareFingerprint"),
+            gpu);
+    }
+
+    private static async Task<JsonDocument?> ReadJsonIfPresentAsync(string path) =>
+        File.Exists(path) ? JsonDocument.Parse(await File.ReadAllTextAsync(path)) : null;
+
+    private static string? JoinIdentity(JsonElement? root, params string[] names)
+    {
+        if (!root.HasValue) return null;
+        var values = names.Select(name => Property(root, name)).ToArray();
+        return values.Any(string.IsNullOrWhiteSpace) ? null : string.Join('|', values);
+    }
+
+    private static string? Property(JsonElement? root, string name) =>
+        root.HasValue && root.Value.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String ? value.GetString() : null;
+
+    private static string CanonicalJson(JsonElement element) => JsonSerializer.Serialize(element, Program.JsonOptions);
+
+    private sealed record RunComparisonMetadata(
+        string? ProfileIdentity,
+        string? BuildConfiguration,
+        string? RepositoryCommit,
+        string? ExecutableSha256,
+        string? CapturePolicy,
+        string? HardwareFingerprint,
+        string? GpuAndDriver);
 
     private static string ResolveRun(GitRepository repository, string value)
     {

--- a/tools/SharpEmu.Tools.AgentHarness/WindowCapture.cs
+++ b/tools/SharpEmu.Tools.AgentHarness/WindowCapture.cs
@@ -1,0 +1,229 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace SharpEmu.Tools.AgentHarness;
+
+internal static class WindowCapture
+{
+    private const uint PwClientOnly = 0x00000001;
+    private const uint Th32csSnapProcess = 0x00000002;
+    private const uint BiRgb = 0;
+    private const uint DibRgbColors = 0;
+
+    public static bool TryCaptureClientArea(Process rootProcess, string frameDirectory, int sampleIndex, double elapsedSeconds, out string status)
+    {
+        status = "unavailable";
+        if (!OperatingSystem.IsWindows() || rootProcess.HasExited) return false;
+        var processIds = DescendantProcessIds(rootProcess.Id);
+        nint selected = 0;
+        _ = EnumWindows((window, parameter) =>
+        {
+            _ = GetWindowThreadProcessId(window, out var processId);
+            if (!processIds.Contains(unchecked((int)processId)) || !IsWindowVisible(window) || IsIconic(window)) return true;
+            if (!GetClientRect(window, out var rectangle) || rectangle.Right - rectangle.Left < 2 || rectangle.Bottom - rectangle.Top < 2) return true;
+            selected = window;
+            return false;
+        }, 0);
+        if (selected == 0)
+        {
+            status = "no-visible-nonminimized-process-window";
+            return false;
+        }
+
+        if (!GetClientRect(selected, out var client)) return false;
+        var width = client.Right - client.Left;
+        var height = client.Bottom - client.Top;
+        var windowDc = GetDC(selected);
+        if (windowDc == 0) return false;
+        var memoryDc = CreateCompatibleDC(windowDc);
+        nint bitmap = 0;
+        nint oldObject = 0;
+        try
+        {
+            var info = new BitmapInfo
+            {
+                Header = new BitmapInfoHeader
+                {
+                    Size = (uint)Marshal.SizeOf<BitmapInfoHeader>(),
+                    Width = width,
+                    Height = -height,
+                    Planes = 1,
+                    BitCount = 32,
+                    Compression = BiRgb,
+                },
+            };
+            bitmap = CreateDIBSection(windowDc, ref info, DibRgbColors, out var bits, 0, 0);
+            if (bitmap == 0 || bits == 0) return false;
+            oldObject = SelectObject(memoryDc, bitmap);
+            if (!PrintWindow(selected, memoryDc, PwClientOnly))
+            {
+                status = "print-window-client-only-failed";
+                return false;
+            }
+            var raw = new byte[checked(width * height * 4)];
+            Marshal.Copy(bits, raw, 0, raw.Length);
+            Directory.CreateDirectory(frameDirectory);
+            var stem = $"window-{sampleIndex:D4}";
+            var rawFile = stem + ".raw";
+            File.WriteAllBytes(Path.Combine(frameDirectory, rawFile), raw);
+            var descriptor = new RawFrameDescriptor(
+                rawFile,
+                width,
+                height,
+                width * 4,
+                "B8G8R8A8_UNORM",
+                "window-fallback",
+                null,
+                elapsedSeconds,
+                DateTimeOffset.UtcNow,
+                null,
+                false,
+                null);
+            File.WriteAllText(Path.Combine(frameDirectory, stem + ".raw.json"), JsonSerializer.Serialize(descriptor, Program.JsonOptions));
+            status = "captured-client-only-nondeterministic; occlusion-status=unknown";
+            return true;
+        }
+        finally
+        {
+            if (oldObject != 0) _ = SelectObject(memoryDc, oldObject);
+            if (bitmap != 0) _ = DeleteObject(bitmap);
+            if (memoryDc != 0) _ = DeleteDC(memoryDc);
+            _ = ReleaseDC(selected, windowDc);
+        }
+    }
+
+    private static HashSet<int> DescendantProcessIds(int root)
+    {
+        var parents = new Dictionary<int, int>();
+        var snapshot = CreateToolhelp32Snapshot(Th32csSnapProcess, 0);
+        if (snapshot == new nint(-1)) return [root];
+        try
+        {
+            var entry = new ProcessEntry32 { Size = (uint)Marshal.SizeOf<ProcessEntry32>() };
+            if (Process32First(snapshot, ref entry))
+            {
+                do
+                {
+                    parents[unchecked((int)entry.ProcessId)] = unchecked((int)entry.ParentProcessId);
+                    entry.Size = (uint)Marshal.SizeOf<ProcessEntry32>();
+                }
+                while (Process32Next(snapshot, ref entry));
+            }
+        }
+        finally { _ = CloseHandle(snapshot); }
+        var result = new HashSet<int> { root };
+        var changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (var pair in parents)
+            {
+                if (!result.Contains(pair.Key) && result.Contains(pair.Value)) changed |= result.Add(pair.Key);
+            }
+        }
+        return result;
+    }
+
+    private delegate bool EnumWindowsCallback(nint window, nint parameter);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Rect
+    {
+        public int Left, Top, Right, Bottom;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BitmapInfoHeader
+    {
+        public uint Size;
+        public int Width, Height;
+        public ushort Planes, BitCount;
+        public uint Compression, SizeImage;
+        public int XPelsPerMeter, YPelsPerMeter;
+        public uint ClrUsed, ClrImportant;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BitmapInfo
+    {
+        public BitmapInfoHeader Header;
+        public uint Colors;
+    }
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct ProcessEntry32
+    {
+        public uint Size, Usage, ProcessId;
+        public nint DefaultHeapId;
+        public uint ModuleId, Threads, ParentProcessId;
+        public int BasePriority;
+        public uint Flags;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+        public string ExeFile;
+    }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool EnumWindows(EnumWindowsCallback callback, nint parameter);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(nint window, out uint processId);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindowVisible(nint window);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsIconic(nint window);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetClientRect(nint window, out Rect rectangle);
+
+    [DllImport("user32.dll")]
+    private static extern nint GetDC(nint window);
+
+    [DllImport("user32.dll")]
+    private static extern int ReleaseDC(nint window, nint dc);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool PrintWindow(nint window, nint dc, uint flags);
+
+    [DllImport("gdi32.dll")]
+    private static extern nint CreateCompatibleDC(nint dc);
+
+    [DllImport("gdi32.dll")]
+    private static extern nint CreateDIBSection(nint dc, ref BitmapInfo info, uint usage, out nint bits, nint section, uint offset);
+
+    [DllImport("gdi32.dll")]
+    private static extern nint SelectObject(nint dc, nint value);
+
+    [DllImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeleteObject(nint value);
+
+    [DllImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeleteDC(nint dc);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern nint CreateToolhelp32Snapshot(uint flags, uint processId);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool Process32First(nint snapshot, ref ProcessEntry32 entry);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool Process32Next(nint snapshot, ref ProcessEntry32 entry);
+
+    [DllImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(nint handle);
+}


### PR DESCRIPTION
## Summary

- harden source-index staleness detection and stale-query refusal
- make target doctor readiness, private scanning, redaction, event evidence, extraction reuse, and process containment strict
- make visual comparisons metadata-aware and validate opt-in Vulkan capture synchronization

## Validation

- Debug tests: 769 passed
- Release tests: 769 passed
- harness tests: 44 passed
- AGC/GPU/VideoOut tests: 187 passed
- shader tests: 31 passed
- REUSE/SPDX: passed (585/585)
- synthetic Vulkan validation capture: active validation layer, zero validation messages
- clean 180-second target seal: exact commit, dirty=false, matched eboot hash, Job Object active processes after cleanup=0

## Scope

No guest-visible compatibility semantics or game-specific fixes were changed. No proprietary content or local run artifact was added to Git.