### PR TITLE
fix(build): select .NET task host runtime

### DIFF
--- a/src/SharpEmu.HLE/SharpEmu.HLE.csproj
+++ b/src/SharpEmu.HLE/SharpEmu.HLE.csproj
@@ -43,6 +43,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
   <UsingTask TaskName="SharpEmu.SourceGenerators.GenerateAerolibBinaryTask"
              TaskFactory="TaskHostFactory"
+             Runtime="NET"
              AssemblyFile="$(SharpEmuAerolibTaskAssembly)" />
 
   <!-- Runs after ResolveProjectReferences (which builds the task assembly) and before


### PR DESCRIPTION
## Before submitting

I have read and agree to follow [CONTRIBUTING.md](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md).

## Description

Fixes #607.

Recent versions of the .NET 10 SDK were unable to load the task that generates the
aerolib catalog during the build process. MSBuild reported error MSB4061 because
the task runtime was not specified.

I added `Runtime="NET"` to the `UsingTask` declaration so that MSBuild knows
the task should run using the .NET runtime.

This affects only the build process and does not alter the behavior of the
emulator or games.

## Testing

- Built `SharpEmu.HLE` using the .NET 10.0.302 SDK.
- Built the entire solution successfully.
- Ran the source generator tests: 33 passed.
- Game testing: N/A, as this is solely a build configuration change.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
