### PR TITLE
fix(cpu): sample repeated import failure logs (#619)

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -34,8 +34,10 @@ public sealed partial class DirectExecutionBackend
 	private const ulong StackCheckGuardValue = 0xC0DEC0DECAFEBA00UL;
 	private static long _canaryReturnRecoveries;
 
+	private const long InitialImportResultLogCount = 8;
+	private const long ImportResultLogSampleInterval = 10_000;
 	private readonly object _importResultLogSampleGate = new();
-	private readonly Dictionary<string, int> _importResultLogSamples = new(StringComparer.Ordinal);
+	private readonly Dictionary<(string Nid, int Result), long> _importResultLogSamples = new();
 	private int _il2CppExceptionDiagnosticCount;
 
 	private static ulong ImportDispatchGatewayManaged(nint backendHandle, int importIndex, nint argPackPtr)
@@ -1511,35 +1513,39 @@ public sealed partial class DirectExecutionBackend
 		var expectedPlayGoChunkEnumerationEnd =
 			string.Equals(nid, "uWIYLFkkwqk", StringComparison.Ordinal) &&
 			resultValue == unchecked((int)0x80B2000C);
-		if (!expectedFileProbeMiss &&
-			!expectedTimedWaitTimeout &&
-			!expectedEqueueTimeout &&
-			!expectedMutexTrylockBusy &&
-			!expectedSemaphoreTrywaitAgain &&
-			!expectedPollSemaBusy &&
-			!expectedNetAcceptWouldBlock &&
-			!expectedUserServiceNoEvent &&
-			!expectedPrivacyInvalidParameter &&
-			!expectedPlayGoChunkEnumerationEnd)
-		{
-			return true;
-		}
-
-		if (!ShouldLogExpectedImportResults())
+		var expectedResult =
+			expectedFileProbeMiss ||
+			expectedTimedWaitTimeout ||
+			expectedEqueueTimeout ||
+			expectedMutexTrylockBusy ||
+			expectedSemaphoreTrywaitAgain ||
+			expectedPollSemaBusy ||
+			expectedNetAcceptWouldBlock ||
+			expectedUserServiceNoEvent ||
+			expectedPrivacyInvalidParameter ||
+			expectedPlayGoChunkEnumerationEnd;
+		if (expectedResult && !ShouldLogExpectedImportResults())
 		{
 			return false;
 		}
 
-		var key = nid + "\0" + resultValue;
-		int count;
+		// Guest polling loops can produce millions of identical failures. Preserve
+		// the initial diagnostics, then sample them without allocating a key string
+		// for every dispatch.
+		var key = (nid, resultValue);
+		long count;
 		lock (_importResultLogSampleGate)
 		{
 			_importResultLogSamples.TryGetValue(key, out count);
-			count++;
-			_importResultLogSamples[key] = count;
+			if (count < long.MaxValue)
+			{
+				count++;
+				_importResultLogSamples[key] = count;
+			}
 		}
 
-		return count <= 8 || count % 10000 == 0;
+		return count <= InitialImportResultLogCount ||
+			count % ImportResultLogSampleInterval == 0;
 	}
 
 	private static bool ShouldLogExpectedImportResults() =>

--- a/tests/SharpEmu.Libs.Tests/Cpu/ImportResultLogSamplingTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/ImportResultLogSamplingTests.cs
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Native;
+using SharpEmu.HLE;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+public sealed class ImportResultLogSamplingTests
+{
+    private const string SaveDataDialogInitializeNid = "s9e3+YpRnzw";
+    private const int SaveDataDialogNotInitialized = unchecked((int)0x80B80004);
+
+    [Fact]
+    public void UnexpectedRepeatedFailureIsSampledAfterInitialDiagnostics()
+    {
+        var backend = CreateBackend();
+        var result = (OrbisGen2Result)SaveDataDialogNotInitialized;
+
+        for (var call = 1; call <= 10_000; call++)
+        {
+            var expected = call <= 8 || call == 10_000;
+            Assert.Equal(
+                expected,
+                InvokeShouldLogImportResult(backend, SaveDataDialogInitializeNid, result));
+        }
+    }
+
+    private static DirectExecutionBackend CreateBackend()
+    {
+        var backend = (DirectExecutionBackend)RuntimeHelpers.GetUninitializedObject(
+            typeof(DirectExecutionBackend));
+        SetField(backend, "_importResultLogSampleGate", new object());
+
+        var samplesField = typeof(DirectExecutionBackend).GetField(
+            "_importResultLogSamples",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(samplesField);
+        SetField(backend, samplesField.Name, Activator.CreateInstance(samplesField.FieldType)!);
+        return backend;
+    }
+
+    private static bool InvokeShouldLogImportResult(
+        DirectExecutionBackend backend,
+        string nid,
+        OrbisGen2Result result)
+    {
+        var method = typeof(DirectExecutionBackend).GetMethod(
+            "ShouldLogImportResult",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (bool)method.Invoke(backend, [nid, result])!;
+    }
+
+    private static void SetField(DirectExecutionBackend backend, string name, object value)
+    {
+        var field = typeof(DirectExecutionBackend).GetField(
+            name,
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field.SetValue(backend, value);
+    }
+}


### PR DESCRIPTION
## Description

Addresses one source of memory pressure identified in #619.

Previously, unexpected import failures were written to `stderr` on every dispatch. If a title repeatedly polls an unimplemented import in a tight loop, the same diagnostic message is formatted and written thousands of times.

This change extends the existing sampling policy to unexpected failures: the first 8 occurrences are logged, followed by one sample every 10,000 calls. It also replaces the concatenated string used as the counter key with a tuple, avoiding an unnecessary string allocation on every dispatch.

Guest return values and execution flow remain unchanged. This PR does not introduce guest-side backoff. Further testing with actual games is still required to determine how much of the memory growth reported in #619 remains.

## Testing

Game testing was not performed because no legally obtained game dump is available locally.

* Built `SharpEmu.slnx` in Release mode using the .NET 10.0.302 SDK: 0 warnings, 0 errors.
* Ran the full synthetic test suite: 757 tests passed.
* Added a regression test based on the repeated `sceSaveDataDialogInitialize` NID/result described in #619, “Unresolved imports retried in a tight loop cause unbounded memory growth.”

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
