### PR TITLE
[ShaderCompiler] Restore Gen5 packed integer operations

### DIFF
--- a/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.Alu.cs
@@ -203,6 +203,8 @@ public static partial class Gen5MslTranslator
                     $"pack_float_to_snorm2x16(float2({F(instruction, 0)}, {F(instruction, 1)}))",
                 "VCvtPknormU16F32" =>
                     $"pack_float_to_unorm2x16(float2({F(instruction, 0)}, {F(instruction, 1)}))",
+                "VCvtPkU16U32" or "VCvtPkI16I32" =>
+                    $"((({RawSource(instruction, 0)}) & 0xFFFFu) | ((({RawSource(instruction, 1)}) & 0xFFFFu) << 16))",
 
                 // ---- integer arithmetic ----
                 "VAddU32" or "VAddI32" =>
@@ -1183,6 +1185,18 @@ public static partial class Gen5MslTranslator
                     var shift = (uint)(instruction.Opcode[5] - '0');
                     resultExpression = $"(({left} << {shift}) + {right})";
                     sccStatement = string.Empty;
+                    break;
+                }
+                case "SAbsdiffI32":
+                {
+                    // Keep the subtraction and absolute value in 32 bits.
+                    // The bitwise form also preserves abs(INT_MIN) == INT_MIN.
+                    var difference = Temp("uint", $"{left} - {right}");
+                    var sign = Temp(
+                        "uint",
+                        $"(uint)(as_type<int>({difference}) >> 31)");
+                    resultExpression = $"(({difference} ^ {sign}) - {sign})";
+                    sccStatement = "NONZERO";
                     break;
                 }
                 case "SPackLlB32B16":

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
@@ -948,6 +948,17 @@ public static partial class Gen5SpirvTranslator
                         vector);
                     break;
                 }
+                case "VCvtPkU16U32":
+                case "VCvtPkI16I32":
+                    // Both conversions truncate each source to its low 16
+                    // bits; signedness only describes how the packed halves
+                    // are interpreted by the guest.
+                    result = BitwiseOr(
+                        BitwiseAnd(GetRawSource(instruction, 0), UInt(0xFFFF)),
+                        ShiftLeftLogical(
+                            BitwiseAnd(GetRawSource(instruction, 1), UInt(0xFFFF)),
+                            UInt(16)));
+                    break;
 
                 case "VPkAddF16":
                 case "VPkMulF16":
@@ -2128,6 +2139,26 @@ public static partial class Gen5SpirvTranslator
                             result = IAdd(
                                 ShiftLeftLogical(left, UInt(shift)),
                                 right);
+                            break;
+                        }
+                        case "SAbsdiffI32":
+                        {
+                            // Subtract and negate in 32 bits so the RDNA
+                            // wrapping behavior is preserved for INT_MIN.
+                            var difference = _module.AddInstruction(
+                                SpirvOp.ISub,
+                                _uintType,
+                                left,
+                                right);
+                            var sign = ShiftRightArithmetic(
+                                difference,
+                                UInt(31));
+                            result = _module.AddInstruction(
+                                SpirvOp.ISub,
+                                _uintType,
+                                BitwiseXor(difference, sign),
+                                sign);
+                            Store(_scc, IsNotZero(result));
                             break;
                         }
                         case "SPackLlB32B16":

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderScalarEvaluator.cs
@@ -1522,9 +1522,16 @@ public static class Gen5ShaderScalarEvaluator
                     break;
                 }
             case "SAbsdiffI32":
-                result = unchecked((uint)Math.Abs((long)(int)left - (int)right));
-                scalarConditionCode = result != 0;
-                break;
+                {
+                    // RDNA performs the subtraction in the signed 32-bit
+                    // domain before taking the absolute value. Preserve both
+                    // wrapping steps, including abs(INT_MIN) == INT_MIN.
+                    var difference = unchecked((int)left - (int)right);
+                    var sign = difference >> 31;
+                    result = unchecked((uint)((difference ^ sign) - sign));
+                    scalarConditionCode = result != 0;
+                    break;
+                }
             case "SLshl1AddU32":
                 {
                     var wide = ((ulong)left << 1) + right;

--- a/tests/SharpEmu.Libs.Tests/Agc/Gen5PackedIntegerTranslationTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/Gen5PackedIntegerTranslationTests.cs
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+// Regression coverage for packed-integer operations that were lost when the
+// shader compiler moved to backend-specific projects. All programs are synthetic
+// GFX10 words assembled from the decoder tables.
+public sealed class Gen5PackedIntegerTranslationTests
+{
+    private const ulong ShaderAddress = 0x1_0000_0000;
+
+    private static readonly uint[] PackedIntegerProgram =
+    [
+        0x600A0501, // v_cvt_pk_u16_u32 v5, v1, v2
+        0x620C0501, // v_cvt_pk_i16_i32 v6, v1, v2
+        0x96820100, // s_absdiff_i32 s2, s0, s1
+    ];
+
+    [Fact]
+    public void PackedIntegerOperations_CompileToSpirv()
+    {
+        var (ctx, state) = CreateState(PackedIntegerProgram, [0x80000000u, 1u]);
+
+        Assert.Contains(state.Program.Instructions, item => item.Opcode == "VCvtPkU16U32");
+        Assert.Contains(state.Program.Instructions, item => item.Opcode == "VCvtPkI16I32");
+        Assert.Contains(state.Program.Instructions, item => item.Opcode == "SAbsdiffI32");
+        Assert.True(
+            Gen5ShaderScalarEvaluator.TryEvaluate(ctx, state, out var evaluation, out var error),
+            error);
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileComputeShader(
+                state,
+                evaluation,
+                1,
+                1,
+                1,
+                out var shader,
+                out error),
+            error);
+
+        var opcodes = ReadSpirvOpcodes(shader.Spirv);
+        Assert.Contains((ushort)SpirvOp.BitwiseAnd, opcodes);
+        Assert.Contains((ushort)SpirvOp.ShiftLeftLogical, opcodes);
+        Assert.Contains((ushort)SpirvOp.BitwiseOr, opcodes);
+        Assert.Contains((ushort)SpirvOp.ShiftRightArithmetic, opcodes);
+        Assert.Contains((ushort)SpirvOp.BitwiseXor, opcodes);
+    }
+
+    [Theory]
+    [InlineData(0x00000002u, 0x00000005u, 0x00000003u)]
+    [InlineData(0xFFFFFFFFu, 0x00000000u, 0x00000001u)]
+    [InlineData(0x80000000u, 0x00000000u, 0x80000000u)]
+    [InlineData(0x80000000u, 0x00000001u, 0x7FFFFFFFu)]
+    [InlineData(0x80000000u, 0xFFFFFFFFu, 0x7FFFFFFFu)]
+    public void ScalarEvaluator_AbsdiffMatchesRdna2WrappingSemantics(
+        uint left,
+        uint right,
+        uint expected)
+    {
+        var (ctx, state) = CreateState([0x96820100], [left, right]);
+
+        Assert.True(
+            Gen5ShaderScalarEvaluator.TryEvaluate(ctx, state, out var evaluation, out var error),
+            error);
+        Assert.Equal(expected, evaluation.ScalarRegisters[2]);
+    }
+
+    private static (CpuContext Context, Gen5ShaderState State) CreateState(
+        uint[] words,
+        uint[] userData)
+    {
+        var memory = new FakeCpuMemory(ShaderAddress, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+        Gen5ShaderAtomicDecodeTests.WriteProgram(memory, ShaderAddress, words);
+        Assert.True(
+            Gen5ShaderTranslator.TryDecodeProgram(
+                context,
+                ShaderAddress,
+                out var program,
+                out var error),
+            error);
+        return (context, new Gen5ShaderState(program!, userData, Metadata: null));
+    }
+
+    private static HashSet<ushort> ReadSpirvOpcodes(byte[] spirv)
+    {
+        var opcodes = new HashSet<ushort>();
+        for (var offset = 5 * sizeof(uint); offset + sizeof(uint) <= spirv.Length;)
+        {
+            var word = BinaryPrimitives.ReadUInt32LittleEndian(
+                spirv.AsSpan(offset, sizeof(uint)));
+            opcodes.Add((ushort)word);
+            offset += Math.Max((int)(word >> 16), 1) * sizeof(uint);
+        }
+
+        return opcodes;
+    }
+}

--- a/tests/SharpEmu.ShaderCompiler.Metal.Tests/MslTranslationTests.cs
+++ b/tests/SharpEmu.ShaderCompiler.Metal.Tests/MslTranslationTests.cs
@@ -160,4 +160,26 @@ public sealed class MslTranslationTests
             () => Gen5ComputeFixtures.CompileOrThrow(fixture));
         Assert.Contains("pc=0x", exception.Message, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void PackedIntegerOperations_TranslateWithWrappingSemantics()
+    {
+        var fixture = new Gen5ComputeFixture(
+            "packed-integer",
+            [
+                0x600A0501, // v_cvt_pk_u16_u32 v5, v1, v2
+                0x620C0501, // v_cvt_pk_i16_i32 v6, v1, v2
+                0x96820100, // s_absdiff_i32 s2, s0, s1
+                0xBF810000, // s_endpgm
+            ],
+            StoreScalarResourceBase: 0,
+            StoreBackingBytes: 0);
+
+        var shader = Gen5ComputeFixtures.CompileOrThrow(fixture);
+
+        Assert.Contains("& 0xFFFFu", shader.Source, StringComparison.Ordinal);
+        Assert.Contains("<< 16", shader.Source, StringComparison.Ordinal);
+        Assert.Contains(">> 31", shader.Source, StringComparison.Ordinal);
+        Assert.Contains(" ^ ", shader.Source, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
## Description

Contribution related to #36.

This PR restores three Gen5 packed-integer operations that were originally added in #135 but were lost during the backend integration in #216:

* `V_CVT_PK_U16_U32`
* `V_CVT_PK_I16_I32`
* `S_ABSDIFF_I32`

The two packed conversion instructions are now supported by both the SPIR-V/Vulkan and MSL/Metal backends. Support for the scalar absolute-difference instruction has also been restored in both backends.

The shared scalar evaluator now performs the subtraction and absolute-value operations entirely in the signed 32-bit domain. This matches the observed RDNA2 behavior in overflow cases. For example, `INT_MIN - 1` wraps before the absolute value is applied, producing `0x7fffffff`.

## Testing

Game testing was not performed because no legally obtained game dump is available locally.

* Built `SharpEmu.slnx` in Release mode using the .NET 10.0.302 SDK: 0 warnings, 0 errors.
* Ran the full test suite: 763 tests passed.
* Added synthetic GFX10 regression coverage for decoding and emitting all three operations through the Vulkan and Metal backends.
* Added evaluator test cases based on the RDNA2 ISA, including the `INT_MIN` overflow behavior.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
