### PR TITLE
updated the allocator in KernelMemoryCompatExports.cs and added a test in KernelMemoryCompatExportsTests.cs

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -2989,28 +2989,27 @@ public static partial class KernelMemoryCompatExports
         ulong aligned;
         lock (_memoryGate)
         {
+            var poolBase = _mainDirectMemoryPoolBase == UnsetMainDirectMemoryPoolBase
+                ? AlignUp(GetDirectMemoryHighWaterMarkLocked(), effectiveAlignment)
+                : _mainDirectMemoryPoolBase;
+
             var allocationLimit = DirectMemorySizeBytes;
-            if (_mainDirectMemoryPoolBase != UnsetMainDirectMemoryPoolBase &&
-                !TryAddU64(_mainDirectMemoryPoolBase, DirectMemorySizeBytes, out allocationLimit))
+            if (!TryAddU64(poolBase, DirectMemorySizeBytes, out allocationLimit))
             {
                 allocationLimit = ulong.MaxValue;
             }
 
-            if (!TryAllocateDirectMemoryLocked(0, allocationLimit, length, effectiveAlignment, memoryType, allocationLimit, out aligned))
+            if (!TryAllocateDirectMemoryLocked(poolBase, allocationLimit, length, effectiveAlignment, memoryType, allocationLimit, out aligned))
             {
-                var poolBase = _mainDirectMemoryPoolBase == UnsetMainDirectMemoryPoolBase
-                    ? AlignUp(GetDirectMemoryHighWaterMarkLocked(), effectiveAlignment)
-                    : _mainDirectMemoryPoolBase;
-
                 if (_mainDirectMemoryPoolBase == UnsetMainDirectMemoryPoolBase &&
-                    TryAddU64(poolBase, DirectMemorySizeBytes, out var shiftedLimit) &&
-                    TryAllocateDirectMemoryLocked(0, shiftedLimit, length, effectiveAlignment, memoryType, shiftedLimit, out aligned))
+                    TryAddU64(0, allocationLimit, out var legacyLimit) &&
+                    TryAllocateDirectMemoryLocked(0, legacyLimit, length, effectiveAlignment, memoryType, legacyLimit, out aligned))
                 {
                     _mainDirectMemoryPoolBase = poolBase;
                     if (ShouldTraceDirectMemory())
                     {
                         Console.Error.WriteLine(
-                            $"[LOADER][TRACE] main_direct_pool: base=0x{poolBase:X16} limit=0x{shiftedLimit:X16}");
+                            $"[LOADER][TRACE] main_direct_pool: base=0x{poolBase:X16} limit=0x{legacyLimit:X16}");
                     }
                 }
                 else
@@ -3025,6 +3024,10 @@ public static partial class KernelMemoryCompatExports
                         result: OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN);
                     return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN;
                 }
+            }
+            else if (_mainDirectMemoryPoolBase == UnsetMainDirectMemoryPoolBase)
+            {
+                _mainDirectMemoryPoolBase = poolBase;
             }
         }
 

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelMemoryCompatExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelMemoryCompatExportsTests.cs
@@ -161,6 +161,46 @@ public sealed class KernelMemoryCompatExportsTests
     }
 
     [Fact]
+    public void AllocateMainDirectMemory_GrowsToAdditionalWindowsWhenEarlierWindowsAreFull()
+    {
+        const ulong windowSize = 0x4000_0000UL;
+        const ulong secondWindowStart = 0x4000_0000UL;
+        const ulong thirdWindowStart = 0x8000_0000UL;
+        var memory = new FakeCpuMemory(GuestMemoryBase, 0x1000);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        try
+        {
+            context[CpuRegister.Rdi] = 0x4000_0000UL;
+            context[CpuRegister.Rsi] = 0x4000;
+            context[CpuRegister.Rdx] = 0;
+            context[CpuRegister.Rcx] = AllocationOutAddress;
+            Assert.Equal(0, KernelMemoryCompatExports.KernelAllocateMainDirectMemory(context));
+
+            context[CpuRegister.Rcx] = AllocationOutAddress + 0x8;
+            Assert.Equal(0, KernelMemoryCompatExports.KernelAllocateMainDirectMemory(context));
+
+            context[CpuRegister.Rdi] = 0x1000;
+            context[CpuRegister.Rcx] = AllocationOutAddress + 0x10;
+            Assert.Equal(0, KernelMemoryCompatExports.KernelAllocateMainDirectMemory(context));
+            Assert.True(context.TryReadUInt64(AllocationOutAddress + 0x10, out var allocatedAddress));
+            Assert.Equal(thirdWindowStart, allocatedAddress);
+        }
+        finally
+        {
+            context[CpuRegister.Rdi] = 0;
+            context[CpuRegister.Rsi] = windowSize;
+            _ = KernelMemoryCompatExports.KernelReleaseDirectMemory(context);
+            context[CpuRegister.Rdi] = secondWindowStart;
+            context[CpuRegister.Rsi] = windowSize;
+            _ = KernelMemoryCompatExports.KernelReleaseDirectMemory(context);
+            context[CpuRegister.Rdi] = thirdWindowStart;
+            context[CpuRegister.Rsi] = 0x1000;
+            _ = KernelMemoryCompatExports.KernelReleaseDirectMemory(context);
+        }
+    }
+
+    [Fact]
     public void AvailableDirectMemorySize_FragmentedRangeReturnsLargestAlignedSpan()
     {
         const ulong firstAllocationStart = 0x0020_0000;


### PR DESCRIPTION
sceKernelAllocateMainDirectMemory is the guest import in question. The game i tested it on was Ghost of Yotei. Currenly it crashes after splash screen is displayed.

The guest was calling the export, asking for direct memory to use but the call was failing multiple times with the message 'ORBIS_GEN2_ERROR_TRY_AGAIN' in the console logs. Implementation inside the emulator was being too strict about where it looked for free space as it was trying to find free area in the current main direct memory pool., if failed, it assumed that allocation cannot be satisfied and returned 'TRY_AGAIN' immediately. 

The bug was that the allocator did not honor that base properly during the initial placement path and gave up after it's first failure. Now it starts and searches the relevant memory window and continues to allow allocation in a later pool window when the earlier one is already occupied or not suitable. Without this change, the emulator could reject a perfectly valid allocation request just because it did not fit in the first window the code checked.

test added in KernelMemoryCompatExportsTests.cs simulates a situation where one window is already occupied, a later window should still be usable, and the allocation should still succeed.

It now stops producing the  'TRY_AGAIN' failure for normal direct allocations