### PR TITLE
[GUI] Update library page layout

### DIFF
--- a/src/SharpEmu.GUI/AddFolderTile.cs
+++ b/src/SharpEmu.GUI/AddFolderTile.cs
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.GUI;
+
+/// <summary>
+/// Stateless trailing action that opens the library folder picker.
+/// </summary>
+public sealed class AddFolderTile : LibraryTile
+{
+    public static AddFolderTile Instance { get; } = new();
+
+    private AddFolderTile()
+    {
+    }
+}

--- a/src/SharpEmu.GUI/GameEntry.cs
+++ b/src/SharpEmu.GUI/GameEntry.cs
@@ -17,7 +17,7 @@ internal enum GameEntryChanges
     Background = 4,
 }
 
-public sealed class GameEntry : INotifyPropertyChanged
+public sealed class GameEntry : LibraryTile, INotifyPropertyChanged
 {
     // Placeholder gradients for games without cover art, picked
     // deterministically from the game name so a game keeps its color.

--- a/src/SharpEmu.GUI/Languages/ar.json
+++ b/src/SharpEmu.GUI/Languages/ar.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} لعبة",
 
   "Library.SearchWatermark": "ابحث في المكتبة...",
-  "Library.AddFolder": "＋ إضافة مجلد",
+  "Library.AddFolder": "إضافة مجلد",
   "Library.OpenFile": "فتح ملف...",
 
   "Library.Context.Launch": "تشغيل",

--- a/src/SharpEmu.GUI/Languages/br.json
+++ b/src/SharpEmu.GUI/Languages/br.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} jogos",
 
   "Library.SearchWatermark": "Pesquisar na biblioteca…",
-  "Library.AddFolder": "＋ Adicionar pasta",
+  "Library.AddFolder": "Adicionar pasta",
   "Library.OpenFile": "Abrir arquivo…",
 
   "Library.Context.Launch": "Jogar",

--- a/src/SharpEmu.GUI/Languages/de.json
+++ b/src/SharpEmu.GUI/Languages/de.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} Spiele",
 
   "Library.SearchWatermark": "Bibliothek durchsuchen…",
-  "Library.AddFolder": "＋ Spielordner hinzufügen",
+  "Library.AddFolder": "Spielordner hinzufügen",
   "Library.OpenFile": "Datei öffnen…",
 
   "Library.Context.Launch": "Starten",

--- a/src/SharpEmu.GUI/Languages/dk.json
+++ b/src/SharpEmu.GUI/Languages/dk.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} spil",
 
   "Library.SearchWatermark": "Søg i biblioteket…",
-  "Library.AddFolder": "＋ Tilføj mappe",
+  "Library.AddFolder": "Tilføj mappe",
   "Library.OpenFile": "Åbn fil…",
 
   "Library.Context.Launch": "Start",

--- a/src/SharpEmu.GUI/Languages/en.json
+++ b/src/SharpEmu.GUI/Languages/en.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} games",
 
   "Library.SearchWatermark": "Search library…",
-  "Library.AddFolder": "＋ Add folder",
+  "Library.AddFolder": "Add folder",
   "Library.OpenFile": "Open file…",
 
   "Library.Context.Launch": "Launch",

--- a/src/SharpEmu.GUI/Languages/es.json
+++ b/src/SharpEmu.GUI/Languages/es.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} juegos",
 
   "Library.SearchWatermark": "Buscar en la biblioteca…",
-  "Library.AddFolder": "＋ Añadir carpeta",
+  "Library.AddFolder": "Añadir carpeta",
   "Library.OpenFile": "Abrir archivo…",
 
   "Library.Context.Launch": "Iniciar",

--- a/src/SharpEmu.GUI/Languages/fr.json
+++ b/src/SharpEmu.GUI/Languages/fr.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} jeux",
 
   "Library.SearchWatermark": "Rechercher dans la bibliothèque…",
-  "Library.AddFolder": "＋ Ajouter un dossier",
+  "Library.AddFolder": "Ajouter un dossier",
   "Library.OpenFile": "Ouvrir un fichier…",
 
   "Library.Context.Launch": "Lancer",

--- a/src/SharpEmu.GUI/Languages/hu.json
+++ b/src/SharpEmu.GUI/Languages/hu.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} játékok",
 
   "Library.SearchWatermark": "Keresés a könyvtárban",
-  "Library.AddFolder": "＋ Mappa hozzáadása",
+  "Library.AddFolder": "Mappa hozzáadása",
   "Library.OpenFile": "Fájl megnyitása…",
 
   "Library.Context.Launch": "Inditás",

--- a/src/SharpEmu.GUI/Languages/it.json
+++ b/src/SharpEmu.GUI/Languages/it.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} giochi",
 
   "Library.SearchWatermark": "Cerca nella libreria…",
-  "Library.AddFolder": "＋ Aggiungi cartella",
+  "Library.AddFolder": "Aggiungi cartella",
   "Library.OpenFile": "Apri file…",
 
   "Library.Context.Launch": "Avvia",

--- a/src/SharpEmu.GUI/Languages/ja.json
+++ b/src/SharpEmu.GUI/Languages/ja.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "ゲーム {0}本",
 
   "Library.SearchWatermark": "ライブラリを検索…",
-  "Library.AddFolder": "＋ フォルダーを追加",
+  "Library.AddFolder": "フォルダーを追加",
   "Library.OpenFile": "ファイルを開く…",
 
   "Library.Context.Launch": "起動",

--- a/src/SharpEmu.GUI/Languages/ko.json
+++ b/src/SharpEmu.GUI/Languages/ko.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "게임 {0}개",
 
   "Library.SearchWatermark": "라이브러리 검색…",
-  "Library.AddFolder": "＋ 폴더 추가",
+  "Library.AddFolder": "폴더 추가",
   "Library.OpenFile": "파일 열기…",
 
   "Library.Context.Launch": "실행",

--- a/src/SharpEmu.GUI/Languages/nl.json
+++ b/src/SharpEmu.GUI/Languages/nl.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} games",
 
   "Library.SearchWatermark": "Zoeken in bibliotheek…",
-  "Library.AddFolder": "＋ Map toevoegen",
+  "Library.AddFolder": "Map toevoegen",
   "Library.OpenFile": "Bestand openen…",
 
   "Library.Context.Launch": "Starten",

--- a/src/SharpEmu.GUI/Languages/pt.json
+++ b/src/SharpEmu.GUI/Languages/pt.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} jogos",
 
   "Library.SearchWatermark": "Pesquisar biblioteca…",
-  "Library.AddFolder": "＋ Adicionar pasta",
+  "Library.AddFolder": "Adicionar pasta",
   "Library.OpenFile": "Abrir ficheiro…",
 
   "Library.Context.Launch": "Iniciar",

--- a/src/SharpEmu.GUI/Languages/ru.json
+++ b/src/SharpEmu.GUI/Languages/ru.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "Игр: {0}",
 
   "Library.SearchWatermark": "Поиск…",
-  "Library.AddFolder": "＋ Добавить папку",
+  "Library.AddFolder": "Добавить папку",
   "Library.OpenFile": "Открыть файл…",
 
   "Library.Context.Launch": "Запустить",

--- a/src/SharpEmu.GUI/Languages/tr.json
+++ b/src/SharpEmu.GUI/Languages/tr.json
@@ -7,7 +7,7 @@
   "Page.GameCount.Other": "{0} oyun",
 
   "Library.SearchWatermark": "Kütüphanede ara…",
-  "Library.AddFolder": "＋ Klasör ekle",
+  "Library.AddFolder": "Klasör ekle",
   "Library.OpenFile": "Dosya aç…",
 
   "Library.Context.Launch": "Başlat",

--- a/src/SharpEmu.GUI/LibraryTile.cs
+++ b/src/SharpEmu.GUI/LibraryTile.cs
@@ -1,0 +1,9 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.GUI;
+
+/// <summary>
+/// Base type for game cards and actions shown in the library rail.
+/// </summary>
+public abstract class LibraryTile;

--- a/src/SharpEmu.GUI/LibraryTileCollection.cs
+++ b/src/SharpEmu.GUI/LibraryTileCollection.cs
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+
+namespace SharpEmu.GUI;
+
+/// <summary>
+/// Read-only view of the visible games with one persistent action tile at
+/// the end. Game collection changes keep their original indices, so Avalonia
+/// can update and virtualize the rail without rebuilding every item.
+/// </summary>
+public sealed class LibraryTileCollection : IReadOnlyList<LibraryTile>, IList, INotifyCollectionChanged
+{
+    private readonly ObservableCollection<GameEntry> _games;
+
+    public LibraryTileCollection(ObservableCollection<GameEntry> games)
+    {
+        _games = games;
+        _games.CollectionChanged += OnGamesCollectionChanged;
+    }
+
+    public event NotifyCollectionChangedEventHandler? CollectionChanged;
+
+    public int Count => _games.Count + 1;
+
+    bool IList.IsFixedSize => false;
+
+    bool IList.IsReadOnly => true;
+
+    bool ICollection.IsSynchronized => false;
+
+    object ICollection.SyncRoot => this;
+
+    public LibraryTile this[int index]
+    {
+        get
+        {
+            if ((uint)index < (uint)_games.Count)
+            {
+                return _games[index];
+            }
+
+            if (index == _games.Count)
+            {
+                return AddFolderTile.Instance;
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+    }
+
+    object? IList.this[int index]
+    {
+        get => this[index];
+        set => throw new NotSupportedException();
+    }
+
+    public IEnumerator<LibraryTile> GetEnumerator()
+    {
+        foreach (var game in _games)
+        {
+            yield return game;
+        }
+
+        yield return AddFolderTile.Instance;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    int IList.Add(object? value) => throw new NotSupportedException();
+
+    void IList.Clear() => throw new NotSupportedException();
+
+    bool IList.Contains(object? value) => ((IList)this).IndexOf(value) >= 0;
+
+    int IList.IndexOf(object? value) => value switch
+    {
+        GameEntry game => _games.IndexOf(game),
+        AddFolderTile => _games.Count,
+        _ => -1,
+    };
+
+    void IList.Insert(int index, object? value) => throw new NotSupportedException();
+
+    void IList.Remove(object? value) => throw new NotSupportedException();
+
+    void IList.RemoveAt(int index) => throw new NotSupportedException();
+
+    void ICollection.CopyTo(Array array, int index)
+    {
+        ArgumentNullException.ThrowIfNull(array);
+        foreach (var tile in this)
+        {
+            array.SetValue(tile, index++);
+        }
+    }
+
+    private void OnGamesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs args) =>
+        CollectionChanged?.Invoke(this, args);
+}

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -119,10 +119,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
                    PlaceholderText="{Binding [Library.SearchWatermark], Source={x:Static local:Localization.Instance}}"
                    Width="240"
                    VerticalAlignment="Center" />
-          <Button x:Name="AddFolderButton"
-                  Classes="ghost"
-                  Content="{Binding [Library.AddFolder], Source={x:Static local:Localization.Instance}}"
-                  VerticalAlignment="Center" />
           <Button x:Name="OpenFileButton"
                   Classes="ghost"
                   Content="{Binding [Library.OpenFile], Source={x:Static local:Localization.Instance}}"
@@ -132,12 +128,12 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
       <Panel Grid.Row="1" x:Name="PagesHost">
 
-        <!-- Library page. The tile row gets extra top margin so it sits
-             closer to eye level (PS5 home-screen style) instead of hugging
-             the Library/Options switcher above it. -->
-        <Panel x:Name="LibraryPage" Margin="0,64,0,0">
+        <!-- Library page. Covers use a horizontal virtualized rail so the
+             number of realized images stays bounded for large libraries. -->
+        <Grid x:Name="LibraryPage" Margin="0,46,0,0" RowDefinitions="238,*">
           <ListBox x:Name="GameList" Classes="tileGrid" Background="Transparent"
-                   SelectionMode="Single" Padding="0">
+                   Grid.Row="0"
+                   SelectionMode="Single" Padding="4,0,28,0">
             <ListBox.ContextMenu>
               <ContextMenu x:Name="GameContextMenu" Placement="Pointer">
                 <MenuItem x:Name="CtxLaunch"
@@ -190,49 +186,116 @@ SPDX-License-Identifier: GPL-2.0-or-later
             </ListBox.ContextMenu>
             <ListBox.ItemsPanel>
               <ItemsPanelTemplate>
-                <WrapPanel />
+                <VirtualizingStackPanel Orientation="Horizontal" />
               </ItemsPanelTemplate>
             </ListBox.ItemsPanel>
-            <ListBox.ItemTemplate>
+            <ListBox.DataTemplates>
               <DataTemplate x:DataType="local:GameEntry" x:CompileBindings="True">
-                <StackPanel Width="128" Height="172" Spacing="7">
-                  <Border Classes="coverShadow" Width="128" Height="128">
-                    <Border Classes="coverClip">
-                      <Panel>
-                        <Border Background="{Binding PlaceholderBrush}" IsVisible="{Binding !HasCover}">
-                          <TextBlock Text="{Binding Initials}" FontSize="36" FontWeight="Bold"
-                                     Foreground="#E8ECF4" Opacity="0.85"
-                                     HorizontalAlignment="Center" VerticalAlignment="Center" />
-                        </Border>
-                        <Image Source="{Binding Cover}" Stretch="UniformToFill" IsVisible="{Binding HasCover}" />
-                      </Panel>
-                    </Border>
+                <Border Classes="coverShadow libraryGameCard"
+                        Width="148"
+                        Height="198"
+                        ToolTip.Tip="{Binding Name}"
+                        AutomationProperties.Name="{Binding Name}">
+                  <Border Classes="coverClip">
+                    <Panel>
+                      <Border Background="{Binding PlaceholderBrush}" IsVisible="{Binding !HasCover}">
+                        <TextBlock Text="{Binding Initials}" FontSize="38" FontWeight="Light"
+                                   Foreground="#C4E8ECF4"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center" />
+                      </Border>
+                      <Image Source="{Binding Cover}"
+                             Stretch="UniformToFill"
+                             RenderOptions.BitmapInterpolationMode="LowQuality"
+                             IsVisible="{Binding HasCover}" />
+                    </Panel>
                   </Border>
-                  <TextBlock Text="{Binding Name}" FontSize="13" FontWeight="SemiBold"
-                             TextWrapping="Wrap" MaxLines="2" TextTrimming="CharacterEllipsis"
-                             TextAlignment="Center" HorizontalAlignment="Center" />
-                </StackPanel>
+                </Border>
               </DataTemplate>
-            </ListBox.ItemTemplate>
+              <DataTemplate x:DataType="local:AddFolderTile">
+                <Border Classes="addFolderTile"
+                        Width="148"
+                        Height="198"
+                        ToolTip.Tip="{Binding [Library.AddFolder],
+                                              Source={x:Static local:Localization.Instance},
+                                              x:CompileBindings=False}"
+                        AutomationProperties.Name="{Binding [Library.AddFolder],
+                                                           Source={x:Static local:Localization.Instance},
+                                                           x:CompileBindings=False}">
+                  <StackPanel HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              Spacing="12">
+                    <Border Classes="addFolderTileIcon">
+                      <TextBlock Classes="addFolderGlyph addFolderIconGlyph"
+                                 Text="+"
+                                 FontSize="34"
+                                 FontWeight="Light"
+                                 LineHeight="34"
+                                 HorizontalAlignment="Center"
+                                 VerticalAlignment="Center" />
+                    </Border>
+                    <TextBlock Classes="addFolderGlyph"
+                               Text="{Binding [Library.AddFolder],
+                                              Source={x:Static local:Localization.Instance},
+                                              x:CompileBindings=False}"
+                               FontSize="12"
+                               FontWeight="SemiBold"
+                               HorizontalAlignment="Center" />
+                  </StackPanel>
+                </Border>
+              </DataTemplate>
+            </ListBox.DataTemplates>
           </ListBox>
 
+          <!-- Selected-game identity stays in the library content while the
+               bottom bar continues to own session status and actions. -->
+          <StackPanel x:Name="LibrarySelectedDetails"
+                      Grid.Row="1"
+                      x:DataType="local:GameEntry"
+                      x:CompileBindings="True"
+                      IsVisible="False"
+                      MaxWidth="980"
+                      HorizontalAlignment="Left"
+                      VerticalAlignment="Top"
+                      Margin="4,8,0,0"
+                      Spacing="18">
+            <TextBlock Text="{Binding Name}"
+                       FontSize="42"
+                       FontWeight="SemiBold"
+                       TextWrapping="Wrap"
+                       TextTrimming="CharacterEllipsis"
+                       MaxLines="2" />
+            <StackPanel Orientation="Horizontal" Spacing="8">
+              <Border Classes="pill" IsVisible="{Binding HasTitleId}">
+                <TextBlock Text="{Binding TitleId}" FontSize="11" FontWeight="SemiBold"
+                           Foreground="{StaticResource MutedBrush}" />
+              </Border>
+              <Border Classes="pill" IsVisible="{Binding HasVersion}">
+                <TextBlock Text="{Binding VersionText}" FontSize="11" FontWeight="SemiBold"
+                           Foreground="{StaticResource MutedBrush}" />
+              </Border>
+              <Border Classes="pill">
+                <TextBlock Text="{Binding SizeText}" FontSize="11" FontWeight="SemiBold"
+                           Foreground="{StaticResource MutedBrush}" />
+              </Border>
+            </StackPanel>
+          </StackPanel>
+
           <!-- Empty state -->
-          <StackPanel x:Name="EmptyState" Spacing="10" HorizontalAlignment="Center" VerticalAlignment="Center"
+          <StackPanel x:Name="EmptyState" Grid.RowSpan="2"
+                      Spacing="10" HorizontalAlignment="Center" VerticalAlignment="Center"
                       IsVisible="False">
             <TextBlock Text="🎮" FontSize="44" HorizontalAlignment="Center" Opacity="0.7" />
             <TextBlock x:Name="EmptyStateTitle" Text="Your library is empty" FontSize="18" FontWeight="SemiBold"
                        HorizontalAlignment="Center" />
             <TextBlock x:Name="EmptyStateHint" Text="Add a folder containing your games to get started."
                        FontSize="13" Foreground="{StaticResource MutedBrush}" HorizontalAlignment="Center" />
-            <Button x:Name="EmptyAddFolderButton" Classes="accent"
-                    Content="{Binding [Library.Empty.AddFolder], Source={x:Static local:Localization.Instance}}"
-                    HorizontalAlignment="Center" Margin="0,8,0,0" />
           </StackPanel>
 
           <!-- Loading state: covers the grid while a scan (initial load,
                rescan, or a just-added folder) is in flight, so the screen
                never looks blank mid-scan. -->
-          <StackPanel x:Name="LoadingState" Spacing="14" HorizontalAlignment="Center" VerticalAlignment="Center"
+          <StackPanel x:Name="LoadingState" Grid.RowSpan="2"
+                      Spacing="14" HorizontalAlignment="Center" VerticalAlignment="Center"
                       IsVisible="False">
             <ProgressBar IsIndeterminate="True" Width="180" Height="3" />
             <TextBlock x:Name="LoadingStateText"
@@ -240,7 +303,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                        FontSize="13"
                        Foreground="{StaticResource MutedBrush}" HorizontalAlignment="Center" />
           </StackPanel>
-        </Panel>
+        </Grid>
 
         <!-- Options page: sub-tabs so future categories (Graphics, …) slot
              in next to General. Card-grouped sections match the visual

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -6,7 +6,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:SharpEmu.GUI"
-        xmlns:primitives="clr-namespace:Avalonia.Controls.Primitives;assembly=Avalonia.Controls"
         x:Class="SharpEmu.GUI.MainWindow"
         Title="SharpEmu"
         Width="1280" Height="820"
@@ -91,7 +90,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     </Grid>
 
     <!-- Main content -->
-    <Grid x:Name="MainContent" Grid.Row="1" Margin="32,24,32,20" RowDefinitions="Auto,*,Auto,Auto">
+    <Grid x:Name="MainContent" Grid.Row="1" Margin="32,24,32,20" RowDefinitions="Auto,*,Auto">
 
       <!-- Library / Options page switcher, with the library toolbar sharing
            the same row on the right. Plain buttons (not TabItem) so there is
@@ -246,8 +245,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
             </ListBox.DataTemplates>
           </ListBox>
 
-          <!-- Selected-game identity stays in the library content while the
-               bottom bar continues to own session status and actions. -->
+          <!-- Selected-game identity and actions share one detail surface so
+               the selected title and metadata are never rendered twice. -->
           <StackPanel x:Name="LibrarySelectedDetails"
                       Grid.Row="1"
                       x:DataType="local:GameEntry"
@@ -278,6 +277,25 @@ SPDX-License-Identifier: GPL-2.0-or-later
                            Foreground="{StaticResource MutedBrush}" />
               </Border>
             </StackPanel>
+            <Grid Width="360"
+                  ColumnDefinitions="*,*"
+                  ColumnSpacing="8"
+                  HorizontalAlignment="Left">
+              <Button x:Name="LaunchButton"
+                      Grid.Column="0"
+                      Classes="accent"
+                      Content="Launch"
+                      HorizontalAlignment="Stretch"
+                      IsEnabled="False" />
+              <ToggleButton x:Name="ConsoleToggle"
+                            Grid.Column="1"
+                            Classes="ghost"
+                            Padding="22,10"
+                            HorizontalAlignment="Stretch"
+                            Content="{Binding [Launch.Console],
+                                              Source={x:Static local:Localization.Instance},
+                                              x:CompileBindings=False}" />
+            </Grid>
           </StackPanel>
 
           <!-- Empty state -->
@@ -307,7 +325,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
         <!-- Options page: sub-tabs so future categories (Graphics, …) slot
              in next to General. Card-grouped sections match the visual
-             language used by the console panel and launch bar below. -->
+             language used by the console panel below. -->
         <Grid x:Name="OptionsPage" IsVisible="False">
           <TabControl>
             <TabItem x:Name="GeneralTabItem"
@@ -723,7 +741,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
       <Border Grid.Row="2" x:Name="ConsolePanel" Classes="card" Padding="0" Height="240"
               Margin="0,12,0,0" IsVisible="False">
         <Grid RowDefinitions="Auto,*">
-          <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" Margin="16,12,16,8">
+          <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto" Margin="16,12,16,8">
             <TextBlock x:Name="ConsoleSectionTitle" Classes="sectionTitle"
                        Text="{Binding [Console.Title], Source={x:Static local:Localization.Instance}}"
                        VerticalAlignment="Center" />
@@ -745,7 +763,15 @@ SPDX-License-Identifier: GPL-2.0-or-later
             <Button Grid.Column="5" x:Name="ClearLogButton" Classes="ghost"
                     Content="{Binding [Console.Clear], Source={x:Static local:Localization.Instance}}"
                     FontSize="12"
-                    Padding="10,4" />
+                    Padding="10,4" Margin="0,0,8,0" />
+            <Button Grid.Column="6"
+                    x:Name="CloseConsoleButton"
+                    Classes="ghost"
+                    Content="×"
+                    AutomationProperties.Name="{Binding [Launch.Console],
+                                                        Source={x:Static local:Localization.Instance}}"
+                    FontSize="16"
+                    Padding="10,2" />
           </Grid>
           <ListBox Grid.Row="1" x:Name="ConsoleList" Classes="console" BorderThickness="0,1,0,0"
                    BorderBrush="{StaticResource CardBorderBrush}" CornerRadius="0,0,12,12">
@@ -758,101 +784,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
         </Grid>
       </Border>
 
-      <!-- Launch bar; capped so it does not sprawl on a maximized window. -->
-      <Border Grid.Row="3" x:Name="LaunchBar" Classes="card" Margin="0,12,0,0" Padding="14" MaxWidth="1280">
-        <StackPanel Spacing="14">
-          <Grid ColumnDefinitions="Auto,*,Auto">
-
-            <!-- Selected game cover thumbnail -->
-            <Border Grid.Column="0" Classes="coverClip" Width="56" Height="56" CornerRadius="8"
-                    VerticalAlignment="Center">
-              <Panel x:Name="SelectedCoverPanel"
-                     x:DataType="local:GameEntry"
-                     x:CompileBindings="True">
-                <Border Background="{Binding PlaceholderBrush, FallbackValue={x:Null}}"
-                        IsVisible="{Binding !HasCover, FallbackValue=False}">
-                  <TextBlock Text="{Binding Initials}" FontSize="20" FontWeight="Bold"
-                             Foreground="#E8ECF4" Opacity="0.85"
-                             HorizontalAlignment="Center" VerticalAlignment="Center" />
-                </Border>
-                <Image Source="{Binding Cover}" Stretch="UniformToFill"
-                       IsVisible="{Binding HasCover, FallbackValue=False}" />
-              </Panel>
-            </Border>
-
-            <StackPanel Grid.Column="1" Spacing="4" VerticalAlignment="Center" Margin="14,0,14,0">
-              <Grid ColumnDefinitions="Auto,Auto,*">
-                <TextBlock Grid.Column="0" x:Name="SelectedGameTitle" Text="No game selected" FontSize="16"
-                           FontWeight="Bold" TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
-                           MaxWidth="340" Margin="0,0,10,0" />
-
-                <!-- Title id / version / size badges, right next to the
-                     title. The title's own MaxWidth (not a "*" column) is
-                     what keeps them from drifting to the far right. -->
-                <StackPanel Grid.Column="1" x:Name="SelectedBadgesRow"
-                            x:DataType="local:GameEntry"
-                            x:CompileBindings="True"
-                            Orientation="Horizontal" Spacing="6"
-                            IsVisible="False" VerticalAlignment="Center">
-                  <Border Classes="pill" IsVisible="{Binding HasTitleId, FallbackValue=False}">
-                    <TextBlock Text="{Binding TitleId}" FontSize="10" FontWeight="SemiBold"
-                               Foreground="{StaticResource MutedBrush}" />
-                  </Border>
-                  <Border Classes="pill" IsVisible="{Binding HasVersion, FallbackValue=False}">
-                    <TextBlock Text="{Binding VersionText}" FontSize="10" FontWeight="SemiBold"
-                               Foreground="{StaticResource MutedBrush}" />
-                  </Border>
-                  <Border Classes="pill">
-                    <TextBlock Text="{Binding SizeText, FallbackValue=''}" FontSize="10" FontWeight="SemiBold"
-                               Foreground="{StaticResource MutedBrush}" />
-                  </Border>
-                </StackPanel>
-              </Grid>
-
-              <TextBlock x:Name="SelectedGamePath" Text="Pick a game from the library, or open an eboot.bin directly."
-                         FontSize="11" Foreground="{StaticResource MutedBrush}" TextTrimming="CharacterEllipsis" />
-              <StackPanel Orientation="Horizontal" Spacing="7">
-                <Ellipse x:Name="StatusDot" Width="8" Height="8" Fill="{StaticResource FaintBrush}"
-                         VerticalAlignment="Center" />
-                <TextBlock x:Name="StatusText" Text="Idle" FontSize="11" Foreground="{StaticResource MutedBrush}"
-                           VerticalAlignment="Center" />
-              </StackPanel>
-            </StackPanel>
-
-            <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-              <ToggleButton x:Name="ConsoleToggle" Classes="ghost"
-                            Content="{Binding [Launch.Console], Source={x:Static local:Localization.Instance}}" />
-              <Button x:Name="LaunchButton" Classes="accent"
-                      Content="{Binding [Launch.Launch], Source={x:Static local:Localization.Instance}}"
-                      IsEnabled="False" />
-              <Button x:Name="StopButton" Classes="danger"
-                      Content="{Binding [Launch.Stop], Source={x:Static local:Localization.Instance}}"
-                      IsEnabled="False" />
-            </StackPanel>
-          </Grid>
-        </StackPanel>
-      </Border>
     </Grid>
-
-    <!-- Keep launch progress above the blurred library while the SDL game
-         process owns its independent top-level window. -->
-    <primitives:Popup x:Name="SessionLoadingPopup"
-                      IsOpen="False"
-                      PlacementTarget="{Binding #MainContent}"
-                      Placement="Center"
-                      Topmost="True"
-                      ShouldUseOverlayLayer="False"
-                      TakesFocusFromNativeControl="False"
-                      IsLightDismissEnabled="False">
-      <Border Classes="card" Width="380" CornerRadius="18" Padding="22,18">
-        <StackPanel Spacing="12">
-          <TextBlock x:Name="SessionLoadingTitle" Text="Loading game" FontSize="16" FontWeight="SemiBold" />
-          <TextBlock x:Name="SessionLoadingDetail" Text="Preparing the emulation session..." FontSize="12"
-                     Foreground="{StaticResource MutedBrush}" TextTrimming="CharacterEllipsis" />
-          <ProgressBar x:Name="SessionLoadingProgress" IsIndeterminate="True" Height="5" />
-        </StackPanel>
-      </Border>
-    </primitives:Popup>
 
     <!-- Status bar -->
     <Grid x:Name="StatusBar" Grid.Row="2" Height="32" Background="{StaticResource ChromeBrush}"

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -129,7 +129,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
         <!-- Library page. Covers use a horizontal virtualized rail so the
              number of realized images stays bounded for large libraries. -->
-        <Grid x:Name="LibraryPage" Margin="0,46,0,0" RowDefinitions="238,*">
+        <Grid x:Name="LibraryPage" Margin="0,46,0,0" RowDefinitions="188,*">
           <ListBox x:Name="GameList" Classes="tileGrid" Background="Transparent"
                    Grid.Row="0"
                    SelectionMode="Single" Padding="4,0,28,0">
@@ -192,7 +192,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
               <DataTemplate x:DataType="local:GameEntry" x:CompileBindings="True">
                 <Border Classes="coverShadow libraryGameCard"
                         Width="148"
-                        Height="198"
+                        Height="148"
                         ToolTip.Tip="{Binding Name}"
                         AutomationProperties.Name="{Binding Name}">
                   <Border Classes="coverClip">
@@ -213,7 +213,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
               <DataTemplate x:DataType="local:AddFolderTile">
                 <Border Classes="addFolderTile"
                         Width="148"
-                        Height="198"
+                        Height="148"
                         ToolTip.Tip="{Binding [Library.AddFolder],
                                               Source={x:Static local:Localization.Instance},
                                               x:CompileBindings=False}"

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -33,8 +33,6 @@ public partial class MainWindow : Window
 {
     private const int MaxConsoleLines = 4000;
     private const int MaxConsoleLinesPerFlush = 500;
-    private const double LaunchBlurRadius = 12;
-    private const double BlurTransitionSeconds = 0.24;
 
     private static readonly IBrush DefaultLineBrush = new SolidColorBrush(Color.Parse("#C7CFDE"));
     private static readonly IBrush DimLineBrush = new SolidColorBrush(Color.Parse("#6B7488"));
@@ -89,12 +87,6 @@ public partial class MainWindow : Window
     private readonly List<LogLine> _allConsoleLines = new();
     private readonly ConcurrentQueue<(string Line, bool IsError)> _pendingLines = new();
     private readonly DispatcherTimer _consoleFlushTimer;
-    private readonly DispatcherTimer _libraryBlurTimer;
-    private BlurEffect? _libraryBlur;
-    private double _libraryBlurStartRadius;
-    private double _libraryBlurTargetRadius;
-    private long _libraryBlurStartedAt;
-    private bool _clearLibraryBlurWhenComplete;
 
     private GuiSettings _settings = new();
     private IReadOnlyList<HostDisplayOption> _hostDisplays = [];
@@ -131,11 +123,6 @@ public partial class MainWindow : Window
     // Bundled key art shown whenever no game-specific backdrop applies; the
     // plain window color remains the fallback when the asset fails to load.
     private Bitmap? _defaultBackdrop;
-
-    // Whether the native loading/closing popup should be showing; it is a
-    // desktop-topmost popup, so it closes while the launcher is in the
-    // background or minimized and reopens from this flag on activation.
-    private bool _sessionLoadingActive;
 
     // Controller navigation state.
     private readonly DispatcherTimer _gamepadTimer;
@@ -190,23 +177,6 @@ public partial class MainWindow : Window
         };
         _consoleFlushTimer.Start();
 
-        _libraryBlurTimer = new DispatcherTimer
-        {
-            Interval = TimeSpan.FromMilliseconds(16),
-        };
-        _libraryBlurTimer.Tick += (_, _) => AdvanceLibraryBlur();
-
-        // Native popups float above every window on the desktop; they must
-        // follow the launcher into the background or a minimized state.
-        Activated += (_, _) =>
-        {
-            SessionLoadingPopup.IsOpen = _sessionLoadingActive;
-        };
-        Deactivated += (_, _) =>
-        {
-            SessionLoadingPopup.IsOpen = false;
-        };
-
         TitleBar.PointerPressed += OnTitleBarPointerPressed;
         TitleBar.DoubleTapped += OnTitleBarDoubleTapped;
         MinimizeButton.Click += (_, _) => WindowState = WindowState.Minimized;
@@ -229,11 +199,21 @@ public partial class MainWindow : Window
         SearchBox.TextChanged += (_, _) => RefreshVisibleGames();
         ConsoleSearchBox.TextChanged += (_, _) => RefreshVisibleConsoleLines();
         OpenFileButton.Click += async (_, _) => await OpenFileAsync();
-        LaunchButton.Click += (_, _) => LaunchSelected();
+        LaunchButton.Click += (_, _) =>
+        {
+            if (_isRunning)
+            {
+                StopEmulator();
+            }
+            else
+            {
+                LaunchSelected();
+            }
+        };
         ClearLogButton.Click += (_, _) => { _consoleLines.Clear(); _allConsoleLines.Clear(); };
-        StopButton.Click += (_, _) => StopEmulator();
         CopyLogButton.Click += async (_, _) => await CopyConsoleAsync();
         DetachConsoleButton.Click += (_, _) => ShowConsoleWindow();
+        CloseConsoleButton.Click += (_, _) => ConsoleToggle.IsChecked = false;
         LibraryTabButton.Click += (_, _) => SetActivePage(0);
         OptionsTabButton.Click += (_, _) => SetActivePage(1);
         ConsoleToggle.IsCheckedChanged += (_, _) => ConsolePanel.IsVisible = ConsoleToggle.IsChecked == true && _consoleWindow is null;
@@ -636,7 +616,7 @@ public partial class MainWindow : Window
         RefreshHostRefreshRates(_settings.RefreshRate);
         RefreshUpdateText();
         UpdateEmptyStateTexts();
-        UpdateSelectedGameTexts();
+        UpdateRunButtons();
     }
 
     // ---- Discord Rich Presence ----
@@ -704,7 +684,6 @@ public partial class MainWindow : Window
         _libraryWatcher.Dispose();
         _settings.Save();
         _consoleFlushTimer.Stop();
-        _libraryBlurTimer.Stop();
         _gamepadTimer.Stop();
         SdlLauncherGamepad.Shutdown();
         _sndPreview.Stop();
@@ -1782,7 +1761,6 @@ public partial class MainWindow : Window
         }
         else
         {
-            UpdateSelectedGameTexts();
             UpdateRunButtons();
             if (selectedAfter is not null && backgroundsChanged?.Contains(selectedAfter) == true)
             {
@@ -1816,47 +1794,20 @@ public partial class MainWindow : Window
     {
         if (GameList.SelectedItem is GameEntry game)
         {
-            UpdateSelectedGameTexts();
             LibrarySelectedDetails.DataContext = game;
             LibrarySelectedDetails.IsVisible = true;
-            SelectedCoverPanel.DataContext = game;
-            SelectedBadgesRow.DataContext = game;
-            SelectedBadgesRow.IsVisible = true;
             _ = UpdateBackdropAsync(game);
             PlaySelectedGamePreview(game);
         }
         else
         {
-            UpdateSelectedGameTexts();
             LibrarySelectedDetails.DataContext = null;
             LibrarySelectedDetails.IsVisible = false;
-            SelectedCoverPanel.DataContext = null;
-            SelectedBadgesRow.DataContext = null;
-            SelectedBadgesRow.IsVisible = false;
             _ = UpdateBackdropAsync(null);
             _sndPreview.Stop();
         }
 
         UpdateRunButtons();
-    }
-
-    /// <summary>
-    /// Text-only refresh of the launch bar's title/path, split out of
-    /// <see cref="UpdateSelectedGame"/> so a language change can re-apply it
-    /// without restarting the backdrop fade or preview music.
-    /// </summary>
-    private void UpdateSelectedGameTexts()
-    {
-        if (GameList.SelectedItem is GameEntry game)
-        {
-            SelectedGameTitle.Text = game.Name;
-            SelectedGamePath.Text = game.Path;
-        }
-        else
-        {
-            SelectedGameTitle.Text = Localization.Instance.Get("Launch.NoGameSelected");
-            SelectedGamePath.Text = Localization.Instance.Get("Launch.NoGameHint");
-        }
     }
 
     /// <summary>
@@ -1908,18 +1859,10 @@ public partial class MainWindow : Window
             if (WindowState == WindowState.Minimized)
             {
                 _sndPreview.Pause();
-                if (SessionLoadingPopup is { } popup)
-                {
-                    popup.IsOpen = false;
-                }
             }
             else
             {
                 _sndPreview.Resume();
-                if (SessionLoadingPopup is { } popup)
-                {
-                    popup.IsOpen = _sessionLoadingActive;
-                }
             }
         }
     }
@@ -2073,16 +2016,14 @@ public partial class MainWindow : Window
         };
 
         _isRunning = true;
+        _isStopping = false;
         _runningGameName = displayName;
         _runningGameTitleId = resolvedTitleId;
         _runningSinceUnixSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-        StatusDot.Fill = SuccessLineBrush;
-        StatusText.Text = Localization.Instance.Format("Launch.Running", displayName);
         StatusBarRight.Text = Localization.Instance.Format("Status.Running", displayName);
         UpdateRunButtons();
         UpdateDiscordPresence();
 
-        BeginSessionUi();
         _pendingLaunch = new PendingLaunch(
             Path.GetFullPath(ebootPath),
             displayName,
@@ -2128,15 +2069,14 @@ public partial class MainWindow : Window
         }
 
         _isStopping = true;
-        StopButton.IsEnabled = false;
-        ShowSessionLoading("Closing game", "Waiting for the emulation session to exit...");
+        UpdateRunButtons();
         _emulator.Stop();
         _runningGameName = null;
         _runningGameTitleId = null;
-        StatusText.Text = Localization.Instance.Get("Launch.Stopping");
         StatusBarRight.Text = Localization.Instance.Get("Status.Stopping");
         UpdateDiscordPresence();
-        ReturnToLibraryWhileStopping();
+        ConsolePanel.IsVisible = ConsoleToggle.IsChecked == true && _consoleWindow is null;
+        Console.Error.WriteLine("[GUI][INFO] Waiting for the SDL game process to exit.");
     }
 
     /// <summary>
@@ -2178,7 +2118,7 @@ public partial class MainWindow : Window
         _emulator?.Dispose();
         _emulator = null;
         _pendingLaunch = null;
-        EndSessionUi();
+        ConsolePanel.IsVisible = ConsoleToggle.IsChecked == true && _consoleWindow is null;
 
         var meaningKey = exitCode switch
         {
@@ -2200,10 +2140,6 @@ public partial class MainWindow : Window
             brush);
         CloseFileLogSoon();
 
-        StatusDot.Fill = exitCode == 0 || stoppedByUser ? (IBrush)SuccessLineBrush : ErrorLineBrush;
-        StatusText.Text = stoppedByUser
-            ? "Game closed by the user."
-            : Localization.Instance.Format("Launch.Exited", exitCode, meaning);
         StatusBarRight.Text = Localization.Instance.Get("Status.Idle");
         _runningGameName = null;
         _runningGameTitleId = null;
@@ -2284,137 +2220,6 @@ public partial class MainWindow : Window
     private void OnEmulatorOutput(string line, bool isError)
     {
         _pendingLines.Enqueue((line, isError));
-        if (!line.Contains("Vulkan VideoOut presented first frame:", StringComparison.Ordinal) &&
-            !line.Contains("Vulkan VideoOut ready:", StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        Dispatcher.UIThread.Post(() =>
-        {
-            if (_isRunning && !_isStopping)
-            {
-                ShowSessionStatus("Game is running");
-            }
-        });
-    }
-
-    private void BeginSessionUi()
-    {
-        _isStopping = false;
-        AnimateLibraryBlur(LaunchBlurRadius);
-        ShowSessionLoading("Loading game", "Preparing the emulation session...");
-        LaunchBar.IsVisible = true;
-    }
-
-    private void EndSessionUi()
-    {
-        HideSessionLoading();
-        AnimateLibraryBlur(0, clearWhenComplete: true);
-        LaunchBar.IsVisible = true;
-        ConsolePanel.IsVisible = ConsoleToggle.IsChecked == true && _consoleWindow is null;
-    }
-
-    private void AnimateLibraryBlur(double targetRadius, bool clearWhenComplete = false)
-    {
-        _libraryBlur ??= new BlurEffect();
-        PagesHost.Effect = _libraryBlur;
-
-        _libraryBlurStartRadius = _libraryBlur.Radius;
-        _libraryBlurTargetRadius = Math.Max(0, targetRadius);
-        _libraryBlurStartedAt = Stopwatch.GetTimestamp();
-        _clearLibraryBlurWhenComplete = clearWhenComplete && _libraryBlurTargetRadius == 0;
-
-        if (Math.Abs(_libraryBlurStartRadius - _libraryBlurTargetRadius) < 0.01)
-        {
-            CompleteLibraryBlur();
-            return;
-        }
-
-        _libraryBlurTimer.Start();
-    }
-
-    private void AdvanceLibraryBlur()
-    {
-        if (_libraryBlur is null)
-        {
-            _libraryBlurTimer.Stop();
-            return;
-        }
-
-        var elapsed = (Stopwatch.GetTimestamp() - _libraryBlurStartedAt) /
-                      (double)Stopwatch.Frequency;
-        var progress = Math.Clamp(elapsed / BlurTransitionSeconds, 0, 1);
-        // Cubic ease-out gives the loading transition a quick response while
-        // keeping the final change of sharpness unobtrusive.
-        var easedProgress = 1 - Math.Pow(1 - progress, 3);
-        _libraryBlur.Radius = _libraryBlurStartRadius +
-                              ((_libraryBlurTargetRadius - _libraryBlurStartRadius) * easedProgress);
-
-        if (progress >= 1)
-        {
-            CompleteLibraryBlur();
-        }
-    }
-
-    private void CompleteLibraryBlur()
-    {
-        _libraryBlurTimer.Stop();
-        if (_libraryBlur is not null)
-        {
-            _libraryBlur.Radius = _libraryBlurTargetRadius;
-        }
-
-        if (_clearLibraryBlurWhenComplete)
-        {
-            PagesHost.Effect = null;
-            _libraryBlur = null;
-            _clearLibraryBlurWhenComplete = false;
-        }
-    }
-
-    private void ClearLibraryBlur()
-    {
-        _libraryBlurTimer.Stop();
-        _libraryBlur = null;
-        _clearLibraryBlurWhenComplete = false;
-        PagesHost.Effect = null;
-    }
-
-    private void ShowSessionLoading(string title, string detail)
-    {
-        SessionLoadingTitle.Text = title;
-        SessionLoadingTitle.IsVisible = true;
-        SessionLoadingDetail.Text = detail;
-        SessionLoadingDetail.IsVisible = true;
-        SessionLoadingProgress.IsVisible = true;
-        _sessionLoadingActive = true;
-        SessionLoadingPopup.IsOpen = IsActive && WindowState != WindowState.Minimized;
-    }
-
-    private void ShowSessionStatus(string message)
-    {
-        SessionLoadingTitle.Text = message;
-        SessionLoadingTitle.IsVisible = true;
-        SessionLoadingDetail.IsVisible = false;
-        SessionLoadingProgress.IsVisible = false;
-        _sessionLoadingActive = true;
-        SessionLoadingPopup.IsOpen = IsActive && WindowState != WindowState.Minimized;
-    }
-
-    private void HideSessionLoading()
-    {
-        _sessionLoadingActive = false;
-        SessionLoadingPopup.IsOpen = false;
-    }
-
-    private void ReturnToLibraryWhileStopping()
-    {
-        AnimateLibraryBlur(LaunchBlurRadius);
-        ConsolePanel.IsVisible = ConsoleToggle.IsChecked == true && _consoleWindow is null;
-        LaunchBar.IsVisible = true;
-        UpdateRunButtons();
-        Console.Error.WriteLine("[GUI][INFO] Waiting for the SDL game process to exit.");
     }
 
     private void OpenFileLog(string? titleId)
@@ -2471,8 +2276,23 @@ public partial class MainWindow : Window
 
     private void UpdateRunButtons()
     {
-        LaunchButton.IsEnabled = !_isRunning && GameList.SelectedItem is GameEntry;
-        StopButton.IsEnabled = _isRunning && !_isStopping;
+        LaunchButton.Classes.Remove("accent");
+        LaunchButton.Classes.Remove("danger");
+
+        if (_isRunning)
+        {
+            LaunchButton.Classes.Add("danger");
+            LaunchButton.Content = Localization.Instance.Get(
+                _isStopping ? "Launch.Stopping" : "Launch.Stop");
+            LaunchButton.IsEnabled = !_isStopping;
+        }
+        else
+        {
+            LaunchButton.Classes.Add("accent");
+            LaunchButton.Content = Localization.Instance.Get("Launch.Launch");
+            LaunchButton.IsEnabled = GameList.SelectedItem is GameEntry;
+        }
+
         OpenFileButton.IsEnabled = !_isRunning;
     }
 

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -83,6 +83,7 @@ public partial class MainWindow : Window
     ];
     private readonly List<GameEntry> _allGames = new();
     private readonly ObservableCollection<GameEntry> _visibleGames = new();
+    private readonly LibraryTileCollection _libraryTiles;
     private readonly GameLibraryWatcher _libraryWatcher = new();
     private readonly AvaloniaList<LogLine> _consoleLines = new();
     private readonly List<LogLine> _allConsoleLines = new();
@@ -123,6 +124,9 @@ public partial class MainWindow : Window
     private int _detailLoadGeneration;
     private int _backdropGeneration;
     private bool _isClosing;
+    private bool _restoringGameSelection;
+    private bool _addFolderInProgress;
+    private GameEntry? _lastSelectedGame;
 
     // Bundled key art shown whenever no game-specific backdrop applies; the
     // plain window color remains the fallback when the asset fails to load.
@@ -138,8 +142,6 @@ public partial class MainWindow : Window
     private HostGamepadButtons _previousPadButtons;
     private long _navLeftNextAt;
     private long _navRightNextAt;
-    private long _navUpNextAt;
-    private long _navDownNextAt;
 
     //Github http client for latest commit
     private static readonly HttpClient GithubHttpClient = CreateGithubHttpClient();
@@ -156,6 +158,7 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         InitializeLocalizedChoiceBoxes();
+        _libraryTiles = new LibraryTileCollection(_visibleGames);
 
         try
         {
@@ -169,7 +172,7 @@ public partial class MainWindow : Window
             _defaultBackdrop = null; // color background remains the fallback
         }
 
-        GameList.ItemsSource = _visibleGames;
+        GameList.ItemsSource = _libraryTiles;
         _libraryWatcher.RefreshRequested += OnLibraryRefreshRequested;
         ConsoleList.ItemsSource = _consoleLines;
         _consoleMirror = GuiConsoleMirror.Install((line, isError) =>
@@ -221,12 +224,10 @@ public partial class MainWindow : Window
             UpdateWindowChromeState();
         };
         UpdateWindowChromeState();
-        GameList.SelectionChanged += (_, _) => UpdateSelectedGame();
-        GameList.DoubleTapped += (_, _) => LaunchSelected();
+        GameList.SelectionChanged += (_, _) => OnGameListSelectionChanged();
+        GameList.DoubleTapped += OnGameListDoubleTapped;
         SearchBox.TextChanged += (_, _) => RefreshVisibleGames();
         ConsoleSearchBox.TextChanged += (_, _) => RefreshVisibleConsoleLines();
-        AddFolderButton.Click += async (_, _) => await AddFolderAsync();
-        EmptyAddFolderButton.Click += async (_, _) => await AddFolderAsync();
         OpenFileButton.Click += async (_, _) => await OpenFileAsync();
         LaunchButton.Click += (_, _) => LaunchSelected();
         ClearLogButton.Click += (_, _) => { _consoleLines.Clear(); _allConsoleLines.Clear(); };
@@ -518,8 +519,6 @@ public partial class MainWindow : Window
         var now = Environment.TickCount64;
         var left = (pad.Buttons & HostGamepadButtons.Left) != 0 || pad.LeftX < 64;
         var right = (pad.Buttons & HostGamepadButtons.Right) != 0 || pad.LeftX > 192;
-        var up = (pad.Buttons & HostGamepadButtons.Up) != 0 || pad.LeftY < 64;
-        var down = (pad.Buttons & HostGamepadButtons.Down) != 0 || pad.LeftY > 192;
 
         if (ShouldNavigate(left, ref _navLeftNextAt, now))
         {
@@ -529,16 +528,6 @@ public partial class MainWindow : Window
         if (ShouldNavigate(right, ref _navRightNextAt, now))
         {
             MoveSelection(1);
-        }
-
-        if (ShouldNavigate(up, ref _navUpNextAt, now))
-        {
-            MoveSelection(-TilesPerRow());
-        }
-
-        if (ShouldNavigate(down, ref _navDownNextAt, now))
-        {
-            MoveSelection(TilesPerRow());
         }
 
         var pressed = pad.Buttons & ~_previousPadButtons;
@@ -579,24 +568,11 @@ public partial class MainWindow : Window
 
     private void MoveSelection(int delta)
     {
-        if (_visibleGames.Count == 0)
-        {
-            return;
-        }
-
         var index = GameList.SelectedIndex < 0
             ? 0
-            : Math.Clamp(GameList.SelectedIndex + delta, 0, _visibleGames.Count - 1);
+            : Math.Clamp(GameList.SelectedIndex + delta, 0, _libraryTiles.Count - 1);
         GameList.SelectedIndex = index;
         GameList.ScrollIntoView(index);
-    }
-
-    private int TilesPerRow()
-    {
-        // Tile footprint: 128 content + 20 item padding + 10 item margin.
-        const double TileOuterWidth = 158;
-        var width = GameList.Bounds.Width;
-        return width > TileOuterWidth ? (int)(width / TileOuterWidth) : 1;
     }
 
     private async Task OnOpenedAsync()
@@ -1600,6 +1576,71 @@ public partial class MainWindow : Window
 
     // ---- Game context menu ----
 
+    private void OnGameListSelectionChanged()
+    {
+        if (_restoringGameSelection)
+        {
+            return;
+        }
+
+        if (GameList.SelectedItem is AddFolderTile)
+        {
+            _restoringGameSelection = true;
+            try
+            {
+                GameList.SelectedItem = _lastSelectedGame;
+            }
+            finally
+            {
+                _restoringGameSelection = false;
+            }
+
+            // A held direction must not reopen the picker after it closes.
+            _navLeftNextAt = long.MaxValue;
+            _navRightNextAt = long.MaxValue;
+            StartAddFolderFromTile();
+            return;
+        }
+
+        _lastSelectedGame = GameList.SelectedItem as GameEntry;
+        UpdateSelectedGame();
+    }
+
+    private void OnGameListDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        var item = (e.Source as Visual)?.FindAncestorOfType<ListBoxItem>(includeSelf: true);
+        if (item?.DataContext is AddFolderTile)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        LaunchSelected();
+    }
+
+    private void StartAddFolderFromTile()
+    {
+        if (_addFolderInProgress)
+        {
+            return;
+        }
+
+        _addFolderInProgress = true;
+        _ = AddFolderFromTileAsync();
+    }
+
+    private async Task AddFolderFromTileAsync()
+    {
+        try
+        {
+            await AddFolderAsync();
+        }
+        finally
+        {
+            _addFolderInProgress = false;
+        }
+    }
+
     /// <summary>
     /// Selects the tile under the pointer before its context menu opens, and
     /// suppresses the menu on empty grid space.
@@ -1769,7 +1810,6 @@ public partial class MainWindow : Window
         EmptyStateHint.Text = hasFilter
             ? Localization.Instance.Format("Library.Empty.SearchHint", query)
             : Localization.Instance.Get("Library.Empty.Hint");
-        EmptyAddFolderButton.IsVisible = !hasFilter;
     }
 
     private void UpdateSelectedGame()
@@ -1777,6 +1817,8 @@ public partial class MainWindow : Window
         if (GameList.SelectedItem is GameEntry game)
         {
             UpdateSelectedGameTexts();
+            LibrarySelectedDetails.DataContext = game;
+            LibrarySelectedDetails.IsVisible = true;
             SelectedCoverPanel.DataContext = game;
             SelectedBadgesRow.DataContext = game;
             SelectedBadgesRow.IsVisible = true;
@@ -1786,6 +1828,8 @@ public partial class MainWindow : Window
         else
         {
             UpdateSelectedGameTexts();
+            LibrarySelectedDetails.DataContext = null;
+            LibrarySelectedDetails.IsVisible = false;
             SelectedCoverPanel.DataContext = null;
             SelectedBadgesRow.DataContext = null;
             SelectedBadgesRow.IsVisible = false;

--- a/src/SharpEmu.GUI/Themes/Styles/Library.axaml
+++ b/src/SharpEmu.GUI/Themes/Styles/Library.axaml
@@ -14,7 +14,7 @@ Cover-art library item states and motion.
   </Style>
   <Style Selector="ListBox.tileGrid ListBoxItem">
     <Setter Property="Width" Value="160" />
-    <Setter Property="Height" Value="222" />
+    <Setter Property="Height" Value="172" />
     <Setter Property="Padding" Value="4" />
     <Setter Property="Margin" Value="0,8,12,8" />
     <Setter Property="CornerRadius" Value="9" />

--- a/src/SharpEmu.GUI/Themes/Styles/Library.axaml
+++ b/src/SharpEmu.GUI/Themes/Styles/Library.axaml
@@ -6,32 +6,121 @@ Cover-art library item states and motion.
 
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <Style Selector="ListBox.tileGrid ListBoxItem">
-    <Setter Property="Padding" Value="10" />
-    <Setter Property="Margin" Value="5" />
-    <Setter Property="CornerRadius" Value="14" />
+  <Style Selector="ListBox.tileGrid">
     <Setter Property="Background" Value="Transparent" />
-    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
+  </Style>
+  <Style Selector="ListBox.tileGrid ListBoxItem">
+    <Setter Property="Width" Value="160" />
+    <Setter Property="Height" Value="222" />
+    <Setter Property="Padding" Value="4" />
+    <Setter Property="Margin" Value="0,8,12,8" />
+    <Setter Property="CornerRadius" Value="9" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="0" />
     <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="Opacity" Value="0.72" />
+    <Setter Property="RenderTransformOrigin" Value="50%,50%" />
     <Setter Property="RenderTransform" Value="translateY(0px)" />
     <Setter Property="Transitions">
       <Transitions>
-        <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.12" />
+        <DoubleTransition Property="Opacity"
+                          Duration="0:0:0.11"
+                          Easing="QuadraticEaseOut" />
+        <TransformOperationsTransition Property="RenderTransform"
+                                       Duration="0:0:0.16"
+                                       Easing="CubicEaseOut" />
       </Transitions>
     </Setter>
   </Style>
-  <Style Selector="ListBox.tileGrid ListBoxItem:pointerover">
-    <Setter Property="RenderTransform" Value="translateY(-3px)" />
+  <Style Selector="ListBox.tileGrid ListBoxItem:pointerover,
+                   ListBox.tileGrid ListBoxItem:selected">
+    <Setter Property="Opacity" Value="1" />
+    <Setter Property="RenderTransform" Value="translateY(-5px) scale(1.035)" />
   </Style>
-  <Style Selector="ListBox.tileGrid ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{StaticResource TileHoverBrush}" />
+  <Style Selector="ListBox.tileGrid ListBoxItem /template/ ContentPresenter#PART_ContentPresenter,
+                   ListBox.tileGrid ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                   ListBox.tileGrid ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
   </Style>
-  <Style Selector="ListBox.tileGrid ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{StaticResource TileSelectedBrush}" />
-    <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+
+  <Style Selector="Border.libraryGameCard">
+    <Setter Property="CornerRadius" Value="7" />
+    <Setter Property="BorderThickness" Value="2" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BoxShadow" Value="0 12 28 0 #61000000" />
+    <Setter Property="Transitions">
+      <Transitions>
+        <BrushTransition Property="BorderBrush"
+                         Duration="0:0:0.12"
+                         Easing="QuadraticEaseOut" />
+      </Transitions>
+    </Setter>
   </Style>
-  <Style Selector="ListBox.tileGrid ListBoxItem:selected:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{StaticResource TileSelectedBrush}" />
-    <Setter Property="BorderBrush" Value="{StaticResource AccentHoverBrush}" />
+  <Style Selector="ListBox.tileGrid ListBoxItem:selected Border.libraryGameCard">
+    <Setter Property="BorderBrush" Value="#E6FFFFFF" />
+  </Style>
+  <Style Selector="Border.libraryGameCard Border.coverClip">
+    <Setter Property="CornerRadius" Value="5" />
+  </Style>
+
+  <Style Selector="Border.addFolderTile">
+    <Setter Property="CornerRadius" Value="7" />
+    <Setter Property="Background" Value="#0CFFFFFF" />
+    <Setter Property="BorderBrush" Value="#2EFFFFFF" />
+    <Setter Property="BorderThickness" Value="1.5" />
+    <Setter Property="BoxShadow" Value="0 12 28 0 #3A000000" />
+    <Setter Property="Transitions">
+      <Transitions>
+        <BrushTransition Property="Background"
+                         Duration="0:0:0.18"
+                         Easing="CubicEaseOut" />
+        <BrushTransition Property="BorderBrush"
+                         Duration="0:0:0.18"
+                         Easing="CubicEaseOut" />
+      </Transitions>
+    </Setter>
+  </Style>
+  <Style Selector="Border.addFolderTileIcon">
+    <Setter Property="Width" Value="60" />
+    <Setter Property="Height" Value="60" />
+    <Setter Property="CornerRadius" Value="30" />
+    <Setter Property="Background" Value="#1BFFFFFF" />
+    <Setter Property="Transitions">
+      <Transitions>
+        <BrushTransition Property="Background"
+                         Duration="0:0:0.18"
+                         Easing="CubicEaseOut" />
+      </Transitions>
+    </Setter>
+  </Style>
+  <Style Selector="TextBlock.addFolderGlyph">
+    <Setter Property="Foreground" Value="#A6FFFFFF" />
+    <Setter Property="Transitions">
+      <Transitions>
+        <BrushTransition Property="Foreground"
+                         Duration="0:0:0.18"
+                         Easing="CubicEaseOut" />
+      </Transitions>
+    </Setter>
+  </Style>
+  <Style Selector="TextBlock.addFolderIconGlyph">
+    <Setter Property="RenderTransform" Value="translateY(-7px)" />
+  </Style>
+  <Style Selector="ListBox.tileGrid ListBoxItem:pointerover TextBlock.addFolderGlyph,
+                   ListBox.tileGrid ListBoxItem:selected TextBlock.addFolderGlyph">
+    <Setter Property="Foreground" Value="White" />
+  </Style>
+  <Style Selector="ListBox.tileGrid ListBoxItem:pointerover Border.addFolderTile,
+                   ListBox.tileGrid ListBoxItem:selected Border.addFolderTile">
+    <Setter Property="Background" Value="#1AFFFFFF" />
+    <Setter Property="BorderBrush" Value="#55FFFFFF" />
+  </Style>
+  <Style Selector="ListBox.tileGrid ListBoxItem:pointerover Border.addFolderTileIcon,
+                   ListBox.tileGrid ListBoxItem:selected Border.addFolderTileIcon">
+    <Setter Property="Background" Value="#2EFFFFFF" />
   </Style>
 </Styles>

--- a/tests/SharpEmu.Libs.Tests/GUI/LibraryTileCollectionTests.cs
+++ b/tests/SharpEmu.Libs.Tests/GUI/LibraryTileCollectionTests.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.GUI;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.GUI;
+
+public sealed class LibraryTileCollectionTests
+{
+    [Fact]
+    public void KeepsAddFolderTileAfterVisibleGames()
+    {
+        var games = new ObservableCollection<GameEntry>();
+        var tiles = new LibraryTileCollection(games);
+        var first = CreateGame("First");
+        var second = CreateGame("Second");
+
+        games.Add(first);
+        games.Add(second);
+
+        Assert.Equal(3, tiles.Count);
+        Assert.True(tiles is IList { IsReadOnly: true });
+        Assert.Same(first, tiles[0]);
+        Assert.Same(second, tiles[1]);
+        Assert.Same(AddFolderTile.Instance, tiles[2]);
+    }
+
+    [Fact]
+    public void ForwardsGameChangesAtTheirOriginalIndices()
+    {
+        var games = new ObservableCollection<GameEntry>();
+        var tiles = new LibraryTileCollection(games);
+        NotifyCollectionChangedEventArgs? change = null;
+        tiles.CollectionChanged += (_, args) => change = args;
+
+        var game = CreateGame("Game");
+        games.Add(game);
+
+        Assert.NotNull(change);
+        Assert.Equal(NotifyCollectionChangedAction.Add, change.Action);
+        Assert.Equal(0, change.NewStartingIndex);
+        Assert.Same(game, Assert.Single(change.NewItems!.Cast<GameEntry>()));
+        Assert.Same(AddFolderTile.Instance, tiles[1]);
+    }
+
+    private static GameEntry CreateGame(string name) =>
+        new(name, null, null, $"/games/{name}/eboot.bin", 0, null, null);
+}


### PR DESCRIPTION
## Motivation

Part of #606

The current library uses a compact cover grid and passes the selected game information in a separate launch bar. In this PR i port the self-contained library part of the redesign while keeping the broader navigation, settings and application architecture outside its scope

## Changes

- Reworked the library into a horizontal cover rail
- Added hover and selection feedback for game tiles
- Added a persistent Add folder tile at the end of the library
- Moved the selected game title, title ID, version and size into a single details surface
- Removed bottom launch bar
- Combined launching and stopping into one stateful button
- Removed the loading popup and background blur shown while a game is running
- Added a close action to the embedded console panel
- Added tests for the library tile collection and Add folder tile placement (will be also needed in future after i decide about ReactiveUI and notifiers)

## Testing

- `dotnet build SharpEmu.slnx -c Release --no-restore`
- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release --no-build`
- Dreaming Sarah (PPSA02929). Checked horizontal tile selection, selected game metadata, launching, stopping, button state changes and the embedded console layout
- No emulator runtime or game compatibility code was changed

## Checklist

By submitting this pull request, I confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).