### PR TITLE
[Loader] Sample repeated import diagnostics instead of logging every …

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -34,8 +34,7 @@ public sealed partial class DirectExecutionBackend
 	private const ulong StackCheckGuardValue = 0xC0DEC0DECAFEBA00UL;
 	private static long _canaryReturnRecoveries;
 
-	private readonly object _importResultLogSampleGate = new();
-	private readonly Dictionary<string, int> _importResultLogSamples = new(StringComparer.Ordinal);
+	private readonly ImportLogSampler _importLogSampler = new();
 	private int _il2CppExceptionDiagnosticCount;
 
 	private static ulong ImportDispatchGatewayManaged(nint backendHandle, int importIndex, nint argPackPtr)
@@ -602,10 +601,19 @@ public sealed partial class DirectExecutionBackend
 				{
 					DumpIl2CppExceptionDiagnostic(cpuContext, value, num7);
 				}
-				Console.Error.WriteLine(
-					$"[LOADER][WARN] Import#{num} unresolved: nid={importStubEntry.Nid} ret=0x{num7:X16} " +
-					$"rdi=0x{value:X16} rsi=0x{value2:X16} rdx=0x{num3:X16} rcx=0x{num4:X16} r8=0x{num5:X16} r9=0x{num6:X16}");
-				if (importStubEntry.Nid == "L-Q3LEjIbgA")
+				// A title that polls an unresolved import retries with no backoff, so
+				// this warning fires once per attempt. Sample it: the head occurrences
+				// still name the missing NID and its arguments.
+				var logUnresolved = _logAllImportResults ||
+					_importLogSampler.ShouldLog(importStubEntry.Nid, UnresolvedImportDiscriminator);
+				if (logUnresolved)
+				{
+					Console.Error.WriteLine(
+						$"[LOADER][WARN] Import#{num} unresolved: nid={importStubEntry.Nid} ret=0x{num7:X16} " +
+						$"rdi=0x{value:X16} rsi=0x{value2:X16} rdx=0x{num3:X16} rcx=0x{num4:X16} r8=0x{num5:X16} r9=0x{num6:X16}");
+				}
+
+				if (logUnresolved && importStubEntry.Nid == "L-Q3LEjIbgA")
 				{
 					string value18 = string.Join(" ", importStubEntry.Nid.Select(delegate (char c)
 					{
@@ -1522,7 +1530,10 @@ public sealed partial class DirectExecutionBackend
 			!expectedPrivacyInvalidParameter &&
 			!expectedPlayGoChunkEnumerationEnd)
 		{
-			return true;
+			// Unexpected results used to log unconditionally. A failing import the
+			// title polls repeats without bound, so sample these as well rather than
+			// emitting one line per retry.
+			return _logAllImportResults || _importLogSampler.ShouldLog(nid, resultValue);
 		}
 
 		if (!ShouldLogExpectedImportResults())
@@ -1530,17 +1541,18 @@ public sealed partial class DirectExecutionBackend
 			return false;
 		}
 
-		var key = nid + "\0" + resultValue;
-		int count;
-		lock (_importResultLogSampleGate)
-		{
-			_importResultLogSamples.TryGetValue(key, out count);
-			count++;
-			_importResultLogSamples[key] = count;
-		}
-
-		return count <= 8 || count % 10000 == 0;
+		return _logAllImportResults || _importLogSampler.ShouldLog(nid, resultValue);
 	}
+
+	// Results are discriminated by their code; unresolved dispatches have no
+	// result, so they get a reserved slot that no real code occupies.
+	private const long UnresolvedImportDiscriminator = long.MinValue;
+
+	private static readonly bool _logAllImportResults =
+		string.Equals(
+			Environment.GetEnvironmentVariable("SHARPEMU_LOG_ALL_IMPORT_RESULTS"),
+			"1",
+			StringComparison.Ordinal);
 
 	private static bool ShouldLogExpectedImportResults() =>
 		string.Equals(

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -1181,10 +1181,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		_importLoopSignatureWriteIndex = 0;
 		_importLoopPatternHits = 0;
 		_importLoopPatternStartTimestamp = 0;
-		lock (_importResultLogSampleGate)
-		{
-			_importResultLogSamples.Clear();
-		}
+		_importLogSampler.Reset();
 		lock (_lazyCommitRangeGate)
 		{
 			_prtLazyCommitRanges.Clear();

--- a/src/SharpEmu.Core/Cpu/Native/ImportLogSampler.cs
+++ b/src/SharpEmu.Core/Cpu/Native/ImportLogSampler.cs
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System;
+using System.Collections.Generic;
+
+namespace SharpEmu.Core.Cpu.Native;
+
+/// <summary>
+/// Occurrence limiter for repeated import diagnostics.
+///
+/// A title that polls an unresolved or failing import retries as fast as the CPU
+/// allows, with no delay between attempts. An unsampled warning on that path turns
+/// every retry into a formatted string plus a synchronous stderr write, so the
+/// diagnostic itself becomes the dominant cost of the loop and buries the rest of
+/// the log.
+///
+/// Sampling keeps the occurrences that carry information — the first few, which
+/// identify what failed and with which arguments — plus a periodic heartbeat that
+/// still shows the loop is running and how far it has got.
+/// </summary>
+internal sealed class ImportLogSampler
+{
+    /// <summary>Occurrences always logged, before sampling begins.</summary>
+    private const long HeadOccurrences = 8;
+
+    /// <summary>After the head, log one occurrence every this many.</summary>
+    private const long SampleInterval = 10_000;
+
+    private readonly object _gate = new();
+
+    // Keyed by a value tuple rather than a composed string: the caller hits this
+    // on every retry, so building a key must not allocate.
+    private readonly Dictionary<(string Nid, long Discriminator), long> _occurrences = new();
+
+    /// <summary>
+    /// Records one occurrence and reports whether it should be logged.
+    /// <paramref name="discriminator"/> separates distinct outcomes for the same
+    /// NID (a result code, for example) so one noisy failure cannot mask another.
+    /// </summary>
+    internal bool ShouldLog(string nid, long discriminator)
+    {
+        // long, not int: the loop in #619 was observed past 73 million dispatches,
+        // which is within range of overflowing a 32-bit counter into negatives and
+        // silently disabling the head check.
+        long count;
+        lock (_gate)
+        {
+            var key = (nid, discriminator);
+            _occurrences.TryGetValue(key, out count);
+            count++;
+            _occurrences[key] = count;
+        }
+
+        return count <= HeadOccurrences || count % SampleInterval == 0;
+    }
+
+    /// <summary>Forgets every counter, so a fresh run logs its head occurrences again.</summary>
+    internal void Reset()
+    {
+        lock (_gate)
+        {
+            _occurrences.Clear();
+        }
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Cpu/ImportLogSamplerTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/ImportLogSamplerTests.cs
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Native;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+// A title polling an unresolved import retries with no backoff, so the import
+// dispatcher can see the same failure tens of millions of times. The sampler has to
+// stay informative on the occurrences that matter while dropping the rest, and it
+// must not lose one NID's diagnostics behind another's noise.
+public sealed class ImportLogSamplerTests
+{
+    private const long Nowhere = 0;
+
+    [Fact]
+    public void LogsTheFirstEightOccurrences()
+    {
+        var sampler = new ImportLogSampler();
+
+        for (var i = 1; i <= 8; i++)
+        {
+            Assert.True(sampler.ShouldLog("s9e3+YpRnzw", Nowhere), $"occurrence {i} should log");
+        }
+    }
+
+    [Fact]
+    public void SuppressesOccurrencesBetweenSamplePoints()
+    {
+        var sampler = new ImportLogSampler();
+        for (var i = 1; i <= 8; i++)
+        {
+            _ = sampler.ShouldLog("s9e3+YpRnzw", Nowhere);
+        }
+
+        for (var i = 9; i < 10_000; i++)
+        {
+            Assert.False(sampler.ShouldLog("s9e3+YpRnzw", Nowhere), $"occurrence {i} should be suppressed");
+        }
+    }
+
+    [Fact]
+    public void EmitsAPeriodicHeartbeatSoALiveLoopStaysVisible()
+    {
+        var sampler = new ImportLogSampler();
+        var logged = 0;
+
+        for (var i = 1; i <= 30_000; i++)
+        {
+            if (sampler.ShouldLog("s9e3+YpRnzw", Nowhere))
+            {
+                logged++;
+            }
+        }
+
+        // 8 head occurrences plus one every 10,000.
+        Assert.Equal(11, logged);
+    }
+
+    [Fact]
+    public void CountsEachNidIndependently()
+    {
+        var sampler = new ImportLogSampler();
+        for (var i = 1; i <= 50_000; i++)
+        {
+            _ = sampler.ShouldLog("s9e3+YpRnzw", Nowhere);
+        }
+
+        // A different NID failing for the first time must still be reported, however
+        // much noise the previous one produced.
+        Assert.True(sampler.ShouldLog("L-Q3LEjIbgA", Nowhere));
+    }
+
+    [Fact]
+    public void CountsEachDiscriminatorIndependently()
+    {
+        var sampler = new ImportLogSampler();
+        for (var i = 1; i <= 50_000; i++)
+        {
+            _ = sampler.ShouldLog("s9e3+YpRnzw", discriminator: -2135425020);
+        }
+
+        // Same import, different outcome: still worth reporting.
+        Assert.True(sampler.ShouldLog("s9e3+YpRnzw", discriminator: -2135425019));
+    }
+
+    [Fact]
+    public void ResetRestoresTheHeadOccurrences()
+    {
+        var sampler = new ImportLogSampler();
+        for (var i = 1; i <= 50_000; i++)
+        {
+            _ = sampler.ShouldLog("s9e3+YpRnzw", Nowhere);
+        }
+
+        Assert.False(sampler.ShouldLog("s9e3+YpRnzw", Nowhere));
+
+        sampler.Reset();
+
+        Assert.True(sampler.ShouldLog("s9e3+YpRnzw", Nowhere));
+    }
+}


### PR DESCRIPTION
Titles that call an unresolved import in a polling loop retry as fast as the CPU allows — no backoff. Two log sites on that path had no occurrence limit: the Import#N unresolved warning fired every attempt, and ShouldLogImportResult logged unconditionally for anything not on the expected-noise list (which is what #619 hit with sceSaveDataDialogInitialize). At that point the logging is the loop's cost — #619 shows the import counter past 73 million dispatches in one session.
Fix: both sites now go through a shared ImportLogSampler — first 8 occurrences, then one every 10,000. You still get the missing NID + args up front, and the periodic sample still shows the loop is alive and how far along it is. SHARPEMU_LOG_ALL_IMPORT_RESULTS=1 brings back the old unbounded output if you want it.
Sharing the counter also fixed two smaller issues: the old dedup key was a string (nid + "\0" + resultValue) built on every call even when discarded — sampler now keys on a value tuple, zero allocation. And the old counter was int, which at #619's dispatch counts is close enough to overflow that it'd wrap and start over-logging for ~2.1 billion iterations. Now long.
Rough numbers from 1M retries of one failing import (Release, redirected stream): before was ~275MB allocated and ~1M lines written; after is basically zero allocation and 108 lines. Extrapolated to #619's ~73M dispatches that's roughly 20GB of transient allocation from logging alone, against the 17GB→40.9GB growth reported there — not proof, but consistent enough to matter.
One trade-off: the tuple key is slower in raw CPU than the string key even including the old lock (roughly 2x), but it allocates nothing vs 114MB, and it only hits the opt-in SHARPEMU_LOG_EXPECTED_IMPORT_RESULTS=1 path, so I took the allocation win. Can revert if people want the string key back.
Scope: loader-level only, no game-specific behavior. Doesn't stop the retry storm itself — #619's ask for real backoff/rate-limiting on the dispatch still stands, I just didn't want to bundle a guest-timing change in with a logging fix.
Behavior change: unexpected import results are now sampled instead of logged every time. That's the point, but flagging it since it changes default output.
Testing: builds clean on .NET 10.0.103, full suite passes (774 tests / 0 failures, 710 in SharpEmu.Libs.Tests including 6 new ImportLogSampler tests — head occurrences, suppression between samples, periodic heartbeat, per-NID isolation, per-result isolation, reset). I have NOT run this against a real game — don't have one to test with.
Checklist:

[V] Read CONTRIBUTING.md
 [V] Tested changes (see above — no real-game testing done)
[V] Wrote this description myself
 [V] Listed tested game(s) — none