### PR TITLE
fix: Add Runtime="NET" to UsingTask to fix build error on .NET 10 SDK (update SharpEmu.HLE.csproj)

### DIFF
--- a/src/SharpEmu.HLE/SharpEmu.HLE.csproj
+++ b/src/SharpEmu.HLE/SharpEmu.HLE.csproj
@@ -38,6 +38,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
   </PropertyGroup>
 
   <UsingTask TaskName="SharpEmu.SourceGenerators.GenerateAerolibBinaryTask"
+             Runtime="NET"
              TaskFactory="TaskHostFactory"
              AssemblyFile="$(SharpEmuAerolibTaskAssembly)" />
 


### PR DESCRIPTION
I tried to run and build the project, but even before it could load, I received the MSB4061 error. To fix this, I added Runtime="NET" to the <UsingTask> tag inside SharpEmu.HLE.csproj.

It is needed because on Windows (using Visual Studio and .NET 10 SDK v10.0.302), MSBuild now requires the runtime to be explicitly specified when a custom task runs via TaskHostFactory. Without this change, the project simply fails to compile on newer SDK versions.

I tested the change locally in my Windows environment and the project compiles successfully. Another community member also verified it on SDK versions 10.0.103 and 10.0.302, confirming that builds pass and it doesn't break Linux.

Adding Runtime="NET" ensures compatibility across different .NET 10 SDK versions without affecting environments where the runtime is selected automatically.

## Testing

N/A

## Checklist

By submitting this pull request, you confirm that:

- [X] I have read and followed `CONTRIBUTING.md`.
- [X] I tested my changes or marked the testing section as `N/A`.
- [X] I wrote this pull request description myself and did not paste AI-generated explanations.
- [X] I listed the game(s) I tested (or marked the testing section as `N/A`).
