### PR TITLE
[GUI] Update window chrome controls

### DIFF
--- a/src/SharpEmu.GUI/App.axaml.cs
+++ b/src/SharpEmu.GUI/App.axaml.cs
@@ -18,6 +18,7 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            desktop.ShutdownMode = Avalonia.Controls.ShutdownMode.OnMainWindowClose;
             desktop.MainWindow = new MainWindow();
         }
 

--- a/src/SharpEmu.GUI/MainWindow.axaml
+++ b/src/SharpEmu.GUI/MainWindow.axaml
@@ -73,19 +73,23 @@ SPDX-License-Identifier: GPL-2.0-or-later
                 Classes="windowChrome"
                 ToolTip.Tip="Minimize"
                 AutomationProperties.Name="Minimize window">
-          <TextBlock Text="—" FontSize="16" />
+          <TextBlock Classes="materialSymbol compact windowChromeGlyph"
+                     Text="minimize" />
         </Button>
         <Button x:Name="MaximizeButton"
                 Classes="windowChrome"
                 ToolTip.Tip="Restore"
                 AutomationProperties.Name="Restore window">
-          <TextBlock x:Name="MaximizeGlyph" Text="❐" FontSize="13" />
+          <TextBlock x:Name="MaximizeGlyph"
+                     Classes="materialSymbol compact windowChromeGlyph"
+                     Text="filter_none" />
         </Button>
         <Button x:Name="CloseButton"
                 Classes="windowChrome windowClose"
                 ToolTip.Tip="Close"
                 AutomationProperties.Name="Close window">
-          <TextBlock Text="×" FontSize="20" />
+          <TextBlock Classes="materialSymbol windowChromeGlyph windowCloseGlyph"
+                     Text="close" />
         </Button>
       </StackPanel>
     </Grid>

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -165,8 +165,6 @@ public partial class MainWindow : Window
         ConsoleList.ItemsSource = _consoleLines;
         _consoleMirror = GuiConsoleMirror.Install((line, isError) =>
             _pendingLines.Enqueue((line, isError)));
-        Closed += (_, _) => _emulator?.Stop();
-
         _consoleFlushTimer = new DispatcherTimer
         {
             Interval = TimeSpan.FromMilliseconds(80),
@@ -297,7 +295,8 @@ public partial class MainWindow : Window
         CtxRemove.Click += (_, _) => RemoveSelectedFromLibrary();
 
         Opened += async (_, _) => await OnOpenedAsync();
-        Closing += (_, _) => OnWindowClosing();
+        Closing += (_, _) => BeginWindowClosing();
+        Closed += (_, _) => CompleteWindowClosing();
 
         SdlLauncherGamepad.EnsureStarted();
         _gamepadTimer = new DispatcherTimer
@@ -816,22 +815,44 @@ public partial class MainWindow : Window
         // still needs a preview hook for its own shortcuts.
     }
 
-    private void OnWindowClosing()
+    private void BeginWindowClosing()
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _isClosing = true;
         Interlocked.Increment(ref _libraryScanGeneration);
         Interlocked.Increment(ref _detailLoadGeneration);
-        _libraryWatcher.Dispose();
-        _settings.Save();
         _consoleFlushTimer.Stop();
         _gamepadTimer.Stop();
-        SdlLauncherGamepad.Shutdown();
-        _sndPreview.Stop();
-        _discord?.Dispose();
-        _consoleWindow?.Close();
-        _emulator?.Dispose();
-        _consoleMirror?.Dispose();
-        DropFileLog();
+    }
+
+    private void CompleteWindowClosing()
+    {
+        RunShutdownStep("library watcher", _libraryWatcher.Dispose);
+        RunShutdownStep("settings", _settings.Save);
+        RunShutdownStep("SDL gamepad", SdlLauncherGamepad.Shutdown);
+        RunShutdownStep("title music", _sndPreview.Stop);
+        RunShutdownStep("Discord Rich Presence", () => _discord?.Dispose());
+        RunShutdownStep("console window", () => _consoleWindow?.Close());
+        RunShutdownStep("emulator process", () => _emulator?.Dispose());
+        RunShutdownStep("console mirror", () => _consoleMirror?.Dispose());
+        RunShutdownStep("file log", DropFileLog);
+    }
+
+    private static void RunShutdownStep(string component, Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                $"[GUI][WARN] Failed to clean up {component}: {exception}");
+        }
     }
 
     private void OnTitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
@@ -868,13 +889,16 @@ public partial class MainWindow : Window
             return;
         }
 
-        var isMaximized = WindowState == WindowState.Maximized;
-        glyph.Text = isMaximized ? "❐" : "□";
-        ToolTip.SetTip(button, isMaximized ? "Restore" : "Maximize");
-        AutomationProperties.SetName(
-            button,
-            isMaximized ? "Restore window" : "Maximize window");
+        var state = GetMaximizeButtonState(WindowState);
+        glyph.Text = state.Glyph;
+        ToolTip.SetTip(button, state.ToolTip);
+        AutomationProperties.SetName(button, state.AutomationName);
     }
+
+    internal static WindowMaximizeButtonState GetMaximizeButtonState(WindowState windowState) =>
+        windowState == WindowState.Maximized
+            ? new("filter_none", "Restore", "Restore window")
+            : new("crop_square", "Maximize", "Maximize window");
 
     private void UpdateWindowChromeState()
     {

--- a/src/SharpEmu.GUI/Themes/Styles/Chrome.axaml
+++ b/src/SharpEmu.GUI/Themes/Styles/Chrome.axaml
@@ -19,6 +19,12 @@ Window chrome button sizing and interaction states.
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
   </Style>
+  <Style Selector="TextBlock.windowChromeGlyph">
+    <Setter Property="IsHitTestVisible" Value="False" />
+  </Style>
+  <Style Selector="TextBlock.windowCloseGlyph">
+    <Setter Property="Margin" Value="0,-1,0,1" />
+  </Style>
   <Style Selector="Button.windowChrome:pointerover /template/ ContentPresenter#PART_ContentPresenter">
     <Setter Property="Background" Value="{StaticResource ElevatedBrush}" />
     <Setter Property="Foreground" Value="{StaticResource TextBrush}" />

--- a/src/SharpEmu.GUI/WindowMaximizeButtonState.cs
+++ b/src/SharpEmu.GUI/WindowMaximizeButtonState.cs
@@ -1,0 +1,9 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.GUI;
+
+internal readonly record struct WindowMaximizeButtonState(
+    string Glyph,
+    string ToolTip,
+    string AutomationName);

--- a/tests/SharpEmu.Libs.Tests/GUI/WindowChromeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/GUI/WindowChromeTests.cs
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Avalonia.Controls;
+using SharpEmu.GUI;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.GUI;
+
+public sealed class WindowChromeTests
+{
+    [Theory]
+    [InlineData(WindowState.Normal, "crop_square", "Maximize", "Maximize window")]
+    [InlineData(WindowState.Maximized, "filter_none", "Restore", "Restore window")]
+    public void GetMaximizeButtonState_ReturnsConsistentVisualAndAccessibleState(
+        WindowState windowState,
+        string expectedGlyph,
+        string expectedToolTip,
+        string expectedAutomationName)
+    {
+        var state = MainWindow.GetMaximizeButtonState(windowState);
+
+        Assert.Equal(expectedGlyph, state.Glyph);
+        Assert.Equal(expectedToolTip, state.ToolTip);
+        Assert.Equal(expectedAutomationName, state.AutomationName);
+    }
+}


### PR DESCRIPTION
## Motivation

Part of #606

As mentioned in comment https://github.com/sharpemu/sharpemu/pull/699#issuecomment-5129349765 i was unable to reach the issue with window closure. So in addition to updating the visual style of the buttons, I also added an exit from the application's lifetime and cleaning after closing

## Summary

- Replace Unicode window controls with bundled Material Symbols
- Keep maximize and restore icons, tooltips, and accessibility names synchronized
- Exit the desktop lifetime when the main window closes
- Run platform-dependent cleanup after native window closure
- Isolate cleanup failures so they cannot interrupt application shutdown
- Add regression coverage for maximize and restore states

## Testing

- N/A, no game runtime behavior affected
- `dotnet build SharpEmu.slnx -c Release --no-restore`
- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release --no-build`
- Verified closing in normal and maximized states on Windows
- Verified closing the main window while SharpEmu Console is detached

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [x] I tested my changes or marked the testing section as `N/A`
- [x] I wrote this pull request description myself and did not paste AI-generated explanations
- [x] I listed the game(s) I tested or marked the testing section as `N/A`