### PR TITLE
ci: add Runtime="NET" to UsingTask for .NET 10 SDK compatibility

### DIFF
--- a/src/SharpEmu.HLE/SharpEmu.HLE.csproj
+++ b/src/SharpEmu.HLE/SharpEmu.HLE.csproj
@@ -43,6 +43,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
   <UsingTask TaskName="SharpEmu.SourceGenerators.GenerateAerolibBinaryTask"
              TaskFactory="TaskHostFactory"
+             Runtime="NET"
              AssemblyFile="$(SharpEmuAerolibTaskAssembly)" />
 
   <!-- Runs after ResolveProjectReferences (which builds the task assembly) and before


### PR DESCRIPTION
## Summary

Fixes #607 by selecting the .NET task-host runtime explicitly for the custom
`GenerateAerolibBinaryTask`. Newer .NET 10 SDK/MSBuild combinations can fail
before compilation when `TaskHostFactory` does not receive `Runtime="NET"`.

This is a one-line build-infrastructure change in
`src/SharpEmu.HLE/SharpEmu.HLE.csproj`; it does not change emulator runtime
behavior or generated catalog contents.

## Changes

- Add `Runtime="NET"` to the existing `UsingTask` declaration.
- Keep the current task assembly, target ordering, and design-time build guard
  unchanged.

## Testing

- Command: `dotnet build SharpEmu.slnx --no-restore -c Release`
- Result: success, 0 errors, 0 warnings in the fresh local run for commit
  `affd73fa2b62ba5250c9249d3731c7e7ee738c36`.
- No game testing is applicable to this MSBuild-only change.

## Related PR

Upstream PR #696 appears to make the same source change from another branch.
Maintainers should retain one implementation and close the duplicate before
merging.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
