### PR TITLE
fix: assign first NGS2 rack handle 0 for Dead Cells compatibility

### DIFF
--- a/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
+++ b/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
@@ -28,6 +28,7 @@ public static class Ngs2Exports
     // receive only the rack handle, so per-system IDs would collide here.
     // Keep them monotonic so a destroyed handle cannot alias a later rack.
     private static ulong _nextRackHandle;
+    private static bool _rackZeroBootstrapAvailable = true;
     private static long _renderCount;
 
     // NGS2 renders one grain of interleaved float32 per sceNgs2SystemRender.
@@ -185,6 +186,11 @@ public static class Ngs2Exports
             }
 
             _nextRackHandle++;
+            if (handle == 0)
+            {
+                _rackZeroBootstrapAvailable = false;
+            }
+
             Racks[handle] = new RackState(systemHandle, rackId);
         }
 
@@ -216,6 +222,10 @@ public static class Ngs2Exports
             }
 
             RemoveRackLocked(handle);
+            if (handle == 0)
+            {
+                _rackZeroBootstrapAvailable = false;
+            }
         }
 
         return SetReturn(ctx, 0);
@@ -233,7 +243,12 @@ public static class Ngs2Exports
         var outHandleAddress = ctx[CpuRegister.Rdx];
         lock (StateGate)
         {
-            if (!Racks.ContainsKey(rackHandle))
+            // Some titles request voices for rack zero before issuing the
+            // explicit rack-create call. Rack zero is the ABI's first-rack
+            // sentinel, so allow that bootstrap order while keeping every
+            // other unknown rack handle strict.
+            if (!Racks.ContainsKey(rackHandle) &&
+                (rackHandle != 0 || !_rackZeroBootstrapAvailable))
             {
                 return SetReturn(ctx, OrbisNgs2ErrorInvalidRackHandle);
             }
@@ -928,6 +943,7 @@ public static class Ngs2Exports
             Voices.Clear();
             _nextUid = 0;
             _nextRackHandle = 0;
+            _rackZeroBootstrapAvailable = true;
             _renderCount = 0;
         }
     }

--- a/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
+++ b/src/SharpEmu.Libs/Ngs2/Ngs2Exports.cs
@@ -24,6 +24,10 @@ public static class Ngs2Exports
     private static readonly Dictionary<ulong, RackState> Racks = new();
     private static readonly Dictionary<ulong, VoiceState> Voices = new();
     private static long _nextUid;
+    // Rack handles are small, globally unique IDs: the follow-up NGS2 APIs
+    // receive only the rack handle, so per-system IDs would collide here.
+    // Keep them monotonic so a destroyed handle cannot alias a later rack.
+    private static ulong _nextRackHandle;
     private static long _renderCount;
 
     // NGS2 renders one grain of interleaved float32 per sceNgs2SystemRender.
@@ -159,14 +163,28 @@ public static class Ngs2Exports
             return SetReturn(ctx, OrbisNgs2ErrorInvalidOutAddress);
         }
 
-        if (!TryCreateHandle(ctx, type: 2, systemHandle, out var handle) ||
-            !ctx.TryWriteUInt64(outHandleAddress, handle))
-        {
-            return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
-        }
-
         lock (StateGate)
         {
+            // The system could have been destroyed after the validation above.
+            if (!Systems.ContainsKey(systemHandle))
+            {
+                return SetReturn(ctx, OrbisNgs2ErrorInvalidSystemHandle);
+            }
+
+            // Reserve ulong.MaxValue as an exhaustion sentinel so the counter
+            // cannot wrap and alias a stale rack handle.
+            if (_nextRackHandle == ulong.MaxValue)
+            {
+                return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TRY_AGAIN);
+            }
+
+            var handle = _nextRackHandle;
+            if (!ctx.TryWriteUInt64(outHandleAddress, handle))
+            {
+                return SetReturn(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            }
+
+            _nextRackHandle++;
             Racks[handle] = new RackState(systemHandle, rackId);
         }
 
@@ -897,6 +915,20 @@ public static class Ngs2Exports
                      .ToArray())
         {
             Voices.Remove(voiceHandle);
+        }
+
+    }
+
+    internal static void ResetStateForTests()
+    {
+        lock (StateGate)
+        {
+            Systems.Clear();
+            Racks.Clear();
+            Voices.Clear();
+            _nextUid = 0;
+            _nextRackHandle = 0;
+            _renderCount = 0;
         }
     }
 

--- a/tests/SharpEmu.Libs.Tests/Ngs2/Ngs2ExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ngs2/Ngs2ExportsTests.cs
@@ -1,0 +1,133 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Memory;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Ngs2;
+using System.Reflection;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Ngs2;
+
+[CollectionDefinition("Ngs2State", DisableParallelization = true)]
+public sealed class Ngs2StateCollection;
+
+[Collection("Ngs2State")]
+public sealed class Ngs2ExportsTests : IDisposable
+{
+    private const int InvalidRackHandle = unchecked((int)0x804A0261);
+    private const int TryAgain = unchecked((int)0x80020023);
+
+    public Ngs2ExportsTests() => Ngs2Exports.ResetStateForTests();
+
+    public void Dispose() => Ngs2Exports.ResetStateForTests();
+
+    [Fact]
+    public void FirstRackUsesZeroHandleAndDoesNotReuseDestroyedHandles()
+    {
+        using var memory = new PhysicalVirtualMemory();
+        var context = new CpuContext(memory, Generation.Gen5);
+        var outputPage = memory.AllocateAt(0, 0x1000, executable: false);
+        Assert.NotEqual(0UL, outputPage);
+        var systemOut = outputPage + 0x100;
+        var rackOut = outputPage + 0x108;
+        var voiceOut = outputPage + 0x110;
+        var replacementRackOut = outputPage + 0x118;
+        var systemHandle = 0UL;
+
+        try
+        {
+            Assert.Equal(0, Ngs2Exports.Ngs2SystemCreateWithAllocator(Reg(context, rdx: systemOut)));
+            Assert.True(context.TryReadUInt64(systemOut, out systemHandle));
+            Assert.NotEqual(0UL, systemHandle);
+
+            Assert.Equal(
+                0,
+                Ngs2Exports.Ngs2RackCreateWithAllocator(
+                    Reg(context, rdi: systemHandle, rsi: 1, r8: rackOut)));
+            Assert.True(context.TryReadUInt64(rackOut, out var rackHandle));
+            Assert.Equal(0UL, rackHandle);
+
+            Assert.Equal(
+                0,
+                Ngs2Exports.Ngs2RackGetVoiceHandle(Reg(context, rdi: 0, rsi: 0, rdx: voiceOut)));
+            Assert.True(context.TryReadUInt64(voiceOut, out var voiceHandle));
+            Assert.NotEqual(0UL, voiceHandle);
+
+            Assert.Equal(0, Ngs2Exports.Ngs2RackDestroy(Reg(context, rdi: rackHandle)));
+            Assert.Equal(
+                0,
+                Ngs2Exports.Ngs2RackCreateWithAllocator(
+                    Reg(context, rdi: systemHandle, rsi: 2, r8: replacementRackOut)));
+            Assert.True(context.TryReadUInt64(replacementRackOut, out var replacementRackHandle));
+            Assert.NotEqual(rackHandle, replacementRackHandle);
+
+            Assert.Equal(
+                InvalidRackHandle,
+                Ngs2Exports.Ngs2RackGetVoiceHandle(
+                    Reg(context, rdi: rackHandle, rsi: 0, rdx: voiceOut)));
+        }
+        finally
+        {
+            if (systemHandle != 0)
+            {
+                Ngs2Exports.Ngs2SystemDestroy(Reg(context, rdi: systemHandle));
+            }
+        }
+    }
+
+    [Fact]
+    public void RackCreation_WhenHandleIdsAreExhausted_PreservesOutputAndRax()
+    {
+        using var memory = new PhysicalVirtualMemory();
+        var context = new CpuContext(memory, Generation.Gen5);
+        var outputPage = memory.AllocateAt(0, 0x1000, executable: false);
+        Assert.NotEqual(0UL, outputPage);
+        var systemOut = outputPage + 0x100;
+        var rackOut = outputPage + 0x108;
+        var systemHandle = 0UL;
+        const ulong sentinel = 0xDEADBEEFDEADBEEFUL;
+
+        try
+        {
+            Assert.Equal(0, Ngs2Exports.Ngs2SystemCreateWithAllocator(Reg(context, rdx: systemOut)));
+            Assert.True(context.TryReadUInt64(systemOut, out systemHandle));
+            Assert.True(context.TryWriteUInt64(rackOut, sentinel));
+
+            var nextRackHandle = typeof(Ngs2Exports).GetField(
+                "_nextRackHandle",
+                BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(nextRackHandle);
+            nextRackHandle.SetValue(null, ulong.MaxValue);
+
+            Assert.Equal(
+                TryAgain,
+                Ngs2Exports.Ngs2RackCreateWithAllocator(
+                    Reg(context, rdi: systemHandle, rsi: 1, r8: rackOut)));
+            Assert.True(context.TryReadUInt64(rackOut, out var output));
+            Assert.Equal(sentinel, output);
+            Assert.Equal(unchecked((ulong)TryAgain), context[CpuRegister.Rax]);
+        }
+        finally
+        {
+            if (systemHandle != 0)
+            {
+                Ngs2Exports.Ngs2SystemDestroy(Reg(context, rdi: systemHandle));
+            }
+        }
+    }
+
+    private static CpuContext Reg(
+        CpuContext context,
+        ulong rdi = 0,
+        ulong rsi = 0,
+        ulong rdx = 0,
+        ulong r8 = 0)
+    {
+        context[CpuRegister.Rdi] = rdi;
+        context[CpuRegister.Rsi] = rsi;
+        context[CpuRegister.Rdx] = rdx;
+        context[CpuRegister.R8] = r8;
+        return context;
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Ngs2/Ngs2ExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ngs2/Ngs2ExportsTests.cs
@@ -77,6 +77,23 @@ public sealed class Ngs2ExportsTests : IDisposable
     }
 
     [Fact]
+    public void VoiceRequestForZeroRackBeforeExplicitRackCreationIsAccepted()
+    {
+        using var memory = new PhysicalVirtualMemory();
+        var context = new CpuContext(memory, Generation.Gen5);
+        var outputPage = memory.AllocateAt(0, 0x1000, executable: false);
+        Assert.NotEqual(0UL, outputPage);
+        var voiceOut = outputPage + 0x110;
+
+        Assert.Equal(
+            0,
+            Ngs2Exports.Ngs2RackGetVoiceHandle(
+                Reg(context, rdi: 0, rsi: 0, rdx: voiceOut)));
+        Assert.True(context.TryReadUInt64(voiceOut, out var voiceHandle));
+        Assert.NotEqual(0UL, voiceHandle);
+    }
+
+    [Fact]
     public void RackCreation_WhenHandleIdsAreExhausted_PreservesOutputAndRax()
     {
         using var memory = new PhysicalVirtualMemory();


### PR DESCRIPTION
## Summary

Fixes #259 by accepting rack handle `0` for the first NGS2 rack, matching the
handle passed by Dead Cells to `sceNgs2RackGetVoiceHandle`.

## Changes

- Allocate small, globally monotonic rack handles starting at `0`.
- Accept the issue-reported bootstrap order where a title requests a voice for
  rack zero before the explicit rack-create call.
- Revalidate the owning system while holding `StateGate` before inserting the
  rack, so a concurrent system destroy cannot leave an orphaned rack.
- Disable the bootstrap exception once rack zero is explicitly created or
  destroyed, so a stale zero handle is still rejected.
- Reserve `ulong.MaxValue` as an exhaustion sentinel and return
  `ORBIS_GEN2_ERROR_TRY_AGAIN` without modifying the output buffer.
- Add serialized-state tests for pre-created rack-zero voice requests,
  first-handle compatibility, stale-handle rejection after destroy, and
  exhaustion behavior.

## Testing

- Command: `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj --no-restore -c Release --verbosity minimal`
- Result: 707/707 tests passed, 0 failed for commit
  `8e8aa753fb8fb8f4e95ed80e327fb2db88ddd516`.
- `git diff --check` is clean.
- No live Dead Cells run was performed in this environment; the issue's
  `rdi=0` call shape is covered directly by the NGS2 contract test.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
