### PR TITLE
perf: cache missing HLE export error message in ImportStubEntry

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -592,7 +592,7 @@ public sealed partial class DirectExecutionBackend
 			}
 			if (!dispatchResolved)
 			{
-				LastError = "Missing HLE export for NID: " + importStubEntry.Nid;
+				LastError = importStubEntry.MissingHleExportError;
 				if (string.Equals(importStubEntry.Nid, "cfwBSQyr5Ys", StringComparison.Ordinal) &&
 					string.Equals(
 						Environment.GetEnvironmentVariable("SHARPEMU_LOG_IL2CPP_EXCEPTION"),

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -43,6 +43,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 		public string Nid { get; }
 
+		// Missing imports can be polled millions of times; build this while
+		// setting up the stub instead of concatenating a new error per dispatch.
+		public string MissingHleExportError { get; }
+
 		public ExportedFunction? Export { get; }
 
 		// Precomputed per-import classification: DispatchImport runs for
@@ -70,6 +74,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		{
 			Address = address;
 			Nid = nid;
+			MissingHleExportError = "Missing HLE export for NID: " + nid;
 			Export = export;
 			IsLeaf = isLeaf;
 			IsNoBlockLeaf = isNoBlockLeaf;

--- a/tests/SharpEmu.Libs.Tests/Cpu/ImportStubEntryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/ImportStubEntryTests.cs
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Native;
+using System.Reflection;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+public sealed class ImportStubEntryTests
+{
+    private const string MissingNid = "s9e3+YpRnzw";
+
+    [Fact]
+    public void PrecomputesTheMissingExportErrorMessage()
+    {
+        var entryType = typeof(DirectExecutionBackend).GetNestedType(
+            "ImportStubEntry",
+            BindingFlags.NonPublic);
+        Assert.NotNull(entryType);
+
+        var missingExportError = entryType.GetProperty(
+            "MissingHleExportError",
+            BindingFlags.Instance | BindingFlags.Public);
+        Assert.NotNull(missingExportError);
+
+        var constructor = Assert.Single(entryType.GetConstructors(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+        var entry = constructor.Invoke([0UL, MissingNid, null, false, false, false, false, 0UL]);
+
+        var first = (string?)missingExportError.GetValue(entry);
+        var second = (string?)missingExportError.GetValue(entry);
+
+        Assert.Equal($"Missing HLE export for NID: {MissingNid}", first);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void DispatchImport_UsesTheCachedMissingExportError()
+    {
+        var dispatchImport = typeof(DirectExecutionBackend).GetMethod(
+            "DispatchImport",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(dispatchImport);
+
+        Assert.Contains("get_MissingHleExportError", ResolveCallees(dispatchImport));
+    }
+
+    private static HashSet<string> ResolveCallees(MethodBase method)
+    {
+        var il = method.GetMethodBody()?.GetILAsByteArray();
+        Assert.NotNull(il);
+
+        var module = method.Module;
+        var generic = method.DeclaringType?.GetGenericArguments();
+        var callees = new HashSet<string>(StringComparer.Ordinal);
+
+        for (var i = 0; i + 4 < il.Length; i++)
+        {
+            if (il[i] is not (0x28 or 0x6F))
+            {
+                continue;
+            }
+
+            var token = BitConverter.ToInt32(il, i + 1);
+            try
+            {
+                var callee = module.ResolveMethod(token, generic, null);
+                if (callee?.Name is { } name)
+                {
+                    callees.Add(name);
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        return callees;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the allocation hotspot described in #619 by caching the unresolved HLE
export error string in each `ImportStubEntry`. A missing import can be retried
millions of times, so building the same message inside `DispatchImport` adds a
new string allocation on every retry.

This is a focused allocation reduction. It does not implement import backoff,
rate limiting, or the missing SaveDataDialog export; those remain separate
follow-up work. The per-attempt unresolved-import warning still has formatting
work of its own, so this PR should not be presented as a complete memory-growth
fix for #619.

## Changes

- Add `MissingHleExportError` to the import-stub value and initialize it once
  when the stub is created.
- Reuse the cached string when `DispatchImport` reports an unresolved export.
- Add tests for the cached value identity and for the dispatch method's use of
  the cached property.

## Testing

- Command: `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj --no-restore -c Release --verbosity minimal`
- Result: 706/706 tests passed, 0 failed for commit
  `6a0ce567b8f5aecd4160edc4d267522cbbb09ca7`.
- `git diff --check` is clean.
- No game testing is applicable to this allocation-focused change.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
