### PR TITLE
Required imports for Astro Bot

### DIFF
--- a/src/SharpEmu.Libs/Json/JsonExports.cs
+++ b/src/SharpEmu.Libs/Json/JsonExports.cs
@@ -345,7 +345,7 @@ public static class JsonExports
 
         var child = parent.ValueKind == System.Text.Json.JsonValueKind.Object &&
                     parent.TryGetProperty(keyState.Value, out var property)
-                    ? property : _nullElement;
+                    ? property.Clone() : _nullElement;
 
         StoreValue(ctx, childAddress, child);
 

--- a/src/SharpEmu.Libs/Json/JsonExports.cs
+++ b/src/SharpEmu.Libs/Json/JsonExports.cs
@@ -324,6 +324,37 @@ public static class JsonExports
     }
 
     [SysAbiExport(
+        Nid = "wLsJlmgEIaI",
+        ExportName = "_ZN3sce4Json5Value10referValueERKNS0_6StringE",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceJson")]
+    public static int ValueReferValue(CpuContext ctx)
+    {
+        var thisAddress = ctx[CpuRegister.Rdi];
+        var keyStringAddress = ctx[CpuRegister.Rsi];
+
+        if (thisAddress == 0 ||
+            !_strings.TryGetValue(keyStringAddress, out var keyState) ||
+            !TryAllocateGuestObject(ctx, ValueObjectSize, out var childAddress))
+        {
+            ctx[CpuRegister.Rax] = 0;
+            return 0;
+        }
+
+        var parent = GetValue(thisAddress);
+
+        var child = parent.ValueKind == System.Text.Json.JsonValueKind.Object &&
+                    parent.TryGetProperty(keyState.Value, out var property)
+                    ? property : _nullElement;
+
+        StoreValue(ctx, childAddress, child);
+
+        ctx[CpuRegister.Rax] = childAddress;
+        TraceJsonText("Value.referValue", thisAddress, keyState.Value);
+        return 0;
+    }
+
+    [SysAbiExport(
         Nid = "zTwZdI8AZ5Y",
         ExportName = "_ZNK3sce4Json5Value10getBooleanEv",
         Target = Generation.Gen4 | Generation.Gen5,

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -3529,6 +3529,33 @@ public static partial class KernelMemoryCompatExports
     }
 
     [SysAbiExport(
+        Nid = "mkgXxsoxWHg",
+        ExportName = "sceKernelClearVirtualRangeName",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int KernelClearVirtualRangeName(CpuContext ctx)
+    {
+        var address = ctx[CpuRegister.Rdi];
+        var length = ctx[CpuRegister.Rsi];
+
+        lock (_memoryGate)
+        {
+            if (!TryFindVirtualQueryRegionLocked(address, findNext: false, out var region) ||
+                length > region.Length ||
+                address < region.Address ||
+                length > region.Address + region.Length - address)
+            {
+                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+            }
+
+            _mappedRegionNames.Remove(region.Address);
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
         Nid = "rVjRvHJ0X6c",
         ExportName = "sceKernelVirtualQuery",
         Target = Generation.Gen4 | Generation.Gen5,


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Summary
- Implemented `sceKernelClearVirtualRangeName` as an inverse of SetVirtualRangeName that removes an address from _mappedRegionNames.
- Added a stub import for `sce::Json::Value::referValue` functionally similar to ValueIndexCString but made to handle JsonStringState indexes. Gets the game past assertion `v.getType() == sce::Json::kValueTypeBoolean` and into the title screen.

The referValue implementation may not be fully accurate behavior, if it is undesired it can be removed from the PR.

## Testing
- ASTRO BOT (PPSA21564 v01.007.000) – Boots to title screen, no graphics but music can be heard.

https://github.com/user-attachments/assets/d8334f2b-38f1-41fe-959d-da834e8d8707

## Checklist

By submitting this pull request, you confirm that:

- [X] I have read and followed `CONTRIBUTING.md`.
- [X] I tested my changes or marked the testing section as `N/A`.
- [X] I wrote this pull request description myself and did not paste AI-generated explanations.
- [X] I listed the game(s) I tested (or marked the testing section as `N/A`).
