### PR TITLE
Vulkan: enable textureCompressionBC when supported

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -4131,6 +4131,7 @@ internal static unsafe class VulkanVideoPresenter
                 ShaderStorageImageExtendedFormats = supportedFeatures.ShaderStorageImageExtendedFormats,
                 ShaderStorageImageReadWithoutFormat = supportedFeatures.ShaderStorageImageReadWithoutFormat,
                 ShaderStorageImageWriteWithoutFormat = supportedFeatures.ShaderStorageImageWriteWithoutFormat,
+                TextureCompressionBC = supportedFeatures.TextureCompressionBC,
                 RobustBufferAccess = supportedFeatures.RobustBufferAccess,
             };
 
@@ -4168,6 +4169,13 @@ internal static unsafe class VulkanVideoPresenter
                 Console.Error.WriteLine(
                     "[LOADER][WARN] GPU does not support shaderStorageImage(Read|Write)WithoutFormat " +
                     "translated shaders using unformatted storage image load/store will fail.");
+            }
+
+            if (!supportedFeatures.TextureCompressionBC)
+            {
+                Console.Error.WriteLine(
+                    "[LOADER][WARN] GPU does not support textureCompressionBC " +
+                    "guest BC1-BC7 textures cannot be sampled directly.");
             }
 
             var maintenance8Features = new PhysicalDeviceMaintenance8FeaturesKHR


### PR DESCRIPTION
## Summary
- Request textureCompressionBC on device create when the GPU supports it
- Warn when BC sampling is unavailable

## Test plan
- [ ] Confirm device features include TextureCompressionBC on BC-capable GPUs
- [ ] Sample a guest BC1–BC7 texture without format fallback errors