### PR TITLE
fix(agc, dialogs): register offsets, dropped draws, and two stuck dia…

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -95,8 +95,10 @@ public static partial class AgcExports
     private const uint SpiShaderPgmRsrc1Hs = 0x10A;
     private const uint SpiShaderPgmLoLs = 0x148;
     private const uint SpiShaderPgmHiLs = 0x149;
-    private const uint SpiShaderPgmLoGs = 0x8A;
-    private const uint SpiShaderPgmHiGs = 0x8B;
+    // Not 0x8A/0x8B - those are SPI_SHADER_PGM_RSRC1/RSRC2_GS, and reading them
+    // as an address yields a 58-bit value (observed live: 0x30004622C008300).
+    private const uint SpiShaderPgmLoGs = 0x88;
+    private const uint SpiShaderPgmHiGs = 0x89;
     private const uint SpiShaderPgmChksumGs = 0x80;
     private const uint SpiPsInputEna = 0x1B3;
     private const uint SpiPsInputAddr = 0x1B4;
@@ -2171,6 +2173,18 @@ public static partial class AgcExports
     public static int DcbDrawIndexIndirectGetSize(CpuContext ctx)
     {
         ctx[CpuRegister.Rax] = 5u * sizeof(uint);
+        return (int)ctx[CpuRegister.Rax];
+    }
+
+    [SysAbiExport(
+        Nid = "r98I08t+LOg",
+        ExportName = "sceAgcDcbDrawIndexIndirectMultiGetSize",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int DcbDrawIndexIndirectMultiGetSize(CpuContext ctx)
+    {
+        // Eight, matching the packet DcbDrawIndexIndirectMulti emits.
+        ctx[CpuRegister.Rax] = 8u * sizeof(uint);
         return (int)ctx[CpuRegister.Rax];
     }
 
@@ -6427,6 +6441,48 @@ public static partial class AgcExports
     }
 
     /// <summary>
+    /// Test-only view of a parsed graphics context register. False when the
+    /// register was never written.
+    /// </summary>
+    internal static bool TryGetGraphicsContextRegisterForTests(
+        CpuContext ctx,
+        uint registerOffset,
+        out uint value)
+    {
+        value = 0;
+        if (!_submittedGpuStates.TryGetValue(ctx.Memory, out var gpuState))
+        {
+            return false;
+        }
+
+        lock (gpuState.Gate)
+        {
+            return gpuState.Graphics.CxRegisters.TryGetValue(registerOffset, out value);
+        }
+    }
+
+    /// <summary>
+    /// SH-register counterpart of <see cref="TryGetGraphicsContextRegisterForTests"/>;
+    /// the shader stage addresses live here.
+    /// </summary>
+    internal static bool TryGetGraphicsShRegisterForTests(
+        CpuContext ctx,
+        uint registerOffset,
+        out uint value)
+    {
+        value = 0;
+        if (!_submittedGpuStates.TryGetValue(ctx.Memory, out var gpuState))
+        {
+            return false;
+        }
+
+        lock (gpuState.Gate)
+        {
+            return gpuState.Graphics.ShRegisters.TryGetValue(registerOffset, out value);
+        }
+    }
+
+    /// <summary>
     /// GraphicsDcbSetIndexSize writes VGT_INDEX_TYPE via SET_UCONFIG_REG.
     /// Mirror that into <see cref="SubmittedDcbState.IndexSize"/>.
     /// </summary>
@@ -7444,22 +7500,6 @@ public static partial class AgcExports
             }
         }
 
-        state.UcRegisters.TryGetValue(VgtPrimitiveType, out var earlyPrimitiveType);
-        if (IsRectListPrimitive(earlyPrimitiveType) &&
-            (exportEvaluation.VertexInputs is null || exportEvaluation.VertexInputs.Count == 0) &&
-            !VertexProgramExportsParameters(exportState.Program) &&
-            GetInterpolatedAttributeCount(pixelState) != 0)
-        {
-            ReturnPooledEvaluationArrays(exportEvaluation);
-            ReturnPooledEvaluationArrays(pixelEvaluation);
-            error =
-                $"rect-list-no-param-exports ps_inputs={GetInterpolatedAttributeCount(pixelState)}";
-            TraceAgcShader(
-                $"agc.rect_list_skip es=0x{exportShaderAddress:X16} " +
-                $"ps=0x{pixelShaderAddress:X16} {error}");
-            return false;
-        }
-
         // Every bound color target the shader exports to. Deferred renderers
         // draw a multi-render-target G-buffer (up to eight slots) in one pass.
         // Fall back to slot 0 if we cannot match any export to a bound target.
@@ -8235,20 +8275,6 @@ public static partial class AgcExports
         target < ColorTargetCount
             ? (packedMasks >> (int)(target * 4)) & 0xFu
             : 0;
-
-    private static bool VertexProgramExportsParameters(Gen5ShaderProgram program)
-    {
-        foreach (var instruction in program.Instructions)
-        {
-            if (instruction.Control is Gen5ExportControl export &&
-                export.Target is >= 32 and < 64)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 
     private static uint GetInterpolatedAttributeCount(Gen5ShaderState state)
     {
@@ -12672,9 +12698,6 @@ public static partial class AgcExports
 
     private static bool IsEsGeometryShaderType(byte shaderType) =>
         shaderType is GsShaderType or GsBackShaderType;
-
-    private static bool IsRectListPrimitive(uint primitiveType) =>
-        AgcPrimitiveHelpers.IsRectListPrimitive(primitiveType);
 
     private static int SetIndirectPatchAddress(CpuContext ctx, string registerSpace)
     {

--- a/src/SharpEmu.Libs/Ime/ImeDialogExports.cs
+++ b/src/SharpEmu.Libs/Ime/ImeDialogExports.cs
@@ -1,13 +1,17 @@
-// Copyright (C) 2026 SharpEmu Emulator Project
+﻿// Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-using System;
+using SharpEmu.HLE;
 using System.Buffers.Binary;
 using System.Text;
-using SharpEmu.HLE;
+using System.Threading;
 
 namespace SharpEmu.Libs.Ime;
 
+/// <summary>
+/// libSceImeDialog: the on-screen keyboard for free-text entry. There is no host overlay
+/// to type into, so the dialog completes immediately with text from ResolveText.
+/// </summary>
 public static class ImeDialogExports
 {
     private const int StatusNone = 0;
@@ -15,16 +19,55 @@ public static class ImeDialogExports
     private const int StatusFinished = 2;
 
     private const int EndStatusOk = 0;
+    private const int EndStatusUserCanceled = 1;
+    private const int EndStatusAborted = 2;
 
-    private const ulong ParamMaxTextLengthOffset = 0x24;
-    private const ulong ParamInputTextBufferOffset = 0x28;
+    private const int ErrorOk = 0;
+    private const int ErrorInvalidAddress = unchecked((int)0x80BC1001);
+    private const int ErrorInvalidParam = unchecked((int)0x80BC1002);
+    private const int ErrorNotOpened = unchecked((int)0x80BC1003);
+    private const int ErrorNotFinished = unchecked((int)0x80BC1004);
+    private const int ErrorBusy = unchecked((int)0x80BC1005);
 
-    private const int ImeDialogErrorInvalidAddress = unchecked((int)0x80BC0001);
+    // OrbisImeDialogParam. Only the fields deciding where the text goes are read.
+    private const int ParamSize = 0x60;
+    private const int ParamMaxTextLengthOffset = 0x24;
+    private const int ParamInputTextBufferOffset = 0x28;
 
-    private const string DefaultInputText = "Sharp";
+    // Caps the stack buffer below against a garbage maxTextLength.
+    private const int MaxSupportedTextLength = 1024;
 
-    private static readonly object _gate = new();
-    private static int _status = StatusNone;
+    private const string DefaultText = "SharpEmu";
+
+    private static int _status;
+    private static int _endStatus;
+
+    [SysAbiExport(
+        Nid = "aAx4WY4uwLc",
+        ExportName = "sceImeDialogParamInit",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceImeDialog")]
+    public static int ImeDialogParamInit(CpuContext ctx)
+    {
+        var paramAddress = ctx[CpuRegister.Rdi];
+        if (paramAddress == 0)
+        {
+            return ctx.SetReturn(ErrorInvalidAddress);
+        }
+
+        // Zeroes the whole struct, as the real entry point does. Safe only because the
+        // caller must have reserved ParamSize to hand the same struct to Init.
+        Span<byte> zeroed = stackalloc byte[ParamSize];
+        zeroed.Clear();
+        if (!ctx.Memory.TryWrite(paramAddress, zeroed))
+        {
+            Trace($"param_init param=0x{paramAddress:X12} FAILED (unwritable)");
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        Trace($"param_init param=0x{paramAddress:X12}");
+        return ctx.SetReturn(ErrorOk);
+    }
 
     [SysAbiExport(
         Nid = "NUeBrN7hzf0",
@@ -33,20 +76,70 @@ public static class ImeDialogExports
         LibraryName = "libSceImeDialog")]
     public static int ImeDialogInit(CpuContext ctx)
     {
-        var parameterAddress = ctx[CpuRegister.Rdi];
-        if (parameterAddress == 0)
+        var paramAddress = ctx[CpuRegister.Rdi];
+        if (paramAddress == 0)
         {
-            return SetReturn(ctx, ImeDialogErrorInvalidAddress);
+            Trace("init REJECTED: null param");
+            return ctx.SetReturn(ErrorInvalidAddress);
         }
 
-        TryWriteInputText(ctx, parameterAddress);
-
-        lock (_gate)
+        if (Volatile.Read(ref _status) == StatusRunning)
         {
-            _status = StatusFinished;
+            Trace($"init REJECTED: busy, a dialog is already running (param=0x{paramAddress:X12})");
+            return ctx.SetReturn(ErrorBusy);
         }
 
-        return SetReturn(ctx, 0);
+        Span<byte> param = stackalloc byte[ParamSize];
+        if (!ctx.Memory.TryRead(paramAddress, param))
+        {
+            Trace($"init REJECTED: param=0x{paramAddress:X12} unreadable for {ParamSize} bytes");
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        Trace($"init param=0x{paramAddress:X12}");
+
+        var maxTextLength = BinaryPrimitives.ReadUInt32LittleEndian(param[ParamMaxTextLengthOffset..]);
+        var textBuffer = BinaryPrimitives.ReadUInt64LittleEndian(param[ParamInputTextBufferOffset..]);
+        if (textBuffer == 0)
+        {
+            Trace($"init REJECTED: inputTextBuffer at +0x{ParamInputTextBufferOffset:X2} is null - offsets are probably wrong for this title");
+            return ctx.SetReturn(ErrorInvalidParam);
+        }
+
+        // Titles read the committed text out of this buffer - GetResult reports only how
+        // the dialog ended - so it has to land here before the first status poll can
+        // report FINISHED. The terminator is reserved inside maxTextLength rather than
+        // written past it: whether the field counts the null is unverifiable here, and
+        // guessing wrong overruns a caller's local by one wide character.
+        var limit = (int)Math.Min(maxTextLength, MaxSupportedTextLength);
+        if (limit == 0)
+        {
+            Trace($"init REJECTED: maxTextLength at +0x{ParamMaxTextLengthOffset:X2} is zero - offsets are probably wrong for this title");
+            return ctx.SetReturn(ErrorInvalidParam);
+        }
+
+        var capacity = limit - 1;
+        var text = ResolveText();
+        if (text.Length > capacity)
+        {
+            text = text[..capacity];
+        }
+
+        // Guest wchar_t is 16-bit; the field is UTF-16LE and null-terminated.
+        Span<byte> encoded = stackalloc byte[(text.Length + 1) * sizeof(char)];
+        Encoding.Unicode.GetBytes(text, encoded);
+        encoded[^2..].Clear();
+
+        if (!ctx.Memory.TryWrite(textBuffer, encoded))
+        {
+            Trace($"init REJECTED: inputTextBuffer=0x{textBuffer:X12} unwritable for {encoded.Length} bytes - offsets are probably wrong for this title");
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        Volatile.Write(ref _endStatus, EndStatusOk);
+        Volatile.Write(ref _status, StatusRunning);
+        Trace($"init text='{text}' buffer=0x{textBuffer:X16} max={maxTextLength}");
+        return ctx.SetReturn(ErrorOk);
     }
 
     [SysAbiExport(
@@ -56,14 +149,16 @@ public static class ImeDialogExports
         LibraryName = "libSceImeDialog")]
     public static int ImeDialogGetStatus(CpuContext ctx)
     {
-        int status;
-        lock (_gate)
+        // Nothing can dismiss the dialog from the host side, so the first poll after Init
+        // observes it as already committed. Titles spin until it leaves RUNNING.
+        var previous = Interlocked.CompareExchange(ref _status, StatusFinished, StatusRunning);
+        var current = Volatile.Read(ref _status);
+        if (previous != current)
         {
-            status = _status;
+            Trace($"get_status {previous} -> {current}");
         }
 
-        ctx[CpuRegister.Rax] = unchecked((ulong)(long)status);
-        return status;
+        return ctx.SetReturn(current);
     }
 
     [SysAbiExport(
@@ -76,15 +171,27 @@ public static class ImeDialogExports
         var resultAddress = ctx[CpuRegister.Rdi];
         if (resultAddress == 0)
         {
-            return SetReturn(ctx, ImeDialogErrorInvalidAddress);
+            return ctx.SetReturn(ErrorInvalidAddress);
         }
 
-        Span<byte> result = stackalloc byte[8];
-        result.Clear();
-        BinaryPrimitives.WriteInt32LittleEndian(result, EndStatusOk);
-        ctx.Memory.TryWrite(resultAddress, result);
+        if (Volatile.Read(ref _status) != StatusFinished)
+        {
+            Trace($"get_result REJECTED: not finished (status={Volatile.Read(ref _status)})");
+            return ctx.SetReturn(ErrorNotFinished);
+        }
 
-        return SetReturn(ctx, 0);
+        // Only endStatus is written. Callers read that and the text buffer, never the
+        // reserved tail of OrbisImeDialogResult, and titles pass this a stack local -
+        // zeroing a tail whose size we cannot verify smashed a frame once already.
+        Span<byte> endStatus = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32LittleEndian(endStatus, Volatile.Read(ref _endStatus));
+        if (!ctx.Memory.TryWrite(resultAddress, endStatus))
+        {
+            return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        Trace($"get_result end_status={Volatile.Read(ref _endStatus)}");
+        return ctx.SetReturn(ErrorOk);
     }
 
     [SysAbiExport(
@@ -92,15 +199,14 @@ public static class ImeDialogExports
         ExportName = "sceImeDialogAbort",
         Target = Generation.Gen4 | Generation.Gen5,
         LibraryName = "libSceImeDialog")]
-    public static int ImeDialogAbort(CpuContext ctx)
-    {
-        lock (_gate)
-        {
-            _status = StatusFinished;
-        }
+    public static int ImeDialogAbort(CpuContext ctx) => Close(ctx, EndStatusAborted);
 
-        return SetReturn(ctx, 0);
-    }
+    [SysAbiExport(
+        Nid = "bX4H+sxPI-o",
+        ExportName = "sceImeDialogForceClose",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceImeDialog")]
+    public static int ImeDialogForceClose(CpuContext ctx) => Close(ctx, EndStatusUserCanceled);
 
     [SysAbiExport(
         Nid = "gyTyVn+bXMw",
@@ -109,67 +215,55 @@ public static class ImeDialogExports
         LibraryName = "libSceImeDialog")]
     public static int ImeDialogTerm(CpuContext ctx)
     {
-        lock (_gate)
+        if (Interlocked.Exchange(ref _status, StatusNone) == StatusNone)
         {
-            _status = StatusNone;
+            return ctx.SetReturn(ErrorNotOpened);
         }
 
-        return SetReturn(ctx, 0);
+        Trace("term");
+        return ctx.SetReturn(ErrorOk);
     }
 
-    private static void TryWriteInputText(CpuContext ctx, ulong parameterAddress)
+    private static int Close(CpuContext ctx, int endStatus)
     {
-        Span<byte> field = stackalloc byte[8];
-        if (!ctx.Memory.TryRead(parameterAddress + ParamInputTextBufferOffset, field))
+        if (Interlocked.CompareExchange(ref _status, StatusFinished, StatusRunning) != StatusRunning)
+        {
+            return ctx.SetReturn(ErrorNotOpened);
+        }
+
+        Volatile.Write(ref _endStatus, endStatus);
+        Trace($"close end_status={endStatus}");
+        return ctx.SetReturn(ErrorOk);
+    }
+
+    /// <summary>The text every IME dialog commits. SHARPEMU_IME_TEXT overrides it.</summary>
+    private static string ResolveText()
+    {
+        var configured = Environment.GetEnvironmentVariable("SHARPEMU_IME_TEXT");
+        return string.IsNullOrEmpty(configured) ? DefaultText : configured;
+    }
+
+    internal static void ResetForTests()
+    {
+        Volatile.Write(ref _status, StatusNone);
+        Volatile.Write(ref _endStatus, EndStatusOk);
+    }
+
+    /// <summary>
+    /// Off unless SHARPEMU_LOG_IME_DIALOG=1. A title whose param layout differs reads
+    /// back an empty name and reopens the dialog forever, which presents as a freeze
+    /// rather than an error, so the lifecycle has to be inspectable.
+    /// </summary>
+    private static void Trace(string message)
+    {
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable("SHARPEMU_LOG_IME_DIALOG"),
+                "1",
+                StringComparison.Ordinal))
         {
             return;
         }
 
-        var bufferAddress = BinaryPrimitives.ReadUInt64LittleEndian(field);
-        if (bufferAddress == 0)
-        {
-            return;
-        }
-
-        var maxTextLength = 16u;
-        Span<byte> lengthField = stackalloc byte[4];
-        if (ctx.Memory.TryRead(parameterAddress + ParamMaxTextLengthOffset, lengthField))
-        {
-            var declared = BinaryPrimitives.ReadUInt32LittleEndian(lengthField);
-            if (declared is > 0 and <= 256)
-            {
-                maxTextLength = declared;
-            }
-        }
-
-        var text = Environment.GetEnvironmentVariable("SHARPEMU_DEFAULT_PROFILE");
-        if (string.IsNullOrEmpty(text))
-        {
-            text = DefaultInputText;
-        }
-
-        if ((uint)text.Length > maxTextLength)
-        {
-            text = text[..(int)maxTextLength];
-        }
-
-        var encoded = Encoding.Unicode.GetBytes(text);
-        Span<byte> payload = stackalloc byte[encoded.Length + 2];
-        encoded.CopyTo(payload);
-        payload[^2] = 0;
-        payload[^1] = 0;
-
-        if (ctx.Memory.TryWrite(bufferAddress, payload))
-        {
-            Console.Error.WriteLine(
-                $"[LOADER][WARN] ime.dialog_autofill buf=0x{bufferAddress:X16} " +
-                $"max={maxTextLength} text=\"{text}\"");
-        }
-    }
-
-    private static int SetReturn(CpuContext ctx, int result)
-    {
-        ctx[CpuRegister.Rax] = unchecked((ulong)(long)result);
-        return result;
+        Console.Error.WriteLine($"[LOADER][TRACE] ime_dialog.{message}");
     }
 }

--- a/src/SharpEmu.Libs/SaveData/SaveDataDialogExports.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataDialogExports.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 SharpEmu Emulator Project
+﻿// Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using SharpEmu.HLE;
@@ -15,14 +15,24 @@ public static class SaveDataDialogExports
 
     private const int ErrorOk = 0;
     private const int ErrorNotInitialized = unchecked((int)0x80B80003);
-    private const int ErrorAlreadyInitialized = unchecked((int)0x80B80004);
     private const int ErrorNotFinished = unchecked((int)0x80B80005);
     private const int ErrorNotRunning = unchecked((int)0x80B8000B);
     private const int ErrorArgNull = unchecked((int)0x80B8000D);
 
     private const int ResultSize = 0x48;
     private const int ButtonIdAffirmative = 1;
+
+    // How many polls report RUNNING before the dialog auto-finishes.
+    private const int RunningPollsBeforeFinish = 1;
+
+    // OrbisSaveDataDialogParam, confirmed against a captured block (see Open).
+    private const int ParamSizeOffset = 0x30;
+    private const int ParamModeOffset = 0x34;
+    private const int ParamDispTypeOffset = 0x38;
+    private const int ParamUserDataOffset = 0xC8;
+
     private static int _status;
+    private static int _runningPolls;
     private static int _lastMode;
     private static ulong _lastUserData;
 
@@ -33,17 +43,13 @@ public static class SaveDataDialogExports
         LibraryName = "libSceSaveDataDialog")]
     public static int SaveDataDialogInitialize(CpuContext ctx)
     {
-        var previous = Interlocked.CompareExchange(
-            ref _status,
-            StatusInitialized,
-            StatusNone);
-        if (previous == StatusNone || previous == StatusFinished)
-        {
-            Interlocked.Exchange(ref _status, StatusInitialized);
-            return ctx.SetReturn(ErrorOk);
-        }
-
-        return ctx.SetReturn(ErrorAlreadyInitialized);
+        // Repeated initialization succeeds, matching MsgDialogInitialize. Retail firmware
+        // reports ALREADY_INITIALIZED, but titles re-initialize defensively and then spin
+        // on the error forever. Only NONE is promoted, so re-initializing mid-flow cannot
+        // clobber a running or finished dialog.
+        var previous = Interlocked.CompareExchange(ref _status, StatusInitialized, StatusNone);
+        TraceSaveDataDialog($"initialize (status was {previous}) -> ok");
+        return ctx.SetReturn(ErrorOk);
     }
 
     [SysAbiExport(
@@ -61,16 +67,33 @@ public static class SaveDataDialogExports
 
         if (_status is not (StatusInitialized or StatusFinished))
         {
+            TraceSaveDataDialog($"open REJECTED: not initialized (status={_status})");
             return ctx.SetReturn(ErrorNotInitialized);
         }
 
-        _lastMode = TryReadInt32(ctx, paramAddress, out var mode) ? mode : 0;
-        _lastUserData = ctx.TryReadUInt64(paramAddress + 0xC8, out var userData) ? userData : 0;
+        // Layout confirmed from a captured param block: +0x00 is
+        // OrbisCommonDialogBaseParam.size (0x30), and the dialog's own fields start at
+        // +0x30 (param.size = 0x98). Reading mode at +0x00 therefore returned a constant
+        // 48, which GetResult echoed back; titles compare that against the mode they
+        // asked for and reopen the dialog when it does not match.
+        _lastMode = TryReadInt32(ctx, paramAddress + ParamModeOffset, out var mode) ? mode : 0;
+
+        // +0xC8 is outside the 0x98 bytes the title declared, so only read it when the
+        // declared size covers it - a null the title can handle beats trailing memory
+        // handed back as a pointer.
+        _lastUserData = TryReadInt32(ctx, paramAddress + ParamSizeOffset, out var declaredSize) &&
+            declaredSize >= ParamUserDataOffset + sizeof(ulong) &&
+            ctx.TryReadUInt64(paramAddress + ParamUserDataOffset, out var userData)
+                ? userData
+                : 0;
 
         // There is no host save dialog yet. Enter RUNNING so the close path sees a live
-        // dialog; the guest's next status poll auto-dismisses it (see PollStatus).
+        // dialog; a later status poll auto-dismisses it (see PollStatus).
+        Interlocked.Exchange(ref _runningPolls, 0);
         Interlocked.Exchange(ref _status, StatusRunning);
-        TraceSaveDataDialog($"open mode={_lastMode} userData=0x{_lastUserData:X16} -> running");
+        var dispType = TryReadInt32(ctx, paramAddress + ParamDispTypeOffset, out var type) ? type : 0;
+        TraceSaveDataDialog(
+            $"open mode={_lastMode} dispType={dispType} userData=0x{_lastUserData:X16} -> running");
         return ctx.SetReturn(ErrorOk);
     }
 
@@ -88,14 +111,30 @@ public static class SaveDataDialogExports
         LibraryName = "libSceSaveDataDialog")]
     public static int SaveDataDialogUpdateStatus(CpuContext ctx) => ctx.SetReturn(PollStatus());
 
-    // With no host UI the dialog cannot wait for user input: the first status poll after
-    // Open observes the dialog as already dismissed. Advancing on both UpdateStatus and
-    // GetStatus keeps every guest polling pattern free of infinite RUNNING loops, while
-    // an Open -> Close sequence with no poll in between still exercises the close path.
+    // With no host UI the dialog cannot wait for user input, so it auto-dismisses - but it
+    // must be observably running first. A title whose state machine only accepts FINISHED
+    // after it has seen RUNNING restarts the dialog forever otherwise, and one spinning in
+    // `while (GetStatus() == RUNNING)` just goes around once more.
     private static int PollStatus()
     {
-        Interlocked.CompareExchange(ref _status, StatusFinished, StatusRunning);
-        return Volatile.Read(ref _status);
+        if (Volatile.Read(ref _status) != StatusRunning)
+        {
+            return Volatile.Read(ref _status);
+        }
+
+        if (Interlocked.Increment(ref _runningPolls) <= RunningPollsBeforeFinish)
+        {
+            return StatusRunning;
+        }
+
+        var previous = Interlocked.CompareExchange(ref _status, StatusFinished, StatusRunning);
+        var current = Volatile.Read(ref _status);
+        if (previous != current)
+        {
+            TraceSaveDataDialog($"status {previous} -> {current}");
+        }
+
+        return current;
     }
 
     [SysAbiExport(
@@ -120,6 +159,7 @@ public static class SaveDataDialogExports
 
         if (Volatile.Read(ref _status) != StatusFinished)
         {
+            TraceSaveDataDialog($"get_result REJECTED: not finished (status={Volatile.Read(ref _status)})");
             return ctx.SetReturn(ErrorNotFinished);
         }
 
@@ -134,9 +174,12 @@ public static class SaveDataDialogExports
 
         if (!ctx.Memory.TryWrite(resultAddress, result))
         {
+            TraceSaveDataDialog($"get_result FAILED: result=0x{resultAddress:X12} unwritable");
             return ctx.SetReturn((int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
         }
 
+        TraceSaveDataDialog(
+            $"get_result mode={_lastMode} buttonId={ButtonIdAffirmative} userData=0x{_lastUserData:X16}");
         return ctx.SetReturn(ErrorOk);
     }
 
@@ -164,11 +207,13 @@ public static class SaveDataDialogExports
     {
         if (Interlocked.Exchange(ref _status, StatusNone) == StatusNone)
         {
+            TraceSaveDataDialog("terminate REJECTED: not initialized");
             return ctx.SetReturn(ErrorNotInitialized);
         }
 
         _lastMode = 0;
         _lastUserData = 0;
+        TraceSaveDataDialog("terminate");
         return ctx.SetReturn(ErrorOk);
     }
 
@@ -186,6 +231,14 @@ public static class SaveDataDialogExports
         LibraryName = "libSceSaveDataDialog")]
     public static int SaveDataDialogProgressBarSetValue(CpuContext ctx) => ctx.SetReturn(ErrorOk);
 
+    internal static void ResetForTests()
+    {
+        Volatile.Write(ref _status, StatusNone);
+        Volatile.Write(ref _runningPolls, 0);
+        _lastMode = 0;
+        _lastUserData = 0;
+    }
+
     private static bool TryReadInt32(CpuContext ctx, ulong address, out int value)
     {
         value = 0;
@@ -201,7 +254,10 @@ public static class SaveDataDialogExports
 
     private static void TraceSaveDataDialog(string message)
     {
-        if (!string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_SAVEDATA"), "1", StringComparison.Ordinal))
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable("SHARPEMU_LOG_SAVEDATA"),
+                "1",
+                StringComparison.Ordinal))
         {
             return;
         }

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcContextRegisterTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcContextRegisterTests.cs
@@ -1,0 +1,215 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+/// <summary>
+/// Coverage for the graphics context-register path in the PM4 parser. Draw
+/// translation reads render state out of this dictionary (CB_TARGET_MASK
+/// decides whether a draw writes alpha, CB_COLOR_CONTROL decides what the draw
+/// means), so a write that lands under the wrong key, or fails to overwrite an
+/// earlier one, silently changes what every later draw does. These drive real
+/// PM4 packets through the public submit export and assert what the parser
+/// retained.
+/// </summary>
+public sealed class AgcContextRegisterTests
+{
+    private const ulong BaseAddress = 0x2_0000_0000;
+    private const ulong SubmitPacketAddress = BaseAddress + 0x40;
+    private const ulong CommandAddress = BaseAddress + 0x200;
+    private const ulong IndirectTableAddress = BaseAddress + 0x600;
+
+    private const uint ItNop = 0x10;
+    private const uint ItSetContextReg = 0x69;
+    private const uint RCxRegsIndirect = 0x12;
+    private const uint CbTargetMask = 0x8E;
+    private const uint CbColorControl = 0x202;
+
+    // PM4 type-3 header: 0xC0000000 | ((dwords - 2) << 16) | (opcode << 8), with the
+    // NOP sub-register in bits 2..7 — the parser reads it as (header >> 2) & 0x3F.
+    private static uint Pm4Header(uint dwords, uint opcode, uint register = 0) =>
+        0xC000_0000u | ((dwords - 2) << 16) | (opcode << 8) | ((register & 0x3Fu) << 2);
+
+    [Fact]
+    public void SetContextRegRetainsTargetMask()
+    {
+        var ctx = CreateContext(out var memory);
+        WriteDwords(
+            memory,
+            CommandAddress,
+            Pm4Header(3, ItSetContextReg),
+            CbTargetMask,
+            0x0000_0007u);
+        Submit(ctx, memory, dwordCount: 3);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsContextRegisterForTests(ctx, CbTargetMask, out var value));
+        Assert.Equal(0x0000_0007u, value);
+    }
+
+    /// <summary>
+    /// The indirect form carries (offset, value) pairs out of guest memory
+    /// rather than inline dwords, so an offset-encoding mismatch here would
+    /// store the register under a key no reader looks at.
+    /// </summary>
+    [Fact]
+    public void IndirectRegisterWriteRetainsTargetMask()
+    {
+        var ctx = CreateContext(out var memory);
+        WriteIndirectRegisterCommand(memory, (CbTargetMask, 0xFFFF_FFFFu));
+        Submit(ctx, memory, dwordCount: 4);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsContextRegisterForTests(ctx, CbTargetMask, out var value));
+        Assert.Equal(0xFFFF_FFFFu, value);
+    }
+
+    /// <summary>
+    /// Context registers persist across submissions on hardware until something
+    /// clears them, so a mask written in one submission has to still be there
+    /// for a draw in the next.
+    /// </summary>
+    [Fact]
+    public void TargetMaskSurvivesASecondSubmission()
+    {
+        var ctx = CreateContext(out var memory);
+        WriteIndirectRegisterCommand(memory, (CbTargetMask, 0x8888_8888u));
+        Submit(ctx, memory, dwordCount: 4);
+
+        // A second, unrelated submission: a bare NOP that touches no registers.
+        WriteDwords(memory, CommandAddress, Pm4Header(2, ItNop), 0);
+        Submit(ctx, memory, dwordCount: 2);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsContextRegisterForTests(ctx, CbTargetMask, out var value));
+        Assert.Equal(0x8888_8888u, value);
+    }
+
+    /// <summary>
+    /// Both encodings must land on the same key, or a title that sets the
+    /// register one way and a reader that expects the other silently disagree.
+    /// </summary>
+    [Fact]
+    public void DirectAndIndirectWritesShareOneKey()
+    {
+        var ctx = CreateContext(out var memory);
+        WriteDwords(
+            memory,
+            CommandAddress,
+            Pm4Header(3, ItSetContextReg),
+            CbTargetMask,
+            0x0000_0007u);
+        Submit(ctx, memory, dwordCount: 3);
+
+        WriteIndirectRegisterCommand(memory, (CbTargetMask, 0x0000_000Fu));
+        Submit(ctx, memory, dwordCount: 4);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsContextRegisterForTests(ctx, CbTargetMask, out var value));
+        Assert.Equal(0x0000_000Fu, value);
+    }
+
+    /// <summary>
+    /// CB_COLOR_CONTROL (0x202) MODE bits [6:4] give Normal=1,
+    /// EliminateFastClear=2, Resolve=3, FmaskDecompress=5, DccDecompress=6. The
+    /// value has to survive the parser intact, ROP3 bits and all, because the
+    /// mode decides whether a draw shades or resolves.
+    /// </summary>
+    [Theory]
+    [InlineData(0x0000_0010u, 1u)] // Normal
+    [InlineData(0x0000_0020u, 2u)] // EliminateFastClear
+    [InlineData(0x00CC_0060u, 6u)] // DccDecompress, with ROP3=0xCC alongside
+    public void ColorControlRetainsMode(uint written, uint expectedMode)
+    {
+        var ctx = CreateContext(out var memory);
+        WriteIndirectRegisterCommand(memory, (CbColorControl, written));
+        Submit(ctx, memory, dwordCount: 4);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsContextRegisterForTests(ctx, CbColorControl, out var value));
+        Assert.Equal(written, value);
+        Assert.Equal(expectedMode, (value >> 4) & 0x7u);
+    }
+
+    /// <summary>
+    /// A later write must win. If the parser kept the first value, a draw that
+    /// sets EliminateFastClear after an earlier Normal would still read Normal
+    /// and the clear would be silently dropped.
+    /// </summary>
+    [Fact]
+    public void ColorControlLaterWriteOverwritesEarlier()
+    {
+        var ctx = CreateContext(out var memory);
+        WriteIndirectRegisterCommand(memory, (CbColorControl, 0x00CC_0010u));
+        Submit(ctx, memory, dwordCount: 4);
+
+        WriteIndirectRegisterCommand(memory, (CbColorControl, 0x00CC_0020u));
+        Submit(ctx, memory, dwordCount: 4);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsContextRegisterForTests(ctx, CbColorControl, out var value));
+        Assert.Equal(0x00CC_0020u, value);
+        Assert.Equal(2u, (value >> 4) & 0x7u);
+    }
+
+    private static void WriteIndirectRegisterCommand(
+        FakeCpuMemory memory,
+        params (uint Offset, uint Value)[] registers)
+    {
+        WriteDwords(
+            memory,
+            CommandAddress,
+            Pm4Header(4, ItNop, RCxRegsIndirect),
+            (uint)registers.Length,
+            (uint)(IndirectTableAddress & 0xFFFF_FFFFu),
+            (uint)(IndirectTableAddress >> 32));
+
+        for (var index = 0; index < registers.Length; index++)
+        {
+            var entry = IndirectTableAddress + ((ulong)index * 8);
+            WriteUInt32(memory, entry, registers[index].Offset);
+            WriteUInt32(memory, entry + 4, registers[index].Value);
+        }
+    }
+
+    private static void Submit(CpuContext ctx, FakeCpuMemory memory, uint dwordCount)
+    {
+        WriteUInt64(memory, SubmitPacketAddress, CommandAddress);
+        WriteUInt32(memory, SubmitPacketAddress + 8, dwordCount);
+        ctx[CpuRegister.Rdi] = SubmitPacketAddress;
+        AgcExports.DriverSubmitDcb(ctx);
+    }
+
+    private static CpuContext CreateContext(out FakeCpuMemory memory)
+    {
+        memory = new FakeCpuMemory(BaseAddress, 0x1000);
+        return new CpuContext(memory, Generation.Gen5);
+    }
+
+    private static void WriteDwords(FakeCpuMemory memory, ulong address, params uint[] values)
+    {
+        for (var index = 0; index < values.Length; index++)
+        {
+            WriteUInt32(memory, address + ((ulong)index * sizeof(uint)), values[index]);
+        }
+    }
+
+    private static void WriteUInt32(FakeCpuMemory memory, ulong address, uint value)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
+        Assert.True(memory.TryWrite(address, buffer));
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+        Assert.True(memory.TryWrite(address, buffer));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/AgcShaderStageRegisterTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/AgcShaderStageRegisterTests.cs
@@ -1,0 +1,232 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Agc;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+/// <summary>
+/// Coverage for the SH-register path in the PM4 parser. A draw resolves its
+/// vertex stage from SPI_SHADER_PGM_LO_ES/HI_ES and its pixel stage from
+/// SPI_SHADER_PGM_LO_PS/HI_PS, both out of this dictionary, so a key that is
+/// dropped or written under a different encoding pairs a current pixel shader
+/// with a stale vertex shader — a failure that produces plausible-looking
+/// garbage rather than an error. These drive real PM4 packets through the
+/// public submit export and assert what the parser retained.
+/// </summary>
+public sealed class AgcShaderStageRegisterTests
+{
+    private const ulong BaseAddress = 0x2_0000_0000;
+    private const ulong SubmitPacketAddress = BaseAddress + 0x40;
+    private const ulong CommandAddress = BaseAddress + 0x200;
+    private const ulong IndirectTableAddress = BaseAddress + 0x600;
+
+    private const uint ItNop = 0x10;
+    private const uint ItSetShReg = 0x76;
+    private const uint RShRegsIndirect = 0x11;
+
+    // SH register offsets. ES is the vertex stage on GFX10 — the standalone
+    // PGM_LO/HI_GS pair is dead post-GCN and the merged ES/GS stage is addressed
+    // through ES.
+    private const uint SpiShaderPgmLoPs = 0x8;
+    private const uint SpiShaderPgmLoEs = 0xC8;
+    private const uint SpiShaderPgmHiEs = 0xC9;
+
+    private static uint Pm4Header(uint dwords, uint opcode, uint register = 0) =>
+        0xC000_0000u | ((dwords - 2) << 16) | (opcode << 8) | ((register & 0x3Fu) << 2);
+
+    /// <summary>
+    /// The baseline: a direct SET_SH_REG write of the vertex stage address has
+    /// to be readable afterwards. If this fails, nothing downstream can pair
+    /// shaders correctly.
+    /// </summary>
+    [Fact]
+    public void SetShRegRetainsExportShaderAddress()
+    {
+        var ctx = CreateContext(out var memory);
+        WriteDwords(
+            memory,
+            CommandAddress,
+            Pm4Header(3, ItSetShReg),
+            SpiShaderPgmLoEs,
+            0x0044_8582u);
+        Submit(ctx, memory, dwordCount: 3);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsShRegisterForTests(ctx, SpiShaderPgmLoEs, out var value));
+        Assert.Equal(0x0044_8582u, value);
+    }
+
+    /// <summary>
+    /// The indirect encoding must land on the same keys as the direct one. A
+    /// mismatch would store the stage address where the draw never reads it,
+    /// leaving the draw to see whatever a previous submission left behind.
+    /// </summary>
+    [Fact]
+    public void IndirectShRegisterWriteRetainsExportShaderAddress()
+    {
+        var ctx = CreateContext(out var memory);
+        WriteIndirectShRegisterCommand(memory, (SpiShaderPgmLoEs, 0x0044_8DD1u));
+        Submit(ctx, memory, dwordCount: 4);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsShRegisterForTests(ctx, SpiShaderPgmLoEs, out var value));
+        Assert.Equal(0x0044_8DD1u, value);
+    }
+
+    /// <summary>
+    /// Both stages written in one submission must both read back as written. If
+    /// the vertex stage kept an older value while the pixel stage updated, every
+    /// draw after it would be mis-paired.
+    /// </summary>
+    [Fact]
+    public void BothStagesUpdateTogetherWithinOneSubmission()
+    {
+        var ctx = CreateContext(out var memory);
+        WriteIndirectShRegisterCommand(
+            memory,
+            (SpiShaderPgmLoEs, 0x0080_2933u),
+            (SpiShaderPgmLoPs, 0x0044_858Au));
+        Submit(ctx, memory, dwordCount: 4);
+
+        WriteIndirectShRegisterCommand(
+            memory,
+            (SpiShaderPgmLoEs, 0x0044_8581u),
+            (SpiShaderPgmLoPs, 0x0044_8719u));
+        Submit(ctx, memory, dwordCount: 4);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsShRegisterForTests(ctx, SpiShaderPgmLoEs, out var es));
+        Assert.True(
+            AgcExports.TryGetGraphicsShRegisterForTests(ctx, SpiShaderPgmLoPs, out var ps));
+        Assert.Equal(0x0044_8581u, es);
+        Assert.Equal(0x0044_8719u, ps);
+    }
+
+    /// <summary>
+    /// Updating only the pixel stage must leave the vertex stage at its previous
+    /// value rather than dropping the key, or the draw falls back to whatever
+    /// default the resolver finds.
+    /// </summary>
+    [Fact]
+    public void PixelStageUpdateLeavesExportStageIntact()
+    {
+        var ctx = CreateContext(out var memory);
+        WriteIndirectShRegisterCommand(memory, (SpiShaderPgmLoEs, 0x0044_8582u));
+        Submit(ctx, memory, dwordCount: 4);
+
+        WriteIndirectShRegisterCommand(memory, (SpiShaderPgmLoPs, 0x0044_858Au));
+        Submit(ctx, memory, dwordCount: 4);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsShRegisterForTests(ctx, SpiShaderPgmLoEs, out var es));
+        Assert.Equal(0x0044_8582u, es);
+    }
+
+    /// <summary>
+    /// Stage addresses are 64-bit: LO carries bits 39:8 and HI the top bits, and
+    /// the draw combines them. A HI retained from an earlier shader while LO
+    /// updates resolves to a splice of two different programs.
+    /// </summary>
+    [Fact]
+    public void HighAndLowHalvesUpdateTogether()
+    {
+        var ctx = CreateContext(out var memory);
+        WriteIndirectShRegisterCommand(
+            memory,
+            (SpiShaderPgmLoEs, 0x0080_2933u),
+            (SpiShaderPgmHiEs, 0x0000_0008u));
+        Submit(ctx, memory, dwordCount: 4);
+
+        WriteIndirectShRegisterCommand(
+            memory,
+            (SpiShaderPgmLoEs, 0x0044_8582u),
+            (SpiShaderPgmHiEs, 0x0000_0004u));
+        Submit(ctx, memory, dwordCount: 4);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsShRegisterForTests(ctx, SpiShaderPgmLoEs, out var lo));
+        Assert.True(
+            AgcExports.TryGetGraphicsShRegisterForTests(ctx, SpiShaderPgmHiEs, out var hi));
+        Assert.Equal(0x0044_8582u, lo);
+        Assert.Equal(0x0000_0004u, hi);
+    }
+
+    /// <summary>
+    /// SH registers persist across submissions on hardware. A stage address set
+    /// in one submission must still be there for a draw in the next.
+    /// </summary>
+    [Fact]
+    public void ExportShaderAddressSurvivesASecondSubmission()
+    {
+        var ctx = CreateContext(out var memory);
+        WriteIndirectShRegisterCommand(memory, (SpiShaderPgmLoEs, 0x0044_8583u));
+        Submit(ctx, memory, dwordCount: 4);
+
+        WriteDwords(memory, CommandAddress, Pm4Header(2, ItNop), 0);
+        Submit(ctx, memory, dwordCount: 2);
+
+        Assert.True(
+            AgcExports.TryGetGraphicsShRegisterForTests(ctx, SpiShaderPgmLoEs, out var value));
+        Assert.Equal(0x0044_8583u, value);
+    }
+
+    private static void WriteIndirectShRegisterCommand(
+        FakeCpuMemory memory,
+        params (uint Offset, uint Value)[] registers)
+    {
+        WriteDwords(
+            memory,
+            CommandAddress,
+            Pm4Header(4, ItNop, RShRegsIndirect),
+            (uint)registers.Length,
+            (uint)(IndirectTableAddress & 0xFFFF_FFFFu),
+            (uint)(IndirectTableAddress >> 32));
+
+        for (var index = 0; index < registers.Length; index++)
+        {
+            var entry = IndirectTableAddress + ((ulong)index * 8);
+            WriteUInt32(memory, entry, registers[index].Offset);
+            WriteUInt32(memory, entry + 4, registers[index].Value);
+        }
+    }
+
+    private static void Submit(CpuContext ctx, FakeCpuMemory memory, uint dwordCount)
+    {
+        WriteUInt64(memory, SubmitPacketAddress, CommandAddress);
+        WriteUInt32(memory, SubmitPacketAddress + 8, dwordCount);
+        ctx[CpuRegister.Rdi] = SubmitPacketAddress;
+        AgcExports.DriverSubmitDcb(ctx);
+    }
+
+    private static CpuContext CreateContext(out FakeCpuMemory memory)
+    {
+        memory = new FakeCpuMemory(BaseAddress, 0x1000);
+        return new CpuContext(memory, Generation.Gen5);
+    }
+
+    private static void WriteDwords(FakeCpuMemory memory, ulong address, params uint[] values)
+    {
+        for (var index = 0; index < values.Length; index++)
+        {
+            WriteUInt32(memory, address + ((ulong)index * sizeof(uint)), values[index]);
+        }
+    }
+
+    private static void WriteUInt32(FakeCpuMemory memory, ulong address, uint value)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
+        Assert.True(memory.TryWrite(address, buffer));
+    }
+
+    private static void WriteUInt64(FakeCpuMemory memory, ulong address, ulong value)
+    {
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+        Assert.True(memory.TryWrite(address, buffer));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Ime/ImeDialogExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ime/ImeDialogExportsTests.cs
@@ -1,0 +1,246 @@
+﻿// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Ime;
+using System.Buffers.Binary;
+using System.Text;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Ime;
+
+public sealed class ImeDialogExportsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong ParamAddress = MemoryBase;
+    private const ulong TextBufferAddress = MemoryBase + 0x100;
+    private const ulong ResultAddress = MemoryBase + 0x300;
+
+    private const int ParamSize = 0x60;
+    private const int ParamMaxTextLengthOffset = 0x24;
+    private const int ParamInputTextBufferOffset = 0x28;
+
+    private const int StatusRunning = 1;
+    private const int StatusFinished = 2;
+
+    public ImeDialogExportsTests()
+    {
+        ImeDialogExports.ResetForTests();
+        Environment.SetEnvironmentVariable("SHARPEMU_IME_TEXT", null);
+    }
+
+    private static (FakeCpuMemory Memory, CpuContext Context) CreateDialog(uint maxTextLength = 16)
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x400);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        Span<byte> param = stackalloc byte[ParamSize];
+        param.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(param[ParamMaxTextLengthOffset..], maxTextLength);
+        BinaryPrimitives.WriteUInt64LittleEndian(param[ParamInputTextBufferOffset..], TextBufferAddress);
+        Assert.True(memory.TryWrite(ParamAddress, param));
+
+        context[CpuRegister.Rdi] = ParamAddress;
+        return (memory, context);
+    }
+
+    private static string ReadGuestText(FakeCpuMemory memory, int maxCharacters)
+    {
+        var bytes = new byte[(maxCharacters + 1) * sizeof(char)];
+        Assert.True(memory.TryRead(TextBufferAddress, bytes));
+        var text = Encoding.Unicode.GetString(bytes);
+        var terminator = text.IndexOf('\0');
+        return terminator < 0 ? text : text[..terminator];
+    }
+
+    // The whole point of the module: the title's buffer has to come back holding text,
+    // because sceImeDialogGetResult reports only how the dialog ended, never the string.
+    [Fact]
+    public void InitWritesConfiguredTextIntoTheGuestBufferAsNullTerminatedUtf16()
+    {
+        Environment.SetEnvironmentVariable("SHARPEMU_IME_TEXT", "Boletaria");
+        var (memory, context) = CreateDialog();
+
+        Assert.Equal(0, ImeDialogExports.ImeDialogInit(context));
+        Assert.Equal("Boletaria", ReadGuestText(memory, 16));
+    }
+
+    // The terminator is reserved inside maxTextLength, so four characters of capacity
+    // hold three characters plus the null.
+    [Fact]
+    public void TextLongerThanMaxTextLengthIsTruncatedToTheGuestCapacity()
+    {
+        Environment.SetEnvironmentVariable("SHARPEMU_IME_TEXT", "AstraeaMaidenInBlack");
+        var (memory, context) = CreateDialog(maxTextLength: 4);
+
+        Assert.Equal(0, ImeDialogExports.ImeDialogInit(context));
+        Assert.Equal("Ast", ReadGuestText(memory, 4));
+    }
+
+    // Regression: writing maxTextLength characters *plus* a terminator overruns the guest
+    // buffer by two bytes, which smashes a stack canary when the field is a local. The
+    // byte at buffer[maxTextLength] must never be touched.
+    [Theory]
+    [InlineData(1u)]
+    [InlineData(2u)]
+    [InlineData(8u)]
+    [InlineData(16u)]
+    public void InitNeverWritesPastMaxTextLengthWideCharacters(uint maxTextLength)
+    {
+        Environment.SetEnvironmentVariable("SHARPEMU_IME_TEXT", "AstraeaMaidenInBlack");
+        var memory = new FakeCpuMemory(MemoryBase, 0x400);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        // Poison the buffer and one wide character past its documented end.
+        var guard = new byte[(maxTextLength + 1) * sizeof(char)];
+        Array.Fill(guard, (byte)0xEE);
+        Assert.True(memory.TryWrite(TextBufferAddress, guard));
+
+        Span<byte> param = stackalloc byte[ParamSize];
+        param.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(param[ParamMaxTextLengthOffset..], maxTextLength);
+        BinaryPrimitives.WriteUInt64LittleEndian(param[ParamInputTextBufferOffset..], TextBufferAddress);
+        Assert.True(memory.TryWrite(ParamAddress, param));
+
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.Equal(0, ImeDialogExports.ImeDialogInit(context));
+
+        Span<byte> pastEnd = stackalloc byte[sizeof(char)];
+        Assert.True(memory.TryRead(TextBufferAddress + (maxTextLength * sizeof(char)), pastEnd));
+        Assert.Equal(0xEE, pastEnd[0]);
+        Assert.Equal(0xEE, pastEnd[1]);
+    }
+
+    // A title that never sees FINISHED spins on GetStatus forever - this is the exact
+    // hang the auto-commit avoids.
+    [Fact]
+    public void StatusAdvancesFromRunningToFinishedOnTheFirstPoll()
+    {
+        var (_, context) = CreateDialog();
+        Assert.Equal(0, ImeDialogExports.ImeDialogInit(context));
+
+        Assert.Equal(StatusFinished, ImeDialogExports.ImeDialogGetStatus(context));
+        Assert.Equal(StatusFinished, ImeDialogExports.ImeDialogGetStatus(context));
+    }
+
+    [Fact]
+    public void GetResultReportsSuccessOnlyAfterTheDialogFinished()
+    {
+        var (memory, context) = CreateDialog();
+        Assert.Equal(0, ImeDialogExports.ImeDialogInit(context));
+
+        context[CpuRegister.Rdi] = ResultAddress;
+        Assert.NotEqual(0, ImeDialogExports.ImeDialogGetResult(context));
+
+        Assert.Equal(StatusFinished, ImeDialogExports.ImeDialogGetStatus(context));
+
+        context[CpuRegister.Rdi] = ResultAddress;
+        Assert.Equal(0, ImeDialogExports.ImeDialogGetResult(context));
+
+        Span<byte> endStatus = stackalloc byte[sizeof(int)];
+        Assert.True(memory.TryRead(ResultAddress, endStatus));
+        Assert.Equal(0, BinaryPrimitives.ReadInt32LittleEndian(endStatus));
+    }
+
+    // Regression: GetResult used to zero 0x34 bytes of assumed OrbisImeDialogResult. Titles
+    // pass a stack local, so writing past endStatus smashed the frame's canary and tripped
+    // __stack_chk_fail when the calling function returned. Only the first four bytes are ours.
+    [Fact]
+    public void GetResultWritesEndStatusOnlyAndNothingPastIt()
+    {
+        var (memory, context) = CreateDialog();
+        Assert.Equal(0, ImeDialogExports.ImeDialogInit(context));
+        Assert.Equal(StatusFinished, ImeDialogExports.ImeDialogGetStatus(context));
+
+        var poison = new byte[0x40];
+        Array.Fill(poison, (byte)0xEE);
+        Assert.True(memory.TryWrite(ResultAddress, poison));
+
+        context[CpuRegister.Rdi] = ResultAddress;
+        Assert.Equal(0, ImeDialogExports.ImeDialogGetResult(context));
+
+        var readBack = new byte[0x40];
+        Assert.True(memory.TryRead(ResultAddress, readBack));
+        Assert.Equal(0, BinaryPrimitives.ReadInt32LittleEndian(readBack));
+        Assert.All(readBack[sizeof(int)..], b => Assert.Equal(0xEE, b));
+    }
+
+    [Fact]
+    public void InitRejectsASecondDialogWhileOneIsRunning()
+    {
+        var (_, context) = CreateDialog();
+        Assert.Equal(0, ImeDialogExports.ImeDialogInit(context));
+
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.NotEqual(0, ImeDialogExports.ImeDialogInit(context));
+    }
+
+    [Fact]
+    public void InitRejectsANullParamAndANullTextBuffer()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x400);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        context[CpuRegister.Rdi] = 0;
+        Assert.NotEqual(0, ImeDialogExports.ImeDialogInit(context));
+
+        Span<byte> param = stackalloc byte[ParamSize];
+        param.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(param[ParamMaxTextLengthOffset..], 16);
+        Assert.True(memory.TryWrite(ParamAddress, param));
+
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.NotEqual(0, ImeDialogExports.ImeDialogInit(context));
+    }
+
+    [Fact]
+    public void TermAfterFinishSucceedsAndAllowsAFreshDialog()
+    {
+        var (_, context) = CreateDialog();
+        Assert.Equal(0, ImeDialogExports.ImeDialogInit(context));
+        Assert.Equal(StatusFinished, ImeDialogExports.ImeDialogGetStatus(context));
+        Assert.Equal(0, ImeDialogExports.ImeDialogTerm(context));
+
+        // Terminating an already-terminated dialog is an error, not a silent success.
+        Assert.NotEqual(0, ImeDialogExports.ImeDialogTerm(context));
+
+        // The new dialog is genuinely RUNNING: a second Init is rejected as busy.
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.Equal(0, ImeDialogExports.ImeDialogInit(context));
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.NotEqual(0, ImeDialogExports.ImeDialogInit(context));
+    }
+
+    [Fact]
+    public void AbortMarksTheDialogAbortedForGetResult()
+    {
+        var (memory, context) = CreateDialog();
+        Assert.Equal(0, ImeDialogExports.ImeDialogInit(context));
+        Assert.Equal(0, ImeDialogExports.ImeDialogAbort(context));
+
+        context[CpuRegister.Rdi] = ResultAddress;
+        Assert.Equal(0, ImeDialogExports.ImeDialogGetResult(context));
+
+        Span<byte> endStatus = stackalloc byte[sizeof(int)];
+        Assert.True(memory.TryRead(ResultAddress, endStatus));
+        Assert.Equal(2, BinaryPrimitives.ReadInt32LittleEndian(endStatus));
+    }
+
+    [Fact]
+    public void ParamInitZeroesTheParameterBlock()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, 0x400);
+        var context = new CpuContext(memory, Generation.Gen5);
+
+        var dirty = new byte[ParamSize];
+        Array.Fill(dirty, (byte)0xCD);
+        Assert.True(memory.TryWrite(ParamAddress, dirty));
+
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.Equal(0, ImeDialogExports.ImeDialogParamInit(context));
+
+        var readBack = new byte[ParamSize];
+        Assert.True(memory.TryRead(ParamAddress, readBack));
+        Assert.All(readBack, b => Assert.Equal(0, b));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/SaveData/SaveDataDialogExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/SaveData/SaveDataDialogExportsTests.cs
@@ -1,0 +1,218 @@
+﻿// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.SaveData;
+using System.Buffers.Binary;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.SaveData;
+
+public sealed class SaveDataDialogExportsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong ParamAddress = MemoryBase;
+    private const ulong ResultAddress = MemoryBase + 0x200;
+
+    private const int StatusRunning = 2;
+    private const int StatusFinished = 3;
+
+    public SaveDataDialogExportsTests()
+    {
+        SaveDataDialogExports.ResetForTests();
+    }
+
+    private static CpuContext CreateContext(out FakeCpuMemory memory)
+    {
+        memory = new FakeCpuMemory(MemoryBase, 0x400);
+        return new CpuContext(memory, Generation.Gen5);
+    }
+
+    // Regression: Initialize used to return ALREADY_INITIALIZED (0x80B80004) on every call
+    // after the first. Titles re-initialize the service defensively and spin on the error -
+    // Demon's Souls retried it forever after name entry, which looked like a freeze with
+    // memory climbing. Repeat initialization must be a success, as it is for MsgDialog.
+    [Fact]
+    public void RepeatedInitializeAlwaysSucceeds()
+    {
+        var context = CreateContext(out _);
+
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+            Assert.Equal(0UL, context[CpuRegister.Rax]);
+        }
+    }
+
+    // Re-initializing mid-flow must not reset a live dialog back to INITIALIZED, or the
+    // status poll would hand the title a dialog that never finishes.
+    [Fact]
+    public void InitializeDoesNotClobberARunningDialog()
+    {
+        var context = CreateContext(out _);
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogOpen(context));
+
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+
+        // Still the running dialog, so polling drives it to FINISHED rather than
+        // reporting a fresh INITIALIZED state.
+        Assert.Equal(StatusRunning, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+        Assert.Equal(StatusFinished, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+    }
+
+    // Regression: the dialog used to finish on the very first poll, so RUNNING was never
+    // returned to the title. Demon's Souls only accepts FINISHED after it has observed
+    // RUNNING, and looped initialize -> open -> status forever without it.
+    [Fact]
+    public void FirstPollReportsRunningBeforeTheDialogFinishes()
+    {
+        var context = CreateContext(out _);
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogOpen(context));
+
+        Assert.Equal(StatusRunning, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+        Assert.Equal(StatusFinished, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+        Assert.Equal(StatusFinished, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+    }
+
+    // The same must hold for UpdateStatus, which titles use interchangeably.
+    [Fact]
+    public void UpdateStatusAlsoReportsRunningFirst()
+    {
+        var context = CreateContext(out _);
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogOpen(context));
+
+        Assert.Equal(StatusRunning, SaveDataDialogExports.SaveDataDialogUpdateStatus(context));
+        Assert.Equal(StatusFinished, SaveDataDialogExports.SaveDataDialogUpdateStatus(context));
+    }
+
+    // Reopening must re-arm the RUNNING observation, or the second dialog finishes
+    // instantly and the title loops again.
+    [Fact]
+    public void ReopeningReArmsTheRunningPoll()
+    {
+        var context = CreateContext(out _);
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+
+        for (var cycle = 0; cycle < 3; cycle++)
+        {
+            context[CpuRegister.Rdi] = ParamAddress;
+            Assert.Equal(0, SaveDataDialogExports.SaveDataDialogOpen(context));
+            Assert.Equal(StatusRunning, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+            Assert.Equal(StatusFinished, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+        }
+    }
+
+    [Fact]
+    public void FullOpenPollResultCycleReportsTheAffirmativeButton()
+    {
+        var context = CreateContext(out var memory);
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogOpen(context));
+        Assert.Equal(StatusRunning, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+        Assert.Equal(StatusFinished, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+
+        context[CpuRegister.Rdi] = ResultAddress;
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogGetResult(context));
+
+        Span<byte> buttonId = stackalloc byte[sizeof(int)];
+        Assert.True(memory.TryRead(ResultAddress + 0x08, buttonId));
+        Assert.Equal(1, BinaryPrimitives.ReadInt32LittleEndian(buttonId));
+    }
+
+    [Fact]
+    public void TerminateThenInitializeStartsACleanDialog()
+    {
+        var context = CreateContext(out _);
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogTerminate(context));
+
+        // Terminating twice is still an error - that path is unchanged.
+        Assert.NotEqual(0, SaveDataDialogExports.SaveDataDialogTerminate(context));
+
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogOpen(context));
+    }
+
+    // A real OrbisSaveDataDialogParam captured from Demon's Souls. Offset 0 is the *base
+    // param's* size (0x30), not the mode - reading the mode there returned a constant 48,
+    // which GetResult echoed back, so the title rejected every result and reopened the
+    // dialog forever. The real mode (3) is at +0x34.
+    private static readonly byte[] CapturedParam = Convert.FromHexString(
+        "30000000000000000000000000000000" +
+        "00000000000000000000000000000000" +
+        "00000000000000000000000069932BC9" +
+        "98000000030000000100000000000000" +
+        "60FE590806000000C0FD590806000000" +
+        "000000000000000080FD590806000000");
+
+    [Fact]
+    public void ModeIsReadFromTheRealFieldNotTheBaseParamSize()
+    {
+        var context = CreateContext(out var memory);
+        Assert.True(memory.TryWrite(ParamAddress, CapturedParam));
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogOpen(context));
+        Assert.Equal(StatusRunning, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+        Assert.Equal(StatusFinished, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+
+        context[CpuRegister.Rdi] = ResultAddress;
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogGetResult(context));
+
+        Span<byte> mode = stackalloc byte[sizeof(int)];
+        Assert.True(memory.TryRead(ResultAddress, mode));
+        Assert.Equal(3, BinaryPrimitives.ReadInt32LittleEndian(mode));
+        Assert.NotEqual(48, BinaryPrimitives.ReadInt32LittleEndian(mode));
+    }
+
+    // userData's offset is unknown; the old fixed +0xC8 read landed outside the 0x98-byte
+    // struct and handed the title whatever followed it as a pointer. Out-of-range must
+    // yield a null, not garbage.
+    [Fact]
+    public void UserDataOutsideTheDeclaredStructSizeIsReportedAsNull()
+    {
+        var context = CreateContext(out var memory);
+        Assert.True(memory.TryWrite(ParamAddress, CapturedParam));
+
+        // Poison well past the declared 0x98-byte struct, where the old read pointed.
+        var poison = new byte[0x40];
+        Array.Fill(poison, (byte)0xEE);
+        Assert.True(memory.TryWrite(ParamAddress + 0xC8, poison));
+
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+        context[CpuRegister.Rdi] = ParamAddress;
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogOpen(context));
+        Assert.Equal(StatusRunning, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+        Assert.Equal(StatusFinished, SaveDataDialogExports.SaveDataDialogGetStatus(context));
+
+        context[CpuRegister.Rdi] = ResultAddress;
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogGetResult(context));
+
+        Span<byte> userData = stackalloc byte[sizeof(ulong)];
+        Assert.True(memory.TryRead(ResultAddress + 0x20, userData));
+        Assert.Equal(0UL, BinaryPrimitives.ReadUInt64LittleEndian(userData));
+    }
+
+    [Fact]
+    public void GetResultBeforeTheDialogFinishesIsRejected()
+    {
+        var context = CreateContext(out _);
+        Assert.Equal(0, SaveDataDialogExports.SaveDataDialogInitialize(context));
+
+        context[CpuRegister.Rdi] = ResultAddress;
+        Assert.NotEqual(0, SaveDataDialogExports.SaveDataDialogGetResult(context));
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Motivation

I tried bringing the Demon's Souls up and progressed greatly with a combination of hacks and genuine fixes. 
I'm creating a PR with the fixes excluding hacks.

Bring up results with hacks:
<img width="1446" height="843" alt="image" src="https://github.com/user-attachments/assets/be668a5e-f966-4503-adcc-702b78c9f16a" />
Menus disappear on the UI (stayed drawn before), alpha channel on the UI lets you see the screen, character input stub allows progressing further into the game.

### Fixes in this PR (no hacks):

GS shader address registers. Fixed addresses (0x8A/0x8B -> 0x88/0x89), took the correct ones from Kyty PS5 and that matched my experiments.

Rect-list draws. Removed a guard dropping RECT_LIST draws with a position-only vertex shader and a pixel shader wanting interpolants, that combination is what AMD drivers emit for clears and blits. 

Save data dialog mode offset. Fixed offset (+0x00 -> +0x34), read the layout off a captured param block where +0x00 is the common header size and the dialog's own fields start at +0x30. 

Save data dialog state. Made initialize idempotent and made the dialog report RUNNING once before FINISHED.

IME dialog text. Write the text into inputTextBuffer at open time, GetResult only reports how the dialog ended. 

sceAgcDcbDrawIndexIndirectMultiGetSize. Added, returns 8 dwords to match what our own emitter writes. 

## Testing

All changes were tested on Demon's Souls [PPSA01341]

GS shader address registers. Logged the address read from 0x8A/0x8B live and got 0x30004622C008300, 58 bits wide, so not an address. 

Rect-list draws. Counted draw dispositions over a run, 620 of every 5000 draws were being dropped by the guard, and removing it got rid of the 3D ghosting. 

Save data dialog mode offset. Game reopened the dialog forever after naming the character, reading mode at +0x34 stopped it. 

Save data dialog state. Game retried initialize forever with memory climbing, and finishing on the first poll made it restart the dialog. 

IME dialog text. Name entry completes and the name shows up in game. This allows to progress beyond the character creation screen.

sceAgcDcbDrawIndexIndirectMultiGetSize. Compared against DcbDrawIndexIndirectMulti, which allocates 8 dwords and writes all 8.   

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
