### PR TITLE
Astrobot - Vulkan fix

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -4060,11 +4060,7 @@ internal static unsafe class VulkanVideoPresenter
             };
             Console.Error.WriteLine($"{prefix} {message}");
 
-            // vkCreateShaderModule() still returns VK_SUCCESS from the driver
-            // even when the validation layer's embedded spirv-val flags the
-            // module as invalid - the failure only surfaces here, never as a
-            // non-Success Result our own Check() calls would catch. Flag it
-            // loudly so it isn't mistaken for a passive/advisory message.
+
             if (severity == DebugUtilsMessageSeverityFlagsEXT.ErrorBitExt &&
                 message is not null &&
                 message.Contains("vkCreateShaderModule", StringComparison.Ordinal))
@@ -6879,7 +6875,7 @@ internal static unsafe class VulkanVideoPresenter
             if (!string.IsNullOrWhiteSpace(dumpDirectory))
             {
                 Directory.CreateDirectory(dumpDirectory);
-                
+
                 var sequence = Interlocked.Increment(ref _shaderModuleDumpSequence);
                 dumpPath = Path.Combine(dumpDirectory, $"{sequence:D4}.spv");
                 File.WriteAllBytes(dumpPath, code);

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -4041,6 +4041,10 @@ internal static unsafe class VulkanVideoPresenter
                 "vkCreateDebugUtilsMessengerEXT");
         }
 
+
+        [ThreadStatic]
+        private static string? _pendingShaderModuleDumpPath;
+
         private static unsafe uint DebugCallback(
             DebugUtilsMessageSeverityFlagsEXT severity,
             DebugUtilsMessageTypeFlagsEXT type,
@@ -4055,6 +4059,28 @@ internal static unsafe class VulkanVideoPresenter
                 _ => "[VULKAN][INFO]",
             };
             Console.Error.WriteLine($"{prefix} {message}");
+
+            // vkCreateShaderModule() still returns VK_SUCCESS from the driver
+            // even when the validation layer's embedded spirv-val flags the
+            // module as invalid - the failure only surfaces here, never as a
+            // non-Success Result our own Check() calls would catch. Flag it
+            // loudly so it isn't mistaken for a passive/advisory message.
+            if (severity == DebugUtilsMessageSeverityFlagsEXT.ErrorBitExt &&
+                message is not null &&
+                message.Contains("vkCreateShaderModule", StringComparison.Ordinal))
+            {
+                var dumpPath = _pendingShaderModuleDumpPath;
+                var dumpHint = dumpPath is null
+                    ? "Set SHARPEMU_SHADER_SPIRV_DUMP_DIR to a directory to "
+                        + "capture every module's .spv bytes for offline "
+                        + "spirv-dis/spirv-val analysis."
+                    : $"Dumped module for this failure: {dumpPath}";
+
+                Console.Error.WriteLine(
+                    "[SHARPEMU][ERROR] A guest shader compiled to invalid SPIR-V."
+                    + "The shader module was created without an API-level error. {dumpHint}");
+            }
+
             return Vk.False;
         }
         private void CreateSurface()
@@ -6844,20 +6870,43 @@ internal static unsafe class VulkanVideoPresenter
             }
         }
 
+        private static int _shaderModuleDumpSequence;
+
         private ShaderModule CreateShaderModule(byte[] code)
         {
-            fixed (byte* codePointer = code)
+            string? dumpPath = null;
+            var dumpDirectory = Environment.GetEnvironmentVariable("SHARPEMU_SHADER_SPIRV_DUMP_DIR");
+            if (!string.IsNullOrWhiteSpace(dumpDirectory))
             {
-                var createInfo = new ShaderModuleCreateInfo
+                Directory.CreateDirectory(dumpDirectory);
+                
+                var sequence = Interlocked.Increment(ref _shaderModuleDumpSequence);
+                dumpPath = Path.Combine(dumpDirectory, $"{sequence:D4}.spv");
+                File.WriteAllBytes(dumpPath, code);
+            
+                _pendingShaderModuleDumpPath = dumpPath;
+            }
+
+            
+            try
+            {
+                fixed (byte* codePointer = code)
                 {
-                    SType = StructureType.ShaderModuleCreateInfo,
-                    CodeSize = (nuint)code.Length,
-                    PCode = (uint*)codePointer,
-                };
-                Check(
-                    _vk.CreateShaderModule(_device, &createInfo, null, out var module),
-                    "vkCreateShaderModule");
-                return module;
+                    var createInfo = new ShaderModuleCreateInfo
+                    {
+                        SType = StructureType.ShaderModuleCreateInfo,
+                        CodeSize = (nuint)code.Length,
+                        PCode = (uint*)codePointer,
+                    };
+                    Check(
+                        _vk.CreateShaderModule(_device, &createInfo, null, out var module),
+                        "vkCreateShaderModule");
+                    return module;
+                }
+            }
+            finally
+            {
+                _pendingShaderModuleDumpPath = null;
             }
         }
 

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -1801,13 +1801,16 @@ public static partial class Gen5SpirvTranslator
 
             if (instruction.Opcode == "SBarrier")
             {
-                var workgroup = UInt(2);
-                var semantics = UInt(0x108);
-                _module.AddStatement(
-                    SpirvOp.ControlBarrier,
-                    workgroup,
-                    workgroup,
-                    semantics);
+                if (_stage == Gen5SpirvStage.Compute)
+                {
+                    var workgroup = UInt(2);
+                    var semantics = UInt(0x108);
+                    _module.AddStatement(
+                        SpirvOp.ControlBarrier,
+                        workgroup,
+                        workgroup,
+                        semantics);
+                }
                 return true;
             }
 

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -712,6 +712,8 @@ public static partial class Gen5SpirvTranslator
             if (UsesSubgroupOperations())
             {
                 _module.AddCapability(SpirvCapability.GroupNonUniform);
+                _module.AddCapability(SpirvCapability.GroupNonUniformBallot);
+
                 if (UsesSubgroupShuffle())
                 {
                     _module.AddCapability(SpirvCapability.GroupNonUniformShuffle);
@@ -722,10 +724,6 @@ public static partial class Gen5SpirvTranslator
                     _module.AddCapability(SpirvCapability.GroupNonUniformVote);
                 }
 
-                if (UsesSubgroupBroadcast() || UsesWaveControl())
-                {
-                    _module.AddCapability(SpirvCapability.GroupNonUniformBallot);
-                }
             }
 
             _glsl = _module.ImportExtInst("GLSL.std.450");


### PR DESCRIPTION
## Context 


1- Debug functions to log spiv
vkCreateShaderModule() still returns VK_SUCCESS even if this is not done correctly.
The error is only on the DebugCallback function, one a log has been implemented and a dump of all spiv has been added if the SHARPEMU_SHADER_SPIRV_DUMP_DIR env variable is set.

2-GroupNonUniformBallot fix

**Error :** 
```
[VULKAN][ERROR] vkCreateShaderModule(): pCreateInfo->pCode (spirv-val produced an error):
Opcode GroupNonUniformBallot requires one of these capabilities: GroupNonUniformBallot 
  %513 = OpGroupNonUniformBallot %v4uint %uint_3 %false
Command to reproduce:
	spirv-val <input.spv> --relax-block-layout --allow-offset-texture-operand --target-env vulkan1.2
The Vulkan spec states: If pCode is a pointer to SPIR-V code, pCode must adhere to the validation rules described by the Validation Rules within a Module section of the SPIR-V Environment appendix (https://docs.vulkan.org/spec/latest/chapters/shaders.html#VUID-VkShaderModuleCreateInfo-pCode-08737)
```

**Explanation** : 
the Ballot capability must always be declared here too, not just when UsesSubgroupBroadcast()/UsesWaveControl()

**Before the fix :** 
<img width="1019" height="221" alt="Capture d&#39;écran 2026-08-01 130143" src="https://github.com/user-attachments/assets/89f72ac2-009a-4635-98f7-56ff6ee5f859" />

**After the fix :** 
<img width="981" height="189" alt="Capture d&#39;écran 2026-08-01 131001" src="https://github.com/user-attachments/assets/8fad6196-779a-4de1-bcde-edd577958206" />


3- SBarrier Opcode fix

**Error :** 
```
[VULKAN][ERROR] vkCreateShaderModule(): pCreateInfo->pCode (spirv-val produced an error):
OpEntryPoint Entry Point <id> '62[%62]'s callgraph contains function <id> '62[%62]', which cannot be used with the current execution model:
[VUID-StandaloneSpirv-OpControlBarrier-04682] in Vulkan environment, OpControlBarrier execution scope must be Subgroup for Fragment, Vertex, Geometry, TessellationEvaluation, RayGeneration, Intersection, AnyHit, ClosestHit, and Miss execution models
[VUID-StandaloneSpirv-None-04637] in Vulkan environment, Workgroup execution scope is only for TaskNV, MeshNV, TaskEXT, MeshEXT, TessellationControl, and GLCompute execution models
[VUID-StandaloneSpirv-None-07321] Workgroup Memory Scope is limited to MeshNV, TaskNV, MeshEXT, TaskEXT, TessellationControl, and GLCompute execution model
  %main = OpFunction %void None %61
Command to reproduce:
	spirv-val <input.spv> --relax-block-layout --allow-offset-texture-operand --target-env vulkan1.2
The Vulkan spec states: If pCode is a pointer to SPIR-V code, pCode must adhere to the validation rules described by the Validation Rules within a Module section of the SPIR-V Environment appendix (https://docs.vulkan.org/spec/latest/chapters/shaders.html#VUID-VkShaderModuleCreateInfo-pCode-08737)
```

**Explanation :** 
There is nothing cross-invocation for a barrier to synchronize outside Compute

**Before the fix :** 
<img width="1797" height="251" alt="Capture d&#39;écran 2026-08-01 130305" src="https://github.com/user-attachments/assets/a471c5b3-a7b1-41e4-a49f-07c3b71057d4" />


**After the fix :** 
<img width="1040" height="126" alt="Capture d&#39;écran 2026-08-01 134916" src="https://github.com/user-attachments/assets/48821e09-498a-492b-ad07-d75b5a2b6ad8" />





## Testing

Try to launch without the modification, you should see the errors.
Try to launch with the modification and the env variable " $env:SHARPEMU_SHADER_SPIRV_DUMP_DIR = "C:\temp\spirv_dump""

You will be available to try the following commands : 
for the first fix (need to wait the creation of the 0051.spv ): 
```spirv-val C:\temp\spirv_dump\0051.spv --relax-block-layout --allow-offset-texture-operand --target-env vulkan1.2```
```spirv-dis C:\temp\spirv_dump\0051.spv | Select-String "OpCapability"```

for the second fix (need to wait the creation of the 0061.spv than can take a few minutes on my PC)
```spirv-val C:\temp\spirv_dump\0061.spv --relax-block-layout --allow-offset-texture-operand --target-env vulkan1.2```
```spirv-dis C:\temp\spirv_dump\0061.spv | Select-String "OpCapability"```

Example:

- Astrobot (PPSA21564)


## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
