### PR TITLE
Astrobot - Vulkan fix : 0x8A

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -99,6 +99,7 @@ public static partial class AgcExports
     // as an address yields a 58-bit value (observed live: 0x30004622C008300).
     private const uint SpiShaderPgmLoGs = 0x88;
     private const uint SpiShaderPgmHiGs = 0x89;
+    private const uint SpiShaderPgmRsrc1Gs = 0x8A;
     private const uint SpiShaderPgmChksumGs = 0x80;
     private const uint SpiPsInputEna = 0x1B3;
     private const uint SpiPsInputAddr = 0x1B4;
@@ -12538,13 +12539,16 @@ public static partial class AgcExports
             // GTA V Enhanced HS headers start at RSRC1/RSRC2 (0x10A/0x10B) and
             // omit PGM_LO/HI from the default table. Still succeed: the code VA
             // lives at ShaderCodeOffset and later binder paths republish it.
-            if (shaderType == HsFrontShaderType && firstLo is SpiShaderPgmRsrc1Hs or SpiShaderPgmLoHs)
+            // GS front headers can likewise start at RSRC1_GS (0x8A) instead of
+            // PGM_LO_GS (0x88) - same deal, skip the patch here.
+            if ((shaderType == HsFrontShaderType && firstLo is SpiShaderPgmRsrc1Hs or SpiShaderPgmLoHs) ||
+                (shaderType == GsFrontShaderType && firstLo is SpiShaderPgmRsrc1Gs or SpiShaderPgmLoGs))
             {
                 TraceCreateShader(
                     0,
                     headerAddress,
                     codeAddress,
-                    $"skip-pgm-patch type={HsFrontShaderType} first_lo=0x{firstLo:X8}");
+                    $"skip-pgm-patch type={shaderType} first_lo=0x{firstLo:X8}");
                 return true;
             }
 


### PR DESCRIPTION
## Explanation

GS front headers can likewise start at RSRC1_GS (0x8A) instead of PGM_LO_GS (0x88) - need to skip the patch here.

## Testing

With the environment variable enable : `SHARPEMU_VK_VALIDATION=1`

Start the game with the last commit.

You will have the following error : 

```
[17:57:25.160] [LOADER][ERROR] Execution stalled with no import progress for 20s (imports=546816).
[17:57:25.229] [LOADER][ERROR] Stall snapshot: rip=0x0000700000006940 rsp=0x00007FFFF01FF558 rbp=0x00007FFFF01FF5C0 rax=0xFFFFFFFF80020003 rbx=0x0000000307AA83B8 rcx=0x0000000000000040 rdx=0x0000000500000100 rsi=0x0000000500000210 rdi=0x0000000307AA83D0
[17:57:25.229] [LOADER][ERROR] Stall import-stub: rip=0x0000700000006940 nid=f3dg2CSgRKY -> libSceAgc:sceAgcCreateShader
[17:57:25.229] [LOADER][ERROR] Stall bytes @rip: 48 B8 00 00 36 3F F5 01 00 00 FF E0 90 90 90 90
[17:57:25.229] [LOADER][ERROR] Stall stack: [rsp]=0x0000000000000000 [rsp+8]=0x0000000000000000
[17:57:25.229] [LOADER][ERROR] Stall guest-thread: handle=0x000001E5A8518110 name='SystemService_ATQT' state=Blocked imports=11 nid=WKAXJ4XBPQ4 ret=0x0000000800011DD1 rdi=0x000000030092B960 rsi=0x00000003009297F0 rdx=0x0000000000000000 block=pthread_cond_wait
[17:57:25.229] [LOADER][ERROR] Stall guest-thread: handle=0x000001E5A8519120 name='SystemWakeup' state=Blocked imports=1 nid=Zxa0VhQVTsk ret=0x00000008000017AE rdi=0x000000000000000E rsi=0x0000000000000001 rdx=0x0000000000000000 block=sceKernelWaitSema
[17:57:25.229] [LOADER][ERROR] Stall guest-thread: handle=0x000001E5A851D160 name='BackgroundTaskWorker' state=Blocked imports=37 nid=Zxa0VhQVTsk ret=0x00000008000017AE rdi=0x000000000000000F rsi=0x0000000000000001 rdx=0x0000000000000000 block=sceKernelWaitSema
[17:57:25.229] [LOADER][ERROR] Stall guest-thread: handle=0x000001E5A851C150 name='BackgroundTaskWorker' state=Blocked imports=14 nid=Zxa0VhQVTsk ret=0x00000008000017AE rdi=0x000000000000000F rsi=0x0000000000000001 rdx=0x0000000000000000 block=sceKernelWaitSema
[17:57:25.229] [LOADER][ERROR] Stall guest-thread: handle=0x000001E5A851A130 name='BackgroundTaskWorker' state=Blocked imports=13 nid=Zxa0VhQVTsk ret=0x00000008000017AE rdi=0x000000000000000F rsi=0x0000000000000001 rdx=0x0000000000000000 block=sceKernelWaitSema
[17:57:25.229] [LOADER][ERROR] Stall guest-thread: handle=0x000001E5A851F180 name='BackgroundTaskWorker' state=Blocked imports=13 nid=Zxa0VhQVTsk ret=0x00000008000017AE rdi=0x000000000000000F rsi=0x0000000000000001 rdx=0x0000000000000000 block=sceKernelWaitSema
[17:57:25.229] [LOADER][ERROR] Stall guest-thread: handle=0x000001E5A8520190 name='BackgroundTaskWorker' state=Blocked imports=13 nid=Zxa0VhQVTsk ret=0x00000008000017AE rdi=0x000000000000000F rsi=0x0000000000000001 rdx=0x0000000000000000 block=sceKernelWaitSema
[17:57:25.229] [LOADER][ERROR] Stall guest-thread: handle=0x000001E5A85211A0 name='BackgroundTaskWorker' state=Blocked imports=13 nid=Zxa0VhQVTsk ret=0x00000008000017AE rdi=0x000000000000000F rsi=0x0000000000000001 rdx=0x0000000000000000 block=sceKernelWaitSema
[17:57:25.229] [LOADER][ERROR] Stall guest-thread: handle=0x000001E5A851E170 name='BackgroundTaskWorker' state=Blocked imports=13 nid=Zxa0VhQVTsk ret=0x00000008000017AE rdi=0x000000000000000F rsi=0x0000000000000001 rdx=0x0000000000000000 block=sceKernelWaitSema
[17:57:25.229] [LOADER][ERROR] Stall guest-thread: handle=0x000001E5A85251E0 name='BackgroundTaskWorker' state=Blocked imports=13 nid=Zxa0VhQVTsk ret=0x00000008000017AE rdi=0x000000000000000F rsi=0x0000000000000001 rdx=0x0000000000000000 block=sceKernelWaitSema
[17:57:25.233] Process exited with code 4 (emulation error).
```

Try with the new build, the error is no more existing.

Example:

- Astrobot (PPSA21564 )


## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
