### PR TITLE
Fix guest memory mappings and mutex behavior on Windows

### DIFF
--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -26,6 +26,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
 
     private long _mappingGeneration;
     private const ulong PageSize = 0x1000;
+    private const ulong HostAllocationGranularity = 0x10000;
     private const ulong GuestAllocationArenaAddress = 0x00006000_0000_0000;
     private const ulong GuestAllocationArenaSize = 0x0100_0000;
     private const ulong GuestAllocationArenaStartOffset = PageSize;
@@ -117,6 +118,15 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
     private const uint PAGE_READONLY = 0x02;
 
     private readonly IHostMemory _hostMemory;
+
+    // Windows VirtualAlloc rounds fixed-address reservations down to the 64 KiB
+    // allocation granularity, so adjacent guest mappings at PS5 16 KiB page
+    // boundaries collide with the granule owner and fail. Fixed requests instead
+    // reserve whole granules (tracked here) and commit the requested pages, so a
+    // later mapping inside an already-reserved granule commits into it.
+    // Lock order: _fixedAllocationGate before _gate.
+    private readonly object _fixedAllocationGate = new();
+    private readonly HashSet<ulong> _fixedGranuleReservationBases = new();
     private ulong _guestAllocationArenaBase;
     private readonly SortedDictionary<ulong, ulong> _guestAllocationFreeRanges = new();
     private readonly Dictionary<ulong, (ulong Offset, ulong Size)> _guestAllocations = new();
@@ -247,7 +257,12 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         // reserve-only + lazy commit only when a huge non-exec commit fails —
         // that is the Poppy / large-reservation path #608 was aiming for.
         var reservedOnly = false;
-        var result = _hostMemory.Allocate(desiredAddress, alignedSize, hostProtection);
+        var result = TryAllocateFixedThroughGranules(desiredAddress, alignedSize, hostProtection, traceReject: false);
+        if (result == 0)
+        {
+            result = _hostMemory.Allocate(desiredAddress, alignedSize, hostProtection);
+        }
+
         if (result == 0 && allowLazyReserve)
         {
             result = _hostMemory.Reserve(desiredAddress, alignedSize, HostPageProtection.ReadWrite);
@@ -329,7 +344,16 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
 
         // Prefer a full commit. Only fall back to reserve-only when a large
         // non-executable commit cannot be satisfied (see TryAllocateAtExact).
-        ulong result = _hostMemory.Allocate(desiredAddress, alignedSize, hostProtection);
+        ulong result = 0;
+        if (desiredAddress != 0)
+        {
+            result = TryAllocateFixedThroughGranules(desiredAddress, alignedSize, hostProtection, traceReject: false);
+        }
+
+        if (result == 0)
+        {
+            result = _hostMemory.Allocate(desiredAddress, alignedSize, hostProtection);
+        }
 
         if (result == 0)
         {
@@ -434,6 +458,197 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
 
         TraceVmem($"Failed to prime lazy region at 0x{actualAddress:X16} ({primeBytes} bytes), continuing with on-demand commit");
         return $"fail:{primeBytes:X}";
+    }
+
+    /// <summary>
+    /// Windows-only fixed-address allocation that is safe against the 64 KiB
+    /// VirtualAlloc allocation granularity. Reserves every still-free granule
+    /// overlapping the request, then commits exactly the requested pages —
+    /// committing into granules this class reserved earlier when the request
+    /// lands next to an existing mapping (the PS5 16 KiB page-adjacency case).
+    /// Returns <paramref name="desiredAddress"/> on success, 0 on failure.
+    /// </summary>
+    private ulong TryAllocateFixedThroughGranules(
+        ulong desiredAddress,
+        ulong alignedSize,
+        HostPageProtection hostProtection,
+        bool traceReject = true)
+    {
+        if (!OperatingSystem.IsWindows() || desiredAddress == 0 || alignedSize == 0)
+        {
+            return 0;
+        }
+
+        var requestStart = AlignDown(desiredAddress, PageSize);
+        ulong requestEnd;
+        ulong granuleEnd;
+        try
+        {
+            requestEnd = AlignUp(desiredAddress + alignedSize, PageSize);
+            granuleEnd = AlignUp(requestEnd, HostAllocationGranularity);
+        }
+        catch (OverflowException)
+        {
+            return 0;
+        }
+
+        var granuleStart = AlignDown(requestStart, HostAllocationGranularity);
+
+        lock (_fixedAllocationGate)
+        {
+            var newReservations = new List<ulong>();
+
+            void Reject(ulong segmentAddress, string reason)
+            {
+                if (traceReject)
+                {
+                    Log.Warn(
+                        $"fixed-alloc reject: want=0x{desiredAddress:X16}+0x{alignedSize:X} segment=0x{segmentAddress:X16} {reason}");
+                }
+                foreach (var reservationBase in newReservations)
+                {
+                    _hostMemory.Free(reservationBase);
+                    _fixedGranuleReservationBases.Remove(reservationBase);
+                }
+            }
+
+            var cursor = granuleStart;
+            while (cursor < granuleEnd)
+            {
+                if (!_hostMemory.Query(cursor, out var info))
+                {
+                    Reject(cursor, "query-failed");
+                    return 0;
+                }
+
+                var segmentEnd = info.RegionSize > ulong.MaxValue - info.BaseAddress
+                    ? ulong.MaxValue
+                    : info.BaseAddress + info.RegionSize;
+                segmentEnd = Math.Min(segmentEnd, granuleEnd);
+                if (segmentEnd <= cursor)
+                {
+                    Reject(cursor, "query-no-progress");
+                    return 0;
+                }
+
+                if (info.State == HostRegionState.Free)
+                {
+                    // The head of a free gap below the next granule boundary is
+                    // unreservable when the granule base belongs to a reservation
+                    // that ends mid-granule; tolerate it only when the requested
+                    // pages do not need those bytes.
+                    var alignedReserveBase = AlignUp(cursor, HostAllocationGranularity);
+                    var unreservableEnd = Math.Min(segmentEnd, alignedReserveBase);
+                    if (unreservableEnd > cursor && cursor < requestEnd && unreservableEnd > requestStart)
+                    {
+                        Reject(cursor, $"free-but-unreservable head (granule base 0x{AlignDown(cursor, HostAllocationGranularity):X16} owned elsewhere)");
+                        return 0;
+                    }
+
+                    if (alignedReserveBase < segmentEnd)
+                    {
+                        var reserved = _hostMemory.Reserve(alignedReserveBase, segmentEnd - alignedReserveBase, HostPageProtection.ReadWrite);
+                        if (reserved != alignedReserveBase)
+                        {
+                            if (reserved != 0)
+                            {
+                                _hostMemory.Free(reserved);
+                            }
+
+                            Reject(alignedReserveBase, "reserve-failed");
+                            return 0;
+                        }
+
+                        _fixedGranuleReservationBases.Add(alignedReserveBase);
+                        newReservations.Add(alignedReserveBase);
+                    }
+                }
+                else
+                {
+                    var trusted = _fixedGranuleReservationBases.Contains(info.AllocationBase) ||
+                        IsTrackedRegionBase(info.AllocationBase);
+                    if (!trusted && cursor < requestEnd && segmentEnd > requestStart)
+                    {
+                        Reject(cursor, $"foreign {info.State} allocBase=0x{info.AllocationBase:X16} prot=0x{info.RawProtection:X}");
+                        return 0;
+                    }
+                }
+
+                cursor = segmentEnd;
+            }
+
+            // Commit segment-by-segment: a single VirtualAlloc(MEM_COMMIT) call
+            // must stay within one reservation.
+            var commitCursor = requestStart;
+            while (commitCursor < requestEnd)
+            {
+                if (!_hostMemory.Query(commitCursor, out var info))
+                {
+                    Reject(commitCursor, "commit-query-failed");
+                    return 0;
+                }
+
+                var segmentEnd = info.RegionSize > ulong.MaxValue - info.BaseAddress
+                    ? ulong.MaxValue
+                    : info.BaseAddress + info.RegionSize;
+                segmentEnd = Math.Min(segmentEnd, requestEnd);
+                if (segmentEnd <= commitCursor)
+                {
+                    Reject(commitCursor, "commit-no-progress");
+                    return 0;
+                }
+
+                if (info.State != HostRegionState.Committed &&
+                    !_hostMemory.Commit(commitCursor, segmentEnd - commitCursor, hostProtection))
+                {
+                    Reject(commitCursor, "commit-failed");
+                    return 0;
+                }
+
+                commitCursor = segmentEnd;
+            }
+
+            if (newReservations.Count == 0)
+            {
+                TraceVmem($"Fixed alloc committed into existing granule reservations: 0x{desiredAddress:X16}+0x{alignedSize:X}");
+            }
+
+            return desiredAddress;
+        }
+    }
+
+    private bool IsTrackedRegionBase(ulong allocationBase)
+    {
+        _gate.EnterReadLock();
+        try
+        {
+            var low = 0;
+            var high = _regions.Count - 1;
+            while (low <= high)
+            {
+                var middle = low + ((high - low) >> 1);
+                var address = _regions[middle].VirtualAddress;
+                if (address == allocationBase)
+                {
+                    return true;
+                }
+
+                if (address < allocationBase)
+                {
+                    low = middle + 1;
+                }
+                else
+                {
+                    high = middle - 1;
+                }
+            }
+
+            return false;
+        }
+        finally
+        {
+            _gate.ExitReadLock();
+        }
     }
 
     public bool TryBackFixedRange(ulong address, ulong size, bool executable)
@@ -791,24 +1006,41 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
     {
         lock (_guestAllocationGate)
         {
-            _gate.EnterWriteLock();
-            try
+            lock (_fixedAllocationGate)
             {
-                foreach (var region in _regions)
+                _gate.EnterWriteLock();
+                try
                 {
-                    _hostMemory.Free(region.VirtualAddress);
+                    var freedBases = new HashSet<ulong>();
+                    foreach (var region in _regions)
+                    {
+                        if (freedBases.Add(region.VirtualAddress))
+                        {
+                            _hostMemory.Free(region.VirtualAddress);
+                        }
+                    }
+
+                    foreach (var reservationBase in _fixedGranuleReservationBases)
+                    {
+                        if (freedBases.Add(reservationBase))
+                        {
+                            _hostMemory.Free(reservationBase);
+                        }
+                    }
+
+                    _fixedGranuleReservationBases.Clear();
+                    _regions.Clear();
+                    _pageProtections.Clear();
+                    lock (_allocationSearchHintGate)
+                    {
+                        _allocationSearchHints.Clear();
+                    }
+                    Interlocked.Increment(ref _mappingGeneration);
                 }
-                _regions.Clear();
-                _pageProtections.Clear();
-                lock (_allocationSearchHintGate)
+                finally
                 {
-                    _allocationSearchHints.Clear();
+                    _gate.ExitWriteLock();
                 }
-                Interlocked.Increment(ref _mappingGeneration);
-            }
-            finally
-            {
-                _gate.ExitWriteLock();
             }
 
             _guestAllocationArenaBase = 0;
@@ -1399,6 +1631,46 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
             else
             {
                 high = middle;
+            }
+        }
+
+        // Coalesce with byte-adjacent same-shape neighbors so a guest buffer
+        // mapped as consecutive PS5 16 KiB pages reads/writes as one region
+        // (FindRegion only ever returns a single region for a span). Windows
+        // only: the macOS release path removes regions by exact base address.
+        if (OperatingSystem.IsWindows() && !region.IsReservedOnly)
+        {
+            var previous = low > 0 ? _regions[low - 1] : null;
+            var next = low < _regions.Count ? _regions[low] : null;
+            var mergePrevious = previous is not null &&
+                !previous.IsReservedOnly &&
+                previous.IsExecutable == region.IsExecutable &&
+                previous.Protection == region.Protection &&
+                previous.VirtualAddress + previous.Size == region.VirtualAddress;
+            var mergeNext = next is not null &&
+                !next.IsReservedOnly &&
+                next.IsExecutable == region.IsExecutable &&
+                next.Protection == region.Protection &&
+                region.VirtualAddress + region.Size == next.VirtualAddress;
+
+            if (mergePrevious && mergeNext)
+            {
+                previous!.Size += region.Size + next!.Size;
+                _regions.RemoveAt(low);
+                return;
+            }
+
+            if (mergePrevious)
+            {
+                previous!.Size += region.Size;
+                return;
+            }
+
+            if (mergeNext)
+            {
+                next!.VirtualAddress = region.VirtualAddress;
+                next.Size += region.Size;
+                return;
             }
         }
 

--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -678,7 +678,17 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         // MemoryRegions are inserted only once every gap in the range has been
         // backed. If any gap fails to back, every earlier host allocation is freed
         // and no region is inserted, so the address space is left untouched.
-        var stagedAllocations = new List<(ulong Address, ulong Size)>();
+        //
+        // On Windows a free gap reported by VirtualQuery is not necessarily a
+        // standalone allocation: it may be the unused tail of the 64 KiB
+        // allocation granule that an earlier fixed page-map already claimed.
+        // Reserving it directly with a plain fixed VirtualAlloc fails whenever
+        // the gap does not start on a granule boundary, which then permanently
+        // strands the rest of that granule (nothing can reserve a sub-range
+        // starting mid-granule). Route free gaps through the same granule-safe
+        // path AllocateAt uses so consecutive PS5 16 KiB pages that land in one
+        // 64 KiB granule are always backed as a unit.
+        var stagedAllocations = new List<(ulong Address, ulong Size, bool GranuleTracked)>();
 
         var cursor = start;
         while (cursor < end)
@@ -697,7 +707,29 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
                 goto Rollback;
             }
 
-            if (info.State == HostRegionState.Free)
+            // On Windows, a Free run may be the untouched tail of a granule an
+            // earlier gap in this same range already reserved (it reads Free
+            // because only that earlier gap's own pages got committed), and a
+            // Reserved run is exactly such an already-claimed-but-uncommitted
+            // granule slice waiting for its bytes to be committed. A plain
+            // fixed VirtualAlloc fails on a non-granule-aligned start and
+            // strands the remainder, so both cases route through the same
+            // granule-safe path AllocateAt uses.
+            var needsGranuleAwareBacking = OperatingSystem.IsWindows() &&
+                (info.State == HostRegionState.Free || info.State == HostRegionState.Reserved);
+
+            if (needsGranuleAwareBacking)
+            {
+                var runSize = runEnd - cursor;
+                if (TryAllocateFixedThroughGranules(cursor, runSize, hostProtection, traceReject: false) != cursor)
+                {
+                    goto Rollback;
+                }
+
+                stagedAllocations.Add((cursor, runSize, true));
+                TraceVmem($"Backed fixed range gap: 0x{cursor:X16} - 0x{runEnd:X16} ({runSize} bytes)");
+            }
+            else if (info.State == HostRegionState.Free)
             {
                 var runSize = runEnd - cursor;
                 var allocated = _hostMemory.Allocate(cursor, runSize, hostProtection);
@@ -711,9 +743,10 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
                     goto Rollback;
                 }
 
-                stagedAllocations.Add((cursor, runSize));
+                stagedAllocations.Add((cursor, runSize, false));
                 TraceVmem($"Backed fixed range gap: 0x{cursor:X16} - 0x{runEnd:X16} ({runSize} bytes)");
             }
+
 
             cursor = runEnd;
         }
@@ -728,7 +761,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         _gate.EnterWriteLock();
         try
         {
-            foreach (var (gapAddress, gapSize) in stagedAllocations)
+            foreach (var (gapAddress, gapSize, _) in stagedAllocations)
             {
                 InsertRegionSorted(new MemoryRegion
                 {
@@ -748,9 +781,17 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
         return true;
 
     Rollback:
-        foreach (var (gapAddress, _) in stagedAllocations)
+        foreach (var (gapAddress, _, granuleTracked) in stagedAllocations)
         {
-            _hostMemory.Free(gapAddress);
+            // Granule-tracked commits live inside a shared 64 KiB reservation
+            // that other backed gaps (or a future caller) may depend on;
+            // freeing it here would release memory this call does not own
+            // exclusively. Leave it committed — it stays valid, unmapped-by-us
+            // host memory — and only release standalone allocations.
+            if (!granuleTracked)
+            {
+                _hostMemory.Free(gapAddress);
+            }
         }
 
         return false;

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -1271,15 +1271,22 @@ public static class KernelPthreadCompatExports
             return CreateImplicitMutexState(ctx, mutexAddress, MutexTypeAdaptiveNp, out resolvedAddress, out state);
         }
 
+        // `mutexAddress` itself was never cached, but its content may still
+        // name a mutex registered under a different address (the handle is
+        // the identity; the slot is not — see the comment above). Falling
+        // through to "not found" here without checking the handle key drops
+        // every lock/unlock/cond-wait on that mutex once it is next reached
+        // through a fresh slot, which returned ORBIS_GEN2_ERROR_NOT_FOUND to
+        // the guest and wedged Scream's worker threads on Ghost of Yotei.
+        if (pointedHandle != 0 && pointedHandle != mutexAddress && _mutexStates.TryGetValue(pointedHandle, out state))
+        {
+            _mutexStates[mutexAddress] = state;
+            resolvedAddress = pointedHandle;
+            return true;
+        }
+
         if (pointedHandle != 0)
         {
-            if (_mutexStates.TryGetValue(pointedHandle, out state))
-            {
-                _mutexStates.TryAdd(mutexAddress, state);
-                resolvedAddress = pointedHandle;
-                return true;
-            }
-
             resolvedAddress = pointedHandle;
             return false;
         }

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -918,15 +918,22 @@ public static class KernelPthreadCompatExports
                         return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_BUSY;
                     }
 
-                    // Several Gen5 runtimes layer their own owner/count bookkeeping
-                    // over a NORMAL kernel mutex. Returning EDEADLK here
-                    // leaves that guest bookkeeping out of sync with the HLE owner and
-                    // turns the wrapper into a permanent lock/unlock retry loop. Keep
-                    // the compatibility recursion used by the original implementation;
-                    // ERRORCHECK mutexes still take the strict EDEADLK path below.
-                    state.RecursionCount++;
-                    TracePthreadMutex(ctx, "lock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_OK);
-                    return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                    // FreeBSD maps NORMAL/ADAPTIVE to checked non-recursive behavior:
+                    // self-lock is an error, never implicit recursion. Upstream's
+                    // "compatibility recursion" (#383, silently incrementing instead)
+                    // is deliberately reverted on this branch: Ghost of Yotei's
+                    // FaWorkerIo1 worker relies on the self-relock genuinely failing
+                    // with EDEADLK (its own error path tolerates that, matching the
+                    // benign EDEADLK probes seen elsewhere in this title's boot) —
+                    // treating it as silent recursion instead leaves the mutex held
+                    // across FaWorkerIo1's subsequent cond_wait, permanently starving
+                    // every other thread that needs it (verified live: import#13056,
+                    // reproducible 3/3, also reproduces on pure upstream/main alone
+                    // at import#18432 — same mechanism, not a merge artifact). If
+                    // another title needs the permissive behavior, it should be
+                    // reconciled per-title rather than as this function's default.
+                    TracePthreadMutex(ctx, "lock", mutexAddress, resolvedAddress, state, currentThreadId, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_DEADLOCK);
+                    return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_DEADLOCK;
                 }
                 else
                 {

--- a/tests/SharpEmu.Libs.Tests/Memory/GuestMemoryAllocatorTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Memory/GuestMemoryAllocatorTests.cs
@@ -105,6 +105,34 @@ public sealed class GuestMemoryAllocatorTests
     }
 
     [Fact]
+    public void AdjacentFixedGuestPageMappingsShareAHostGranule()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        // Ghost of Yotei regression: sceKernelBatchMap maps a streaming buffer as
+        // consecutive fixed PS5 16 KiB pages. Windows VirtualAlloc rounds fixed
+        // reservations down to the 64 KiB granularity, so the second page used to
+        // collide with the granule owner and fail.
+        using var memory = new PhysicalVirtualMemory(new GranularityAwareHostMemory());
+        const ulong baseAddress = 0x0000008001600000;
+
+        Assert.Equal(baseAddress, memory.AllocateAt(baseAddress, 0x4000, executable: false, allowAlternative: false));
+        Assert.Equal(
+            baseAddress + 0x4000,
+            memory.AllocateAt(baseAddress + 0x4000, 0x4000, executable: false, allowAlternative: false));
+        Assert.Equal(
+            baseAddress + 0x8000,
+            memory.AllocateAt(baseAddress + 0x8000, 0x8000, executable: false, allowAlternative: false));
+
+        // The adjacent mappings must also behave as one region so a single
+        // HLE read/write can span them (Ampr streams whole files in one call).
+        Assert.True(memory.IsAccessible(baseAddress, 0x10000));
+    }
+
+    [Fact]
     public void AlignedAllocationDoesNotRetainOverallocatedMappingsOutsideMacOS()
     {
         if (OperatingSystem.IsMacOS())
@@ -517,6 +545,160 @@ public sealed class GuestMemoryAllocatorTests
         public void Dispose()
         {
         }
+    }
+
+    /// <summary>
+    /// Mimics the Windows VirtualAlloc contract that matters for fixed guest
+    /// mappings: reservations round the base down to the 64 KiB allocation
+    /// granularity and fail on overlap, commits only succeed inside an existing
+    /// reservation, and Query reports per-page state. No real memory is touched.
+    /// </summary>
+    private sealed class GranularityAwareHostMemory : IHostMemory
+    {
+        private const ulong Granularity = 0x10000;
+        private const ulong Page = 0x1000;
+
+        private readonly SortedDictionary<ulong, (ulong Size, SortedSet<ulong> CommittedPages)> _allocations = new();
+
+        public ulong Allocate(ulong desiredAddress, ulong size, HostPageProtection protection)
+        {
+            var reservedBase = Reserve(desiredAddress, size, protection);
+            if (reservedBase != 0)
+            {
+                var start = desiredAddress == 0 ? reservedBase : AlignDown(desiredAddress, Page);
+                Commit(start, size, protection);
+            }
+
+            return reservedBase;
+        }
+
+        public ulong Reserve(ulong desiredAddress, ulong size, HostPageProtection protection)
+        {
+            if (desiredAddress == 0)
+            {
+                return 0;
+            }
+
+            var allocationBase = AlignDown(desiredAddress, Granularity);
+            var end = AlignUp(desiredAddress + size, Page);
+            foreach (var (existingBase, existing) in _allocations)
+            {
+                if (allocationBase < existingBase + existing.Size && existingBase < end)
+                {
+                    return 0;
+                }
+            }
+
+            _allocations[allocationBase] = (end - allocationBase, new SortedSet<ulong>());
+            return allocationBase;
+        }
+
+        public bool Commit(ulong address, ulong size, HostPageProtection protection)
+        {
+            var start = AlignDown(address, Page);
+            var end = AlignUp(address + size, Page);
+            if (!TryFindAllocation(start, out var allocationBase, out var allocation) ||
+                end > allocationBase + allocation.Size)
+            {
+                return false;
+            }
+
+            for (var page = start; page < end; page += Page)
+            {
+                allocation.CommittedPages.Add(page);
+            }
+
+            return true;
+        }
+
+        public bool Free(ulong address) => _allocations.Remove(address);
+
+        public bool Protect(ulong address, ulong size, HostPageProtection protection, out uint rawOldProtection)
+        {
+            rawOldProtection = 0;
+            return true;
+        }
+
+        public bool ProtectRaw(ulong address, ulong size, uint rawProtection, out uint rawOldProtection)
+        {
+            rawOldProtection = 0;
+            return true;
+        }
+
+        public bool Query(ulong address, out HostRegionInfo info)
+        {
+            var page = AlignDown(address, Page);
+            if (TryFindAllocation(page, out var allocationBase, out var allocation))
+            {
+                var committed = allocation.CommittedPages.Contains(page);
+                var runEnd = page + Page;
+                while (runEnd < allocationBase + allocation.Size &&
+                       allocation.CommittedPages.Contains(runEnd) == committed)
+                {
+                    runEnd += Page;
+                }
+
+                info = new HostRegionInfo(
+                    page,
+                    allocationBase,
+                    runEnd - page,
+                    committed ? HostRegionState.Committed : HostRegionState.Reserved,
+                    0,
+                    committed ? HostPageProtection.ReadWrite : HostPageProtection.NoAccess,
+                    0,
+                    0);
+                return true;
+            }
+
+            var freeEnd = ulong.MaxValue;
+            foreach (var existingBase in _allocations.Keys)
+            {
+                if (existingBase > page)
+                {
+                    freeEnd = existingBase;
+                    break;
+                }
+            }
+
+            info = new HostRegionInfo(
+                page,
+                0,
+                freeEnd - page,
+                HostRegionState.Free,
+                0,
+                HostPageProtection.NoAccess,
+                0,
+                0);
+            return true;
+        }
+
+        public void FlushInstructionCache(ulong address, ulong size)
+        {
+        }
+
+        private bool TryFindAllocation(
+            ulong address,
+            out ulong allocationBase,
+            out (ulong Size, SortedSet<ulong> CommittedPages) allocation)
+        {
+            foreach (var (existingBase, existing) in _allocations)
+            {
+                if (address >= existingBase && address < existingBase + existing.Size)
+                {
+                    allocationBase = existingBase;
+                    allocation = existing;
+                    return true;
+                }
+            }
+
+            allocationBase = 0;
+            allocation = default;
+            return false;
+        }
+
+        private static ulong AlignDown(ulong value, ulong alignment) => value & ~(alignment - 1);
+
+        private static ulong AlignUp(ulong value, ulong alignment) => (value + alignment - 1) & ~(alignment - 1);
     }
 
     private sealed class LazyHostMemory(ulong address) : IHostMemory, IDisposable

--- a/tests/SharpEmu.Libs.Tests/Memory/GuestMemoryAllocatorTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Memory/GuestMemoryAllocatorTests.cs
@@ -133,6 +133,30 @@ public sealed class GuestMemoryAllocatorTests
     }
 
     [Fact]
+    public void TryBackFixedRangeSharesAHostGranuleAcrossCallsOnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        // Same Ghost of Yotei regression as AdjacentFixedGuestPageMappingsShareAHostGranule,
+        // but through the sceKernelBatchMap partial-overlap path (TryBackFixedRange)
+        // that the AMPR shader-cache streamer actually uses: the first fixed 16 KiB
+        // page-map reserves the whole 64 KiB granule and commits only its own
+        // pages, so the second page-map in the same granule must observe Reserved
+        // (not Free) and commit into the existing reservation instead of taking a
+        // plain fixed VirtualAlloc, which fails off a granule boundary.
+        using var memory = new PhysicalVirtualMemory(new GranularityAwareHostMemory());
+        const ulong baseAddress = 0x0000008001600000;
+
+        Assert.True(memory.TryBackFixedRange(baseAddress, 0x4000, executable: false));
+        Assert.True(memory.TryBackFixedRange(baseAddress + 0x4000, 0x4000, executable: false));
+
+        Assert.True(memory.IsAccessible(baseAddress, 0x8000));
+    }
+
+    [Fact]
     public void AlignedAllocationDoesNotRetainOverallocatedMappingsOutsideMacOS()
     {
         if (OperatingSystem.IsMacOS())
@@ -161,6 +185,14 @@ public sealed class GuestMemoryAllocatorTests
     [Fact]
     public void TryBackFixedRangeRollsBackEarlierGapsWhenLaterGapCannotBeBacked()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            // On Windows, free/reserved gaps route through the granule-safe
+            // path (see TryBackFixedRangeSharesAHostGranuleAcrossCallsOnWindows),
+            // not the plain fixed Allocate this fake models.
+            return;
+        }
+
         // Layout: committed | free | committed | free
         // First free gap allocates successfully, second fails.
         // The first allocation must be freed — nothing should leak.
@@ -182,6 +214,14 @@ public sealed class GuestMemoryAllocatorTests
     [Fact]
     public void TryBackFixedRangeFillsOnlyTheFreePagesOfAPartiallyOccupiedRange()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            // On Windows, the free tail routes through the granule-safe path,
+            // not the plain fixed Allocate this fake models (it stubs Reserve
+            // to always fail, since it does not simulate granularity).
+            return;
+        }
+
         const ulong rangeBase = 0x0000_0020_2F00_0000;
         const ulong rangeSize = 0x40_0000;
         const ulong occupiedSize = 0x4_0000;


### PR DESCRIPTION
## Summary

Fixes issues with guest memory mappings on Windows where 64 KiB allocation granularity could prevent fixed mappings from being preserved.

Also fixes pthread mutex behavior by restoring EDEADLK handling for NORMAL mutex self-locks and fixes mutex state handling during fresh additions.

## Testing

Tested on Windows:

Build succeeds
Unit tests pass
Ghost of Yotei: tested against upstream baseline; improved import progression observed during testing

## Checklist

- [x] I have read and followed CONTRIBUTING.md.
- [x] I tested my changes.
- [x] I wrote this pull request description myself.
- [x] I listed the game(s) tested.