### PR TITLE
[HLE] Fix VideoOut and AGC synchronization paths

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -1080,6 +1080,45 @@ public static partial class AgcExports
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
+    // Symbol name unconfirmed (not in ps5_names.txt); resolved from the
+    // decrypted eboot's call site only. Called immediately after
+    // sceAgcCreatePrimState with the SAME ucRegistersAddress base (Ghost of
+    // Yotei: caller lea's [rbp-0x130] for both), and a later fixed-size
+    // (immediate 0x20, not read from any header) scan of that buffer reads
+    // 32 (offset,value) pairs starting at that base and open-address-probes
+    // them as a register hash table -- an out-of-bounds probe index sourced
+    // from an unwritten pair here was the AV (read at an absurd offset
+    // derived from uninitialized guest-stack bytes). CreatePrimState only
+    // populates the first 3 pairs (bytes 0-23); zero the rest of the
+    // scanned window so every unpopulated slot is a harmless failed probe
+    // instead of guest-stack garbage.
+    [SysAbiExport(
+        Nid = "dbOlWdppb4o",
+        ExportName = "sceAgcAddPrimStateRegisters",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAgc")]
+    public static int AddPrimStateRegisters(CpuContext ctx)
+    {
+        var ucRegistersAddress = ctx[CpuRegister.Rdi];
+        if (ucRegistersAddress == 0)
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+        }
+
+        const int prefilledPairBytes = 3 * 8; // sceAgcCreatePrimState's 3 (offset,value) pairs
+        const int scannedTableBytes = 0x20 * 8; // caller's hardcoded probe-window size
+        Span<byte> zero = stackalloc byte[scannedTableBytes - prefilledPairBytes];
+        zero.Clear();
+        if (!ctx.Memory.TryWrite(ucRegistersAddress + prefilledPairBytes, zero))
+        {
+            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+        }
+
+        TraceAgc($"agc.add_prim_state_registers uc=0x{ucRegistersAddress:X16}");
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
     // NID captured from shipped titles; the friendly name collides with a real catalog symbol of a different NID. Rename pending AGC API confirmation.
     #pragma warning disable SHEM004
     [SysAbiExport(

--- a/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventQueueCompatExports.cs
@@ -1070,15 +1070,37 @@ public static class KernelEventQueueCompatExports
                         _pendingEvents[handle] = queue;
                     }
 
-                    QueueOrUpdateEvent(
-                        queue,
-                        new KernelQueuedEvent(
-                            registration.Ident,
-                            registration.Filter,
-                            registration.Flags,
-                            1,
-                            data,
-                            registration.UserData));
+                    // GPU interrupt events must not coalesce: the AGC driver's
+                    // interrupt thread accounts exactly one completion per
+                    // delivered kevent (it never reads the kevent payload), so
+                    // merging N triggers into one pending entry silently drops
+                    // N-1 completions and wedges its dependency counters. Queue
+                    // a distinct entry per trigger, with a defensive cap so an
+                    // undrained queue cannot grow without bound.
+                    if (CountPendingEvents(queue, registration.Ident, registration.Filter) < 256)
+                    {
+                        queue.AddLast(
+                            new KernelQueuedEvent(
+                                registration.Ident,
+                                registration.Filter,
+                                registration.Flags,
+                                1,
+                                data,
+                                registration.UserData));
+                    }
+                    else
+                    {
+                        QueueOrUpdateEvent(
+                            queue,
+                            new KernelQueuedEvent(
+                                registration.Ident,
+                                registration.Filter,
+                                registration.Flags,
+                                1,
+                                data,
+                                registration.UserData));
+                    }
+
                     (wakeQueues ??= []).Add(state);
                     triggeredCount++;
 
@@ -1302,6 +1324,24 @@ public static class KernelEventQueueCompatExports
         {
             ArrayPool<KernelQueuedEvent>.Shared.Return(events);
         }
+    }
+
+    private static int CountPendingEvents(
+        KernelEventDeque queue,
+        ulong ident,
+        short filter)
+    {
+        var count = 0;
+        for (var i = 0; i < queue.Count; i++)
+        {
+            var pending = queue[i];
+            if (pending.Ident == ident && pending.Filter == filter)
+            {
+                count++;
+            }
+        }
+
+        return count;
     }
 
     private static void QueueOrUpdateEvent(

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -1122,7 +1122,14 @@ public static class VideoOutExports
 
         if (category > 1 || option != 0)
         {
-            return OrbisVideoOutErrorInvalidValue;
+            // Ghost of Yotei registers its display buffers with a nonzero
+            // category/option pair; rejecting the registration guarantees the
+            // title can never flip. Treat unknown categories as the standard
+            // uncompressed layout instead of failing the whole registration.
+            Console.Error.WriteLine(
+                $"[LOADER][TRACE] videoout.register_buffers2 nonstandard " +
+                $"category=0x{categoryRaw:X} option=0x{option:X} handle={handle} " +
+                $"set={setIndex} start={bufferIndexStart} count={bufferNum}");
         }
 
         if (!TryReadBufferAttribute(ctx, attributeAddress, true, out var attribute))

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -727,6 +727,16 @@ public static class VideoOutExports
         KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x10, 0);
         KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x18, 0);
         KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x20, currentBuffer);
+        // Ghost of Yotei reads a flip-pending flag past the classic 0x28-byte
+        // struct (observed at +0x34 in its poll loop, ret site 0x800CD1335 in
+        // the decrypted eboot) and spins on sceKernelUsleep(1) while it is
+        // nonzero. The caller never pre-zeroes that stack buffer, so an
+        // untouched field reads back as garbage. Flips complete synchronously
+        // in this emulator (see SubmitFlip and sceVideoOutIsFlipPending,
+        // which always reports not-pending), so the whole extended region
+        // must read zero here too.
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x28, 0);
+        KernelMemoryCompatExports.TryWriteUInt64Compat(ctx, statusAddress + 0x30, 0);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 


### PR DESCRIPTION
## Summary

Fix several HLE synchronization issues affecting VideoOut and AGC behavior.

This includes fixes for:
- EOP interrupt delivery to ensure releases are signaled correctly.
- VideoOut buffer handling and presentation state consistency.
- AGC-related state updates required for correct synchronization with guest workloads.

These changes improve the reliability of the HLE paths used by games relying on AGC fences and VideoOut events.

## Testing

Tested on Windows:

Build succeeds
Unit tests pass
Ghost of Yotei (isolated): no measurable effect on its own. These changes were tested as part of the AGC/VideoOut investigation and the real rendering progress (splash dismissed, draws >700) only occurs when combined with the AGC arena/fences fixes.
No regression observed in isolation.
## Checklist

- [x] I have read and followed CONTRIBUTING.md.
- [x] I tested my changes.
- [x] I wrote this pull request description myself.
- [x] I listed the game(s) tested.