### PR TITLE
Functions exports in kernel and NpTrophy2

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelExports.cs
@@ -466,4 +466,47 @@ public static class KernelExports
         ctx[CpuRegister.Rax] = unchecked((ulong)(-1L));
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
+
+    [SysAbiExport(
+    Nid = "tU5e3f9gSiU",
+    ExportName = "sceKernelIsTrinityMode",
+    Target = Generation.Gen4 | Generation.Gen5,
+    LibraryName = "libKernel")]
+    public static int KernelIsTrinityMode(CpuContext ctx)
+    {
+        Console.WriteLine($"[LOADER][TRACE] KernelIsTrinityMode called");
+
+        ctx[CpuRegister.Rax] = 0;
+
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+    Nid = "DLORcroUqbc",
+    ExportName = "sceKernelGetOpenPsId",
+    Target = Generation.Gen4 | Generation.Gen5,
+    LibraryName = "libKernel")]
+    public static int KernelGetOpenPsId(CpuContext ctx)
+    {
+        ulong bufferPtr = ctx[CpuRegister.Rdi];
+
+        if (bufferPtr == 0)
+        {
+            ctx[CpuRegister.Rax] = unchecked((ulong)(uint)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        Span<byte> openPsId = stackalloc byte[16];
+
+        if (!ctx.Memory.TryWrite(bufferPtr, openPsId))
+        {
+            ctx[CpuRegister.Rax] = unchecked((ulong)(int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
 }

--- a/src/SharpEmu.Libs/Kernel/KernelExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelExports.cs
@@ -490,7 +490,7 @@ public static class KernelExports
 
         if (bufferPtr == 0)
         {
-            ctx[CpuRegister.Rax] = unchecked((ulong)(uint)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
+            ctx[CpuRegister.Rax] = unchecked((ulong)(int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT);
 
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }

--- a/src/SharpEmu.Libs/Kernel/KernelExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelExports.cs
@@ -474,8 +474,6 @@ public static class KernelExports
     LibraryName = "libKernel")]
     public static int KernelIsTrinityMode(CpuContext ctx)
     {
-        Console.WriteLine($"[LOADER][TRACE] KernelIsTrinityMode called");
-
         ctx[CpuRegister.Rax] = 0;
 
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;

--- a/src/SharpEmu.Libs/Np/NpTrophy2Exports.cs
+++ b/src/SharpEmu.Libs/Np/NpTrophy2Exports.cs
@@ -99,6 +99,16 @@ public static class NpTrophy2Exports
     public static int NpTrophy2GetTrophyInfo(CpuContext ctx) =>
         SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND);
 
+    // SHP!!! NpTrophy2
+    [SysAbiExport(
+        Nid = "y3zHpdZO6ME",
+        ExportName = "sceNpTrophy2GetTrophyInfoArray",
+        Target = Generation.Gen5,
+        LibraryName = "libSceNpTrophy2")]
+    public static int NpTrophy2GetTrophyInfoArray(CpuContext ctx) =>
+        SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND);
+
+
     private static int WriteIdAndReturn(CpuContext ctx, ulong outAddress, ref int nextId)
     {
         if (outAddress == 0)

--- a/src/SharpEmu.Libs/Np/NpTrophy2Exports.cs
+++ b/src/SharpEmu.Libs/Np/NpTrophy2Exports.cs
@@ -99,7 +99,6 @@ public static class NpTrophy2Exports
     public static int NpTrophy2GetTrophyInfo(CpuContext ctx) =>
         SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND);
 
-    // SHP!!! NpTrophy2GetTrophyInfoArray
     [SysAbiExport(
         Nid = "y3zHpdZO6ME",
         ExportName = "sceNpTrophy2GetTrophyInfoArray",

--- a/src/SharpEmu.Libs/Np/NpTrophy2Exports.cs
+++ b/src/SharpEmu.Libs/Np/NpTrophy2Exports.cs
@@ -99,7 +99,7 @@ public static class NpTrophy2Exports
     public static int NpTrophy2GetTrophyInfo(CpuContext ctx) =>
         SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND);
 
-    // SHP!!! NpTrophy2
+    // SHP!!! NpTrophy2GetTrophyInfoArray
     [SysAbiExport(
         Nid = "y3zHpdZO6ME",
         ExportName = "sceNpTrophy2GetTrophyInfoArray",


### PR DESCRIPTION
## Summary
I tested Ghost of Yotei in SharpEmu and found some functions that didnt exported. So, i wrote exports.

## Changes
### KernelExports.cs:
- sceKernelIsTrinityMode is a function that checks if our emulating PS5 is Pro (codename Trinity). In my case it returns 0.
- sceKernelGetOpenPsId is a function that gets and return Open PSID. In my case i created Open PSID with 16-sized span<byte> and filled it with 0 and return.
### NpTrophy2Exports.cs
- sceNpTrophy2GetTrophyInfoArray is a function that gets and return all trophys infos of launched game.
## Testing
- log now has no those functions unresolved exports warnings
[SharpEmuLog-PPSA26344-20260803-001634.txt](https://github.com/user-attachments/files/30637514/SharpEmuLog-PPSA26344-20260803-001634.txt)

## Checklist
- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
