### PR TITLE
[Ampr] Fix host path case comparisons on Linux

### DIFF
--- a/src/SharpEmu.Libs/Ampr/AmprExports.cs
+++ b/src/SharpEmu.Libs/Ampr/AmprExports.cs
@@ -72,7 +72,7 @@ public static class AmprExports
     private const int MaxCachedHostFiles = 1536;
     private static readonly object _hostFileCacheGate = new();
     private static readonly Dictionary<string, LinkedListNode<CachedHostFileEntry>> _hostFileByPath =
-        new(StringComparer.OrdinalIgnoreCase);
+        new(HostFsPath.Comparer);
     private static readonly LinkedList<CachedHostFileEntry> _hostFileLru = new();
 
     [SysAbiExport(

--- a/src/SharpEmu.Libs/Ampr/AmprFileRegistry.cs
+++ b/src/SharpEmu.Libs/Ampr/AmprFileRegistry.cs
@@ -111,7 +111,7 @@ internal static class AmprFileRegistry
         {
             while (true)
             {
-                if (string.Equals(_indexedApp0Root, normalizedRoot, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(_indexedApp0Root, normalizedRoot, HostFsPath.Comparison))
                 {
                     return;
                 }
@@ -123,7 +123,7 @@ internal static class AmprFileRegistry
                     if (string.Equals(
                             _indexingApp0Root,
                             normalizedRoot,
-                            StringComparison.OrdinalIgnoreCase))
+                            HostFsPath.Comparison))
                     {
                         Monitor.Wait(_indexGate);
                         continue;
@@ -174,20 +174,34 @@ internal static class AmprFileRegistry
             }
 
             var relatives = new List<string>(256 * 1024);
-            foreach (var hostPath in Directory.EnumerateFiles(
-                         normalizedRoot,
-                         "*",
-                         SearchOption.AllDirectories))
+            try
             {
-                var relative = Path.GetRelativePath(normalizedRoot, hostPath)
-                    .Replace('\\', '/');
-                if (string.IsNullOrEmpty(relative) ||
-                    relative.StartsWith("..", StringComparison.Ordinal))
+                foreach (var hostPath in Directory.EnumerateFiles(
+                             normalizedRoot,
+                             "*",
+                             SearchOption.AllDirectories))
                 {
-                    continue;
-                }
+                    var relative = Path.GetRelativePath(normalizedRoot, hostPath)
+                        .Replace('\\', '/');
+                    if (string.IsNullOrEmpty(relative) ||
+                        relative.StartsWith("..", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
 
-                relatives.Add(relative);
+                    relatives.Add(relative);
+                }
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                // The walk is an opportunistic warm-up reached synchronously from
+                // sceAmprCommandBufferConstructor; a dump that moves or a mount
+                // that hiccups must not fault the guest export. The background
+                // preload already swallows this. Leave the root unindexed so a
+                // later call retries.
+                Console.Error.WriteLine(
+                    $"[LOADER][WARN] ampr.app0_index_walk_failed root={normalizedRoot}: {exception.Message}");
+                return;
             }
 
             // Hash + dictionary fill dominates under Rosetta once the walk is
@@ -315,7 +329,10 @@ internal static class AmprFileRegistry
                 "ampr-index");
         Directory.CreateDirectory(cacheDir);
 
-        var rootHash = ComputeFileId(normalizedRoot.ToLowerInvariant());
+        // Distinct roots must not share a cache file. Folding case is only
+        // correct where the host filesystem folds it too.
+        var rootKey = OperatingSystem.IsWindows() ? normalizedRoot.ToLowerInvariant() : normalizedRoot;
+        var rootHash = ComputeFileId(rootKey);
         return Path.Combine(cacheDir, $"app0-{rootHash:x8}.v{version}.idx");
     }
 
@@ -360,7 +377,7 @@ internal static class AmprFileRegistry
             }
 
             var root = reader.ReadString();
-            if (!string.Equals(root, normalizedRoot, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(root, normalizedRoot, HostFsPath.Comparison))
             {
                 return false;
             }
@@ -470,7 +487,7 @@ internal static class AmprFileRegistry
                 return;
             }
 
-            var relatives = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var relatives = new HashSet<string>(HostFsPath.Comparer);
             foreach (var hostPath in _hostPathsById.Values)
             {
                 var relative = Path.GetRelativePath(normalizedRoot, hostPath)

--- a/src/SharpEmu.Libs/HostFsPath.cs
+++ b/src/SharpEmu.Libs/HostFsPath.cs
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Libs;
+
+/// <summary>
+/// Key equivalence for caches and comparisons over <em>host</em> filesystem
+/// paths. Windows resolves names case-insensitively, but Linux hosts are
+/// case-sensitive and the guest filesystem is too, so a dump can legitimately
+/// contain "DATA.BIN" alongside "Data.bin". An ignore-case cache aliases those
+/// distinct files into one entry there, which silently serves the wrong bytes
+/// or drops one of them entirely.
+/// </summary>
+internal static class HostFsPath
+{
+    public static readonly StringComparer Comparer =
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+    public static readonly StringComparison Comparison =
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+}

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -117,17 +117,12 @@ public static partial class KernelMemoryCompatExports
     private static readonly Dictionary<string, string> _guestMounts = new(StringComparer.OrdinalIgnoreCase);
     private static readonly HashSet<string> _tracedStatResults = new(StringComparer.Ordinal);
     // Both caches memoize host filesystem probe outcomes, so their key
-    // equivalence must match the host filesystem's: Windows resolves names
-    // case-insensitively, but Linux hosts are case-sensitive, and an
-    // ignore-case cache there aliases distinct paths — a cached miss for
-    // "/app0/DATA.BIN" keeps answering NOT_FOUND for "/app0/Data.bin" even
-    // though that file exists and a fresh probe would find it.
-    private static readonly StringComparer HostFsPathComparer =
-        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-    private static readonly StringComparison HostFsPathComparison =
-        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-    private static readonly HashSet<string> _negativeStatCache = new(HostFsPathComparer);
-    private static readonly ConcurrentDictionary<string, ulong> _aprFileSizeCache = new(HostFsPathComparer);
+    // equivalence must match the host filesystem's — see HostFsPath. On a
+    // case-sensitive host an ignore-case cache aliases distinct paths: a
+    // cached miss for "/app0/DATA.BIN" keeps answering NOT_FOUND for
+    // "/app0/Data.bin" even though that file exists.
+    private static readonly HashSet<string> _negativeStatCache = new(HostFsPath.Comparer);
+    private static readonly ConcurrentDictionary<string, ulong> _aprFileSizeCache = new(HostFsPath.Comparer);
     private static long _nextFileDescriptor = 2;
     private static string _applicationTitleId = "UNKNOWN";
 
@@ -5203,8 +5198,8 @@ public static partial class KernelMemoryCompatExports
         // host would let a relative path escape into a sibling directory that
         // differs from the mount root only by case (root ".../Save" vs
         // sibling ".../save").
-        if (!string.Equals(candidate, matchedHostRoot, HostFsPathComparison) &&
-            !candidate.StartsWith(rootWithSeparator, HostFsPathComparison))
+        if (!string.Equals(candidate, matchedHostRoot, HostFsPath.Comparison) &&
+            !candidate.StartsWith(rootWithSeparator, HostFsPath.Comparison))
         {
             return false;
         }
@@ -5305,8 +5300,8 @@ public static partial class KernelMemoryCompatExports
 
         var rootWithSeparator =
             Path.TrimEndingDirectorySeparator(fullRoot) + Path.DirectorySeparatorChar;
-        if (!string.Equals(candidate, fullRoot, HostFsPathComparison) &&
-            !candidate.StartsWith(rootWithSeparator, HostFsPathComparison))
+        if (!string.Equals(candidate, fullRoot, HostFsPath.Comparison) &&
+            !candidate.StartsWith(rootWithSeparator, HostFsPath.Comparison))
         {
             return string.Empty;
         }
@@ -5332,7 +5327,7 @@ public static partial class KernelMemoryCompatExports
     private static bool EscapesMountViaReparsePoint(string mountRoot, string candidate)
     {
         var rootTrimmed = Path.TrimEndingDirectorySeparator(mountRoot);
-        if (string.Equals(candidate, rootTrimmed, HostFsPathComparison))
+        if (string.Equals(candidate, rootTrimmed, HostFsPath.Comparison))
         {
             return false;
         }

--- a/tests/SharpEmu.Libs.Tests/Ampr/AmprFileRegistryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ampr/AmprFileRegistryTests.cs
@@ -6,6 +6,9 @@ using Xunit;
 
 namespace SharpEmu.Libs.Tests.Ampr;
 
+// AmprFileRegistry is process-global static state, so the classes that index
+// or clear it must not run concurrently with each other.
+[Collection("AmprFileRegistry")]
 public class AmprFileRegistryTests
 {
     [Fact]
@@ -60,6 +63,79 @@ public class AmprFileRegistryTests
         Assert.Equal(host, b);
         Assert.Equal(host, c);
         Assert.Equal(host, d);
+    }
+
+    [Fact]
+    public void App0_index_cache_keeps_files_that_differ_only_by_case()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "sharpemu-ampr-case-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = Path.Combine(root, "..", "sharpemu-ampr-cache-" + Guid.NewGuid().ToString("N"));
+        var upper = Path.Combine(root, "data", "ASSET.bin");
+        var lower = Path.Combine(root, "data", "asset.bin");
+        var previousCacheDir = Environment.GetEnvironmentVariable("SHARPEMU_AMPR_INDEX_CACHE");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "sce_sys"));
+            Directory.CreateDirectory(Path.Combine(root, "data"));
+            File.WriteAllText(Path.Combine(root, "sce_sys", "param.json"), "{}");
+            File.WriteAllBytes(upper, [1, 2, 3]);
+            if (File.Exists(lower))
+            {
+                // Case-insensitive host: the two names are one file, so there is
+                // nothing for an ignore-case index to lose.
+                return;
+            }
+
+            File.WriteAllBytes(lower, [4, 5, 6]);
+            Environment.SetEnvironmentVariable("SHARPEMU_AMPR_INDEX_CACHE", cacheDir);
+
+            var normalizedRoot = Path.GetFullPath(root);
+            var expectedUpper = Path.Combine(normalizedRoot, "data", "ASSET.bin");
+            var expectedLower = Path.Combine(normalizedRoot, "data", "asset.bin");
+
+            // Fresh tree walk, which also writes the on-disk index cache.
+            AmprFileRegistry.ClearForTests();
+            AmprFileRegistry.EnsureApp0Indexed(root);
+            AssertResolves(expectedUpper, expectedLower);
+
+            // Second boot: served from the cache the walk just wrote.
+            AmprFileRegistry.ClearForTests();
+            AmprFileRegistry.EnsureApp0Indexed(root);
+            AssertResolves(expectedUpper, expectedLower);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHARPEMU_AMPR_INDEX_CACHE", previousCacheDir);
+            AmprFileRegistry.ClearForTests();
+            TryDeleteDirectory(cacheDir);
+            TryDeleteDirectory(root);
+        }
+
+        static void AssertResolves(string expectedUpper, string expectedLower)
+        {
+            Assert.True(
+                AmprFileRegistry.TryGetHostPath(
+                    AmprFileRegistry.ComputeFileId("$/data/ASSET.bin"), out var actualUpper),
+                "data/ASSET.bin is missing from the app0 index.");
+            Assert.True(
+                AmprFileRegistry.TryGetHostPath(
+                    AmprFileRegistry.ComputeFileId("$/data/asset.bin"), out var actualLower),
+                "data/asset.bin is missing from the app0 index.");
+            Assert.Equal(expectedUpper, actualUpper);
+            Assert.Equal(expectedLower, actualLower);
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (Exception)
+        {
+            // Temp cleanup is best-effort.
+        }
     }
 
     private static uint FnvUtf8(string text)

--- a/tests/SharpEmu.Libs.Tests/Ampr/AmprWriteAddressTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ampr/AmprWriteAddressTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace SharpEmu.Libs.Tests.Ampr;
 
+[Collection("AmprFileRegistry")]
 public sealed class AmprWriteAddressTests
 {
     [Fact]

--- a/tests/SharpEmu.Libs.Tests/Ampr/AprStreamingContractTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Ampr/AprStreamingContractTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace SharpEmu.Libs.Tests.Ampr;
 
+[Collection("AmprFileRegistry")]
 public sealed class AprStreamingContractTests
 {
     [Fact]


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

The app0 index and the host FD cache added in #725 key on **host** paths with `OrdinalIgnoreCase`. That is right on Windows, but Linux hosts are case-sensitive and so is the guest filesystem, so a dump can legitimately contain `data/ASSET.bin` next to `data/asset.bin`. On Linux those two collapse into one cache entry:

* `TrySaveIndexCache` dedupes app0-relative paths through an ignore-case `HashSet`, so one of the pair never reaches the persisted index. Because later boots take the cache-hit path instead of re-walking the tree, that file is then permanently `NOT_FOUND`.
* The open-handle LRU in `AmprExports` (`_hostFileByPath`) hands back the other file's `SafeFileHandle`, so the guest reads the wrong bytes.
* `EnsureApp0Indexed` treats two genuinely distinct roots as already indexed, and `GetIndexCachePath` lowercases the root so both land on the same `.idx` file — which `TryLoadIndexCache` then accepts, because its root check is ignore-case too.

#381 already settled this rule for the kernel path caches. This moves that comparer into a shared `HostFsPath` (Windows -> `OrdinalIgnoreCase`, otherwise `Ordinal`) and uses it in the Ampr paths as well, so the next cache added does not have to rediscover it.

One extra fix in the same function: the app0 tree walk runs synchronously from `sceAmprCommandBufferConstructor` via `TryPreindexApp0`, so an IO error during the walk propagated out of the guest export. The background preload of the exact same walk already swallowed it. The walk now catches `IOException`/`UnauthorizedAccessException`, warns, and leaves the root unindexed so a later call retries.

## Testing

No PS5 dump here, so no game boot to report — the change is host-path-aliasing only and I could not exercise it in-game.

What I did run, on Linux (Arch, x86-64, .NET SDK 10.0.103):

* New regression test `App0_index_cache_keeps_files_that_differ_only_by_case` builds a real app0 tree containing `data/ASSET.bin` and `data/asset.bin`, calls `EnsureApp0Indexed` (fresh walk, writes the `.idx`), clears the registry, calls it again (cache-hit path), and asserts both ids still resolve to their own host file. On `main` it fails with `data/asset.bin is missing from the app0 index`; with this change it passes. It self-skips on a case-insensitive host, where the two names are one file.
* `dotnet build SharpEmu.slnx -c Release` clean, and the full suite green 12 consecutive runs (787 tests).
* The Ampr test classes all touch the process-global `AmprFileRegistry`, so they are now in one xunit collection — without that, `ClearForTests` from one class races the assertions of another. That race was already latent; the new test just made it reproducible.

If someone with a Linux host and a dump wants to sanity-check a boot before this is merged, I am happy to wait.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
