### PR TITLE
[videoout] guard degenerate guest buffer ranges

### DIFF
--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -10179,7 +10179,12 @@ internal static unsafe class VulkanVideoPresenter
             }
 
             var size = (ulong)Math.Max(guestBuffer.Length, sizeof(uint));
-            var endAddress = checked(guestBuffer.BaseAddress + size);
+            if (guestBuffer.BaseAddress > ulong.MaxValue - size)
+            {
+                return CreateTransientGlobalBufferResource(guestBuffer);
+            }
+
+            var endAddress = guestBuffer.BaseAddress + size;
             GuestBufferAllocation? allocation = null;
             foreach (var candidate in _guestBufferAllocations)
             {
@@ -10414,9 +10419,14 @@ internal static unsafe class VulkanVideoPresenter
                 }
 
                 var size = (ulong)Math.Max(buffer.Length, sizeof(uint));
+                if (buffer.BaseAddress > ulong.MaxValue - size - 3)
+                {
+                    continue;
+                }
+
                 var alignedStart = buffer.BaseAddress &
                     ~(GuestStorageBufferOffsetAlignment - 1);
-                var paddedEnd = checked(buffer.BaseAddress + size + 3) & ~3UL;
+                var paddedEnd = (buffer.BaseAddress + size + 3) & ~3UL;
                 ranges.Add((
                     alignedStart,
                     paddedEnd));


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## Testing

- Demon's Souls

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

# What PR does?

* A guest buffer descriptor with a base address near `2^64` overflowed checked(BaseAddress + size), and the exception dropped the entire offscreen draw 11 valid textures and its geometry with it. Both sites now treat such a range like `BaseAddress == 0`: skipped in the range walk, transient resource in the lookup.