### PR TITLE
Fix GuestDataPool lease leak on non-GPU compute dispatch paths

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -11307,7 +11307,9 @@ public static partial class AgcExports
             }
         }
 
-        if (evaluationHandledByCpu)
+        // Rejected/CPU-handled dispatches never hand evaluation's pooled buffers to a
+        // consumer that would return them; reclaim here to keep GuestDataPool.Shared bounded.
+        if (evaluationHandledByCpu || !gpuDispatch)
         {
             ReturnPooledEvaluationArrays(evaluation);
         }

--- a/src/SharpEmu.Libs/Gpu/GuestDataPool.cs
+++ b/src/SharpEmu.Libs/Gpu/GuestDataPool.cs
@@ -23,6 +23,10 @@ internal static class GuestDataPool
 
     public static void Trim() => ((BoundedByteArrayPool)Shared).Trim();
 
+    /// <summary>Outstanding lease count and idle cached bytes, for leak diagnostics.</summary>
+    public static (int LeaseCount, ulong CachedBytes) DiagnosticStats() =>
+        ((BoundedByteArrayPool)Shared).Stats();
+
     private sealed class BoundedByteArrayPool : ArrayPool<byte>
     {
         private readonly object _gate = new();
@@ -116,6 +120,14 @@ internal static class GuestDataPool
             {
                 _cachedByBucket.Clear();
                 _cachedBytes = 0;
+            }
+        }
+
+        public (int LeaseCount, ulong CachedBytes) Stats()
+        {
+            lock (_gate)
+            {
+                return (_leases.Count, _cachedBytes);
             }
         }
 

--- a/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
+++ b/src/SharpEmu.Libs/VideoOut/VideoOutExports.cs
@@ -1300,10 +1300,12 @@ public static class VideoOutExports
         var submitted = Interlocked.Exchange(ref _submittedFrameCount, 0);
         var presentedCount = Interlocked.Exchange(ref _presentedFrameCount, 0);
         var (draws, drawMs, pipelines, spirvCompiles) = GuestGpu.Current.ReadAndResetPerfCounters();
+        var (poolLeases, poolCachedBytes) = SharpEmu.Libs.Gpu.GuestDataPool.DiagnosticStats();
         Console.Error.WriteLine(
             $"[LOADER][PERF] videoout submitted_fps={submitted / elapsedSeconds:F1} " +
             $"presented_fps={presentedCount / elapsedSeconds:F1} " +
-            $"draws={draws} draw_ms={drawMs:F0} pipelines={pipelines} spirv={spirvCompiles}");
+            $"draws={draws} draw_ms={drawMs:F0} pipelines={pipelines} spirv={spirvCompiles} " +
+            $"pool_leases={poolLeases} pool_cached_mb={poolCachedBytes / 1024.0 / 1024.0:F1}");
     }
 
     private static readonly bool _flipPacingDisabled = string.Equals(


### PR DESCRIPTION
## Summary

Fix a GuestDataPool lease leak in AGC compute dispatch evaluation.

ObserveComputeDispatch could allocate pooled global-memory bindings during shader evaluation, but some paths never transferred ownership to a consumer and never returned the pooled arrays.

Affected paths:
- compute dispatch rejected before submission (empty resource tables, oversized workgroup, shader compile failure)
- compute submission returning no work sequence (`workSequence == 0`)

Previously, these paths leaked one pool lease per occurrence, causing GuestDataPool.Shared to grow continuously during long-running sessions.

The fix tracks actual ownership transfer: pooled arrays are only kept alive when a GPU work item was successfully queued. All other paths now return their pooled arrays immediately.

## Diagnostics

Added GuestDataPool.DiagnosticStats() to expose:
- outstanding lease count
- cached pooled bytes

These values are included in the periodic PERF log to detect future regressions.

## Testing

Verified on Windows:

- Ghost of Yotei (PPSA01327)
  - Before: pool_leases increased from 2 to 1114 over the same test window, with the longer run eventually ending in OutOfMemoryException.
  - After: pool_leases was significantly lower (~440) at a comparable execution point. Further comparison was limited by an unrelated pre-existing FaWorkerIo1 stall stopping frame progression.
  - No OutOfMemoryException observed after the fix.
  
- Demon's Souls (PPSA01342)
  - Before: pool_leases increased from 0 to 525 over 5 minutes
  - After: pool_leases stayed bounded (0 to 6)
  - No regression observed
 