### PR TITLE
fix(audioout2): wire skipped-submit trace counter

### DIFF
--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -921,6 +921,7 @@ public static class AudioOut2Exports
 
                 if (mixedPorts == 0)
                 {
+                    TraceSubmitSkipped(context, frames, "no-ports");
                     return false;
                 }
 
@@ -942,6 +943,7 @@ public static class AudioOut2Exports
                 var backend = ResolveContextBackend(context, out var backendName);
                 if (backend is null)
                 {
+                    TraceSubmitSkipped(context, frames, "no-backend");
                     return false;
                 }
 
@@ -1210,6 +1212,16 @@ public static class AudioOut2Exports
         if (string.Equals(Environment.GetEnvironmentVariable("SHARPEMU_LOG_AUDIO_OUT2"), "1", StringComparison.Ordinal))
         {
             Console.Error.WriteLine($"[LOADER][TRACE] audio_out2.{message}");
+        }
+    }
+
+    private static void TraceSubmitSkipped(ContextState context, int frames, string reason)
+    {
+        var n = Interlocked.Increment(ref _submitSkipTraceCount);
+        if (n <= 8 || n % 500 == 0)
+        {
+            TraceAudioOut2(
+                $"context-submit-skip#{n} handle=0x{context.Handle:X} frames={frames} reason={reason}");
         }
     }
 }


### PR DESCRIPTION
Fixed a build warning: _submitSkipTraceCount in AudioOut2Exports was declared but never used (since #679). Wired it into the two paths where TrySubmitContextAudio returns without submitting (no ports, no backend), mirroring the existing submit counter trace.

Testing: N/A no runtime behavior change; build clean, all tests pass.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
