### PR TITLE
Fix/loader overflow and posix sentinel

### DIFF
--- a/src/SharpEmu.Core/Loader/SelfLoader.cs
+++ b/src/SharpEmu.Core/Loader/SelfLoader.cs
@@ -474,6 +474,12 @@ public sealed class SelfLoader : ISelfLoader
                 ? 0UL
                 : ResolvePhysicalSegmentOffset(imageData.Length, loadContext, header, index);
 
+            if (header.VirtualAddress > ulong.MaxValue - imageBase)
+            {
+                throw new InvalidDataException(
+                    $"ELF segment {index} virtual address 0x{header.VirtualAddress:X} overflows when combined with the image base 0x{imageBase:X}.");
+            }
+
             var virtualAddress = header.VirtualAddress + imageBase;
 
             Console.Error.WriteLine($"[LOADER] Segment {index}: VAddr=0x{virtualAddress:X16}, FileSize=0x{header.FileSize:X}, MemSize=0x{header.MemorySize:X}, Align=0x{header.Alignment:X}");
@@ -2130,6 +2136,12 @@ public sealed class SelfLoader : ISelfLoader
         {
             if (header.HeaderType == ProgramHeaderType.Load && header.MemorySize > 0)
             {
+                if (header.VirtualAddress > ulong.MaxValue - header.MemorySize)
+                {
+                    throw new InvalidDataException(
+                        $"ELF segment virtual address 0x{header.VirtualAddress:X} plus memory size 0x{header.MemorySize:X} overflows the address space.");
+                }
+
                 if (header.VirtualAddress < minAddr)
                     minAddr = header.VirtualAddress;
 

--- a/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelFileExtendedExports.cs
@@ -46,7 +46,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ezv-RSBNKqI", ExportName = "pread",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixPread(CpuContext ctx) => KernelPreadCore(ctx);
+    public static int PosixPread(CpuContext ctx)
+    {
+        var result = KernelPreadCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "+r3rMFwItV4", ExportName = "sceKernelPread",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -97,7 +103,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "C2kJ-byS5rM", ExportName = "pwrite",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixPwrite(CpuContext ctx) => KernelPwriteCore(ctx);
+    public static int PosixPwrite(CpuContext ctx)
+    {
+        var result = KernelPwriteCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "nKWi-N2HBV4", ExportName = "sceKernelPwrite",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -149,7 +161,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "juWbTNM+8hw", ExportName = "fsync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFsync(CpuContext ctx) => KernelFsyncCore(ctx);
+    public static int PosixFsync(CpuContext ctx)
+    {
+        var result = KernelFsyncCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "fTx66l5iWIA", ExportName = "sceKernelFsync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -157,7 +175,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "KIbJFQ0I1Cg", ExportName = "fdatasync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFdatasync(CpuContext ctx) => KernelFsyncCore(ctx);
+    public static int PosixFdatasync(CpuContext ctx)
+    {
+        var result = KernelFsyncCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "30Rh4ixbKy4", ExportName = "sceKernelFdatasync",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -210,7 +234,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ih4CD9-gghM", ExportName = "ftruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFtruncate(CpuContext ctx) => KernelFtruncateCore(ctx);
+    public static int PosixFtruncate(CpuContext ctx)
+    {
+        var result = KernelFtruncateCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "VW3TVZiM4-E", ExportName = "sceKernelFtruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -246,7 +276,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "ayrtszI7GBg", ExportName = "truncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixTruncate(CpuContext ctx) => KernelTruncateCore(ctx);
+    public static int PosixTruncate(CpuContext ctx)
+    {
+        var result = KernelTruncateCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result);
+    }
 
     [SysAbiExport(Nid = "WlyEA-sLDf0", ExportName = "sceKernelTruncate",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -294,7 +330,13 @@ public static partial class KernelMemoryCompatExports
 
     [SysAbiExport(Nid = "NN01qLRhiqU", ExportName = "rename",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixRename(CpuContext ctx) => KernelRenameCore(ctx);
+    public static int PosixRename(CpuContext ctx)
+    {
+        var result = KernelRenameCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result);
+    }
 
     [SysAbiExport(Nid = "52NcYU9+lEo", ExportName = "sceKernelRename",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
@@ -363,7 +405,7 @@ public static partial class KernelMemoryCompatExports
         {
             if (!_openFiles.TryGetValue(fd, out var stream))
             {
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                return PosixFailure(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND, notFoundErrno: Ebadf);
             }
 
             // POSIX dup shares the open file description (and offset), which is
@@ -373,7 +415,7 @@ public static partial class KernelMemoryCompatExports
             ctx[CpuRegister.Rax] = unchecked((ulong)newFd);
         }
 
-        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        return 0;
     }
 
     [SysAbiExport(Nid = "wdUufa9g-D8", ExportName = "dup2",
@@ -386,13 +428,13 @@ public static partial class KernelMemoryCompatExports
         {
             if (!_openFiles.TryGetValue(oldFd, out var stream))
             {
-                return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND;
+                return PosixFailure(ctx, (int)OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_FOUND, notFoundErrno: Ebadf);
             }
 
             if (oldFd == newFd)
             {
                 ctx[CpuRegister.Rax] = unchecked((ulong)newFd);
-                return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+                return 0;
             }
 
             // If newFd names an open file, dup2 closes it first.
@@ -405,14 +447,20 @@ public static partial class KernelMemoryCompatExports
             ctx[CpuRegister.Rax] = unchecked((ulong)newFd);
         }
 
-        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+        return 0;
     }
 
     // ---- fcntl ----
 
     [SysAbiExport(Nid = "8nY19bKoiZk", ExportName = "fcntl",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]
-    public static int PosixFcntl(CpuContext ctx) => KernelFcntlCore(ctx);
+    public static int PosixFcntl(CpuContext ctx)
+    {
+        var result = KernelFcntlCore(ctx);
+        return result == (int)OrbisGen2Result.ORBIS_GEN2_OK
+            ? 0
+            : PosixFailure(ctx, result, notFoundErrno: Ebadf);
+    }
 
     [SysAbiExport(Nid = "SoZkxZkCHaw", ExportName = "sceKernelFcntl",
         Target = Generation.Gen4 | Generation.Gen5, LibraryName = "libKernel")]

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelFileExtendedExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelFileExtendedExportsTests.cs
@@ -1,0 +1,166 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+// Regression coverage for the sentinel leak described in #491: these
+// libc/POSIX-named exports must translate a failed raw OrbisGen2Result into
+// -1/errno (see KernelMemoryCompatExports.PosixFailure), mirroring the fix
+// already applied to open/fstat/close/read/write/stat in #461. Leaking the
+// raw 0x8002xxxx sentinel through RAX makes a libc caller treat it as a
+// "successful" non-negative return instead of a POSIX failure.
+public sealed class KernelFileExtendedExportsTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const int MemorySize = 0x2000;
+    private const uint NeverOpenedFd = 0x80020002; // the not-found sentinel misused as an fd
+
+    [Fact]
+    public void PosixPread_BadDescriptorReturnsMinusOne()
+    {
+        var (memory, context) = NewContext();
+        context[CpuRegister.Rdi] = unchecked((ulong)NeverOpenedFd);
+        context[CpuRegister.Rsi] = MemoryBase + 0x200;
+        context[CpuRegister.Rdx] = 0x40;
+        context[CpuRegister.Rcx] = 0;
+
+        var result = KernelMemoryCompatExports.PosixPread(context);
+
+        AssertPosixFailure(context, result);
+    }
+
+    [Fact]
+    public void PosixPwrite_BadDescriptorReturnsMinusOne()
+    {
+        var (memory, context) = NewContext();
+        memory.WriteCString(MemoryBase + 0x200, "payload");
+        context[CpuRegister.Rdi] = unchecked((ulong)NeverOpenedFd);
+        context[CpuRegister.Rsi] = MemoryBase + 0x200;
+        context[CpuRegister.Rdx] = 0x7;
+        context[CpuRegister.Rcx] = 0;
+
+        var result = KernelMemoryCompatExports.PosixPwrite(context);
+
+        AssertPosixFailure(context, result);
+    }
+
+    [Fact]
+    public void PosixFtruncate_BadDescriptorReturnsMinusOne()
+    {
+        var (_, context) = NewContext();
+        context[CpuRegister.Rdi] = unchecked((ulong)NeverOpenedFd);
+        context[CpuRegister.Rsi] = 0;
+
+        var result = KernelMemoryCompatExports.PosixFtruncate(context);
+
+        AssertPosixFailure(context, result);
+    }
+
+    [Fact]
+    public void PosixTruncate_MissingFileReturnsMinusOne()
+    {
+        var (memory, context) = NewContext();
+        var pathAddress = MemoryBase + 0x100;
+        memory.WriteCString(pathAddress, "/__sharpemu_test_missing__/save.dat");
+        context[CpuRegister.Rdi] = pathAddress;
+        context[CpuRegister.Rsi] = 0;
+
+        var result = KernelMemoryCompatExports.PosixTruncate(context);
+
+        AssertPosixFailure(context, result);
+    }
+
+    [Fact]
+    public void PosixFsync_BadDescriptorReturnsMinusOne()
+    {
+        var (_, context) = NewContext();
+        context[CpuRegister.Rdi] = unchecked((ulong)NeverOpenedFd);
+
+        var result = KernelMemoryCompatExports.PosixFsync(context);
+
+        AssertPosixFailure(context, result);
+    }
+
+    [Fact]
+    public void PosixFdatasync_BadDescriptorReturnsMinusOne()
+    {
+        var (_, context) = NewContext();
+        context[CpuRegister.Rdi] = unchecked((ulong)NeverOpenedFd);
+
+        var result = KernelMemoryCompatExports.PosixFdatasync(context);
+
+        AssertPosixFailure(context, result);
+    }
+
+    [Fact]
+    public void PosixRename_MissingSourceReturnsMinusOne()
+    {
+        var (memory, context) = NewContext();
+        var fromAddress = MemoryBase + 0x100;
+        var toAddress = MemoryBase + 0x300;
+        memory.WriteCString(fromAddress, "/__sharpemu_test_missing__/from.dat");
+        memory.WriteCString(toAddress, "/__sharpemu_test_missing__/to.dat");
+        context[CpuRegister.Rdi] = fromAddress;
+        context[CpuRegister.Rsi] = toAddress;
+
+        var result = KernelMemoryCompatExports.PosixRename(context);
+
+        AssertPosixFailure(context, result);
+    }
+
+    [Fact]
+    public void PosixDup_BadDescriptorReturnsMinusOne()
+    {
+        var (_, context) = NewContext();
+        context[CpuRegister.Rdi] = unchecked((ulong)NeverOpenedFd);
+
+        var result = KernelMemoryCompatExports.PosixDup(context);
+
+        AssertPosixFailure(context, result);
+    }
+
+    [Fact]
+    public void PosixDup2_BadOldDescriptorReturnsMinusOne()
+    {
+        var (_, context) = NewContext();
+        context[CpuRegister.Rdi] = unchecked((ulong)NeverOpenedFd);
+        context[CpuRegister.Rsi] = 5;
+
+        var result = KernelMemoryCompatExports.PosixDup2(context);
+
+        AssertPosixFailure(context, result);
+    }
+
+    [Fact]
+    public void PosixFcntl_DupfdOnBadDescriptorReturnsMinusOne()
+    {
+        var (_, context) = NewContext();
+        const int fDupFd = 0;
+        context[CpuRegister.Rdi] = unchecked((ulong)NeverOpenedFd);
+        context[CpuRegister.Rsi] = fDupFd;
+        context[CpuRegister.Rdx] = 0;
+
+        var result = KernelMemoryCompatExports.PosixFcntl(context);
+
+        AssertPosixFailure(context, result);
+    }
+
+    private static (FakeCpuMemory Memory, CpuContext Context) NewContext()
+    {
+        var memory = new FakeCpuMemory(MemoryBase, MemorySize);
+        return (memory, new CpuContext(memory, Generation.Gen5));
+    }
+
+    // A libc failure must be exactly -1 with RAX == (ulong)-1, not the raw
+    // 0x8002xxxx OrbisGen2Result sentinel a guest would store as a "valid"
+    // fd/count and later misuse.
+    private static void AssertPosixFailure(CpuContext context, int result)
+    {
+        Assert.Equal(-1, result);
+        Assert.Equal(ulong.MaxValue, context[CpuRegister.Rax]);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Loader/SelfLoaderTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Loader/SelfLoaderTests.cs
@@ -127,6 +127,60 @@ public sealed class SelfLoaderTests
         Assert.Empty(image.MappedRegions);
     }
 
+    // Regression coverage for the loader address-overflow bug behind #235
+    // ("Could not allocate main image at required base 0x0000000800000000"):
+    // a PT_LOAD program header with a pathological VirtualAddress must be
+    // rejected with a clear InvalidDataException instead of either crashing
+    // with an unhandled OverflowException deep in VirtualMemory.Map, or
+    // (worse) silently wrapping around and mapping the segment at the wrong
+    // host address.
+    [Fact]
+    public void Load_RejectsProgramHeaderWhoseVirtualAddressPlusMemorySizeOverflows()
+    {
+        // VirtualAddress + MemorySize wraps past ulong.MaxValue.
+        var imageData = CreateBareElfWithSingleLoadSegment(
+            virtualAddress: ulong.MaxValue - 0x0FFF,
+            memorySize: 0x2000);
+
+        Assert.Throws<InvalidDataException>(() =>
+            new SelfLoader().Load(imageData, new VirtualMemory()));
+    }
+
+    [Fact]
+    public void Load_RejectsProgramHeaderWhoseVirtualAddressPlusImageBaseOverflows()
+    {
+        // MemorySize is small enough that VirtualAddress + MemorySize alone
+        // does not overflow, but VirtualAddress is close enough to
+        // ulong.MaxValue that adding the PS5 image base (AbiVersion == 2
+        // selects 0x0000000800000000) wraps around.
+        var imageData = CreateBareElfWithSingleLoadSegment(
+            virtualAddress: ulong.MaxValue - 0x100,
+            memorySize: 0x10);
+
+        Assert.Throws<InvalidDataException>(() =>
+            new SelfLoader().Load(imageData, new VirtualMemory()));
+    }
+
+    private static byte[] CreateBareElfWithSingleLoadSegment(ulong virtualAddress, ulong memorySize)
+    {
+        const int programHeaderSize = 0x38;
+        var imageData = new byte[ElfHeaderSize + programHeaderSize];
+        WriteMinimalElfHeader(imageData.AsSpan(0, ElfHeaderSize));
+        BinaryPrimitives.WriteUInt16LittleEndian(imageData.AsSpan(0x38), 1); // e_phnum = 1
+
+        var ph = imageData.AsSpan(ElfHeaderSize, programHeaderSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(ph, 1); // p_type = PT_LOAD
+        BinaryPrimitives.WriteUInt32LittleEndian(ph[4..], 4); // p_flags = PF_R
+        BinaryPrimitives.WriteUInt64LittleEndian(ph[8..], 0); // p_offset
+        BinaryPrimitives.WriteUInt64LittleEndian(ph[16..], virtualAddress); // p_vaddr
+        BinaryPrimitives.WriteUInt64LittleEndian(ph[24..], 0); // p_paddr
+        BinaryPrimitives.WriteUInt64LittleEndian(ph[32..], 0); // p_filesz (no file-backed data)
+        BinaryPrimitives.WriteUInt64LittleEndian(ph[40..], memorySize); // p_memsz
+        BinaryPrimitives.WriteUInt64LittleEndian(ph[48..], 0); // p_align
+
+        return imageData;
+    }
+
     private static byte[] CreateSelfImage(uint magic, byte version, uint keyType, ushort flags)
     {
         var imageData = new byte[SelfHeaderSize + ElfHeaderSize];


### PR DESCRIPTION
Fix 1 — issue #491 (wrong error signal)

Imagine a function that reads a file. If the file doesn't exist, it should say "I failed, error code X" in the way the calling code expects. Some functions in this emulator (pread, pwrite, ftruncate, truncate, fsync, fdatasync, rename, dup, dup2, fcntl) were saying "I failed" in the WRONG language — they returned an internal error code instead of the standard -1 that C programs check for. So the game's code looked at the result, didn't see -1, and thought "great, it worked!" — then kept using a broken file handle, which can crash later. This same bug was already fixed for other similar functions in a past PR (#461); I just applied the same fix to the ones that were forgotten (issue #491 asked for exactly this).

Fix: made these functions translate the internal error into the standard -1 + error code before returning, using a helper function that already existed in the code for this exact purpose.

Fix 2 — issue #235 (crash loading big/weird game files)

When the emulator loads a game file, it reads a list of "memory blocks" the game needs (called segments), each with a starting address and a size. The code was adding numbers together (address + size) without checking if the result gets too big to fit — like a car odometer rolling over from 999999 back to 000000. If a game file (even accidentally malformed) had a segment address close to the maximum possible number, the addition would silently "roll over" to a tiny wrong number instead of giving an error. Two bad things could happen: the emulator would place game data at the wrong spot in memory with no warning, or it would calculate a wrong total size and then fail to reserve memory at the fixed address PS5 games expect — which matches exactly the error message people report in issue #235.

Fix: added a check before doing the addition — if it would roll over, stop and give a clear error message instead of silently continuing with a wrong number.

Verified with new automated unit tests (TDD): 10 tests for the POSIX sentinel fix, 2 tests for the loader overflow fix. Full solution test suite: 811 passing, 0 failing. No real game tested — I don't own a PS5, so no legal game dump available.

## Checklist

By submitting this pull request, you confirm that:

- [x ] I have read and followed `CONTRIBUTING.md`.
- [x ] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x ] I listed the game(s) I tested (or marked the testing section as `N/A`).
