### PR TITLE
Fix duplicate event-handler registration in MainWindow

### DIFF
--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -290,32 +290,7 @@ public partial class MainWindow : Window
             SetEnvironmentToggle(
                 "SHARPEMU_GUEST_IMAGE_CPU_SYNC",
                 EnvGuestImageCpuSyncToggle.IsChecked == true);
-        DefaultProfileBox.TextChanged += (_, _) =>
-            _settings.DefaultProfile = GuiSettings.NormalizeDefaultProfile(DefaultProfileBox.Text);
-        LanguageBox.SelectionChanged += (_, _) => OnLanguageChanged();
-
-        GameList.AddHandler(ContextRequestedEvent, OnGameContextRequested, RoutingStrategies.Tunnel);
-        AddHandler(KeyDownEvent, OnPreviewKeyDown, RoutingStrategies.Tunnel);
-        CtxLaunch.Click += (_, _) => LaunchSelected();
-        CtxOpenFolder.Click += (_, _) => OpenSelectedGameFolder();
-        CtxCopyPath.Click += async (_, _) =>
-            await CopyToClipboardAsync((GameList.SelectedItem as GameEntry)?.Path);
-        CtxCopyTitleId.Click += async (_, _) =>
-            await CopyToClipboardAsync((GameList.SelectedItem as GameEntry)?.TitleId);
-        CtxGameSettings.Click += (_, _) => OpenSelectedGameSettings();
-        CtxRemove.Click += (_, _) => RemoveSelectedFromLibrary();
-
-        Opened += async (_, _) => await OnOpenedAsync();
-        Closing += (_, _) => BeginWindowClosing();
-        Closed += (_, _) => CompleteWindowClosing();
-
-        SdlLauncherGamepad.EnsureStarted();
-        _gamepadTimer = new DispatcherTimer
-        {
-            Interval = TimeSpan.FromMilliseconds(50),
-        };
         EnvRenderDocToggle.IsCheckedChanged += (_, _) =>
-
             SetEnvironmentToggle(
                 "SHARPEMU_RENDERDOC",
                 EnvRenderDocToggle.IsChecked == true);


### PR DESCRIPTION



## Testing
N/A — GUI cleanup only, does not affect game runtime behavior.
The project builds successfully (dotnet build, 0 errors).

## Checklist
- [x] I have read and followed CONTRIBUTING.md.
- [x] I tested my changes or marked the testing section as N/A.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as N/A).

منشئ نافذة MainWindow كان يسجّل كتلة أحداث كاملة مرتين — معالج قائمة النقر الأيمن وأزراره الستة، ومعالجات فتح/إغلاق النافذة، والذراع. هذا التكرار يجعلها تُنفَّذ مرتين لكل حدث (مثلاً تُمسح المكتبة مرتين عند فتح التطبيق، وتتضاعف نقرات قائمة السياق). أزلت النسخة المكررة مع الإبقاء على معالج EnvRenderDocToggle الفريد ومؤقّت الذراع.