### PR TITLE
Bound host memory budgets, Windows path encoding, and related caps

### DIFF
--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -266,6 +266,7 @@ internal static partial class Program
 
         Log.Info(BuildInfo.Banner);
         Log.Info(HostSystemInfo.Summary);
+        Log.Info(HostMemoryBudget.Summary);
 
         ebootPath = Path.GetFullPath(ebootPath);
         Console.Error.WriteLine($"[DEBUG] Full path: {ebootPath}");
@@ -989,9 +990,11 @@ internal static partial class Program
 
     private static void PrintUsage()
     {
-        Log.Info("Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] [--cpu-engine=<native>] [--log-level=<level>] [--log-file[=<path>]] [--window-mode=<windowed|borderless|exclusive>] [--resolution=<WIDTHxHEIGHT>] [--display=<N>] [--refresh-rate=<HZ>] [--scaling=<fit|cover|stretch|integer>] [--vsync=<on|off>] [--hdr=<auto|on|off>] [--debug-server[=host:port]] <path-to-eboot.bin>");
+        Log.Info("Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] [--cpu-engine=<native>] [--log-level=<level>] [--log-file[=<path>]] [--window-mode=<windowed|borderless|exclusive>] [-f|--fullscreen] [--resolution=<WIDTHxHEIGHT>] [--display=<N>] [--refresh-rate=<HZ>] [--scaling=<fit|cover|stretch|integer>] [--vsync=<on|off>] [--hdr=<auto|on|off>] [--debug-server[=host:port]] <path-to-eboot.bin>");
         Log.Info(@"Example: SharpEmu.CLI --cpu-engine=native --trace-imports=64 --log-level=debug --log-file ""E:\Games\...\eboot.bin""");
         Log.Info("Debug server: --debug-server starts a live debug listener (default 127.0.0.1:5714); connect with SharpEmu.DebugClient.");
+        Log.Info("Memory: SHARPEMU_DIRECT_MEMORY_MB overrides guest direct-memory size (default auto-scales for host RAM). SHARPEMU_PENDING_GUEST_WORK_MB / SHARPEMU_RENDER_SCALE also override GPU budgets.");
+        Log.Info("Fullscreen: -f, --f, -fullscreen, or --fullscreen is the same as --window-mode=exclusive.");
     }
 
     /// <summary>
@@ -1077,6 +1080,13 @@ internal static partial class Program
                 windowModeOverride = windowMode;
                 continue;
             }
+
+            if (IsFullscreenFlag(argument))
+            {
+                windowModeOverride = HostWindowMode.ExclusiveFullscreen;
+                continue;
+            }
+
             if (TrySplitOption(argument, "--resolution", out var resolutionText))
             {
                 if (!TryParseResolution(resolutionText, out var windowWidth, out var windowHeight))
@@ -1387,6 +1397,12 @@ internal static partial class Program
         };
         return Enum.IsDefined(mode);
     }
+
+    private static bool IsFullscreenFlag(string argument) =>
+        argument.Equals("-f", StringComparison.OrdinalIgnoreCase) ||
+        argument.Equals("--f", StringComparison.OrdinalIgnoreCase) ||
+        argument.Equals("-fullscreen", StringComparison.OrdinalIgnoreCase) ||
+        argument.Equals("--fullscreen", StringComparison.OrdinalIgnoreCase);
 
     private static bool TryParseScalingMode(string value, out HostScalingMode mode)
     {

--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -30,8 +30,10 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
     private const ulong GuestAllocationArenaAddress = 0x00006000_0000_0000;
     private const ulong GuestAllocationArenaSize = 0x0100_0000;
     private const ulong GuestAllocationArenaStartOffset = PageSize;
-    private const ulong LargeDataReserveThreshold = 0x4000_0000UL; // 1 GiB
-    private const ulong FullCommitRegionLimit = 4UL << 30;
+    // Scaled down on constrained hosts (~16 GiB) so huge non-exec maps can fall
+    // back to reserve + lazy commit instead of pinning multi-GiB host commits.
+    private static readonly ulong LargeDataReserveThreshold = HostMemoryBudget.LargeDataReserveThresholdBytes;
+    private static readonly ulong FullCommitRegionLimit = HostMemoryBudget.FullCommitRegionLimitBytes;
     private const ulong DefaultLazyReservePrimeBytes = 0x0400_0000UL; // 64 MiB
     private const ulong LazyReservePrimeChunkBytes = 0x0200_0000UL; // 32 MiB
     private const int CommittedRangeCacheCapacity = 4;

--- a/src/SharpEmu.Libs/Agc/GpuWaitRegistry.cs
+++ b/src/SharpEmu.Libs/Agc/GpuWaitRegistry.cs
@@ -53,12 +53,19 @@ internal static class GpuWaitRegistry
 
     private static readonly object _gate = new();
     private static readonly Dictionary<ulong, List<WaitingDcb>> _waiters = new();
+    // Soft bound on suspended waiters. Producerless waits never expire through
+    // CollectExpiredRetries / CollectDeadlockBroken, so Demon's Souls-style
+    // boot storms can grow this table without bound (#639). Over the cap we
+    // drop the oldest waiters that never saw a producer — they were already
+    // stuck — without force-resuming (which would corrupt ordering).
+    private const int MaxRegisteredWaiters = 4096;
     // The last value each label producer wrote. Used only by the deadlock
     // breaker: our serial submission parser cannot model two GPU queues running
     // concurrently, so a label written -> reset -> re-waited across queues can
     // cycle forever even though a real producer did signal it. Keyed by (memory,
     // address) so distinct guest processes never alias.
     private static readonly Dictionary<(object, ulong), ulong> _lastProduced = new();
+    private static int _waiterCount;
 
     public static int Count
     {
@@ -66,13 +73,7 @@ internal static class GpuWaitRegistry
         {
             lock (_gate)
             {
-                var total = 0;
-                foreach (var (_, list) in _waiters)
-                {
-                    total += list.Count;
-                }
-
-                return total;
+                return _waiterCount;
             }
         }
     }
@@ -157,6 +158,11 @@ internal static class GpuWaitRegistry
         waiter.WaitAddress = address;
         lock (_gate)
         {
+            if (_waiterCount >= MaxRegisteredWaiters)
+            {
+                PruneOrphanedWaitersLocked(keepAtMost: MaxRegisteredWaiters / 2);
+            }
+
             if (!_waiters.TryGetValue(address, out var list))
             {
                 list = new List<WaitingDcb>();
@@ -164,6 +170,7 @@ internal static class GpuWaitRegistry
             }
 
             list.Add(waiter);
+            _waiterCount++;
         }
     }
 
@@ -204,7 +211,7 @@ internal static class GpuWaitRegistry
 
                     woken ??= new List<WaitingDcb>();
                     woken.Add(list[i]);
-                    list.RemoveAt(i);
+                    RemoveWaiterAtLocked(list, i);
                 }
 
                 if (list.Count == 0)
@@ -381,7 +388,7 @@ internal static class GpuWaitRegistry
 
                     expired ??= new List<WaitingDcb>();
                     expired.Add(waiter);
-                    list.RemoveAt(i);
+                    RemoveWaiterAtLocked(list, i);
                 }
 
                 if (list.Count == 0)
@@ -420,7 +427,7 @@ internal static class GpuWaitRegistry
 
                     collected ??= new List<WaitingDcb>();
                     collected.Add(list[index]);
-                    list.RemoveAt(index);
+                    RemoveWaiterAtLocked(list, index);
                 }
 
                 if (list.Count == 0)
@@ -486,6 +493,110 @@ internal static class GpuWaitRegistry
         }
     }
 
+    /// <summary>
+    /// Drops the oldest producerless waiters until at most
+    /// <paramref name="keepAtMost"/> remain. Prefer waiters that never had a
+    /// recorded producer — they cannot be released by CollectDeadlockBroken.
+    /// Must be called under <see cref="_gate"/>.
+    /// </summary>
+    private static void PruneOrphanedWaitersLocked(int keepAtMost)
+    {
+        if (_waiterCount <= keepAtMost)
+        {
+            return;
+        }
+
+        DropOldestWaitersLocked(
+            keepAtMost,
+            orphansOnly: true);
+
+        if (_waiterCount > keepAtMost)
+        {
+            // Still over the cap: every remaining waiter has a producer record
+            // or retry deadline. Prefer a bounded registry over an OOM.
+            DropOldestWaitersLocked(keepAtMost, orphansOnly: false);
+        }
+    }
+
+    private static void DropOldestWaitersLocked(int keepAtMost, bool orphansOnly)
+    {
+        if (_waiterCount <= keepAtMost)
+        {
+            return;
+        }
+
+        var candidates = new List<(ulong Address, int Index, long RegisteredTicks)>(_waiterCount);
+        foreach (var (address, list) in _waiters)
+        {
+            for (var i = 0; i < list.Count; i++)
+            {
+                var waiter = list[i];
+                if (orphansOnly &&
+                    (waiter.Latched ||
+                     waiter.RetryDeadlineTicks != 0 ||
+                     (waiter.Memory is not null &&
+                      _lastProduced.ContainsKey((waiter.Memory, address)))))
+                {
+                    continue;
+                }
+
+                candidates.Add((address, i, waiter.RegisteredTicks));
+            }
+        }
+
+        if (candidates.Count == 0)
+        {
+            return;
+        }
+
+        candidates.Sort(static (left, right) => left.RegisteredTicks.CompareTo(right.RegisteredTicks));
+        var toDrop = Math.Min(candidates.Count, _waiterCount - keepAtMost);
+        var dropSet = candidates.GetRange(0, toDrop);
+        // Highest index first per address so earlier removals do not shift later ones.
+        dropSet.Sort(static (left, right) =>
+        {
+            var addressCompare = left.Address.CompareTo(right.Address);
+            return addressCompare != 0
+                ? addressCompare
+                : right.Index.CompareTo(left.Index);
+        });
+
+        List<ulong>? emptied = null;
+        foreach (var (address, index, _) in dropSet)
+        {
+            if (!_waiters.TryGetValue(address, out var list) ||
+                index < 0 ||
+                index >= list.Count)
+            {
+                continue;
+            }
+
+            RemoveWaiterAtLocked(list, index);
+            if (list.Count == 0)
+            {
+                emptied ??= new List<ulong>();
+                emptied.Add(address);
+            }
+        }
+
+        if (emptied is not null)
+        {
+            foreach (var address in emptied)
+            {
+                _waiters.Remove(address);
+            }
+        }
+    }
+
+    private static void RemoveWaiterAtLocked(List<WaitingDcb> list, int index)
+    {
+        list.RemoveAt(index);
+        if (_waiterCount > 0)
+        {
+            _waiterCount--;
+        }
+    }
+
     /// <summary>Records the value a label producer wrote, for the deadlock
     /// breaker. Also latches any already-waiting waiter it satisfies.</summary>
     public static bool RecordProduced(object memory, ulong address, ulong value)
@@ -542,7 +653,7 @@ internal static class GpuWaitRegistry
 
                     broken ??= new List<WaitingDcb>();
                     broken.Add(waiter);
-                    list.RemoveAt(i);
+                    RemoveWaiterAtLocked(list, i);
                 }
 
                 if (list.Count == 0)
@@ -589,6 +700,7 @@ internal static class GpuWaitRegistry
         {
             _waiters.Clear();
             _lastProduced.Clear();
+            _waiterCount = 0;
         }
     }
 }

--- a/src/SharpEmu.Libs/Gpu/GuestDataPool.cs
+++ b/src/SharpEmu.Libs/Gpu/GuestDataPool.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Numerics;
+using SharpEmu.Logging;
 
 namespace SharpEmu.Libs.Gpu;
 
@@ -18,8 +19,10 @@ internal static class GuestDataPool
 {
     public static ArrayPool<byte> Shared { get; } = new BoundedByteArrayPool(
         maxArrayLength: 16 * 1024 * 1024,
-        maxCachedBytes: 256UL * 1024 * 1024,
-        maxArraysPerBucket: 8);
+        maxCachedBytes: HostMemoryBudget.IsConstrained
+            ? 128UL * 1024 * 1024
+            : 256UL * 1024 * 1024,
+        maxArraysPerBucket: HostMemoryBudget.IsConstrained ? 4 : 8);
 
     public static void Trim() => ((BoundedByteArrayPool)Shared).Trim();
 

--- a/src/SharpEmu.Libs/HostFsPath.cs
+++ b/src/SharpEmu.Libs/HostFsPath.cs
@@ -1,6 +1,9 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Globalization;
+using System.Text;
+
 namespace SharpEmu.Libs;
 
 /// <summary>
@@ -18,4 +21,141 @@ internal static class HostFsPath
 
     public static readonly StringComparison Comparison =
         OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Maps a guest path segment onto a Windows-safe host segment. FreeBSD-style
+    /// guest names may contain characters that Windows rejects or truncates
+    /// (notably ':'), which previously cut save files short and broke reloads.
+    /// Percent-encoding is invertible and collision-free, unlike replacing with '_'.
+    /// No-op on non-Windows hosts where those characters are legal.
+    /// </summary>
+    public static string EncodeHostPathSegment(string segment)
+    {
+        if (!OperatingSystem.IsWindows() || string.IsNullOrEmpty(segment))
+        {
+            return segment;
+        }
+
+        var needsEncoding = false;
+        foreach (var ch in segment)
+        {
+            if (NeedsWindowsEncoding(ch))
+            {
+                needsEncoding = true;
+                break;
+            }
+        }
+
+        if (!needsEncoding)
+        {
+            return segment;
+        }
+
+        var sb = new StringBuilder(segment.Length + 8);
+        foreach (var ch in segment)
+        {
+            if (NeedsWindowsEncoding(ch))
+            {
+                sb.Append('%');
+                sb.Append(((int)ch).ToString("X2", CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                sb.Append(ch);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Inverse of <see cref="EncodeHostPathSegment"/> for directory listings
+    /// returned to the guest. Harmless on already-decoded names.
+    /// </summary>
+    public static string DecodeHostPathSegment(string segment)
+    {
+        if (string.IsNullOrEmpty(segment) || segment.IndexOf('%') < 0)
+        {
+            return segment;
+        }
+
+        var sb = new StringBuilder(segment.Length);
+        for (var i = 0; i < segment.Length; i++)
+        {
+            if (segment[i] == '%' &&
+                i + 2 < segment.Length &&
+                IsHex(segment[i + 1]) &&
+                IsHex(segment[i + 2]))
+            {
+                var value = (FromHex(segment[i + 1]) << 4) | FromHex(segment[i + 2]);
+                sb.Append((char)value);
+                i += 2;
+                continue;
+            }
+
+            sb.Append(segment[i]);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Percent-encodes characters that are illegal in a host filename on the
+    /// current OS. Used for SharpEmu-owned save-slot names so ':' and similar
+    /// stay round-trippable without colliding with '_' replacements.
+    /// </summary>
+    public static string EncodeInvalidFileNameChars(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var needsEncoding = false;
+        foreach (var ch in value)
+        {
+            if (ch == '%' || Array.IndexOf(invalid, ch) >= 0)
+            {
+                needsEncoding = true;
+                break;
+            }
+        }
+
+        if (!needsEncoding)
+        {
+            return value;
+        }
+
+        var sb = new StringBuilder(value.Length + 8);
+        foreach (var ch in value)
+        {
+            if (ch == '%' || Array.IndexOf(invalid, ch) >= 0)
+            {
+                sb.Append('%');
+                sb.Append(((int)ch).ToString("X2", CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                sb.Append(ch);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static bool NeedsWindowsEncoding(char ch) =>
+        ch is '%' or ':' or '*' or '?' or '"' or '<' or '>' or '|' or '/' or '\\' ||
+        char.IsControl(ch);
+
+    private static bool IsHex(char ch) =>
+        ch is >= '0' and <= '9' or >= 'A' and <= 'F' or >= 'a' and <= 'f';
+
+    private static int FromHex(char ch) => ch switch
+    {
+        >= '0' and <= '9' => ch - '0',
+        >= 'A' and <= 'F' => ch - 'A' + 10,
+        >= 'a' and <= 'f' => ch - 'a' + 10,
+        _ => 0,
+    };
 }

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -4,6 +4,7 @@
 using SharpEmu.HLE;
 using SharpEmu.Libs.Ampr;
 using SharpEmu.Libs.Media;
+using SharpEmu.Logging;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
@@ -50,7 +51,10 @@ public static partial class KernelMemoryCompatExports
     private const int SeekSet = 0;
     private const int SeekCur = 1;
     private const int SeekEnd = 2;
-    private const ulong DirectMemorySizeBytes = 16384UL * 1024 * 1024;
+    // Host-aware: on ~16 GiB PCs this is smaller than the real PS5 16 GiB pool so
+    // titles that size themselves from sceKernelGetDirectMemorySize do not push
+    // the host into OOM. Override with SHARPEMU_DIRECT_MEMORY_MB.
+    private static readonly ulong DirectMemorySizeBytes = HostMemoryBudget.AdvertisedDirectMemoryBytes;
     private const ulong UnsetMainDirectMemoryPoolBase = ulong.MaxValue;
     private const ulong FlexibleMemorySizeBytes = 448UL * 1024 * 1024;
     private const int OrbisVirtualQueryInfoSize = 72;
@@ -5264,7 +5268,7 @@ public static partial class KernelMemoryCompatExports
                 continue;
             }
 
-            resolved.Add(segment);
+            resolved.Add(HostFsPath.EncodeHostPathSegment(segment));
         }
 
         return string.Join(Path.DirectorySeparatorChar, resolved);
@@ -7374,12 +7378,15 @@ public static partial class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_OK;
         }
 
-        var entryName = directory.Entries[currentIndex];
+        var hostEntryName = directory.Entries[currentIndex];
         directory.NextIndex = currentIndex + 1;
 
-        var entryBytes = Encoding.UTF8.GetBytes(entryName);
+        // Host names may be percent-encoded (#683); the guest must see the
+        // original FreeBSD-legal filename, including characters Windows rejects.
+        var guestEntryName = HostFsPath.DecodeHostPathSegment(hostEntryName);
+        var entryBytes = Encoding.UTF8.GetBytes(guestEntryName);
         var nameLength = Math.Min(entryBytes.Length, 255);
-        var entryPath = Path.Combine(directory.Path, entryName);
+        var entryPath = Path.Combine(directory.Path, hostEntryName);
         var entryType = Directory.Exists(entryPath) ? (byte)4 : (byte)8;
 
         var payload = new byte[512];

--- a/src/SharpEmu.Libs/SaveData/SaveDataStorage.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataStorage.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using SharpEmu.Libs;
 
 namespace SharpEmu.Libs.SaveData;
 
@@ -104,7 +105,9 @@ public static class SaveDataStorage
         Path.Combine(slotDir, "sce_sys", "icon0.png");
 
     /// <summary>
-    /// Replaces characters that are invalid in a host path segment. Empty or
+    /// Percent-encodes characters that are invalid in a host path segment so
+    /// guest names like "Arcade Spirits: …" round-trip on Windows without
+    /// truncating at ':' or colliding when replaced with '_'. Empty or
     /// all-invalid input collapses to "default" so a bad guest name can never
     /// escape the save root or produce an empty segment.
     /// </summary>
@@ -115,15 +118,7 @@ public static class SaveDataStorage
             return "default";
         }
 
-        var invalid = Path.GetInvalidFileNameChars();
-        Span<char> buffer = value.Length <= 128 ? stackalloc char[value.Length] : new char[value.Length];
-        for (var i = 0; i < value.Length; i++)
-        {
-            var ch = value[i];
-            buffer[i] = Array.IndexOf(invalid, ch) >= 0 ? '_' : ch;
-        }
-
-        var sanitized = new string(buffer).Trim();
+        var sanitized = HostFsPath.EncodeInvalidFileNameChars(value).Trim();
         return string.IsNullOrWhiteSpace(sanitized) ? "default" : sanitized;
     }
 

--- a/src/SharpEmu.Libs/VideoOut/VulkanDetilePass.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanDetilePass.cs
@@ -4,6 +4,7 @@
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using SharpEmu.Libs.Agc;
+using SharpEmu.Logging;
 using SharpEmu.ShaderCompiler.Vulkan;
 using Silk.NET.Vulkan;
 using VkBuffer = Silk.NET.Vulkan.Buffer;
@@ -55,11 +56,20 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
 
     private readonly Dictionary<(ulong Bucket, bool HostVisible), Stack<Allocation>> _bufferPool = new();
     private readonly List<Allocation> _allAllocations = new();
+    private ulong _pooledBytes;
 
     private readonly Stack<DescriptorSet> _freeDescriptorSets = new();
     private readonly List<DescriptorPool> _descriptorPools = new();
     private const uint DescriptorSetsPerPool = 64;
     private const ulong MinimumBufferBucket = 4096;
+    // Busy Demon's Souls loading screens thrash many texture sizes. Without a
+    // cap the free lists retain every bucket forever and native device memory
+    // climbs with each new size class (#618 / #639).
+    private const int MaxBuffersPerBucket = 4;
+    private static readonly ulong MaxPooledBufferBytes =
+        HostMemoryBudget.IsConstrained
+            ? 128UL * 1024 * 1024
+            : 256UL * 1024 * 1024;
 
     public VulkanDetilePass(
         Vk vk,
@@ -348,7 +358,11 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
         var bucket = BucketFor(size);
         if (_bufferPool.TryGetValue((bucket, hostVisible), out var free) && free.Count > 0)
         {
-            return free.Pop();
+            var rented = free.Pop();
+            _pooledBytes = rented.Capacity >= _pooledBytes
+                ? 0
+                : _pooledBytes - rented.Capacity;
+            return rented;
         }
 
         return CreateBuffer(bucket, hostVisible);
@@ -368,7 +382,16 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
             _bufferPool[key] = free;
         }
 
+        if (free.Count >= MaxBuffersPerBucket ||
+            _pooledBytes + allocation.Capacity > MaxPooledBufferBytes)
+        {
+            DestroyBuffer(allocation.Buffer, allocation.Memory);
+            _allAllocations.Remove(allocation);
+            return;
+        }
+
         free.Push(allocation);
+        _pooledBytes += allocation.Capacity;
     }
 
     private DescriptorSet RentDescriptorSet()
@@ -855,6 +878,7 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
 
         _allAllocations.Clear();
         _bufferPool.Clear();
+        _pooledBytes = 0;
         _xorTermBuffers.Clear();
         _blockTermBuffers.Clear();
         _placeholderTermBuffer = default;

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -8,6 +8,7 @@ using SharpEmu.HLE;
 using SharpEmu.Libs.Agc;
 using SharpEmu.Libs.Media;
 using SharpEmu.Libs.Gpu;
+using SharpEmu.Logging;
 using SharpEmu.ShaderCompiler;
 using SharpEmu.ShaderCompiler.Vulkan;
 using Silk.NET.Vulkan;
@@ -380,7 +381,8 @@ internal static unsafe class VulkanVideoPresenter
             out var pendingGuestWorkItems) && pendingGuestWorkItems > 0
             ? pendingGuestWorkItems
             : OperatingSystem.IsMacOS() ? 64 : 512;
-    private const ulong MaximumCachedHostBufferBytes = 128UL * 1024 * 1024;
+    private static readonly ulong MaximumCachedHostBufferBytes =
+        HostMemoryBudget.DefaultCachedHostBufferBytes;
     // A captured 4K flip can consume tens of MiB of device-local memory.
     // Retain only a short presentation queue while always preserving the
     // newest generation; older immutable versions are retired immediately.
@@ -391,11 +393,11 @@ internal static unsafe class VulkanVideoPresenter
     // render thread could upload them.  Keep the count cap for small work and
     // independently apply backpressure to the actual retained payload.
     private static readonly ulong _maxPendingGuestWorkBytes =
-        (ulong.TryParse(
-             Environment.GetEnvironmentVariable("SHARPEMU_PENDING_GUEST_WORK_MB"),
-             out var pendingGuestWorkMb) && pendingGuestWorkMb > 0
-            ? pendingGuestWorkMb
-            : 256UL) * 1024UL * 1024UL;
+        ulong.TryParse(
+            Environment.GetEnvironmentVariable("SHARPEMU_PENDING_GUEST_WORK_MB"),
+            out var pendingGuestWorkMb) && pendingGuestWorkMb > 0
+            ? pendingGuestWorkMb * 1024UL * 1024UL
+            : HostMemoryBudget.DefaultPendingGuestWorkBytes;
     private static readonly int _maxGuestWorkPerRender =
         int.TryParse(
             Environment.GetEnvironmentVariable("SHARPEMU_MAX_GUEST_WORK_PER_RENDER"),
@@ -17395,7 +17397,7 @@ internal static unsafe class VulkanVideoPresenter
             renderResolutionScale > 0 &&
             renderResolutionScale <= 2.0
                 ? renderResolutionScale
-                : 1.0;
+                : HostMemoryBudget.DefaultRenderScale;
 
         private static uint ScaleGuestDimension(uint value) =>
             _renderResolutionScale == 1.0

--- a/src/SharpEmu.Logging/HostMemoryBudget.cs
+++ b/src/SharpEmu.Logging/HostMemoryBudget.cs
@@ -1,0 +1,231 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace SharpEmu.Logging;
+
+/// <summary>
+/// Host-aware memory budgets so PCs with ~16 GiB RAM do not advertise a full
+/// PS5-scale direct-memory pool and then commit it into host OOM.
+/// Override with SHARPEMU_DIRECT_MEMORY_MB (MiB, clamped).
+/// </summary>
+public static class HostMemoryBudget
+{
+    /// <summary>PS5-class direct memory pool size reported by real hardware.</summary>
+    public const ulong Ps5DirectMemoryBytes = 16384UL * 1024 * 1024;
+
+    private const ulong MinimumDirectMemoryBytes = 2048UL * 1024 * 1024;
+    private const ulong HostRuntimeHeadroomBytes = 6144UL * 1024 * 1024;
+    private const ulong UnknownHostFallbackDirectMemoryBytes = 8192UL * 1024 * 1024;
+
+    private static readonly Lazy<Budget> Resolved = new(Resolve);
+
+    /// <summary>Best-effort total host physical RAM, or 0 when unknown.</summary>
+    public static ulong TotalPhysicalMemoryBytes => Resolved.Value.TotalPhysicalBytes;
+
+    /// <summary>Size exposed through sceKernelGetDirectMemorySize / DM allocators.</summary>
+    public static ulong AdvertisedDirectMemoryBytes => Resolved.Value.AdvertisedDirectMemoryBytes;
+
+    /// <summary>
+    /// Non-executable mappings larger than this prefer reserve + lazy commit when
+    /// the host is memory-constrained (still after a full-commit attempt fails).
+    /// </summary>
+    public static ulong FullCommitRegionLimitBytes => Resolved.Value.FullCommitRegionLimitBytes;
+
+    /// <summary>Minimum size before a mapping may use the lazy-reserve fallback.</summary>
+    public static ulong LargeDataReserveThresholdBytes => Resolved.Value.LargeDataReserveThresholdBytes;
+
+    /// <summary>Default pending guest GPU work queue cap when env is unset.</summary>
+    public static ulong DefaultPendingGuestWorkBytes => Resolved.Value.DefaultPendingGuestWorkBytes;
+
+    /// <summary>Default host buffer cache cap when env is unset.</summary>
+    public static ulong DefaultCachedHostBufferBytes => Resolved.Value.DefaultCachedHostBufferBytes;
+
+    /// <summary>Default SHARPEMU_RENDER_SCALE when env is unset.</summary>
+    public static double DefaultRenderScale => Resolved.Value.DefaultRenderScale;
+
+    /// <summary>True when the advertised DM pool is smaller than the PS5 default.</summary>
+    public static bool IsConstrained => AdvertisedDirectMemoryBytes < Ps5DirectMemoryBytes;
+
+    /// <summary>One-line diagnostic for startup logs.</summary>
+    public static string Summary => Resolved.Value.Summary;
+
+    private static Budget Resolve()
+    {
+        var totalPhysical = TryGetTotalPhysicalMemoryBytes();
+        var advertised = ResolveAdvertisedDirectMemory(totalPhysical, out var source);
+        var constrained = advertised < Ps5DirectMemoryBytes ||
+            (totalPhysical != 0 && totalPhysical <= 20UL * 1024 * 1024 * 1024);
+
+        // On constrained hosts, allow lazy reserve for multi-hundred-MiB maps so
+        // guest "allocate everything" paths do not pin 8+ GiB of host RAM.
+        var largeThreshold = constrained ? 512UL * 1024 * 1024 : 1024UL * 1024 * 1024;
+        var fullCommitLimit = constrained ? 512UL * 1024 * 1024 : 4UL << 30;
+        var pendingWorkMb = constrained ? 128UL : 256UL;
+        var cachedBuffers = constrained ? 64UL * 1024 * 1024 : 128UL * 1024 * 1024;
+        var renderScale = constrained ? 0.75 : 1.0;
+
+        if (totalPhysical != 0 && totalPhysical < 12UL * 1024 * 1024 * 1024)
+        {
+            pendingWorkMb = 64UL;
+            cachedBuffers = 32UL * 1024 * 1024;
+            renderScale = 0.5;
+        }
+
+        var hostText = totalPhysical == 0
+            ? "unknown"
+            : $"{totalPhysical / (1024 * 1024):N0} MB";
+        var summary =
+            $"Host memory budget: host_ram={hostText}, " +
+            $"direct_memory={advertised / (1024 * 1024):N0} MB ({source}), " +
+            $"lazy_threshold={largeThreshold / (1024 * 1024)} MB, " +
+            $"full_commit_limit={fullCommitLimit / (1024 * 1024)} MB, " +
+            $"pending_gpu_work={pendingWorkMb} MB, " +
+            $"render_scale_default={renderScale.ToString("0.##", CultureInfo.InvariantCulture)}";
+
+        return new Budget(
+            totalPhysical,
+            advertised,
+            fullCommitLimit,
+            largeThreshold,
+            pendingWorkMb * 1024UL * 1024UL,
+            cachedBuffers,
+            renderScale,
+            summary);
+    }
+
+    private static ulong ResolveAdvertisedDirectMemory(ulong totalPhysical, out string source)
+    {
+        var overrideMb = Environment.GetEnvironmentVariable("SHARPEMU_DIRECT_MEMORY_MB");
+        if (ulong.TryParse(overrideMb, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mb) &&
+            mb > 0)
+        {
+            // Keep a playable floor and never advertise more than real PS5 DM.
+            var clamped = Math.Clamp(mb, 512UL, 16384UL) * 1024UL * 1024UL;
+            source = $"SHARPEMU_DIRECT_MEMORY_MB={mb}";
+            return clamped;
+        }
+
+        if (totalPhysical == 0)
+        {
+            source = "fallback";
+            return UnknownHostFallbackDirectMemoryBytes;
+        }
+
+        // Leave headroom for the OS, GPU driver, .NET runtime, and Vulkan images.
+        var usable = totalPhysical > HostRuntimeHeadroomBytes
+            ? totalPhysical - HostRuntimeHeadroomBytes
+            : MinimumDirectMemoryBytes;
+        var advertised = Math.Clamp(usable, MinimumDirectMemoryBytes, Ps5DirectMemoryBytes);
+        source = "auto";
+        return advertised;
+    }
+
+    private static ulong TryGetTotalPhysicalMemoryBytes()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            try
+            {
+                var status = new MemoryStatusEx
+                {
+                    dwLength = (uint)Marshal.SizeOf<MemoryStatusEx>(),
+                };
+                if (GlobalMemoryStatusEx(ref status) && status.ullTotalPhys > 0)
+                {
+                    return status.ullTotalPhys;
+                }
+            }
+            catch (Exception)
+            {
+                // Diagnostic / budgeting only.
+            }
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            try
+            {
+                foreach (var line in File.ReadLines("/proc/meminfo"))
+                {
+                    if (!line.StartsWith("MemTotal:", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length >= 2 &&
+                        ulong.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var kb))
+                    {
+                        return kb * 1024UL;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Diagnostic / budgeting only.
+            }
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            try
+            {
+                // sysctl hw.memsize
+                var startInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "/usr/sbin/sysctl",
+                    Arguments = "-n hw.memsize",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+                using var process = System.Diagnostics.Process.Start(startInfo);
+                if (process is not null)
+                {
+                    var text = process.StandardOutput.ReadToEnd().Trim();
+                    process.WaitForExit(2000);
+                    if (ulong.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var bytes) &&
+                        bytes > 0)
+                    {
+                        return bytes;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Diagnostic / budgeting only.
+            }
+        }
+
+        return 0;
+    }
+
+    private readonly record struct Budget(
+        ulong TotalPhysicalBytes,
+        ulong AdvertisedDirectMemoryBytes,
+        ulong FullCommitRegionLimitBytes,
+        ulong LargeDataReserveThresholdBytes,
+        ulong DefaultPendingGuestWorkBytes,
+        ulong DefaultCachedHostBufferBytes,
+        double DefaultRenderScale,
+        string Summary);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    private struct MemoryStatusEx
+    {
+        public uint dwLength;
+        public uint dwMemoryLoad;
+        public ulong ullTotalPhys;
+        public ulong ullAvailPhys;
+        public ulong ullTotalPageFile;
+        public ulong ullAvailPageFile;
+        public ulong ullTotalVirtual;
+        public ulong ullAvailVirtual;
+        public ulong ullAvailExtendedVirtual;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GlobalMemoryStatusEx(ref MemoryStatusEx buffer);
+}

--- a/tests/SharpEmu.Libs.Tests/Agc/GpuWaitRegistryProducedRetentionTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/GpuWaitRegistryProducedRetentionTests.cs
@@ -58,6 +58,25 @@ public sealed class GpuWaitRegistryProducedRetentionTests
         GpuWaitRegistry.Clear();
     }
 
+    [Fact]
+    public void OrphanedWaitersArePrunedWhenTheRegistryHitsItsCap()
+    {
+        GpuWaitRegistry.Clear();
+        var memory = new object();
+
+        // Flood the registry with producerless waits past the hard cap.
+        for (var i = 0; i < 5000; i++)
+        {
+            GpuWaitRegistry.Register(
+                0x7040_0000_0000UL + ((ulong)i * 8),
+                NewWaiter(memory, 0x7040_0000_0000UL + ((ulong)i * 8)));
+        }
+
+        Assert.True(GpuWaitRegistry.Count <= 4096);
+        Assert.True(GpuWaitRegistry.Count > 0);
+        GpuWaitRegistry.Clear();
+    }
+
     private static GpuWaitRegistry.WaitingDcb NewWaiter(object memory, ulong address) => new()
     {
         WaitAddress = address,

--- a/tests/SharpEmu.Libs.Tests/HostFsPathEncodingTests.cs
+++ b/tests/SharpEmu.Libs.Tests/HostFsPathEncodingTests.cs
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Xunit;
+
+namespace SharpEmu.Libs.Tests;
+
+public sealed class HostFsPathEncodingTests
+{
+    [Fact]
+    public void EncodeRoundTripsColonAndPercentOnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        const string guest = "rg_ac_Arcade Spirits: The New Challengers_0.dat";
+        var host = HostFsPath.EncodeHostPathSegment(guest);
+        Assert.Equal("rg_ac_Arcade Spirits%3A The New Challengers_0.dat", host);
+        Assert.Equal(guest, HostFsPath.DecodeHostPathSegment(host));
+        Assert.DoesNotContain(':', host);
+    }
+
+    [Fact]
+    public void EncodeIsNoOpOnNonWindows()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        const string guest = "Arcade Spirits: The New Challengers";
+        Assert.Equal(guest, HostFsPath.EncodeHostPathSegment(guest));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/SaveDataStorageTests.cs
+++ b/tests/SharpEmu.Libs.Tests/SaveDataStorageTests.cs
@@ -40,13 +40,28 @@ public sealed class SaveDataStorageTests
 
     [Theory]
     [InlineData("SAVE0000", "SAVE0000")]
-    [InlineData("../../etc/passwd", ".._.._etc_passwd")] // '/' separators -> '_', collapsing to one segment
-    [InlineData("a/b", "a_b")]
+    [InlineData("../../etc/passwd", "..%2F..%2Fetc%2Fpasswd")]
+    [InlineData("a/b", "a%2Fb")]
     [InlineData("", "default")]
     [InlineData("   ", "default")]
     public void SanitizeNeutralizesPathSeparatorsAndEmpties(string input, string expected)
     {
         Assert.Equal(expected, SaveDataStorage.Sanitize(input));
+    }
+
+    [Fact]
+    public void SanitizePercentEncodesColonOnWindows()
+    {
+        const string input = "Arcade Spirits: The New Challengers";
+        var sanitized = SaveDataStorage.Sanitize(input);
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal("Arcade Spirits%3A The New Challengers", sanitized);
+        }
+        else
+        {
+            Assert.Equal(input, sanitized);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Before submitting

I read CONTRIBUTING.md. This PR was developed with AI assistance (Cursor / Grok). I reviewed every change below and can explain why each exists. I am not pasting unexplained generated text as the point of the PR.

## Summary

Generic host-side hardening for ~16 GiB Windows PCs and a Windows filesystem bug that truncates guest filenames containing `:` (issue #683). Also small CLI aliases for fullscreen (#758) and bounded registries that grow during heavy AGC boot (related to #618 / #639 discussion).

No game-specific hacks. Personal UI branding was intentionally kept out of this PR.

## What changed and why

### 1. `HostMemoryBudget` (new)
- **Why:** `sceKernelGetDirectMemorySize` previously always advertised a full 16 GiB PS5 pool. On a 16 GiB host that invites commit/OOM because OS + GPU + .NET still need RAM.
- **What:** Auto-scales advertised direct memory from host RAM (leaves ~6 GiB headroom), with `SHARPEMU_DIRECT_MEMORY_MB` override to force a specific size (including 16384 for full PS5 behavior).
- **Also sets defaults for:** lazy-commit thresholds, pending GPU work bytes, cached host buffers, and default `SHARPEMU_RENDER_SCALE` when the env var is unset.
- **Logged at startup** so testers can see the chosen budget.

### 2. `PhysicalVirtualMemory` lazy thresholds
- **Why:** Full-commit preference for multi-GiB maps is correct for accuracy, but on constrained hosts it pins too much host RAM early.
- **What:** Uses `HostMemoryBudget` thresholds so large non-exec maps become eligible for reserve + lazy commit sooner on low-RAM hosts. Executable mappings are unchanged.

### 3. Windows guest path percent-encoding (#683)
- **Why:** Guest FreeBSD-style names like `Arcade Spirits: The New Challengers.dat` are legal on the guest but Windows truncates/fails at `:`. Saves then cannot reload.
- **What:**
  - `HostFsPath.EncodeHostPathSegment` / `DecodeHostPathSegment` (Windows only for mount translation).
  - `NormalizeMountRelativePath` encodes each segment before `Path.Combine`.
  - `getdirentries` decodes host names back to the guest.
  - `SaveDataStorage.Sanitize` uses percent-encoding instead of `_` replacement to avoid collisions (`foo:bar` vs `foo_bar`).
- **Tests:** round-trip colon encoding + updated Sanitize expectations.

### 4. `VulkanDetilePass` pool cap (#618-related)
- **Why:** Free lists retained every size bucket forever; busy loading screens create many texture sizes and native Vulkan memory climbs.
- **What:** Cap 4 buffers per bucket and a total pooled-byte budget (128–256 MiB depending on host). Excess allocations are destroyed on return instead of cached forever.

### 5. `GuestDataPool` / presenter defaults on constrained hosts
- **Why:** Same 16 GiB pressure; keep managed caches smaller by default when the host is constrained.
- **What:** Lower max cached bytes / arrays-per-bucket; presenter pending-work and render-scale defaults read from `HostMemoryBudget` unless env overrides are set.

### 6. `GpuWaitRegistry` hard cap (#639-related)
- **Why:** Producerless waits are never removed by `CollectExpiredRetries` / `CollectDeadlockBroken`, so the waiter table can grow without bound during boot storms.
- **What:** Soft hard-cap at 4096 waiters. When exceeded, drop oldest *orphan* waiters (no recorded producer, no retry deadline, not latched) first; only if still over budget drop oldest remaining. This does **not** force-resume DCBs (still fail-closed for ordering). Tradeoff: orphaned DCBs that were already stuck may be abandoned instead of retaining unbounded host state.
- **Test:** registry stays <= 4096 after flooding 5000 producerless waits. Existing produced-value retention tests still pass.

### 7. CLI `--fullscreen` aliases (#758)
- **Why:** Users asked for `-f` / `--fullscreen`; `--window-mode=fullscreen` already mapped to exclusive.
- **What:** Accept `-f`, `--f`, `-fullscreen`, `--fullscreen` as aliases for exclusive fullscreen. Usage text updated.

## Testing

- Unit: `SaveDataStorageTests`, `HostFsPathEncodingTests`, `GpuWaitRegistryProducedRetentionTests` — **17 passed** on Windows Release.
- Runtime game testing for Demon's Souls / Arcade Spirits: **not yet done on this exact commit** (no dump attached in this session). Please treat runtime claims as unverified until I (or a reviewer) run a title and attach logs showing `Host memory budget:` and save/path behavior.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes (unit tests) or marked remaining runtime testing clearly above.
- [x] I wrote / thoroughly edited this description so each change has a concrete why (AI-assisted development disclosed above).
- [x] I listed testing status above.

## Reviewer notes / possible split

If this is too broad, I can split into:
1. Windows path encoding only (#683)
2. HostMemoryBudget + detile/presenter caps
3. GpuWaitRegistry cap (most controversial correctness tradeoff)

Happy to revise based on maintainer preference.

Made with [Cursor](https://cursor.com)