### PR TITLE
fix(fs): percent-encode Windows-invalid guest path segments (#683)

### DIFF
--- a/src/SharpEmu.Libs/HostFsPath.cs
+++ b/src/SharpEmu.Libs/HostFsPath.cs
@@ -1,6 +1,9 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Globalization;
+using System.Text;
+
 namespace SharpEmu.Libs;
 
 /// <summary>
@@ -18,4 +21,141 @@ internal static class HostFsPath
 
     public static readonly StringComparison Comparison =
         OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Maps a guest path segment onto a Windows-safe host segment. FreeBSD-style
+    /// guest names may contain characters that Windows rejects or truncates
+    /// (notably ':'), which previously cut save files short and broke reloads.
+    /// Percent-encoding is invertible and collision-free, unlike replacing with '_'.
+    /// No-op on non-Windows hosts where those characters are legal.
+    /// </summary>
+    public static string EncodeHostPathSegment(string segment)
+    {
+        if (!OperatingSystem.IsWindows() || string.IsNullOrEmpty(segment))
+        {
+            return segment;
+        }
+
+        var needsEncoding = false;
+        foreach (var ch in segment)
+        {
+            if (NeedsWindowsEncoding(ch))
+            {
+                needsEncoding = true;
+                break;
+            }
+        }
+
+        if (!needsEncoding)
+        {
+            return segment;
+        }
+
+        var sb = new StringBuilder(segment.Length + 8);
+        foreach (var ch in segment)
+        {
+            if (NeedsWindowsEncoding(ch))
+            {
+                sb.Append('%');
+                sb.Append(((int)ch).ToString("X2", CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                sb.Append(ch);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Inverse of <see cref="EncodeHostPathSegment"/> for directory listings
+    /// returned to the guest. Harmless on already-decoded names.
+    /// </summary>
+    public static string DecodeHostPathSegment(string segment)
+    {
+        if (string.IsNullOrEmpty(segment) || segment.IndexOf('%') < 0)
+        {
+            return segment;
+        }
+
+        var sb = new StringBuilder(segment.Length);
+        for (var i = 0; i < segment.Length; i++)
+        {
+            if (segment[i] == '%' &&
+                i + 2 < segment.Length &&
+                IsHex(segment[i + 1]) &&
+                IsHex(segment[i + 2]))
+            {
+                var value = (FromHex(segment[i + 1]) << 4) | FromHex(segment[i + 2]);
+                sb.Append((char)value);
+                i += 2;
+                continue;
+            }
+
+            sb.Append(segment[i]);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Percent-encodes characters that are illegal in a host filename on the
+    /// current OS. Used for SharpEmu-owned save-slot names so ':' and similar
+    /// stay round-trippable without colliding with '_' replacements.
+    /// </summary>
+    public static string EncodeInvalidFileNameChars(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var needsEncoding = false;
+        foreach (var ch in value)
+        {
+            if (ch == '%' || Array.IndexOf(invalid, ch) >= 0)
+            {
+                needsEncoding = true;
+                break;
+            }
+        }
+
+        if (!needsEncoding)
+        {
+            return value;
+        }
+
+        var sb = new StringBuilder(value.Length + 8);
+        foreach (var ch in value)
+        {
+            if (ch == '%' || Array.IndexOf(invalid, ch) >= 0)
+            {
+                sb.Append('%');
+                sb.Append(((int)ch).ToString("X2", CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                sb.Append(ch);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static bool NeedsWindowsEncoding(char ch) =>
+        ch is '%' or ':' or '*' or '?' or '"' or '<' or '>' or '|' or '/' or '\\' ||
+        char.IsControl(ch);
+
+    private static bool IsHex(char ch) =>
+        ch is >= '0' and <= '9' or >= 'A' and <= 'F' or >= 'a' and <= 'f';
+
+    private static int FromHex(char ch) => ch switch
+    {
+        >= '0' and <= '9' => ch - '0',
+        >= 'A' and <= 'F' => ch - 'A' + 10,
+        >= 'a' and <= 'f' => ch - 'a' + 10,
+        _ => 0,
+    };
 }

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -5264,7 +5264,7 @@ public static partial class KernelMemoryCompatExports
                 continue;
             }
 
-            resolved.Add(segment);
+            resolved.Add(HostFsPath.EncodeHostPathSegment(segment));
         }
 
         return string.Join(Path.DirectorySeparatorChar, resolved);
@@ -7374,12 +7374,15 @@ public static partial class KernelMemoryCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_OK;
         }
 
-        var entryName = directory.Entries[currentIndex];
+        var hostEntryName = directory.Entries[currentIndex];
         directory.NextIndex = currentIndex + 1;
 
-        var entryBytes = Encoding.UTF8.GetBytes(entryName);
+        // Host names may be percent-encoded (#683); the guest must see the
+        // original FreeBSD-legal filename, including characters Windows rejects.
+        var guestEntryName = HostFsPath.DecodeHostPathSegment(hostEntryName);
+        var entryBytes = Encoding.UTF8.GetBytes(guestEntryName);
         var nameLength = Math.Min(entryBytes.Length, 255);
-        var entryPath = Path.Combine(directory.Path, entryName);
+        var entryPath = Path.Combine(directory.Path, hostEntryName);
         var entryType = Directory.Exists(entryPath) ? (byte)4 : (byte)8;
 
         var payload = new byte[512];

--- a/src/SharpEmu.Libs/SaveData/SaveDataStorage.cs
+++ b/src/SharpEmu.Libs/SaveData/SaveDataStorage.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using SharpEmu.Libs;
 
 namespace SharpEmu.Libs.SaveData;
 
@@ -104,7 +105,9 @@ public static class SaveDataStorage
         Path.Combine(slotDir, "sce_sys", "icon0.png");
 
     /// <summary>
-    /// Replaces characters that are invalid in a host path segment. Empty or
+    /// Percent-encodes characters that are invalid in a host path segment so
+    /// guest names like "Arcade Spirits: …" round-trip on Windows without
+    /// truncating at ':' or colliding when replaced with '_'. Empty or
     /// all-invalid input collapses to "default" so a bad guest name can never
     /// escape the save root or produce an empty segment.
     /// </summary>
@@ -115,15 +118,7 @@ public static class SaveDataStorage
             return "default";
         }
 
-        var invalid = Path.GetInvalidFileNameChars();
-        Span<char> buffer = value.Length <= 128 ? stackalloc char[value.Length] : new char[value.Length];
-        for (var i = 0; i < value.Length; i++)
-        {
-            var ch = value[i];
-            buffer[i] = Array.IndexOf(invalid, ch) >= 0 ? '_' : ch;
-        }
-
-        var sanitized = new string(buffer).Trim();
+        var sanitized = HostFsPath.EncodeInvalidFileNameChars(value).Trim();
         return string.IsNullOrWhiteSpace(sanitized) ? "default" : sanitized;
     }
 

--- a/tests/SharpEmu.Libs.Tests/HostFsPathEncodingTests.cs
+++ b/tests/SharpEmu.Libs.Tests/HostFsPathEncodingTests.cs
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using Xunit;
+
+namespace SharpEmu.Libs.Tests;
+
+public sealed class HostFsPathEncodingTests
+{
+    [Fact]
+    public void EncodeRoundTripsColonAndPercentOnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        const string guest = "rg_ac_Arcade Spirits: The New Challengers_0.dat";
+        var host = HostFsPath.EncodeHostPathSegment(guest);
+        Assert.Equal("rg_ac_Arcade Spirits%3A The New Challengers_0.dat", host);
+        Assert.Equal(guest, HostFsPath.DecodeHostPathSegment(host));
+        Assert.DoesNotContain(':', host);
+    }
+
+    [Fact]
+    public void EncodeIsNoOpOnNonWindows()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        const string guest = "Arcade Spirits: The New Challengers";
+        Assert.Equal(guest, HostFsPath.EncodeHostPathSegment(guest));
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/SaveDataStorageTests.cs
+++ b/tests/SharpEmu.Libs.Tests/SaveDataStorageTests.cs
@@ -40,13 +40,28 @@ public sealed class SaveDataStorageTests
 
     [Theory]
     [InlineData("SAVE0000", "SAVE0000")]
-    [InlineData("../../etc/passwd", ".._.._etc_passwd")] // '/' separators -> '_', collapsing to one segment
-    [InlineData("a/b", "a_b")]
+    [InlineData("../../etc/passwd", "..%2F..%2Fetc%2Fpasswd")]
+    [InlineData("a/b", "a%2Fb")]
     [InlineData("", "default")]
     [InlineData("   ", "default")]
     public void SanitizeNeutralizesPathSeparatorsAndEmpties(string input, string expected)
     {
         Assert.Equal(expected, SaveDataStorage.Sanitize(input));
+    }
+
+    [Fact]
+    public void SanitizePercentEncodesColonOnWindows()
+    {
+        const string input = "Arcade Spirits: The New Challengers";
+        var sanitized = SaveDataStorage.Sanitize(input);
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal("Arcade Spirits%3A The New Challengers", sanitized);
+        }
+        else
+        {
+            Assert.Equal(input, sanitized);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this does

On Windows, some guest file names use characters that Windows does not allow in paths (mainly `:`). When a game saves something like `Arcade Spirits: The New Challengers.dat`, Windows cuts the name and later the game cannot find the file.

This PR percent-encodes those characters when mapping guest paths to the host, and decodes them again when listing directories back to the guest. SaveData slot names use the same encoding instead of replacing bad characters with `_`, so two different names cannot collide.

Related: #683

## Testing

- Unit tests for path encoding / SaveData sanitize on Windows.
- I still need to re-test Arcade Spirits save/reload on a real dump with this build.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).