### PR TITLE
perf: host-aware memory budgets, detile pool caps, --fullscreen

### DIFF
--- a/src/SharpEmu.CLI/Program.cs
+++ b/src/SharpEmu.CLI/Program.cs
@@ -266,6 +266,7 @@ internal static partial class Program
 
         Log.Info(BuildInfo.Banner);
         Log.Info(HostSystemInfo.Summary);
+        Log.Info(HostMemoryBudget.Summary);
 
         ebootPath = Path.GetFullPath(ebootPath);
         Console.Error.WriteLine($"[DEBUG] Full path: {ebootPath}");
@@ -989,9 +990,11 @@ internal static partial class Program
 
     private static void PrintUsage()
     {
-        Log.Info("Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] [--cpu-engine=<native>] [--log-level=<level>] [--log-file[=<path>]] [--window-mode=<windowed|borderless|exclusive>] [--resolution=<WIDTHxHEIGHT>] [--display=<N>] [--refresh-rate=<HZ>] [--scaling=<fit|cover|stretch|integer>] [--vsync=<on|off>] [--hdr=<auto|on|off>] [--debug-server[=host:port]] <path-to-eboot.bin>");
+        Log.Info("Usage: SharpEmu.CLI [--strict] [--trace-imports[=N]] [--cpu-engine=<native>] [--log-level=<level>] [--log-file[=<path>]] [--window-mode=<windowed|borderless|exclusive>] [-f|--fullscreen] [--resolution=<WIDTHxHEIGHT>] [--display=<N>] [--refresh-rate=<HZ>] [--scaling=<fit|cover|stretch|integer>] [--vsync=<on|off>] [--hdr=<auto|on|off>] [--debug-server[=host:port]] <path-to-eboot.bin>");
         Log.Info(@"Example: SharpEmu.CLI --cpu-engine=native --trace-imports=64 --log-level=debug --log-file ""E:\Games\...\eboot.bin""");
         Log.Info("Debug server: --debug-server starts a live debug listener (default 127.0.0.1:5714); connect with SharpEmu.DebugClient.");
+        Log.Info("Memory: SHARPEMU_DIRECT_MEMORY_MB overrides guest direct-memory size (default auto-scales for host RAM). SHARPEMU_PENDING_GUEST_WORK_MB / SHARPEMU_RENDER_SCALE also override GPU budgets.");
+        Log.Info("Fullscreen: -f, --f, -fullscreen, or --fullscreen is the same as --window-mode=exclusive.");
     }
 
     /// <summary>
@@ -1077,6 +1080,13 @@ internal static partial class Program
                 windowModeOverride = windowMode;
                 continue;
             }
+
+            if (IsFullscreenFlag(argument))
+            {
+                windowModeOverride = HostWindowMode.ExclusiveFullscreen;
+                continue;
+            }
+
             if (TrySplitOption(argument, "--resolution", out var resolutionText))
             {
                 if (!TryParseResolution(resolutionText, out var windowWidth, out var windowHeight))
@@ -1387,6 +1397,12 @@ internal static partial class Program
         };
         return Enum.IsDefined(mode);
     }
+
+    private static bool IsFullscreenFlag(string argument) =>
+        argument.Equals("-f", StringComparison.OrdinalIgnoreCase) ||
+        argument.Equals("--f", StringComparison.OrdinalIgnoreCase) ||
+        argument.Equals("-fullscreen", StringComparison.OrdinalIgnoreCase) ||
+        argument.Equals("--fullscreen", StringComparison.OrdinalIgnoreCase);
 
     private static bool TryParseScalingMode(string value, out HostScalingMode mode)
     {

--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -30,8 +30,10 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
     private const ulong GuestAllocationArenaAddress = 0x00006000_0000_0000;
     private const ulong GuestAllocationArenaSize = 0x0100_0000;
     private const ulong GuestAllocationArenaStartOffset = PageSize;
-    private const ulong LargeDataReserveThreshold = 0x4000_0000UL; // 1 GiB
-    private const ulong FullCommitRegionLimit = 4UL << 30;
+    // Scaled down on constrained hosts (~16 GiB) so huge non-exec maps can fall
+    // back to reserve + lazy commit instead of pinning multi-GiB host commits.
+    private static readonly ulong LargeDataReserveThreshold = HostMemoryBudget.LargeDataReserveThresholdBytes;
+    private static readonly ulong FullCommitRegionLimit = HostMemoryBudget.FullCommitRegionLimitBytes;
     private const ulong DefaultLazyReservePrimeBytes = 0x0400_0000UL; // 64 MiB
     private const ulong LazyReservePrimeChunkBytes = 0x0200_0000UL; // 32 MiB
     private const int CommittedRangeCacheCapacity = 4;

--- a/src/SharpEmu.Libs/Gpu/GuestDataPool.cs
+++ b/src/SharpEmu.Libs/Gpu/GuestDataPool.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Numerics;
+using SharpEmu.Logging;
 
 namespace SharpEmu.Libs.Gpu;
 
@@ -18,8 +19,10 @@ internal static class GuestDataPool
 {
     public static ArrayPool<byte> Shared { get; } = new BoundedByteArrayPool(
         maxArrayLength: 16 * 1024 * 1024,
-        maxCachedBytes: 256UL * 1024 * 1024,
-        maxArraysPerBucket: 8);
+        maxCachedBytes: HostMemoryBudget.IsConstrained
+            ? 128UL * 1024 * 1024
+            : 256UL * 1024 * 1024,
+        maxArraysPerBucket: HostMemoryBudget.IsConstrained ? 4 : 8);
 
     public static void Trim() => ((BoundedByteArrayPool)Shared).Trim();
 

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -4,6 +4,7 @@
 using SharpEmu.HLE;
 using SharpEmu.Libs.Ampr;
 using SharpEmu.Libs.Media;
+using SharpEmu.Logging;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
@@ -50,7 +51,10 @@ public static partial class KernelMemoryCompatExports
     private const int SeekSet = 0;
     private const int SeekCur = 1;
     private const int SeekEnd = 2;
-    private const ulong DirectMemorySizeBytes = 16384UL * 1024 * 1024;
+    // Host-aware: on ~16 GiB PCs this is smaller than the real PS5 16 GiB pool so
+    // titles that size themselves from sceKernelGetDirectMemorySize do not push
+    // the host into OOM. Override with SHARPEMU_DIRECT_MEMORY_MB.
+    private static readonly ulong DirectMemorySizeBytes = HostMemoryBudget.AdvertisedDirectMemoryBytes;
     private const ulong UnsetMainDirectMemoryPoolBase = ulong.MaxValue;
     private const ulong FlexibleMemorySizeBytes = 448UL * 1024 * 1024;
     private const int OrbisVirtualQueryInfoSize = 72;

--- a/src/SharpEmu.Libs/VideoOut/VulkanDetilePass.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanDetilePass.cs
@@ -4,6 +4,7 @@
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using SharpEmu.Libs.Agc;
+using SharpEmu.Logging;
 using SharpEmu.ShaderCompiler.Vulkan;
 using Silk.NET.Vulkan;
 using VkBuffer = Silk.NET.Vulkan.Buffer;
@@ -55,11 +56,20 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
 
     private readonly Dictionary<(ulong Bucket, bool HostVisible), Stack<Allocation>> _bufferPool = new();
     private readonly List<Allocation> _allAllocations = new();
+    private ulong _pooledBytes;
 
     private readonly Stack<DescriptorSet> _freeDescriptorSets = new();
     private readonly List<DescriptorPool> _descriptorPools = new();
     private const uint DescriptorSetsPerPool = 64;
     private const ulong MinimumBufferBucket = 4096;
+    // Busy Demon's Souls loading screens thrash many texture sizes. Without a
+    // cap the free lists retain every bucket forever and native device memory
+    // climbs with each new size class (#618 / #639).
+    private const int MaxBuffersPerBucket = 4;
+    private static readonly ulong MaxPooledBufferBytes =
+        HostMemoryBudget.IsConstrained
+            ? 128UL * 1024 * 1024
+            : 256UL * 1024 * 1024;
 
     public VulkanDetilePass(
         Vk vk,
@@ -348,7 +358,11 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
         var bucket = BucketFor(size);
         if (_bufferPool.TryGetValue((bucket, hostVisible), out var free) && free.Count > 0)
         {
-            return free.Pop();
+            var rented = free.Pop();
+            _pooledBytes = rented.Capacity >= _pooledBytes
+                ? 0
+                : _pooledBytes - rented.Capacity;
+            return rented;
         }
 
         return CreateBuffer(bucket, hostVisible);
@@ -368,7 +382,16 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
             _bufferPool[key] = free;
         }
 
+        if (free.Count >= MaxBuffersPerBucket ||
+            _pooledBytes + allocation.Capacity > MaxPooledBufferBytes)
+        {
+            DestroyBuffer(allocation.Buffer, allocation.Memory);
+            _allAllocations.Remove(allocation);
+            return;
+        }
+
         free.Push(allocation);
+        _pooledBytes += allocation.Capacity;
     }
 
     private DescriptorSet RentDescriptorSet()
@@ -855,6 +878,7 @@ internal sealed unsafe class VulkanDetilePass : IDisposable
 
         _allAllocations.Clear();
         _bufferPool.Clear();
+        _pooledBytes = 0;
         _xorTermBuffers.Clear();
         _blockTermBuffers.Clear();
         _placeholderTermBuffer = default;

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -8,6 +8,7 @@ using SharpEmu.HLE;
 using SharpEmu.Libs.Agc;
 using SharpEmu.Libs.Media;
 using SharpEmu.Libs.Gpu;
+using SharpEmu.Logging;
 using SharpEmu.ShaderCompiler;
 using SharpEmu.ShaderCompiler.Vulkan;
 using Silk.NET.Vulkan;
@@ -380,7 +381,8 @@ internal static unsafe class VulkanVideoPresenter
             out var pendingGuestWorkItems) && pendingGuestWorkItems > 0
             ? pendingGuestWorkItems
             : OperatingSystem.IsMacOS() ? 64 : 512;
-    private const ulong MaximumCachedHostBufferBytes = 128UL * 1024 * 1024;
+    private static readonly ulong MaximumCachedHostBufferBytes =
+        HostMemoryBudget.DefaultCachedHostBufferBytes;
     // A captured 4K flip can consume tens of MiB of device-local memory.
     // Retain only a short presentation queue while always preserving the
     // newest generation; older immutable versions are retired immediately.
@@ -391,11 +393,11 @@ internal static unsafe class VulkanVideoPresenter
     // render thread could upload them.  Keep the count cap for small work and
     // independently apply backpressure to the actual retained payload.
     private static readonly ulong _maxPendingGuestWorkBytes =
-        (ulong.TryParse(
-             Environment.GetEnvironmentVariable("SHARPEMU_PENDING_GUEST_WORK_MB"),
-             out var pendingGuestWorkMb) && pendingGuestWorkMb > 0
-            ? pendingGuestWorkMb
-            : 256UL) * 1024UL * 1024UL;
+        ulong.TryParse(
+            Environment.GetEnvironmentVariable("SHARPEMU_PENDING_GUEST_WORK_MB"),
+            out var pendingGuestWorkMb) && pendingGuestWorkMb > 0
+            ? pendingGuestWorkMb * 1024UL * 1024UL
+            : HostMemoryBudget.DefaultPendingGuestWorkBytes;
     private static readonly int _maxGuestWorkPerRender =
         int.TryParse(
             Environment.GetEnvironmentVariable("SHARPEMU_MAX_GUEST_WORK_PER_RENDER"),
@@ -17395,7 +17397,7 @@ internal static unsafe class VulkanVideoPresenter
             renderResolutionScale > 0 &&
             renderResolutionScale <= 2.0
                 ? renderResolutionScale
-                : 1.0;
+                : HostMemoryBudget.DefaultRenderScale;
 
         private static uint ScaleGuestDimension(uint value) =>
             _renderResolutionScale == 1.0

--- a/src/SharpEmu.Logging/HostMemoryBudget.cs
+++ b/src/SharpEmu.Logging/HostMemoryBudget.cs
@@ -1,0 +1,231 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace SharpEmu.Logging;
+
+/// <summary>
+/// Host-aware memory budgets so PCs with ~16 GiB RAM do not advertise a full
+/// PS5-scale direct-memory pool and then commit it into host OOM.
+/// Override with SHARPEMU_DIRECT_MEMORY_MB (MiB, clamped).
+/// </summary>
+public static class HostMemoryBudget
+{
+    /// <summary>PS5-class direct memory pool size reported by real hardware.</summary>
+    public const ulong Ps5DirectMemoryBytes = 16384UL * 1024 * 1024;
+
+    private const ulong MinimumDirectMemoryBytes = 2048UL * 1024 * 1024;
+    private const ulong HostRuntimeHeadroomBytes = 6144UL * 1024 * 1024;
+    private const ulong UnknownHostFallbackDirectMemoryBytes = 8192UL * 1024 * 1024;
+
+    private static readonly Lazy<Budget> Resolved = new(Resolve);
+
+    /// <summary>Best-effort total host physical RAM, or 0 when unknown.</summary>
+    public static ulong TotalPhysicalMemoryBytes => Resolved.Value.TotalPhysicalBytes;
+
+    /// <summary>Size exposed through sceKernelGetDirectMemorySize / DM allocators.</summary>
+    public static ulong AdvertisedDirectMemoryBytes => Resolved.Value.AdvertisedDirectMemoryBytes;
+
+    /// <summary>
+    /// Non-executable mappings larger than this prefer reserve + lazy commit when
+    /// the host is memory-constrained (still after a full-commit attempt fails).
+    /// </summary>
+    public static ulong FullCommitRegionLimitBytes => Resolved.Value.FullCommitRegionLimitBytes;
+
+    /// <summary>Minimum size before a mapping may use the lazy-reserve fallback.</summary>
+    public static ulong LargeDataReserveThresholdBytes => Resolved.Value.LargeDataReserveThresholdBytes;
+
+    /// <summary>Default pending guest GPU work queue cap when env is unset.</summary>
+    public static ulong DefaultPendingGuestWorkBytes => Resolved.Value.DefaultPendingGuestWorkBytes;
+
+    /// <summary>Default host buffer cache cap when env is unset.</summary>
+    public static ulong DefaultCachedHostBufferBytes => Resolved.Value.DefaultCachedHostBufferBytes;
+
+    /// <summary>Default SHARPEMU_RENDER_SCALE when env is unset.</summary>
+    public static double DefaultRenderScale => Resolved.Value.DefaultRenderScale;
+
+    /// <summary>True when the advertised DM pool is smaller than the PS5 default.</summary>
+    public static bool IsConstrained => AdvertisedDirectMemoryBytes < Ps5DirectMemoryBytes;
+
+    /// <summary>One-line diagnostic for startup logs.</summary>
+    public static string Summary => Resolved.Value.Summary;
+
+    private static Budget Resolve()
+    {
+        var totalPhysical = TryGetTotalPhysicalMemoryBytes();
+        var advertised = ResolveAdvertisedDirectMemory(totalPhysical, out var source);
+        var constrained = advertised < Ps5DirectMemoryBytes ||
+            (totalPhysical != 0 && totalPhysical <= 20UL * 1024 * 1024 * 1024);
+
+        // On constrained hosts, allow lazy reserve for multi-hundred-MiB maps so
+        // guest "allocate everything" paths do not pin 8+ GiB of host RAM.
+        var largeThreshold = constrained ? 512UL * 1024 * 1024 : 1024UL * 1024 * 1024;
+        var fullCommitLimit = constrained ? 512UL * 1024 * 1024 : 4UL << 30;
+        var pendingWorkMb = constrained ? 128UL : 256UL;
+        var cachedBuffers = constrained ? 64UL * 1024 * 1024 : 128UL * 1024 * 1024;
+        var renderScale = constrained ? 0.75 : 1.0;
+
+        if (totalPhysical != 0 && totalPhysical < 12UL * 1024 * 1024 * 1024)
+        {
+            pendingWorkMb = 64UL;
+            cachedBuffers = 32UL * 1024 * 1024;
+            renderScale = 0.5;
+        }
+
+        var hostText = totalPhysical == 0
+            ? "unknown"
+            : $"{totalPhysical / (1024 * 1024):N0} MB";
+        var summary =
+            $"Host memory budget: host_ram={hostText}, " +
+            $"direct_memory={advertised / (1024 * 1024):N0} MB ({source}), " +
+            $"lazy_threshold={largeThreshold / (1024 * 1024)} MB, " +
+            $"full_commit_limit={fullCommitLimit / (1024 * 1024)} MB, " +
+            $"pending_gpu_work={pendingWorkMb} MB, " +
+            $"render_scale_default={renderScale.ToString("0.##", CultureInfo.InvariantCulture)}";
+
+        return new Budget(
+            totalPhysical,
+            advertised,
+            fullCommitLimit,
+            largeThreshold,
+            pendingWorkMb * 1024UL * 1024UL,
+            cachedBuffers,
+            renderScale,
+            summary);
+    }
+
+    private static ulong ResolveAdvertisedDirectMemory(ulong totalPhysical, out string source)
+    {
+        var overrideMb = Environment.GetEnvironmentVariable("SHARPEMU_DIRECT_MEMORY_MB");
+        if (ulong.TryParse(overrideMb, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mb) &&
+            mb > 0)
+        {
+            // Keep a playable floor and never advertise more than real PS5 DM.
+            var clamped = Math.Clamp(mb, 512UL, 16384UL) * 1024UL * 1024UL;
+            source = $"SHARPEMU_DIRECT_MEMORY_MB={mb}";
+            return clamped;
+        }
+
+        if (totalPhysical == 0)
+        {
+            source = "fallback";
+            return UnknownHostFallbackDirectMemoryBytes;
+        }
+
+        // Leave headroom for the OS, GPU driver, .NET runtime, and Vulkan images.
+        var usable = totalPhysical > HostRuntimeHeadroomBytes
+            ? totalPhysical - HostRuntimeHeadroomBytes
+            : MinimumDirectMemoryBytes;
+        var advertised = Math.Clamp(usable, MinimumDirectMemoryBytes, Ps5DirectMemoryBytes);
+        source = "auto";
+        return advertised;
+    }
+
+    private static ulong TryGetTotalPhysicalMemoryBytes()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            try
+            {
+                var status = new MemoryStatusEx
+                {
+                    dwLength = (uint)Marshal.SizeOf<MemoryStatusEx>(),
+                };
+                if (GlobalMemoryStatusEx(ref status) && status.ullTotalPhys > 0)
+                {
+                    return status.ullTotalPhys;
+                }
+            }
+            catch (Exception)
+            {
+                // Diagnostic / budgeting only.
+            }
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            try
+            {
+                foreach (var line in File.ReadLines("/proc/meminfo"))
+                {
+                    if (!line.StartsWith("MemTotal:", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length >= 2 &&
+                        ulong.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var kb))
+                    {
+                        return kb * 1024UL;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Diagnostic / budgeting only.
+            }
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            try
+            {
+                // sysctl hw.memsize
+                var startInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "/usr/sbin/sysctl",
+                    Arguments = "-n hw.memsize",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+                using var process = System.Diagnostics.Process.Start(startInfo);
+                if (process is not null)
+                {
+                    var text = process.StandardOutput.ReadToEnd().Trim();
+                    process.WaitForExit(2000);
+                    if (ulong.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var bytes) &&
+                        bytes > 0)
+                    {
+                        return bytes;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Diagnostic / budgeting only.
+            }
+        }
+
+        return 0;
+    }
+
+    private readonly record struct Budget(
+        ulong TotalPhysicalBytes,
+        ulong AdvertisedDirectMemoryBytes,
+        ulong FullCommitRegionLimitBytes,
+        ulong LargeDataReserveThresholdBytes,
+        ulong DefaultPendingGuestWorkBytes,
+        ulong DefaultCachedHostBufferBytes,
+        double DefaultRenderScale,
+        string Summary);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    private struct MemoryStatusEx
+    {
+        public uint dwLength;
+        public uint dwMemoryLoad;
+        public ulong ullTotalPhys;
+        public ulong ullAvailPhys;
+        public ulong ullTotalPageFile;
+        public ulong ullAvailPageFile;
+        public ulong ullTotalVirtual;
+        public ulong ullAvailVirtual;
+        public ulong ullAvailExtendedVirtual;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GlobalMemoryStatusEx(ref MemoryStatusEx buffer);
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this does

On PCs with about 16 GB of RAM, telling the guest it has a full 16 GB direct-memory pool can push the host into heavy memory use / OOM, because Windows, the GPU driver, and the emulator still need RAM.

This PR:
- scales the advertised direct-memory size from host RAM (can force a value with `SHARPEMU_DIRECT_MEMORY_MB`)
- uses tighter defaults for GPU pending work / cache / render scale on smaller hosts
- caps how many Vulkan detile buffers stay pooled, so loading screens do not keep every size forever
- adds `-f` / `--fullscreen` as shortcuts for exclusive fullscreen

Related: #618, #639, #758

## Testing

- Project builds on Windows.
- I have not finished a full Demon's Souls A/B memory/FPS run on this exact commit yet.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).