### PR TITLE
fix(agc): cap GpuWaitRegistry to bound producerless waiter growth

### DIFF
--- a/src/SharpEmu.Libs/Agc/GpuWaitRegistry.cs
+++ b/src/SharpEmu.Libs/Agc/GpuWaitRegistry.cs
@@ -53,12 +53,19 @@ internal static class GpuWaitRegistry
 
     private static readonly object _gate = new();
     private static readonly Dictionary<ulong, List<WaitingDcb>> _waiters = new();
+    // Soft bound on suspended waiters. Producerless waits never expire through
+    // CollectExpiredRetries / CollectDeadlockBroken, so Demon's Souls-style
+    // boot storms can grow this table without bound (#639). Over the cap we
+    // drop the oldest waiters that never saw a producer — they were already
+    // stuck — without force-resuming (which would corrupt ordering).
+    private const int MaxRegisteredWaiters = 4096;
     // The last value each label producer wrote. Used only by the deadlock
     // breaker: our serial submission parser cannot model two GPU queues running
     // concurrently, so a label written -> reset -> re-waited across queues can
     // cycle forever even though a real producer did signal it. Keyed by (memory,
     // address) so distinct guest processes never alias.
     private static readonly Dictionary<(object, ulong), ulong> _lastProduced = new();
+    private static int _waiterCount;
 
     public static int Count
     {
@@ -66,13 +73,7 @@ internal static class GpuWaitRegistry
         {
             lock (_gate)
             {
-                var total = 0;
-                foreach (var (_, list) in _waiters)
-                {
-                    total += list.Count;
-                }
-
-                return total;
+                return _waiterCount;
             }
         }
     }
@@ -157,6 +158,11 @@ internal static class GpuWaitRegistry
         waiter.WaitAddress = address;
         lock (_gate)
         {
+            if (_waiterCount >= MaxRegisteredWaiters)
+            {
+                PruneOrphanedWaitersLocked(keepAtMost: MaxRegisteredWaiters / 2);
+            }
+
             if (!_waiters.TryGetValue(address, out var list))
             {
                 list = new List<WaitingDcb>();
@@ -164,6 +170,7 @@ internal static class GpuWaitRegistry
             }
 
             list.Add(waiter);
+            _waiterCount++;
         }
     }
 
@@ -204,7 +211,7 @@ internal static class GpuWaitRegistry
 
                     woken ??= new List<WaitingDcb>();
                     woken.Add(list[i]);
-                    list.RemoveAt(i);
+                    RemoveWaiterAtLocked(list, i);
                 }
 
                 if (list.Count == 0)
@@ -381,7 +388,7 @@ internal static class GpuWaitRegistry
 
                     expired ??= new List<WaitingDcb>();
                     expired.Add(waiter);
-                    list.RemoveAt(i);
+                    RemoveWaiterAtLocked(list, i);
                 }
 
                 if (list.Count == 0)
@@ -420,7 +427,7 @@ internal static class GpuWaitRegistry
 
                     collected ??= new List<WaitingDcb>();
                     collected.Add(list[index]);
-                    list.RemoveAt(index);
+                    RemoveWaiterAtLocked(list, index);
                 }
 
                 if (list.Count == 0)
@@ -486,6 +493,110 @@ internal static class GpuWaitRegistry
         }
     }
 
+    /// <summary>
+    /// Drops the oldest producerless waiters until at most
+    /// <paramref name="keepAtMost"/> remain. Prefer waiters that never had a
+    /// recorded producer — they cannot be released by CollectDeadlockBroken.
+    /// Must be called under <see cref="_gate"/>.
+    /// </summary>
+    private static void PruneOrphanedWaitersLocked(int keepAtMost)
+    {
+        if (_waiterCount <= keepAtMost)
+        {
+            return;
+        }
+
+        DropOldestWaitersLocked(
+            keepAtMost,
+            orphansOnly: true);
+
+        if (_waiterCount > keepAtMost)
+        {
+            // Still over the cap: every remaining waiter has a producer record
+            // or retry deadline. Prefer a bounded registry over an OOM.
+            DropOldestWaitersLocked(keepAtMost, orphansOnly: false);
+        }
+    }
+
+    private static void DropOldestWaitersLocked(int keepAtMost, bool orphansOnly)
+    {
+        if (_waiterCount <= keepAtMost)
+        {
+            return;
+        }
+
+        var candidates = new List<(ulong Address, int Index, long RegisteredTicks)>(_waiterCount);
+        foreach (var (address, list) in _waiters)
+        {
+            for (var i = 0; i < list.Count; i++)
+            {
+                var waiter = list[i];
+                if (orphansOnly &&
+                    (waiter.Latched ||
+                     waiter.RetryDeadlineTicks != 0 ||
+                     (waiter.Memory is not null &&
+                      _lastProduced.ContainsKey((waiter.Memory, address)))))
+                {
+                    continue;
+                }
+
+                candidates.Add((address, i, waiter.RegisteredTicks));
+            }
+        }
+
+        if (candidates.Count == 0)
+        {
+            return;
+        }
+
+        candidates.Sort(static (left, right) => left.RegisteredTicks.CompareTo(right.RegisteredTicks));
+        var toDrop = Math.Min(candidates.Count, _waiterCount - keepAtMost);
+        var dropSet = candidates.GetRange(0, toDrop);
+        // Highest index first per address so earlier removals do not shift later ones.
+        dropSet.Sort(static (left, right) =>
+        {
+            var addressCompare = left.Address.CompareTo(right.Address);
+            return addressCompare != 0
+                ? addressCompare
+                : right.Index.CompareTo(left.Index);
+        });
+
+        List<ulong>? emptied = null;
+        foreach (var (address, index, _) in dropSet)
+        {
+            if (!_waiters.TryGetValue(address, out var list) ||
+                index < 0 ||
+                index >= list.Count)
+            {
+                continue;
+            }
+
+            RemoveWaiterAtLocked(list, index);
+            if (list.Count == 0)
+            {
+                emptied ??= new List<ulong>();
+                emptied.Add(address);
+            }
+        }
+
+        if (emptied is not null)
+        {
+            foreach (var address in emptied)
+            {
+                _waiters.Remove(address);
+            }
+        }
+    }
+
+    private static void RemoveWaiterAtLocked(List<WaitingDcb> list, int index)
+    {
+        list.RemoveAt(index);
+        if (_waiterCount > 0)
+        {
+            _waiterCount--;
+        }
+    }
+
     /// <summary>Records the value a label producer wrote, for the deadlock
     /// breaker. Also latches any already-waiting waiter it satisfies.</summary>
     public static bool RecordProduced(object memory, ulong address, ulong value)
@@ -542,7 +653,7 @@ internal static class GpuWaitRegistry
 
                     broken ??= new List<WaitingDcb>();
                     broken.Add(waiter);
-                    list.RemoveAt(i);
+                    RemoveWaiterAtLocked(list, i);
                 }
 
                 if (list.Count == 0)
@@ -589,6 +700,7 @@ internal static class GpuWaitRegistry
         {
             _waiters.Clear();
             _lastProduced.Clear();
+            _waiterCount = 0;
         }
     }
 }

--- a/tests/SharpEmu.Libs.Tests/Agc/GpuWaitRegistryProducedRetentionTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/GpuWaitRegistryProducedRetentionTests.cs
@@ -58,6 +58,25 @@ public sealed class GpuWaitRegistryProducedRetentionTests
         GpuWaitRegistry.Clear();
     }
 
+    [Fact]
+    public void OrphanedWaitersArePrunedWhenTheRegistryHitsItsCap()
+    {
+        GpuWaitRegistry.Clear();
+        var memory = new object();
+
+        // Flood the registry with producerless waits past the hard cap.
+        for (var i = 0; i < 5000; i++)
+        {
+            GpuWaitRegistry.Register(
+                0x7040_0000_0000UL + ((ulong)i * 8),
+                NewWaiter(memory, 0x7040_0000_0000UL + ((ulong)i * 8)));
+        }
+
+        Assert.True(GpuWaitRegistry.Count <= 4096);
+        Assert.True(GpuWaitRegistry.Count > 0);
+        GpuWaitRegistry.Clear();
+    }
+
     private static GpuWaitRegistry.WaitingDcb NewWaiter(object memory, ulong address) => new()
     {
         WaitAddress = address,


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this does

`GpuWaitRegistry` can keep growing when waiters never get a producer. Those entries are not cleaned by the normal expired-retry / deadlock paths, so during long boots the table can get very large.

This PR caps how many waiters can be registered. When the cap is hit, it removes the oldest orphan waiters first (no producer recorded). It does not force-resume DCBs.

I know this is a tradeoff. If you want a different policy I can change it.

Related: #639

## Testing

- Unit tests for GpuWaitRegistry (including a test that registers many waiters and checks the cap).
- No full Demon's Souls memory profile attached for this exact commit yet.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).