### PR TITLE
[CPU] Recover the register forms of SSE4a EXTRQ/INSERTQ (#328)

### DIFF
--- a/src/SharpEmu.Core/Cpu/Emulation/Sse4aBitFieldEmulator.cs
+++ b/src/SharpEmu.Core/Cpu/Emulation/Sse4aBitFieldEmulator.cs
@@ -5,7 +5,7 @@ namespace SharpEmu.Core.Cpu.Emulation;
 
 /// <summary>
 /// Pure software implementation of the bit-field math behind AMD's SSE4a EXTRQ/INSERTQ
-/// (immediate-form) instructions.
+/// instructions, in both their immediate and register forms.
 ///
 /// The direct-execution backend runs guest PS5 code natively on the host CPU. The PS5's Zen 2
 /// cores implement AMD-only SSE4a (EXTRQ/INSERTQ), but Intel hosts - and Rosetta 2 on Apple
@@ -15,8 +15,8 @@ namespace SharpEmu.Core.Cpu.Emulation;
 /// a different register allocation, a title built with a different compiler version, and so on
 /// - still aborts the title. This class ported from Kyty's
 /// <c>Loader::X64InstructionEmulator::TryEmulateSse4a</c> provides the general bit-field
-/// extract/insert so the illegal-instruction handler can finish *any* immediate-form
-/// EXTRQ/INSERTQ in software and resume, instead of relying on a single hard-coded byte pattern.
+/// extract/insert so the illegal-instruction handler can finish *any* EXTRQ/INSERTQ in software
+/// and resume, instead of relying on a single hard-coded byte pattern.
 ///
 /// The methods operate on plain 64-bit integers rather than the OS CONTEXT record so the bit
 /// math can be unit-tested in isolation; the unsafe CONTEXT/XMM plumbing lives in the backend
@@ -24,6 +24,18 @@ namespace SharpEmu.Core.Cpu.Emulation;
 /// </summary>
 public static class Sse4aBitFieldEmulator
 {
+    /// <summary>
+    /// Splits the length/index pair that the register forms of EXTRQ and INSERTQ read out of a
+    /// source register rather than out of immediates: length in bits [5:0] of the controlling
+    /// quadword, index in bits [13:8]. Which quadword that is differs between the two
+    /// instructions, so the caller selects it - see the backend adapter.
+    /// </summary>
+    public static void DecodeRegisterControl(ulong control, out int length, out int index)
+    {
+        length = (int)(control & 0x3F);
+        index = (int)((control >> 8) & 0x3F);
+    }
+
     public static bool IsValidBitField(int length, int index)
     {
         var len = length & 0x3F;

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Amd64Compat.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Amd64Compat.cs
@@ -9,17 +9,21 @@ namespace SharpEmu.Core.Cpu.Native;
 
 // General software fallback for the AMD-only instructions PS5 titles occasionally emit that a
 // Zen 2-only host implements but Intel hosts (and Rosetta 2 on Apple Silicon) do not:
-//   - SSE4a EXTRQ/INSERTQ, immediate form
+//   - SSE4a EXTRQ/INSERTQ, both the immediate and the register forms
 //   - MONITORX/MWAITX
 //
-// This is a direct port of Kyty's Loader::X64InstructionEmulator (TryEmulateSse4a /
-// TryEmulateMonitorxMwaitx). SharpEmu already special-cases exactly one compiled EXTRQ+VPBLENDD
-// byte sequence at load time (Sse4aExtrqBlendPatch), which only helps the one idiom it was
-// reverse-engineered from. This file is a general, fault-time fallback that engages for any
-// immediate-form EXTRQ/INSERTQ or MONITORX/MWAITX the narrower patch (or a title using a
-// different compiler/register allocation) does not cover, complementing rather than replacing
-// it: the load-time patch still avoids paying the fault-and-recover cost on the hot path it was
-// built for, while this method is the safety net for everything else.
+// The SSE4a bit math and MONITORX/MWAITX handling follow Kyty's
+// Loader::X64InstructionEmulator (TryEmulateSse4a / TryEmulateMonitorxMwaitx); the register
+// forms (66 0F 79 /r and F2 0F 79 /r, which take their length/index from a register rather than
+// from immediates) are not in Kyty and are decoded here from the AMD64 definition.
+//
+// SharpEmu already special-cases exactly one compiled EXTRQ+VPBLENDD byte sequence at load time
+// (Sse4aExtrqBlendPatch), which only helps the one idiom it was reverse-engineered from. This
+// file is a general, fault-time fallback that engages for any EXTRQ/INSERTQ or MONITORX/MWAITX
+// the narrower patch (or a title using a different compiler/register allocation) does not cover,
+// complementing rather than replacing it: the load-time patch still avoids paying the
+// fault-and-recover cost on the hot path it was built for, while this method is the safety net
+// for everything else.
 //
 // This is deliberately additive: DirectExecutionBackend.IllegalInstruction.cs (the BMI1/BMI2/ABM
 // fallback) is untouched, and this method is only reached from VectoredHandler after that one
@@ -104,56 +108,78 @@ public sealed partial class DirectExecutionBackend
             return false;
         }
 
-        var isExtrq = instruction.Mnemonic == Mnemonic.Extrq;
-        var isInsertq = instruction.Mnemonic == Mnemonic.Insertq;
-        if (!isExtrq && !isInsertq)
-        {
-            return false;
-        }
-
-        if (isExtrq && instruction.OpCount != 3 || isInsertq && instruction.OpCount != 4)
-        {
-            return false;
-        }
-
         if (instruction.GetOpKind(0) != OpKind.Register ||
             !TryGetXmmOffset(instruction.GetOpRegister(0), out var destOffset))
         {
             return false;
         }
 
+        // Every form except the immediate EXTRQ carries a second XMM operand. INSERTQ takes the
+        // bits to insert from it; the register forms additionally read their length/index out of
+        // it instead of out of immediates.
+        var srcOffset = 0;
+        if (instruction.Code != Code.Extrq_xmm_imm8_imm8 &&
+            (instruction.GetOpKind(1) != OpKind.Register ||
+                !TryGetXmmOffset(instruction.GetOpRegister(1), out srcOffset)))
+        {
+            return false;
+        }
+
+        // Read the destination before writing it: the register forms allow the source and
+        // destination to be the same XMM, and EXTRQ extracts out of its destination either way.
         var destLow = ReadCtxU64(contextRecord, destOffset);
-        if (isExtrq)
+        int length;
+        int index;
+        ulong source;
+        switch (instruction.Code)
         {
-            var length = (int)instruction.GetImmediate(1);
-            var index = (int)instruction.GetImmediate(2);
-            if (!Sse4aBitFieldEmulator.IsValidBitField(length, index))
-            {
-                return false;
-            }
+            case Code.Extrq_xmm_imm8_imm8:
+                length = (int)instruction.GetImmediate(1);
+                index = (int)instruction.GetImmediate(2);
+                source = destLow;
+                break;
 
-            WriteCtxU64(contextRecord, destOffset, Sse4aBitFieldEmulator.ExtractBitField(destLow, length, index));
-            WriteCtxU64(contextRecord, destOffset + 8, 0);
+            case Code.Extrq_xmm_xmm:
+                Sse4aBitFieldEmulator.DecodeRegisterControl(
+                    ReadCtxU64(contextRecord, srcOffset), out length, out index);
+                source = destLow;
+                break;
+
+            case Code.Insertq_xmm_xmm_imm8_imm8:
+                length = (int)instruction.GetImmediate(2);
+                index = (int)instruction.GetImmediate(3);
+                source = ReadCtxU64(contextRecord, srcOffset);
+                break;
+
+            // The one asymmetry between the two register forms: INSERTQ's control fields live in
+            // the *high* quadword of the source (xmm2[69:64] length, xmm2[77:72] index) while the
+            // bits it inserts still come from the low one. EXTRQ reads both from the low quadword.
+            case Code.Insertq_xmm_xmm:
+                Sse4aBitFieldEmulator.DecodeRegisterControl(
+                    ReadCtxU64(contextRecord, srcOffset + 8), out length, out index);
+                source = ReadCtxU64(contextRecord, srcOffset);
+                break;
+
+            default:
+                return false;
         }
-        else
+
+        // AMD leaves the result undefined when the field runs off the end of the quadword. Decline
+        // rather than invent one, matching how the BMI fallback refuses anything it does not fully
+        // model, so an encoding we mis-read still reaches the existing diagnostics.
+        if (!Sse4aBitFieldEmulator.IsValidBitField(length, index))
         {
-            if (instruction.GetOpKind(1) != OpKind.Register ||
-                !TryGetXmmOffset(instruction.GetOpRegister(1), out var srcOffset))
-            {
-                return false;
-            }
-
-            var length = (int)instruction.GetImmediate(2);
-            var index = (int)instruction.GetImmediate(3);
-            if (!Sse4aBitFieldEmulator.IsValidBitField(length, index))
-            {
-                return false;
-            }
-
-            WriteCtxU64(contextRecord, destOffset, Sse4aBitFieldEmulator.InsertBitField(
-                destLow, ReadCtxU64(contextRecord, srcOffset), length, index));
-            WriteCtxU64(contextRecord, destOffset + 8, 0);
+            return false;
         }
+
+        var isExtract = instruction.Code is Code.Extrq_xmm_imm8_imm8 or Code.Extrq_xmm_xmm;
+        WriteCtxU64(
+            contextRecord,
+            destOffset,
+            isExtract
+                ? Sse4aBitFieldEmulator.ExtractBitField(source, length, index)
+                : Sse4aBitFieldEmulator.InsertBitField(destLow, source, length, index));
+        WriteCtxU64(contextRecord, destOffset + 8, 0);
 
         WriteCtxU64(contextRecord, CTX_RIP, rip + (ulong)instruction.Length);
 

--- a/tests/SharpEmu.Libs.Tests/Cpu/Sse4aBitFieldEmulatorTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/Sse4aBitFieldEmulatorTests.cs
@@ -144,4 +144,49 @@ public sealed class Sse4aBitFieldEmulatorTests
 
         Assert.Equal(0xABCD_EF01_0005_6789UL, result);
     }
+
+    [Fact]
+    public void DecodeRegisterControl_TakesLengthFromLowSixBitsAndIndexFromBitsThirteenToEight()
+    {
+        Sse4aBitFieldEmulator.DecodeRegisterControl(0x0000_0000_0000_1020, out var length, out var index);
+
+        Assert.Equal(0x20, length);
+        Assert.Equal(0x10, index);
+    }
+
+    [Fact]
+    public void DecodeRegisterControl_IgnoresEverythingAboveBitFifteen()
+    {
+        // AMD specifies only [5:0] and [13:8] of the controlling quadword; the rest is
+        // "ignored", so a source register carrying unrelated data must decode identically.
+        Sse4aBitFieldEmulator.DecodeRegisterControl(0xDEAD_BEEF_CAFE_1020, out var length, out var index);
+
+        Assert.Equal(0x20, length);
+        Assert.Equal(0x10, index);
+    }
+
+    [Fact]
+    public void DecodeRegisterControl_MasksTheTwoBitsAboveEachSixBitField()
+    {
+        // Bits [7:6] and [15:14] sit outside both fields. Setting them must not widen either
+        // value past 0x3F, which is what makes the decode agree with the immediate form where
+        // the emulator already applies "& 0x3F".
+        Sse4aBitFieldEmulator.DecodeRegisterControl(0x0000_0000_0000_FFFF, out var length, out var index);
+
+        Assert.Equal(0x3F, length);
+        Assert.Equal(0x3F, index);
+    }
+
+    [Fact]
+    public void DecodeRegisterControl_ZeroControlIsTheLengthSixtyFourCase()
+    {
+        Sse4aBitFieldEmulator.DecodeRegisterControl(0, out var length, out var index);
+
+        Assert.Equal(0, length);
+        Assert.Equal(0, index);
+        Assert.True(Sse4aBitFieldEmulator.IsValidBitField(length, index));
+        Assert.Equal(
+            0x1234_5678_9ABC_DEF0UL,
+            Sse4aBitFieldEmulator.ExtractBitField(0x1234_5678_9ABC_DEF0, length, index));
+    }
 }

--- a/tests/SharpEmu.Libs.Tests/Cpu/Sse4aRegisterFormRecoveryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/Sse4aRegisterFormRecoveryTests.cs
@@ -1,0 +1,307 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using SharpEmu.Core.Cpu.Emulation;
+using SharpEmu.Core.Cpu.Native;
+using SharpEmu.HLE;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+/// <summary>
+/// Coverage for the register forms of SSE4a EXTRQ (66 0F 79 /r) and INSERTQ (F2 0F 79 /r), which
+/// take their bit-field length and index from a source register instead of from immediates.
+///
+/// Each test fabricates the state the OS hands the #UD handler - a Win64 CONTEXT record carrying
+/// the XMM registers, plus a RIP pointing at real instruction bytes in probe-visible host memory -
+/// and drives the production entry point (TryRecoverAmdCompatInstruction) over it, so the decode,
+/// the bit math and the CONTEXT write-back are all exercised exactly as they are on a live fault.
+/// </summary>
+public sealed unsafe class Sse4aRegisterFormRecoveryTests
+{
+    private const int Win64ContextSize = 0x4D0;
+    private const int Win64ContextXmm0Offset = 0x1A0;
+    private const int CtxRip = 248;
+
+    private static readonly MethodInfo TryRecoverAmdCompat = typeof(DirectExecutionBackend).GetMethod(
+        "TryRecoverAmdCompatInstruction",
+        BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly FieldInfo XmmBridgedFlag = typeof(DirectExecutionBackend).GetField(
+        "_posixXmmContextBridged",
+        BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    /// <summary>
+    /// Packs a length/index pair the way a guest register carries it for the register forms:
+    /// length in bits [5:0] of the controlling quadword, index in bits [13:8].
+    /// </summary>
+    private static ulong Control(int length, int index) =>
+        (ulong)(uint)(length & 0x3F) | ((ulong)(uint)(index & 0x3F) << 8);
+
+    [Fact]
+    public void ExtrqRegisterForm_TakesControlFromTheSourceLowQuadwordAndExtractsFromTheDestination()
+    {
+        if (!IsSupportedHost)
+        {
+            return;
+        }
+
+        // extrq xmm1, xmm2
+        using var frame = new FaultFrame([0x66, 0x0F, 0x79, 0xCA]);
+        const ulong data = 0x1234_5678_9ABC_DEF0UL;
+        frame.SetXmmLow(1, data);
+        frame.SetXmmLow(2, Control(length: 0x10, index: 0x08));
+
+        Assert.True(frame.Recover());
+
+        Assert.Equal(
+            Sse4aBitFieldEmulator.ExtractBitField(data, length: 0x10, index: 0x08),
+            frame.XmmLow(1));
+        Assert.Equal(0UL, frame.XmmHigh(1));
+        Assert.Equal(frame.CodeAddress + 4, frame.Rip);
+    }
+
+    [Fact]
+    public void InsertqRegisterForm_TakesControlFromTheSourceHighQuadword()
+    {
+        if (!IsSupportedHost)
+        {
+            return;
+        }
+
+        // insertq xmm1, xmm2
+        using var frame = new FaultFrame([0xF2, 0x0F, 0x79, 0xCA]);
+        const ulong destination = 0x1111_2222_3333_4444UL;
+        const ulong source = 0xAAAA_BBBB_CCCC_DDDDUL;
+        frame.SetXmmLow(1, destination);
+        frame.SetXmmLow(2, source);
+        frame.SetXmmHigh(2, Control(length: 0x10, index: 0x08));
+
+        Assert.True(frame.Recover());
+
+        Assert.Equal(
+            Sse4aBitFieldEmulator.InsertBitField(destination, source, length: 0x10, index: 0x08),
+            frame.XmmLow(1));
+        Assert.Equal(0UL, frame.XmmHigh(1));
+        Assert.Equal(frame.CodeAddress + 4, frame.Rip);
+    }
+
+    /// <summary>
+    /// The asymmetry that makes these two forms easy to get wrong: EXTRQ reads its control fields
+    /// out of the low quadword of the source, INSERTQ out of the high one. Here the source's low
+    /// quadword also happens to look like a (different) control pair, so reading the wrong half
+    /// produces a different, detectably wrong result rather than silently agreeing.
+    /// </summary>
+    [Fact]
+    public void InsertqRegisterForm_IgnoresAControlPairSittingInTheSourceLowQuadword()
+    {
+        if (!IsSupportedHost)
+        {
+            return;
+        }
+
+        // insertq xmm1, xmm2
+        using var frame = new FaultFrame([0xF2, 0x0F, 0x79, 0xCA]);
+        const ulong destination = 0xFFFF_FFFF_FFFF_FFFFUL;
+        var source = 0xAAAA_BBBB_CCCC_0000UL | Control(length: 0x04, index: 0x20);
+        frame.SetXmmLow(1, destination);
+        frame.SetXmmLow(2, source);
+        frame.SetXmmHigh(2, Control(length: 0x10, index: 0x08));
+
+        Assert.True(frame.Recover());
+
+        Assert.Equal(
+            Sse4aBitFieldEmulator.InsertBitField(destination, source, length: 0x10, index: 0x08),
+            frame.XmmLow(1));
+        Assert.NotEqual(
+            Sse4aBitFieldEmulator.InsertBitField(destination, source, length: 0x04, index: 0x20),
+            frame.XmmLow(1));
+    }
+
+    /// <summary>
+    /// Nothing stops a compiler emitting the register form against a single register, and then the
+    /// control fields and the data being extracted share one quadword. The recovery has to read
+    /// the destination before it writes it for that to come out right.
+    /// </summary>
+    [Fact]
+    public void ExtrqRegisterForm_HandlesTheSameRegisterAsBothSourceAndDestination()
+    {
+        if (!IsSupportedHost)
+        {
+            return;
+        }
+
+        // extrq xmm1, xmm1
+        using var frame = new FaultFrame([0x66, 0x0F, 0x79, 0xC9]);
+        var value = 0xDEAD_BEEF_0000_0000UL | Control(length: 0x20, index: 0x00);
+        frame.SetXmmLow(1, value);
+
+        Assert.True(frame.Recover());
+
+        Assert.Equal(
+            Sse4aBitFieldEmulator.ExtractBitField(value, length: 0x20, index: 0x00),
+            frame.XmmLow(1));
+        Assert.Equal(frame.CodeAddress + 4, frame.Rip);
+    }
+
+    /// <summary>
+    /// AMD leaves the result undefined once index + length runs past the quadword. The recovery
+    /// declines instead of inventing one, and must not have partially written the CONTEXT on the
+    /// way to that decision - the fault then reaches the existing diagnostics unchanged.
+    /// </summary>
+    [Fact]
+    public void RegisterForm_DeclinesAndLeavesTheContextUntouchedWhenTheFieldOverrunsTheQuadword()
+    {
+        if (!IsSupportedHost)
+        {
+            return;
+        }
+
+        // extrq xmm1, xmm2
+        using var frame = new FaultFrame([0x66, 0x0F, 0x79, 0xCA]);
+        const ulong data = 0x1234_5678_9ABC_DEF0UL;
+        const ulong untouchedHigh = 0x5555_5555_5555_5555UL;
+        frame.SetXmmLow(1, data);
+        frame.SetXmmHigh(1, untouchedHigh);
+        frame.SetXmmLow(2, Control(length: 0x30, index: 0x30));
+
+        Assert.False(frame.Recover());
+
+        Assert.Equal(data, frame.XmmLow(1));
+        Assert.Equal(untouchedHigh, frame.XmmHigh(1));
+        Assert.Equal(0UL, frame.Rip);
+    }
+
+    [Fact]
+    public void ImmediateExtrqStillRecoversAfterTheRegisterFormsWereAdded()
+    {
+        if (!IsSupportedHost)
+        {
+            return;
+        }
+
+        // extrq xmm0, 0x10, 0x08
+        using var frame = new FaultFrame([0x66, 0x0F, 0x78, 0xC0, 0x10, 0x08]);
+        const ulong data = 0x1234_5678_9ABC_DEF0UL;
+        frame.SetXmmLow(0, data);
+
+        Assert.True(frame.Recover());
+
+        Assert.Equal(
+            Sse4aBitFieldEmulator.ExtractBitField(data, length: 0x10, index: 0x08),
+            frame.XmmLow(0));
+        Assert.Equal(frame.CodeAddress + 6, frame.Rip);
+    }
+
+    [Fact]
+    public void ImmediateInsertqStillRecoversAfterTheRegisterFormsWereAdded()
+    {
+        if (!IsSupportedHost)
+        {
+            return;
+        }
+
+        // insertq xmm0, xmm1, 0x10, 0x08
+        using var frame = new FaultFrame([0xF2, 0x0F, 0x78, 0xC1, 0x10, 0x08]);
+        const ulong destination = 0x1111_2222_3333_4444UL;
+        const ulong source = 0xAAAA_BBBB_CCCC_DDDDUL;
+        frame.SetXmmLow(0, destination);
+        frame.SetXmmLow(1, source);
+
+        Assert.True(frame.Recover());
+
+        Assert.Equal(
+            Sse4aBitFieldEmulator.InsertBitField(destination, source, length: 0x10, index: 0x08),
+            frame.XmmLow(0));
+        Assert.Equal(frame.CodeAddress + 6, frame.Rip);
+    }
+
+    /// <summary>
+    /// The recovery reads and writes guest XMM state, so it only runs where the host CPU actually
+    /// has those registers in the CONTEXT this test fabricates.
+    /// </summary>
+    private static bool IsSupportedHost =>
+        RuntimeInformation.ProcessArchitecture == Architecture.X64;
+
+    /// <summary>
+    /// A fabricated #UD fault: a Win64 CONTEXT record plus a page of probe-visible host memory
+    /// holding the faulting instruction.
+    /// </summary>
+    private sealed class FaultFrame : IDisposable
+    {
+        private readonly byte[] _context = new byte[Win64ContextSize];
+        private readonly nint _code;
+
+        public FaultFrame(ReadOnlySpan<byte> instruction)
+        {
+            // The instruction bytes must live where the fault-time page probe can see them, which
+            // is HostMemory's region table - the allocator guest code pages come from. A pinned
+            // managed array would be invisible and the recovery would decline before decoding.
+            var size = checked((nuint)Environment.SystemPageSize);
+            _code = (nint)HostMemory.Alloc(
+                null,
+                size,
+                HostMemory.MEM_COMMIT | HostMemory.MEM_RESERVE,
+                HostMemory.PAGE_READWRITE);
+            Assert.NotEqual((nint)0, _code);
+            instruction.CopyTo(new Span<byte>((void*)_code, checked((int)size)));
+        }
+
+        public ulong CodeAddress => (ulong)_code;
+
+        public ulong Rip
+        {
+            get
+            {
+                fixed (byte* context = _context)
+                {
+                    return *(ulong*)(context + CtxRip);
+                }
+            }
+        }
+
+        public void SetXmmLow(int register, ulong value) => WriteXmm(register, 0, value);
+
+        public void SetXmmHigh(int register, ulong value) => WriteXmm(register, 8, value);
+
+        public ulong XmmLow(int register) => ReadXmm(register, 0);
+
+        public ulong XmmHigh(int register) => ReadXmm(register, 8);
+
+        public bool Recover()
+        {
+            // On POSIX hosts the recovery is gated on the signal bridge having copied real XMM
+            // state into the CONTEXT. This frame supplies that state directly, so assert the same
+            // precondition the bridge would have established.
+            XmmBridgedFlag.SetValue(null, true);
+            var backend = RuntimeHelpers.GetUninitializedObject(typeof(DirectExecutionBackend));
+            fixed (byte* context = _context)
+            {
+                return (bool)TryRecoverAmdCompat.Invoke(
+                    backend,
+                    [Pointer.Box(context, typeof(void*)), (ulong)_code])!;
+            }
+        }
+
+        public void Dispose() => Assert.True(HostMemory.Free((void*)_code, 0, HostMemory.MEM_RELEASE));
+
+        private void WriteXmm(int register, int half, ulong value)
+        {
+            fixed (byte* context = _context)
+            {
+                *(ulong*)(context + Win64ContextXmm0Offset + (16 * register) + half) = value;
+            }
+        }
+
+        private ulong ReadXmm(int register, int half)
+        {
+            fixed (byte* context = _context)
+            {
+                return *(ulong*)(context + Win64ContextXmm0Offset + (16 * register) + half);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

SSE4a is an AMD-only extension. Every Intel host raises `#UD` on it, and so does Rosetta 2 — which is what #328 is about. `DirectExecutionBackend.Amd64Compat.cs` already recovers `EXTRQ`/`INSERTQ` from that fault and resumes the guest, but only for their **immediate** forms. The guard was:

```csharp
if (isExtrq && instruction.OpCount != 3 || isInsertq && instruction.OpCount != 4)
{
    return false;
}
```

Both instructions also have a **register** form (`66 0F 79 /r` and `F2 0F 79 /r`, the `_mm_extract_si64` / `_mm_insert_si64` intrinsics) that takes its length and index from a register rather than from immediates. Those decode to `OpCount == 2`, so the guard rejected them, the recovery declined, and the process died on the opcode. I verified the four encodings against the Iced version this repo pins:

| encoding | bytes | `Mnemonic` | `OpCount` | recovered before |
|---|---|---|---|---|
| `EXTRQ xmm1, 0x28, 0x00` | `66 0F 78 C1 28 00` | `Extrq` | 3 | yes |
| `EXTRQ xmm1, xmm2` | `66 0F 79 CA` | `Extrq` | 2 | **no** |
| `INSERTQ xmm1, xmm2, 0x28, 0x00` | `F2 0F 78 CA 28 00` | `Insertq` | 4 | yes |
| `INSERTQ xmm1, xmm2` | `F2 0F 79 CA` | `Insertq` | 2 | **no** |

The load-time patcher can't cover them either — `Sse4aExtrqBlendPatch.TryMatch` requires the literal bytes `66 0F 78` followed by the immediates `28 00`.

## What changed

`DirectExecutionBackend.Amd64Compat.cs` — the operand-count gate becomes a dispatch over the four `Code` values. The interesting part is that the two register forms disagree about where their control fields live:

- **`EXTRQ xmm1, xmm2`** takes length from `xmm2[5:0]` and index from `xmm2[13:8]` — both in the **low** quadword — and still extracts out of `xmm1` itself.
- **`INSERTQ xmm1, xmm2`** takes length from `xmm2[69:64]` and index from `xmm2[77:72]` — the **high** quadword — while the bits it inserts still come from the low one.

That asymmetry is the whole reason this needed care, so there's a test dedicated to it that fails if the halves are swapped.

`Sse4aBitFieldEmulator.cs` — adds `DecodeRegisterControl`, which splits that length/index pair out of a quadword. It's kept in the emulator rather than the backend for the reason the class comment already gives: the bit math stays testable without the unsafe CONTEXT plumbing.

The extract/insert math itself is untouched. Fields that overrun the quadword (`index + length > 64`, or `length == 0` with a non-zero index — undefined per AMD) are still declined rather than emulated, which matches both the immediate forms and the rule the BMI fallback states for itself: never half-handle an opcode. I also read the destination before writing it, so `EXTRQ xmm1, xmm1` — where the control fields and the extracted data share one quadword — comes out right.

This is strictly additive. The code path it touches previously returned `false` and let the title die, so it cannot regress a title that works today.

## Testing

**N/A** — I have no PS5 title that emits the register forms, and I want to be straight about that rather than imply otherwise. What this does have is direct coverage of the faulting path:

`Sse4aRegisterFormRecoveryTests.cs` (new, 7 tests) fabricates the state the OS hands the `#UD` handler — a Win64 `CONTEXT` carrying the XMM registers, and a RIP pointing at real instruction bytes in probe-visible host memory — and drives the production entry point `TryRecoverAmdCompatInstruction` over it, so decode, bit math and CONTEXT write-back are exercised exactly as on a live fault:

- `EXTRQ xmm1, xmm2` reads control from the source's low quadword, extracts from the destination, zeroes `[127:64]`, advances RIP by 4
- `INSERTQ xmm1, xmm2` reads control from the source's **high** quadword
- a control pair planted in `INSERTQ`'s source *low* quadword is ignored — asserts the result differs from what reading the wrong half would give
- `EXTRQ xmm1, xmm1` (same register as source and destination)
- an overrunning field declines **and** leaves the CONTEXT byte-for-byte untouched
- both immediate forms still recover, as regression guards on the refactor

`Sse4aBitFieldEmulatorTests.cs` (+4) covers `DecodeRegisterControl`: field placement, that bits above 15 are ignored, that the two bits above each 6-bit field are masked off, and that an all-zero control is the length-64 case.

I checked the new tests are load-bearing by reverting the source change and re-running them: 4 of the 7 fail, and they pass again with it restored.

Verified as CI does, on Windows with .NET SDK 10.0.302:

```
dotnet build SharpEmu.slnx -c Release
dotnet test SharpEmu.slnx -c Release --no-build
```

`Build succeeded`, and 900 tests pass with 0 failures (889 before this branch, +11 new).

## Notes on #328

The originally reported crash — the fixed 12-byte `EXTRQ`+`VPBLENDD` pattern hard-coded against `xmm2` missing PPSA15552's `xmm1` encoding — is genuinely gone; `Sse4aExtrqBlendPatch` now reads the source register from the ModRM r/m field, and the reporter confirmed that on current `main`. This PR closes a different, still-open hole in the same issue: the generic `#UD` fallback that is meant to be the safety net for everything the patcher misses did not actually cover half the instruction's encodings.

The other remaining gap in #328 — the Darwin XMM bridge, so `_posixXmmContextBridged` can become true on macOS — is untouched here. I don't have an Apple Silicon machine, and getting a raw `mcontext` offset wrong is a memory-corruption risk rather than a non-functional patch, so I've left it alone.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
