### PR TITLE
[Kernel] Run queued guest exceptions from host-thread waits (#254)

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -4860,6 +4860,53 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		return 0;
 	}
 
+	/// <summary>
+	/// Delivers a queued kernel exception to the calling thread on demand. TryRaiseGuestException
+	/// queues rather than delivers when the target is a primary/external executor, because running
+	/// the handler concurrently on another managed thread would corrupt that executor's control
+	/// state; it relies on the executor consuming the queue at its next import boundary. A thread
+	/// parked in a host-thread wait is *inside* an import and never reaches one, which strands the
+	/// raiser forever. Blocking exports call this from their wait loop to close that gap.
+	/// </summary>
+	public bool TryDeliverPendingGuestException(CpuContext callerContext)
+	{
+		// This runs from kernel wait loops, so the overwhelmingly common no-exception case must
+		// not take the gate. The count is republished on every mutation of the dictionary.
+		if (Volatile.Read(ref _pendingGuestExceptionCount) == 0)
+		{
+			return false;
+		}
+
+		// Resolve the caller exactly the way the import safe point does, so the two cannot
+		// disagree about which thread they mean.
+		var threadHandle = GuestThreadExecution.CurrentGuestThreadHandle;
+		if (threadHandle == 0)
+		{
+			threadHandle = _currentExternalGuestThreadHandle;
+		}
+		if (threadHandle == 0)
+		{
+			return false;
+		}
+
+		lock (_guestThreadGate)
+		{
+			// The count above is process-wide; only this thread's own exception may be run here.
+			if (!_pendingGuestExceptions.ContainsKey(threadHandle))
+			{
+				return false;
+			}
+		}
+
+		// No continuation: the caller's context already carries the guest register state the
+		// collector scans for roots, and unlike an import boundary this delivery does not resume
+		// the guest through a continuation - the export returns to its wait when the handler ends.
+		// DeliverPendingGuestExceptionAtSafePoint re-checks and dequeues under the gate, so losing
+		// the race against another consumer just makes it return without running anything.
+		DeliverPendingGuestExceptionAtSafePoint(callerContext, default);
+		return true;
+	}
+
 	private void DeliverPendingGuestExceptionAtSafePoint(
 		CpuContext currentContext,
 		GuestCpuContinuation interruptedContinuation)

--- a/src/SharpEmu.HLE/GuestThreadExecution.cs
+++ b/src/SharpEmu.HLE/GuestThreadExecution.cs
@@ -116,6 +116,15 @@ public interface IGuestThreadScheduler
         ulong handler,
         int exceptionType,
         out string? error);
+
+    /// <summary>
+    /// Runs a kernel exception already queued for the calling thread, rather than leaving it for
+    /// that thread's next import boundary. <see cref="TryRaiseGuestException"/> queues instead of
+    /// delivering when the target is a primary/external executor, on the assumption that the
+    /// executor will reach a boundary shortly; a thread parked in a host-thread wait inside an HLE
+    /// export never does. Returns true when a handler was run.
+    /// </summary>
+    bool TryDeliverPendingGuestException(CpuContext callerContext);
 }
 
 public readonly record struct GuestImportCallFrame(
@@ -243,6 +252,18 @@ public static class GuestThreadExecution
             return 0;
         }
     }
+
+    /// <summary>
+    /// Gives the calling thread a chance to run a kernel exception raised on it while it is parked
+    /// inside an HLE wait, so blocking exports stay reachable by the guest's own signal mechanism.
+    ///
+    /// Call this with no kernel-object lock held. The handler is guest code, and a title that
+    /// suspends a thread this way routinely has the handler touch the very object the caller is
+    /// waiting on - IL2CPP's stop-the-world collector acknowledges on one semaphore while the
+    /// interrupted thread waits on another.
+    /// </summary>
+    public static bool TryDeliverPendingGuestException(CpuContext context) =>
+        Scheduler is { } scheduler && scheduler.TryDeliverPendingGuestException(context);
 
     public static bool IsGuestThread => _currentGuestThreadHandle != 0;
 

--- a/src/SharpEmu.Libs/Kernel/KernelEventFlagCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelEventFlagCompatExports.cs
@@ -313,6 +313,12 @@ public static class KernelEventFlagCompatExports
                         try
                         {
                             scheduler.Pump(ctx, "sceKernelWaitEventFlag");
+
+                            // Same reason the pump runs out here rather than under the gate: a
+                            // kernel exception queued for this thread is only delivered at an
+                            // import boundary, and a thread parked in this export never reaches
+                            // one. The handler is guest code and sets event flags of its own.
+                            scheduler.TryDeliverPendingGuestException(ctx);
                         }
                         finally
                         {

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadCompatExports.cs
@@ -1626,26 +1626,54 @@ public static class KernelPthreadCompatExports
         // Non-guest callers have no resumable CPU continuation. Park only
         // those host-side compatibility callers, preserving the same FIFO
         // mutex reacquisition rules as cooperative guest waiters.
-        lock (state.SyncRoot)
+        //
+        // The park is sliced and the lock retaken per slice so the thread can run a kernel
+        // exception raised on it while it waits. The primary guest executor is not cooperative,
+        // so it lands here, and a queued exception for it is only delivered at an import
+        // boundary - which a thread parked inside this export never reaches. IL2CPP suspends
+        // threads by raising on them and waiting for the handler's acknowledgement, so an
+        // uninterruptible park here hangs the collection (#254).
+        var deadline = timed
+            ? GuestThreadExecution.ComputeDeadlineTimestamp(GetCondWaitTimeout(timeoutUsec))
+            : long.MaxValue;
+        while (true)
         {
-            var deadline = timed
-                ? GuestThreadExecution.ComputeDeadlineTimestamp(GetCondWaitTimeout(timeoutUsec))
-                : long.MaxValue;
-            while (waiter.CompletionState == 0)
+            lock (state.SyncRoot)
             {
-                if (!timed)
+                if (waiter.CompletionState != 0)
                 {
-                    Monitor.Wait(state.SyncRoot);
-                    continue;
+                    break;
                 }
 
-                var remaining = GetRemainingTimeout(deadline);
-                if (remaining <= TimeSpan.Zero || !Monitor.Wait(state.SyncRoot, remaining))
+                if (timed)
                 {
-                    CompleteCondWaiterLocked(state, waiter, timedOut: true);
+                    // Re-derived from the deadline each slice: a slice expiring is not the
+                    // overall timeout, so only an exhausted deadline completes the waiter.
+                    var remaining = GetRemainingTimeout(deadline);
+                    if (remaining <= TimeSpan.Zero)
+                    {
+                        CompleteCondWaiterLocked(state, waiter, timedOut: true);
+                        break;
+                    }
+
+                    Monitor.Wait(
+                        state.SyncRoot,
+                        remaining < HostCondWaitPumpInterval ? remaining : HostCondWaitPumpInterval);
+                }
+                else
+                {
+                    Monitor.Wait(state.SyncRoot, HostCondWaitPumpInterval);
+                }
+
+                if (waiter.CompletionState != 0)
+                {
                     break;
                 }
             }
+
+            // Outside state.SyncRoot on purpose: the handler is guest code and signals condition
+            // variables of its own.
+            GuestThreadExecution.TryDeliverPendingGuestException(ctx);
         }
 
         if (waiter.MutexWaiter is null)
@@ -2034,6 +2062,12 @@ public static class KernelPthreadCompatExports
 
         return TimeSpan.FromTicks((long)timeoutUsec * 10L);
     }
+
+    // How long a host-side condition-variable park sleeps before it drops the lock to check for
+    // work that has to happen off it (a kernel exception queued for this thread). Short enough
+    // that a suspend request is acknowledged without a visible stall, long enough that an idle
+    // waiter costs nothing measurable.
+    private static readonly TimeSpan HostCondWaitPumpInterval = TimeSpan.FromMilliseconds(50);
 
     private static TimeSpan GetRemainingTimeout(long deadlineTimestamp)
     {

--- a/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
@@ -1593,7 +1593,12 @@ public static class KernelPthreadExtendedCompatExports
 
                     while (rwlock.WriterThreadId != 0 || rwlock.ReaderTotalCount != 0 || rwlock.CompatWriterTotalCount != 0)
                     {
-                        Monitor.Wait(rwlock.SyncRoot);
+                        // Bounded, so a park that is never pulsed still reaches the delivery
+                        // point below instead of being unreachable for the lifetime of the wait.
+                        if (!Monitor.Wait(rwlock.SyncRoot, HostRwlockWaitPumpInterval))
+                        {
+                            PumpGuestExceptionOffRwlockGate(ctx, rwlock);
+                        }
                     }
 
                     rwlock.WriterThreadId = currentThreadId;
@@ -1626,7 +1631,10 @@ public static class KernelPthreadExtendedCompatExports
                         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
                     }
 
-                    Monitor.Wait(rwlock.SyncRoot);
+                    if (!Monitor.Wait(rwlock.SyncRoot, HostRwlockWaitPumpInterval))
+                    {
+                        PumpGuestExceptionOffRwlockGate(ctx, rwlock);
+                    }
                 }
 
                 if (rwlock.WriterThreadId != 0 ||
@@ -1750,6 +1758,32 @@ public static class KernelPthreadExtendedCompatExports
         }
 
         return rwlockAddress;
+    }
+
+    // How long a host-side rwlock park sleeps before it drops the gate to check for work that has
+    // to happen off it. The waits below were untimed, which left a thread parked here unreachable
+    // by the guest's own signal mechanism.
+    private static readonly TimeSpan HostRwlockWaitPumpInterval = TimeSpan.FromMilliseconds(50);
+
+    /// <summary>
+    /// Drops the rwlock gate, gives the calling thread a chance to run a kernel exception raised
+    /// on it while parked, and retakes the gate.
+    ///
+    /// A queued kernel exception is only delivered at an import boundary, and a thread parked
+    /// inside this export never reaches one. The handler must run off the gate: it is guest code
+    /// and takes rwlocks of its own, including potentially this one.
+    /// </summary>
+    private static void PumpGuestExceptionOffRwlockGate(CpuContext ctx, PthreadRwlockState rwlock)
+    {
+        Monitor.Exit(rwlock.SyncRoot);
+        try
+        {
+            GuestThreadExecution.TryDeliverPendingGuestException(ctx);
+        }
+        finally
+        {
+            Monitor.Enter(rwlock.SyncRoot);
+        }
     }
 
     private static bool TryResolveRwlockState(CpuContext ctx, ulong rwlockAddress, bool createIfZero, out ulong resolvedAddress, [NotNullWhen(true)] out PthreadRwlockState? rwlock)

--- a/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
@@ -235,16 +235,38 @@ public static class KernelSemaphoreCompatExports
         var deadlineMs = timeoutAddress != 0
             ? Environment.TickCount64 + Math.Max(1L, timeoutUsec / 1000L)
             : long.MaxValue;
-        lock (semaphore.Gate)
+        if (_traceSema)
         {
-            if (_traceSema)
+            TraceSemaphore(
+                $"wait-host-block handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} " +
+                $"count={semaphore.Count} timeout={(timeoutAddress == 0 ? "infinite" : timeoutUsec)} {FormatCallSite(ctx)}");
+        }
+
+        // The gate is taken per attempt rather than held across the whole park so the thread can
+        // run a kernel exception raised on it while it waits (see below). Re-checking Count under
+        // the gate at the top of every attempt keeps that safe: a token that arrives while the
+        // gate is released is observed here instead of being lost.
+        while (true)
+        {
+            lock (semaphore.Gate)
             {
-                TraceSemaphore(
-                    $"wait-host-block handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} " +
-                    $"count={semaphore.Count} timeout={(timeoutAddress == 0 ? "infinite" : timeoutUsec)} {FormatCallSite(ctx)}");
-            }
-            while (semaphore.Count < needCount)
-            {
+                if (semaphore.Count >= needCount)
+                {
+                    semaphore.Count -= needCount;
+                    semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
+                    if (_traceSema)
+                    {
+                        TraceSemaphore(
+                            $"wait-host-wake handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} {FormatCallSite(ctx)}");
+                    }
+                    if (timeoutAddress != 0)
+                    {
+                        _ = TryWriteUInt32(ctx, timeoutAddress, 0);
+                    }
+
+                    return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
+                }
+
                 var remaining = deadlineMs - Environment.TickCount64;
                 if (timeoutAddress != 0 && remaining <= 0)
                 {
@@ -256,19 +278,18 @@ public static class KernelSemaphoreCompatExports
                 Monitor.Wait(semaphore.Gate, (int)Math.Min(remaining, 100));
             }
 
-            semaphore.Count -= needCount;
-            semaphore.WaitingThreads = Math.Max(0, semaphore.WaitingThreads - 1);
-            if (_traceSema)
-            {
-                TraceSemaphore(
-                    $"wait-host-wake handle=0x{handle:X8} name='{semaphore.Name}' need={needCount} count={semaphore.Count} {FormatCallSite(ctx)}");
-            }
-            if (timeoutAddress != 0)
-            {
-                _ = TryWriteUInt32(ctx, timeoutAddress, 0);
-            }
-
-            return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_OK);
+            // Deliberately outside the gate. This is the only point in a host-thread wait where
+            // the guest's own signal mechanism can reach the thread: the raiser queued the
+            // exception for delivery at the next import boundary, and a thread parked here is
+            // inside an import and will never reach one. IL2CPP's stop-the-world collector
+            // depends on it - it suspends every thread by raising on it and then waits for the
+            // acknowledgement the handler posts, so a thread that cannot run its handler while
+            // blocked strands the whole collection and hangs the title.
+            //
+            // The handler must not run under semaphore.Gate: it is guest code and signals
+            // semaphores of its own, including, in the collector's case, ones other threads are
+            // parked on through this same path.
+            GuestThreadExecution.TryDeliverPendingGuestException(ctx);
         }
     }
 

--- a/tests/SharpEmu.Libs.Tests/Kernel/DeliveryStubScheduler.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/DeliveryStubScheduler.cs
@@ -73,7 +73,10 @@ internal sealed class DeliveryStubScheduler : IGuestThreadScheduler
     public bool TryJoinThread(CpuContext callerContext, ulong threadHandle, out ulong returnValue, out string? error) =>
         throw new NotSupportedException();
 
-    public void Pump(CpuContext callerContext, string reason) => throw new NotSupportedException();
+    // The event-flag park pumps the scheduler on every tick; nothing to advance here.
+    public void Pump(CpuContext callerContext, string reason)
+    {
+    }
 
     public bool TrySetGuestThreadPriority(ulong guestThreadHandle, int guestPriority) =>
         throw new NotSupportedException();

--- a/tests/SharpEmu.Libs.Tests/Kernel/DeliveryStubScheduler.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/DeliveryStubScheduler.cs
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+/// <summary>
+/// GuestThreadExecution.Scheduler is process-wide, so every test that installs one shares this
+/// collection and runs serially.
+/// </summary>
+[CollectionDefinition("GuestThreadSchedulerState", DisableParallelization = true)]
+public sealed class GuestThreadSchedulerStateCollection
+{
+}
+
+/// <summary>Installs a scheduler for the duration of a test and puts the previous one back.</summary>
+internal sealed class SchedulerScope : IDisposable
+{
+    private readonly IGuestThreadScheduler? _previous;
+
+    public SchedulerScope(IGuestThreadScheduler scheduler)
+    {
+        _previous = GuestThreadExecution.Scheduler;
+        GuestThreadExecution.Scheduler = scheduler;
+    }
+
+    public void Dispose() => GuestThreadExecution.Scheduler = _previous;
+}
+
+/// <summary>
+/// Stands in for the CPU backend on the one call a blocking HLE wait makes into the scheduler
+/// while it is parked. Only the members such a wait actually reaches are implemented; anything
+/// else throws, so a change that starts routing through this stub cannot pass unnoticed.
+/// </summary>
+internal sealed class DeliveryStubScheduler : IGuestThreadScheduler
+{
+    private int _deliverCalls;
+
+    /// <summary>Runs on the parked thread, standing in for the guest's exception handler.</summary>
+    public Action? OnDeliver { get; set; }
+
+    public int DeliverCalls => Volatile.Read(ref _deliverCalls);
+
+    public volatile bool SignalCompleted;
+
+    public bool SupportsGuestContextTransfer => false;
+
+    public bool TryDeliverPendingGuestException(CpuContext callerContext)
+    {
+        // Act once only: the park polls this every slice, and the production hook likewise stops
+        // reporting work once this thread's queue is drained.
+        if (Interlocked.Increment(ref _deliverCalls) != 1)
+        {
+            return false;
+        }
+
+        OnDeliver?.Invoke();
+        return true;
+    }
+
+    // Blocking exports notify the cooperative scheduler after posting; nothing is registered
+    // here, so report that nothing was woken.
+    public int WakeBlockedThreads(string wakeKey, int maxCount = int.MaxValue) => 0;
+
+    public void RegisterGuestThreadContext(ulong threadHandle, CpuContext context) =>
+        throw new NotSupportedException();
+
+    public bool TryStartThread(CpuContext creatorContext, GuestThreadStartRequest request, out string? error) =>
+        throw new NotSupportedException();
+
+    public bool TryJoinThread(CpuContext callerContext, ulong threadHandle, out ulong returnValue, out string? error) =>
+        throw new NotSupportedException();
+
+    public void Pump(CpuContext callerContext, string reason) => throw new NotSupportedException();
+
+    public bool TrySetGuestThreadPriority(ulong guestThreadHandle, int guestPriority) =>
+        throw new NotSupportedException();
+
+    public bool TrySetGuestThreadAffinity(ulong guestThreadHandle, ulong affinityMask) =>
+        throw new NotSupportedException();
+
+    public IReadOnlyList<GuestThreadSnapshot> SnapshotThreads() => throw new NotSupportedException();
+
+    public bool TryCallGuestFunction(
+        CpuContext callerContext,
+        ulong entryPoint,
+        ulong arg0,
+        ulong arg1,
+        ulong stackAddress,
+        ulong stackSize,
+        string reason,
+        out string? error) => throw new NotSupportedException();
+
+    public bool TryCallGuestFunction(
+        CpuContext callerContext,
+        ulong entryPoint,
+        ulong arg0,
+        ulong arg1,
+        ulong arg2,
+        ulong stackAddress,
+        ulong stackSize,
+        string reason,
+        out ulong returnValue,
+        out string? error) => throw new NotSupportedException();
+
+    public bool TryCallGuestContinuation(
+        CpuContext callerContext,
+        GuestCpuContinuation continuation,
+        string reason,
+        out string? error) => throw new NotSupportedException();
+
+    public bool TryRaiseGuestException(
+        CpuContext callerContext,
+        ulong threadHandle,
+        ulong handler,
+        int exceptionType,
+        out string? error) => throw new NotSupportedException();
+}

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelEventFlagExceptionDeliveryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelEventFlagExceptionDeliveryTests.cs
@@ -1,0 +1,115 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+/// <summary>
+/// The event-flag host park already leaves its gate to pump the scheduler, so it is the one place
+/// that needed nothing restructured - only the delivery call added alongside the pump. These pin
+/// that it is actually made, since a thread parked here is inside an import and never reaches the
+/// boundary where a queued kernel exception would otherwise be delivered (#254).
+/// </summary>
+[Collection("GuestThreadSchedulerState")]
+public sealed class KernelEventFlagExceptionDeliveryTests
+{
+    private const ulong MemoryBase = 0x3_0000_0000;
+    private const ulong HandleAddress = MemoryBase + 0x100;
+    private const ulong NameAddress = MemoryBase + 0x200;
+    private const ulong ResultAddress = MemoryBase + 0x300;
+
+    private const uint WaitOr = 0x02;
+    private const ulong WaitedPattern = 0x4;
+
+    [Fact]
+    public void HostEventFlagParkRunsAKernelExceptionRaisedWhileItIsParked()
+    {
+        var context = CreateContext();
+        var handle = CreateEventFlag(context);
+        var scheduler = new DeliveryStubScheduler();
+        var setContext = CreateContext();
+
+        // Raise the awaited bits from the delivery hook, on another thread. If the park still held
+        // state.Gate when it called us, KernelSetEventFlag could not take that lock and the join
+        // below would time out.
+        scheduler.OnDeliver = () => scheduler.SignalCompleted = Task
+            .Run(() =>
+            {
+                setContext[CpuRegister.Rdi] = handle;
+                setContext[CpuRegister.Rsi] = WaitedPattern;
+                return KernelEventFlagCompatExports.KernelSetEventFlag(setContext);
+            })
+            .Wait(TimeSpan.FromSeconds(10));
+
+        using var _ = new SchedulerScope(scheduler);
+        var waiter = Task.Run(() => WaitOnEventFlag(context, handle));
+
+        Assert.True(waiter.Wait(TimeSpan.FromSeconds(20)), "the parked event-flag wait was never released");
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, waiter.Result);
+        Assert.True(scheduler.DeliverCalls > 0, "the park never offered to run a queued exception");
+        Assert.True(scheduler.SignalCompleted, "the handler ran while the event-flag gate was held");
+
+        DeleteEventFlag(context, handle);
+    }
+
+    [Fact]
+    public void AnAlreadySatisfiedEventFlagWaitNeverConsultsTheDeliveryHook()
+    {
+        var context = CreateContext();
+        var handle = CreateEventFlag(context);
+        var scheduler = new DeliveryStubScheduler();
+
+        using var _ = new SchedulerScope(scheduler);
+        context[CpuRegister.Rdi] = handle;
+        context[CpuRegister.Rsi] = WaitedPattern;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            KernelEventFlagCompatExports.KernelSetEventFlag(context));
+
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, WaitOnEventFlag(context, handle));
+        Assert.Equal(0, scheduler.DeliverCalls);
+
+        DeleteEventFlag(context, handle);
+    }
+
+    private static int WaitOnEventFlag(CpuContext template, ulong handle)
+    {
+        var context = new CpuContext(template.Memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = handle;
+        context[CpuRegister.Rsi] = WaitedPattern;
+        context[CpuRegister.Rdx] = WaitOr;
+        context[CpuRegister.Rcx] = ResultAddress;
+        context[CpuRegister.R8] = 0;
+        return KernelEventFlagCompatExports.KernelWaitEventFlag(context);
+    }
+
+    private static CpuContext CreateContext() => new(new FakeCpuMemory(MemoryBase, 0x1000), Generation.Gen5);
+
+    private static ulong CreateEventFlag(CpuContext context)
+    {
+        Assert.True(context.Memory.TryWrite(NameAddress, Encoding.UTF8.GetBytes("test_evf\0")));
+
+        context[CpuRegister.Rdi] = HandleAddress;
+        context[CpuRegister.Rsi] = NameAddress;
+        context[CpuRegister.Rdx] = 0x20; // multi-thread wait
+        context[CpuRegister.Rcx] = 0;
+        context[CpuRegister.R8] = 0;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            KernelEventFlagCompatExports.KernelCreateEventFlag(context));
+
+        var bytes = new byte[sizeof(ulong)];
+        Assert.True(context.Memory.TryRead(HandleAddress, bytes));
+        return BitConverter.ToUInt64(bytes);
+    }
+
+    private static void DeleteEventFlag(CpuContext context, ulong handle)
+    {
+        context[CpuRegister.Rdi] = handle;
+        KernelEventFlagCompatExports.KernelDeleteEventFlag(context);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelSemaphoreExceptionDeliveryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelSemaphoreExceptionDeliveryTests.cs
@@ -8,11 +8,6 @@ using Xunit;
 
 namespace SharpEmu.Libs.Tests.Kernel;
 
-[CollectionDefinition("GuestThreadSchedulerState", DisableParallelization = true)]
-public sealed class GuestThreadSchedulerStateCollection
-{
-}
-
 /// <summary>
 /// A guest thread that blocks in sceKernelWaitSema without a cooperative identity parks on the
 /// host inside the HLE export, so it never reaches the import boundary where queued kernel
@@ -40,7 +35,7 @@ public sealed class KernelSemaphoreExceptionDeliveryTests
     {
         var context = CreateContext();
         var handle = CreateSemaphore(context, initialCount: 0);
-        var scheduler = new StubScheduler();
+        var scheduler = new DeliveryStubScheduler();
         var signalContext = CreateContext();
 
         // Post the token from the delivery hook, standing in for a guest handler that
@@ -72,7 +67,7 @@ public sealed class KernelSemaphoreExceptionDeliveryTests
     {
         var context = CreateContext();
         var handle = CreateSemaphore(context, initialCount: 0);
-        var scheduler = new StubScheduler();
+        var scheduler = new DeliveryStubScheduler();
         var signalContext = CreateContext();
 
         using var _ = new SchedulerScope(scheduler);
@@ -103,7 +98,7 @@ public sealed class KernelSemaphoreExceptionDeliveryTests
     {
         var context = CreateContext();
         var handle = CreateSemaphore(context, initialCount: 0);
-        var scheduler = new StubScheduler();
+        var scheduler = new DeliveryStubScheduler();
 
         using var _ = new SchedulerScope(scheduler);
         context[CpuRegister.Rdi] = handle;
@@ -128,7 +123,7 @@ public sealed class KernelSemaphoreExceptionDeliveryTests
     {
         var context = CreateContext();
         var handle = CreateSemaphore(context, initialCount: 1);
-        var scheduler = new StubScheduler();
+        var scheduler = new DeliveryStubScheduler();
 
         using var _ = new SchedulerScope(scheduler);
         context[CpuRegister.Rdi] = handle;
@@ -201,107 +196,5 @@ public sealed class KernelSemaphoreExceptionDeliveryTests
         var bytes = new byte[sizeof(uint)];
         Assert.True(context.Memory.TryRead(address, bytes));
         return BitConverter.ToUInt32(bytes);
-    }
-
-    /// <summary>GuestThreadExecution.Scheduler is process-wide; put it back afterwards.</summary>
-    private sealed class SchedulerScope : IDisposable
-    {
-        private readonly IGuestThreadScheduler? _previous;
-
-        public SchedulerScope(IGuestThreadScheduler scheduler)
-        {
-            _previous = GuestThreadExecution.Scheduler;
-            GuestThreadExecution.Scheduler = scheduler;
-        }
-
-        public void Dispose() => GuestThreadExecution.Scheduler = _previous;
-    }
-
-    /// <summary>
-    /// Only the members a blocking semaphore wait reaches are implemented. Anything else throws so
-    /// a future change that starts routing through this stub cannot pass by accident.
-    /// </summary>
-    private sealed class StubScheduler : IGuestThreadScheduler
-    {
-        private int _deliverCalls;
-
-        public Action? OnDeliver { get; set; }
-
-        public int DeliverCalls => Volatile.Read(ref _deliverCalls);
-
-        public volatile bool SignalCompleted;
-
-        public bool SupportsGuestContextTransfer => false;
-
-        public bool TryDeliverPendingGuestException(CpuContext callerContext)
-        {
-            // Only act once: the wait polls this on every tick, and the production hook likewise
-            // returns false once the queue for this thread is drained.
-            if (Interlocked.Increment(ref _deliverCalls) != 1)
-            {
-                return false;
-            }
-
-            OnDeliver?.Invoke();
-            return true;
-        }
-
-        // sceKernelSignalSema notifies the cooperative scheduler after posting; nothing is
-        // registered here, so report that nothing was woken.
-        public int WakeBlockedThreads(string wakeKey, int maxCount = int.MaxValue) => 0;
-
-        public void RegisterGuestThreadContext(ulong threadHandle, CpuContext context) =>
-            throw new NotSupportedException();
-
-        public bool TryStartThread(CpuContext creatorContext, GuestThreadStartRequest request, out string? error) =>
-            throw new NotSupportedException();
-
-        public bool TryJoinThread(CpuContext callerContext, ulong threadHandle, out ulong returnValue, out string? error) =>
-            throw new NotSupportedException();
-
-        public void Pump(CpuContext callerContext, string reason) => throw new NotSupportedException();
-
-        public bool TrySetGuestThreadPriority(ulong guestThreadHandle, int guestPriority) =>
-            throw new NotSupportedException();
-
-        public bool TrySetGuestThreadAffinity(ulong guestThreadHandle, ulong affinityMask) =>
-            throw new NotSupportedException();
-
-        public IReadOnlyList<GuestThreadSnapshot> SnapshotThreads() => throw new NotSupportedException();
-
-        public bool TryCallGuestFunction(
-            CpuContext callerContext,
-            ulong entryPoint,
-            ulong arg0,
-            ulong arg1,
-            ulong stackAddress,
-            ulong stackSize,
-            string reason,
-            out string? error) => throw new NotSupportedException();
-
-        public bool TryCallGuestFunction(
-            CpuContext callerContext,
-            ulong entryPoint,
-            ulong arg0,
-            ulong arg1,
-            ulong arg2,
-            ulong stackAddress,
-            ulong stackSize,
-            string reason,
-            out ulong returnValue,
-            out string? error) => throw new NotSupportedException();
-
-        public bool TryCallGuestContinuation(
-            CpuContext callerContext,
-            GuestCpuContinuation continuation,
-            string reason,
-            out string? error) => throw new NotSupportedException();
-
-        public bool TryRaiseGuestException(
-            CpuContext callerContext,
-            ulong threadHandle,
-            ulong handler,
-            int exceptionType,
-            out string? error) => throw new NotSupportedException();
     }
 }

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelSemaphoreExceptionDeliveryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelSemaphoreExceptionDeliveryTests.cs
@@ -1,0 +1,307 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+[CollectionDefinition("GuestThreadSchedulerState", DisableParallelization = true)]
+public sealed class GuestThreadSchedulerStateCollection
+{
+}
+
+/// <summary>
+/// A guest thread that blocks in sceKernelWaitSema without a cooperative identity parks on the
+/// host inside the HLE export, so it never reaches the import boundary where queued kernel
+/// exceptions are delivered. IL2CPP's stop-the-world collector suspends threads by raising an
+/// exception on them and then waits for the acknowledgement the handler posts, so a thread that
+/// cannot run its handler while blocked strands the collection and hangs the title (#254).
+///
+/// These drive the real export against a stub scheduler, with no CPU backend and no guest image.
+/// </summary>
+[Collection("GuestThreadSchedulerState")]
+public sealed class KernelSemaphoreExceptionDeliveryTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong HandleAddress = MemoryBase + 0x100;
+    private const ulong NameAddress = MemoryBase + 0x200;
+    private const ulong TimeoutAddress = MemoryBase + 0x300;
+
+    /// <summary>
+    /// The headline regression. The waiter parks with no tokens available and is released only by
+    /// work the delivery hook performs, so on a build where the wait never consults that hook the
+    /// task never completes and this fails on its timeout.
+    /// </summary>
+    [Fact]
+    public void HostThreadWaitRunsAKernelExceptionRaisedWhileItIsParked()
+    {
+        var context = CreateContext();
+        var handle = CreateSemaphore(context, initialCount: 0);
+        var scheduler = new StubScheduler();
+        var signalContext = CreateContext();
+
+        // Post the token from the delivery hook, standing in for a guest handler that
+        // acknowledges its suspension. Doing it from another thread is the point: if the waiter
+        // were still holding the semaphore gate when it called us, that thread could not enter
+        // KernelSignalSema and the join below would time out.
+        scheduler.OnDeliver = () => scheduler.SignalCompleted = Task
+            .Run(() => KernelSemaphoreCompatExports.KernelSignalSema(signalContext, handle, 1))
+            .Wait(TimeSpan.FromSeconds(10));
+
+        using var _ = new SchedulerScope(scheduler);
+        var waiter = Task.Run(() => WaitForever(context, handle));
+
+        Assert.True(waiter.Wait(TimeSpan.FromSeconds(20)), "the parked wait was never released");
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, waiter.Result);
+        Assert.True(scheduler.DeliverCalls > 0, "the wait never offered to run a queued exception");
+        Assert.True(scheduler.SignalCompleted, "the handler ran while the semaphore gate was held");
+
+        DeleteSemaphore(context, handle);
+    }
+
+    /// <summary>
+    /// The delivery hook is an addition to the wait, not a replacement for it: an ordinary
+    /// sceKernelSignalSema from another thread must still release the waiter with a token
+    /// consumed, whether or not anything is ever delivered.
+    /// </summary>
+    [Fact]
+    public void OrdinarySignalStillWakesTheHostThreadWaitAndConsumesOneToken()
+    {
+        var context = CreateContext();
+        var handle = CreateSemaphore(context, initialCount: 0);
+        var scheduler = new StubScheduler();
+        var signalContext = CreateContext();
+
+        using var _ = new SchedulerScope(scheduler);
+        var waiter = Task.Run(() => WaitForever(context, handle));
+
+        // Signal repeatedly until the waiter observes it, so the test cannot race the park.
+        Assert.True(
+            SpinUntil(
+                () =>
+                {
+                    if (waiter.IsCompleted)
+                    {
+                        return true;
+                    }
+
+                    KernelSemaphoreCompatExports.KernelSignalSema(signalContext, handle, 1);
+                    return waiter.Wait(TimeSpan.FromMilliseconds(250));
+                },
+                TimeSpan.FromSeconds(20)),
+            "an ordinary signal never released the wait");
+        Assert.Equal((int)OrbisGen2Result.ORBIS_GEN2_OK, waiter.Result);
+
+        DeleteSemaphore(context, handle);
+    }
+
+    [Fact]
+    public void HostThreadWaitStillTimesOutAndWritesBackTheRemainingTimeout()
+    {
+        var context = CreateContext();
+        var handle = CreateSemaphore(context, initialCount: 0);
+        var scheduler = new StubScheduler();
+
+        using var _ = new SchedulerScope(scheduler);
+        context[CpuRegister.Rdi] = handle;
+        context[CpuRegister.Rsi] = 1;
+        context[CpuRegister.Rdx] = TimeoutAddress;
+        WriteUInt32(context, TimeoutAddress, 5_000);
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_TIMED_OUT,
+            KernelSemaphoreCompatExports.KernelWaitSema(context));
+        Assert.Equal(0u, ReadUInt32(context, TimeoutAddress));
+
+        DeleteSemaphore(context, handle);
+    }
+
+    /// <summary>
+    /// A wait that can be satisfied immediately must not take the parking path at all, so the
+    /// added hook costs an uncontended acquire nothing.
+    /// </summary>
+    [Fact]
+    public void AnImmediatelySatisfiableWaitNeverConsultsTheDeliveryHook()
+    {
+        var context = CreateContext();
+        var handle = CreateSemaphore(context, initialCount: 1);
+        var scheduler = new StubScheduler();
+
+        using var _ = new SchedulerScope(scheduler);
+        context[CpuRegister.Rdi] = handle;
+        context[CpuRegister.Rsi] = 1;
+        context[CpuRegister.Rdx] = 0;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            KernelSemaphoreCompatExports.KernelWaitSema(context));
+        Assert.Equal(0, scheduler.DeliverCalls);
+
+        DeleteSemaphore(context, handle);
+    }
+
+    private static int WaitForever(CpuContext template, uint handle)
+    {
+        // A private context per thread: CpuContext holds the guest register file and the export
+        // writes RAX into it.
+        var context = new CpuContext(template.Memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = handle;
+        context[CpuRegister.Rsi] = 1;
+        context[CpuRegister.Rdx] = 0;
+        return KernelSemaphoreCompatExports.KernelWaitSema(context);
+    }
+
+    private static bool SpinUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        while (Environment.TickCount64 < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static CpuContext CreateContext() => new(new FakeCpuMemory(MemoryBase, 0x1000), Generation.Gen5);
+
+    private static uint CreateSemaphore(CpuContext context, int initialCount)
+    {
+        var name = Encoding.UTF8.GetBytes("test_sema\0");
+        Assert.True(context.Memory.TryWrite(NameAddress, name));
+
+        context[CpuRegister.Rdi] = HandleAddress;
+        context[CpuRegister.Rsi] = NameAddress;
+        context[CpuRegister.Rdx] = 0;
+        context[CpuRegister.Rcx] = unchecked((ulong)(long)initialCount);
+        context[CpuRegister.R8] = 16;
+        context[CpuRegister.R9] = 0;
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            KernelSemaphoreCompatExports.KernelCreateSema(context));
+        return ReadUInt32(context, HandleAddress);
+    }
+
+    private static void DeleteSemaphore(CpuContext context, uint handle)
+    {
+        context[CpuRegister.Rdi] = handle;
+        KernelSemaphoreCompatExports.KernelDeleteSema(context);
+    }
+
+    private static void WriteUInt32(CpuContext context, ulong address, uint value) =>
+        Assert.True(context.Memory.TryWrite(address, BitConverter.GetBytes(value)));
+
+    private static uint ReadUInt32(CpuContext context, ulong address)
+    {
+        var bytes = new byte[sizeof(uint)];
+        Assert.True(context.Memory.TryRead(address, bytes));
+        return BitConverter.ToUInt32(bytes);
+    }
+
+    /// <summary>GuestThreadExecution.Scheduler is process-wide; put it back afterwards.</summary>
+    private sealed class SchedulerScope : IDisposable
+    {
+        private readonly IGuestThreadScheduler? _previous;
+
+        public SchedulerScope(IGuestThreadScheduler scheduler)
+        {
+            _previous = GuestThreadExecution.Scheduler;
+            GuestThreadExecution.Scheduler = scheduler;
+        }
+
+        public void Dispose() => GuestThreadExecution.Scheduler = _previous;
+    }
+
+    /// <summary>
+    /// Only the members a blocking semaphore wait reaches are implemented. Anything else throws so
+    /// a future change that starts routing through this stub cannot pass by accident.
+    /// </summary>
+    private sealed class StubScheduler : IGuestThreadScheduler
+    {
+        private int _deliverCalls;
+
+        public Action? OnDeliver { get; set; }
+
+        public int DeliverCalls => Volatile.Read(ref _deliverCalls);
+
+        public volatile bool SignalCompleted;
+
+        public bool SupportsGuestContextTransfer => false;
+
+        public bool TryDeliverPendingGuestException(CpuContext callerContext)
+        {
+            // Only act once: the wait polls this on every tick, and the production hook likewise
+            // returns false once the queue for this thread is drained.
+            if (Interlocked.Increment(ref _deliverCalls) != 1)
+            {
+                return false;
+            }
+
+            OnDeliver?.Invoke();
+            return true;
+        }
+
+        // sceKernelSignalSema notifies the cooperative scheduler after posting; nothing is
+        // registered here, so report that nothing was woken.
+        public int WakeBlockedThreads(string wakeKey, int maxCount = int.MaxValue) => 0;
+
+        public void RegisterGuestThreadContext(ulong threadHandle, CpuContext context) =>
+            throw new NotSupportedException();
+
+        public bool TryStartThread(CpuContext creatorContext, GuestThreadStartRequest request, out string? error) =>
+            throw new NotSupportedException();
+
+        public bool TryJoinThread(CpuContext callerContext, ulong threadHandle, out ulong returnValue, out string? error) =>
+            throw new NotSupportedException();
+
+        public void Pump(CpuContext callerContext, string reason) => throw new NotSupportedException();
+
+        public bool TrySetGuestThreadPriority(ulong guestThreadHandle, int guestPriority) =>
+            throw new NotSupportedException();
+
+        public bool TrySetGuestThreadAffinity(ulong guestThreadHandle, ulong affinityMask) =>
+            throw new NotSupportedException();
+
+        public IReadOnlyList<GuestThreadSnapshot> SnapshotThreads() => throw new NotSupportedException();
+
+        public bool TryCallGuestFunction(
+            CpuContext callerContext,
+            ulong entryPoint,
+            ulong arg0,
+            ulong arg1,
+            ulong stackAddress,
+            ulong stackSize,
+            string reason,
+            out string? error) => throw new NotSupportedException();
+
+        public bool TryCallGuestFunction(
+            CpuContext callerContext,
+            ulong entryPoint,
+            ulong arg0,
+            ulong arg1,
+            ulong arg2,
+            ulong stackAddress,
+            ulong stackSize,
+            string reason,
+            out ulong returnValue,
+            out string? error) => throw new NotSupportedException();
+
+        public bool TryCallGuestContinuation(
+            CpuContext callerContext,
+            GuestCpuContinuation continuation,
+            string reason,
+            out string? error) => throw new NotSupportedException();
+
+        public bool TryRaiseGuestException(
+            CpuContext callerContext,
+            ulong threadHandle,
+            ulong handler,
+            int exceptionType,
+            out string? error) => throw new NotSupportedException();
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Pthread/PthreadCondExceptionDeliveryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Pthread/PthreadCondExceptionDeliveryTests.cs
@@ -1,0 +1,144 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using SharpEmu.Libs.Tests.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Pthread;
+
+/// <summary>
+/// The host-side condition-variable park is the other place a non-cooperative guest thread can
+/// stop indefinitely inside an HLE export, so it needs the same escape hatch the semaphore wait
+/// has: a queued kernel exception is only ever delivered at an import boundary, and a thread
+/// parked in here never reaches one. Before this the untimed park was a bare
+/// <c>Monitor.Wait(SyncRoot)</c> with no timeout at all, so the thread could not be reached even
+/// in principle.
+/// </summary>
+[Collection("GuestThreadSchedulerState")]
+public sealed class PthreadCondExceptionDeliveryTests
+{
+    private const ulong MemoryBase = 0x2_0000_0000;
+    private const ulong MutexAddress = MemoryBase + 0x100;
+    private const ulong CondAddress = MemoryBase + 0x200;
+
+    /// <summary>
+    /// The waiter is released only by the signal the delivery hook posts, so on a build whose
+    /// park never drops the lock to consult that hook this fails on its timeout.
+    /// </summary>
+    [Fact]
+    public void UntimedHostCondWaitRunsAKernelExceptionRaisedWhileItIsParked()
+    {
+        var context = CreateContext();
+        InitializeCondAndMutex(context);
+        var scheduler = new DeliveryStubScheduler();
+        var signalContext = CreateContext();
+
+        // Signal from another thread, mirroring a guest handler that runs off the waiter's stack.
+        // If the waiter still held state.SyncRoot when it called us, PthreadCondSignal could not
+        // take that lock and the join below would time out.
+        scheduler.OnDeliver = () => scheduler.SignalCompleted = Task
+            .Run(() =>
+            {
+                signalContext[CpuRegister.Rdi] = CondAddress;
+                return KernelPthreadCompatExports.PthreadCondSignal(signalContext);
+            })
+            .Wait(TimeSpan.FromSeconds(10));
+
+        using var _ = new SchedulerScope(scheduler);
+        var waiter = Task.Run(() => WaitOnCond(context));
+
+        Assert.True(waiter.Wait(TimeSpan.FromSeconds(20)), "the parked condition wait was never released");
+        Assert.True(scheduler.DeliverCalls > 0, "the park never offered to run a queued exception");
+        Assert.True(scheduler.SignalCompleted, "the handler ran while the condvar lock was held");
+
+        DestroyCondAndMutex(context);
+    }
+
+    [Fact]
+    public void OrdinaryCondSignalStillReleasesTheHostPark()
+    {
+        var context = CreateContext();
+        InitializeCondAndMutex(context);
+        var scheduler = new DeliveryStubScheduler();
+        var signalContext = CreateContext();
+
+        using var _ = new SchedulerScope(scheduler);
+        var waiter = Task.Run(() => WaitOnCond(context));
+
+        // Signal repeatedly: a condition variable is an edge, so a signal delivered before the
+        // waiter has registered is correctly lost and has to be repeated.
+        var deadline = Environment.TickCount64 + 20_000;
+        var released = false;
+        while (!released && Environment.TickCount64 < deadline)
+        {
+            signalContext[CpuRegister.Rdi] = CondAddress;
+            KernelPthreadCompatExports.PthreadCondSignal(signalContext);
+            released = waiter.Wait(TimeSpan.FromMilliseconds(250));
+        }
+
+        Assert.True(released, "an ordinary signal never released the host park");
+
+        DestroyCondAndMutex(context);
+    }
+
+    /// <summary>
+    /// Slicing the park must not turn a finite timeout into a longer one: the deadline is
+    /// re-derived from the original timeout on every slice, so a slice expiring is not the
+    /// overall timeout.
+    /// </summary>
+    [Fact]
+    public void TimedHostCondWaitStillHonoursItsOverallDeadline()
+    {
+        var context = CreateContext();
+        InitializeCondAndMutex(context);
+        var scheduler = new DeliveryStubScheduler();
+
+        using var _ = new SchedulerScope(scheduler);
+        context[CpuRegister.Rdi] = CondAddress;
+        context[CpuRegister.Rsi] = MutexAddress;
+        context[CpuRegister.Rdx] = 300_000;
+
+        var elapsed = System.Diagnostics.Stopwatch.StartNew();
+        KernelPthreadCompatExports.PthreadCondTimedwait(context);
+        elapsed.Stop();
+
+        // The 300 ms request must not have been rounded up to anything near the slice-driven
+        // worst case, and must not have returned instantly either.
+        Assert.InRange(elapsed.Elapsed.TotalMilliseconds, 150, 5_000);
+
+        DestroyCondAndMutex(context);
+    }
+
+    private static int WaitOnCond(CpuContext template)
+    {
+        var context = new CpuContext(template.Memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = MutexAddress;
+        KernelPthreadCompatExports.PthreadMutexLock(context);
+
+        context[CpuRegister.Rdi] = CondAddress;
+        context[CpuRegister.Rsi] = MutexAddress;
+        return KernelPthreadCompatExports.PthreadCondWait(context);
+    }
+
+    private static CpuContext CreateContext() => new(new FakeCpuMemory(MemoryBase, 0x1000), Generation.Gen5);
+
+    private static void InitializeCondAndMutex(CpuContext context)
+    {
+        context[CpuRegister.Rdi] = MutexAddress;
+        context[CpuRegister.Rsi] = 0;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadMutexInit(context));
+
+        context[CpuRegister.Rdi] = CondAddress;
+        Assert.Equal(0, KernelPthreadCompatExports.PthreadCondInit(context));
+    }
+
+    private static void DestroyCondAndMutex(CpuContext context)
+    {
+        context[CpuRegister.Rdi] = CondAddress;
+        KernelPthreadCompatExports.PthreadCondDestroy(context);
+        context[CpuRegister.Rdi] = MutexAddress;
+        KernelPthreadCompatExports.PthreadMutexDestroy(context);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Pthread/PthreadRwlockExceptionDeliveryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Pthread/PthreadRwlockExceptionDeliveryTests.cs
@@ -1,0 +1,118 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using SharpEmu.Libs.Tests.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Pthread;
+
+/// <summary>
+/// The last of the four host-side parks a non-cooperative guest thread can stop in. Both rwlock
+/// waits were bare untimed <c>Monitor.Wait(rwlock.SyncRoot)</c> calls, so a thread parked in one
+/// could not run a kernel exception raised on it at all - the queue is only drained at an import
+/// boundary, and a thread parked inside this export never reaches one (#254).
+/// </summary>
+[Collection("GuestThreadSchedulerState")]
+public sealed class PthreadRwlockExceptionDeliveryTests
+{
+    private const ulong MemoryBase = 0x4_0000_0000;
+    private const ulong RwlockAddress = MemoryBase + 0x100;
+
+    /// <summary>
+    /// A writer parks behind a held read lock and is released only by the unlock the delivery hook
+    /// performs, so a build whose park never drops the gate to consult that hook fails on timeout.
+    /// </summary>
+    [Fact]
+    public void HostRwlockWriterParkRunsAKernelExceptionRaisedWhileItIsParked()
+    {
+        var context = CreateContext();
+        InitializeRwlock(context);
+        var scheduler = new DeliveryStubScheduler();
+
+        // Reader counts are per-thread, so the read lock has to be released by the same thread
+        // that took it. Park a dedicated one on the two events below.
+        using var releaseReader = new ManualResetEventSlim(false);
+        using var readerReleased = new ManualResetEventSlim(false);
+        using var readerHeld = new ManualResetEventSlim(false);
+        var readerThread = new Thread(() =>
+        {
+            var readerContext = CreateContext();
+            readerContext[CpuRegister.Rdi] = RwlockAddress;
+            if (KernelPthreadExtendedCompatExports.PthreadRwlockRdlock(readerContext) != 0)
+            {
+                return;
+            }
+
+            readerHeld.Set();
+            releaseReader.Wait(TimeSpan.FromSeconds(25));
+            readerContext[CpuRegister.Rdi] = RwlockAddress;
+            KernelPthreadExtendedCompatExports.PthreadRwlockUnlock(readerContext);
+            readerReleased.Set();
+        })
+        {
+            IsBackground = true,
+        };
+        readerThread.Start();
+        Assert.True(readerHeld.Wait(TimeSpan.FromSeconds(10)), "the read lock was never taken");
+
+        // Release it from the delivery hook. The unlock runs on the reader thread, so if the
+        // parked writer still held rwlock.SyncRoot when it called us, that thread could not enter
+        // PthreadRwlockUnlock and this wait would time out.
+        scheduler.OnDeliver = () =>
+        {
+            releaseReader.Set();
+            scheduler.SignalCompleted = readerReleased.Wait(TimeSpan.FromSeconds(10));
+        };
+
+        using var _ = new SchedulerScope(scheduler);
+        var writer = Task.Run(() => WriteLock(context));
+
+        Assert.True(writer.Wait(TimeSpan.FromSeconds(20)), "the parked rwlock writer was never released");
+        Assert.Equal(0, writer.Result);
+        Assert.True(scheduler.DeliverCalls > 0, "the park never offered to run a queued exception");
+        Assert.True(scheduler.SignalCompleted, "the handler ran while the rwlock gate was held");
+
+        DestroyRwlock(context);
+    }
+
+    [Fact]
+    public void AnUncontendedRwlockAcquireNeverConsultsTheDeliveryHook()
+    {
+        var context = CreateContext();
+        InitializeRwlock(context);
+        var scheduler = new DeliveryStubScheduler();
+
+        using var _ = new SchedulerScope(scheduler);
+        context[CpuRegister.Rdi] = RwlockAddress;
+        Assert.Equal(0, KernelPthreadExtendedCompatExports.PthreadRwlockWrlock(context));
+        Assert.Equal(0, scheduler.DeliverCalls);
+
+        context[CpuRegister.Rdi] = RwlockAddress;
+        KernelPthreadExtendedCompatExports.PthreadRwlockUnlock(context);
+        DestroyRwlock(context);
+    }
+
+    private static int WriteLock(CpuContext template)
+    {
+        var context = new CpuContext(template.Memory, Generation.Gen5);
+        context[CpuRegister.Rdi] = RwlockAddress;
+        return KernelPthreadExtendedCompatExports.PthreadRwlockWrlock(context);
+    }
+
+    private static CpuContext CreateContext() => new(new FakeCpuMemory(MemoryBase, 0x1000), Generation.Gen5);
+
+    private static void InitializeRwlock(CpuContext context)
+    {
+        context[CpuRegister.Rdi] = RwlockAddress;
+        context[CpuRegister.Rsi] = 0;
+        Assert.Equal(0, KernelPthreadExtendedCompatExports.PthreadRwlockInit(context));
+    }
+
+    private static void DestroyRwlock(CpuContext context)
+    {
+        context[CpuRegister.Rdi] = RwlockAddress;
+        KernelPthreadExtendedCompatExports.PthreadRwlockDestroy(context);
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

#254 — Unity/IL2CPP titles that boot fine and then hang forever in a GC, with the reported thread shape: helpers parked on work semaphores, the coordinator on `SuspendSemaphore`, the main thread on `sceKernelWaitSema:Baselib_SystemSemaphore`.

The cause isn't the semaphores. It's that **a thread parked in a host-thread wait can never receive a kernel exception**, so it can never acknowledge a suspend request.

`TryRaiseGuestException` deliberately does not deliver when the target is a primary/external executor — running the handler concurrently on another managed thread would corrupt that executor's control state. It queues instead, and the comment states the assumption:

```
// A primary/external executor is already running guest code on its
// own host thread. ... Queue the request and let that exact executor
// consume it at its next HLE boundary, where the original guest thread
// is safely paused.
```

That assumption doesn't hold for a blocking wait. `RequestCurrentThreadBlock` returns `false` unless `IsGuestThread`, and `IsGuestThread` is `_currentGuestThreadHandle != 0`, which only `EnterGuestThread` sets. The primary executor reaches guest code through `ExecuteEntry` → `CallNativeEntry` and never calls it — it is registered as an *external* thread by `RegisterGuestThreadContext` instead. So the wait falls through to the host-side park, which sits in `Monitor.Wait` **inside** the import handler. The safe points that drain the queue are on the far side of the export that is parked.

IL2CPP suspends every thread by raising on it and waiting for the handler's acknowledgement. Main cannot answer → the collector never signals the worker semaphores → nothing moves again.

## What changed

- **`IGuestThreadScheduler`** gains `TryDeliverPendingGuestException(CpuContext)`. `DirectExecutionBackend` is the only implementer.
- **`DirectExecutionBackend`** answers it: early-out on the existing `_pendingGuestExceptionCount` volatile so the common case takes no lock, resolve the caller exactly the way the import safe point does (`CurrentGuestThreadHandle`, falling back to `_currentExternalGuestThreadHandle`), confirm the queued exception belongs to *this* thread — the count is process-wide — then run it through the existing `DeliverPendingGuestExceptionAtSafePoint`.
- **`WaitSemaphoreOnHostThread`** takes the gate per attempt instead of holding it across the whole park, and calls the hook between attempts.
- **`PthreadCondWaitCore`**'s non-cooperative park does the same. It needed it more: the untimed branch was a bare `Monitor.Wait(state.SyncRoot)` with **no timeout at all**, so a thread parked there could not be reached even in principle. Unity blocks on condition variables as readily as on semaphores, so fixing only the semaphore would have left the same hang reachable through a different primitive.
- **`KernelWaitEventFlag`**'s host park needed nothing restructured: it already leaves `state.Gate` every tick to pump the scheduler, so the delivery call simply joins the pump inside that existing window.
- **`PthreadRwlockLockCore`**'s two parks (reader and writer) were also bare untimed `Monitor.Wait(rwlock.SyncRoot)` calls. Bounded the same way, pumping off the gate only when a slice expires, so a heavily-pulsed rwlock does not pay for it on the contended path.

Releasing the lock is load-bearing, not incidental: the handler is guest code and signals synchronisation objects of its own — in the collector's case, ones other threads are parked on through this same path. Running it under `semaphore.Gate` / `state.SyncRoot` / `state.Gate` / `rwlock.SyncRoot` would trade one deadlock for another.

## On safety

**Guest-visible results are unchanged.** Every converted wait still returns `ORBIS_GEN2_OK` when satisfied and times out exactly as before. I deliberately did not introduce an `EINTR`-style code: that would require every caller to retry correctly, which I cannot verify, and a title that does not use this mechanism would then observe a change in behaviour. As written, a title that never raises a kernel exception cannot tell this patch is present.

Two details make the per-slice locking safe:

- The semaphore re-checks `Count` under the gate at the top of every attempt, so a token posted while the gate is released is observed on the next pass rather than lost.
- The timed condvar branch re-derives its remaining time from the original deadline on every slice, so a slice expiring is never mistaken for the overall timeout and the caller's requested duration is preserved.

**Not included on purpose:** `sceKernelSuspendScheduler` / `sceKernelResumeScheduler`, which the issue floats as a possible cause. Neither NID appears in `scripts/ps5_names.txt` or the aerolib catalog, so the export is unverified; and returning fake success from it would tell IL2CPP that every thread is suspended when none is, which is worse than the hang. Two earlier PRs took that route and were closed.

## Testing

**N/A** — I do not have Arcade Game Zone (PPSA19015) or another IL2CPP title to run, and I would rather say so than imply otherwise.

What I can show is that the deadlock is now reproducible and fixed *as a unit test*. All four suites drive the real exports against a stub scheduler, with no CPU backend and no guest image.

`KernelSemaphoreExceptionDeliveryTests.cs` (new, 4 tests):

- **`HostThreadWaitRunsAKernelExceptionRaisedWhileItIsParked`** — the headline. A waiter parks with no tokens available and is released *only* by work the delivery hook performs. The hook posts the token **from another thread**, which is the point: if the waiter still held `semaphore.Gate`, that thread could not enter `KernelSignalSema` and the join would time out. This proves both that the hook is reached and that the gate is released around it.
- `OrdinarySignalStillWakesTheHostThreadWaitAndConsumesOneToken` — the hook is an addition, not a replacement.
- `HostThreadWaitStillTimesOutAndWritesBackTheRemainingTimeout` — timeout path and write-back untouched.
- `AnImmediatelySatisfiableWaitNeverConsultsTheDeliveryHook` — an uncontended acquire pays nothing.

`PthreadCondExceptionDeliveryTests.cs` (new, 3 tests): the same headline shape for the condvar park, an ordinary-signal non-regression, and a check that a 300 ms `pthread_cond_timedwait` still honours its overall deadline rather than being stretched by the slicing.

`KernelEventFlagExceptionDeliveryTests.cs` (new, 2 tests): the headline shape again for the event-flag park, plus a check that an already-satisfied wait never consults the hook.

`PthreadRwlockExceptionDeliveryTests.cs` (new, 2 tests): a writer parked behind a held read lock, released only by the hook, plus an uncontended-acquire check. Reader counts are per-thread, so the read lock is released by the thread that took it - which still proves the gate is dropped, since that thread could not enter `PthreadRwlockUnlock` otherwise.

All four headline tests are load-bearing. Reverting the corresponding source file and re-running gives, respectively:

```
Error Message:
 the parked wait was never released

Error Message:
 the parked condition wait was never released

Error Message:
 the parked event-flag wait was never released

Error Message:
 the parked rwlock writer was never released
```

which is #254's hang, in 20 seconds, on a machine with no PS5 game on it.

Verified as CI does, on Windows with .NET SDK 10.0.302:

```
dotnet build SharpEmu.slnx -c Release
dotnet test SharpEmu.slnx -c Release --no-build
```

`Build succeeded`, 900 tests pass, 0 failures (889 before this branch, +11 new).

## Scope

All four host-side parks a non-cooperative guest thread can stop in are now covered: semaphore, condition variable, event flag and rwlock. Three of them (condvar and both rwlock waits) were untimed, meaning a thread parked in them could not be reached even in principle.

Related: #588 fixes a different defect on the same delivery path — a nested handler consuming the interrupted import's pending block state. The two are independent and do not overlap in what they change; both are needed.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
