### PR TITLE
[GUI] Bound the pending console queue so a noisy title cannot exhaust memory (#619)

### DIFF
--- a/src/SharpEmu.GUI/ConsoleLineBuffer.cs
+++ b/src/SharpEmu.GUI/ConsoleLineBuffer.cs
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace SharpEmu.GUI;
+
+/// <summary>
+/// The hand-off between the threads that read the emulator's output and the UI timer that renders
+/// it.
+///
+/// The window drains a fixed number of lines per tick, so a title that logs faster than that
+/// outruns the display. Held in an unbounded queue the backlog is retained in full, even though
+/// the two lists it eventually feeds are both capped - which is how a title polling an unresolved
+/// import in a tight loop turns console output into tens of gigabytes of process memory and
+/// eventually an out-of-memory kill.
+///
+/// This bounds the backlog instead. Past capacity the oldest lines are dropped, because the newest
+/// output is the part worth keeping when a title is stuck, and the number dropped is counted so
+/// the gap can be shown rather than silently hidden.
+/// </summary>
+public sealed class ConsoleLineBuffer
+{
+    private readonly ConcurrentQueue<(string Line, bool IsError)> _lines = new();
+    private int _count;
+    private long _dropped;
+
+    public ConsoleLineBuffer(int capacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+        Capacity = capacity;
+    }
+
+    public int Capacity { get; }
+
+    /// <summary>Lines currently queued. Never exceeds <see cref="Capacity"/>.</summary>
+    public int Count => Volatile.Read(ref _count);
+
+    public bool IsEmpty => Count == 0;
+
+    public void Enqueue(string line, bool isError)
+    {
+        _lines.Enqueue((line, isError));
+        if (Interlocked.Increment(ref _count) <= Capacity)
+        {
+            return;
+        }
+
+        // Over capacity: make room by discarding from the front. Only account for a dequeue that
+        // actually removed something - the UI may have drained this line already, and in that
+        // case it has done the decrement itself.
+        if (_lines.TryDequeue(out _))
+        {
+            Interlocked.Decrement(ref _count);
+            Interlocked.Increment(ref _dropped);
+        }
+    }
+
+    public bool TryDequeue(out string line, out bool isError)
+    {
+        if (!_lines.TryDequeue(out var entry))
+        {
+            line = string.Empty;
+            isError = false;
+            return false;
+        }
+
+        Interlocked.Decrement(ref _count);
+        line = entry.Line;
+        isError = entry.IsError;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns how many lines have been dropped since the last call and resets the tally, so a
+    /// caller reports each drop exactly once.
+    /// </summary>
+    public long ExchangeDroppedCount() => Interlocked.Exchange(ref _dropped, 0);
+}

--- a/src/SharpEmu.GUI/MainWindow.axaml.cs
+++ b/src/SharpEmu.GUI/MainWindow.axaml.cs
@@ -22,7 +22,6 @@ using SharpEmu.HLE.Host;
 using SharpEmu.Libs.Pad;
 using SharpEmu.Libs.VideoOut;
 using SharpEmu.Logging;
-using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Reflection;
@@ -35,6 +34,12 @@ public partial class MainWindow : Window
 {
     private const int MaxConsoleLines = 4000;
     private const int MaxConsoleLinesPerFlush = 500;
+
+    // MaxConsoleLinesPerFlush every 80 ms is roughly 6k lines/second, and a title can emit far
+    // more than that, so the queue feeding the flush needs a ceiling of its own or it retains the
+    // entire overflow. About 40 flushes' worth: deep enough to ride out a burst without losing
+    // anything, small enough that a runaway logger costs a few megabytes instead of the process.
+    private const int MaxPendingConsoleLines = 20_000;
     private static readonly TimeSpan NavigationIndicatorAnimationDuration =
         TimeSpan.FromMilliseconds(180);
 
@@ -89,7 +94,7 @@ public partial class MainWindow : Window
     private readonly GameLibraryWatcher _libraryWatcher = new();
     private readonly AvaloniaList<LogLine> _consoleLines = new();
     private readonly List<LogLine> _allConsoleLines = new();
-    private readonly ConcurrentQueue<(string Line, bool IsError)> _pendingLines = new();
+    private readonly ConsoleLineBuffer _pendingLines = new(MaxPendingConsoleLines);
     private readonly DispatcherTimer _consoleFlushTimer;
 
     private GuiSettings _settings = new();
@@ -170,8 +175,7 @@ public partial class MainWindow : Window
         GameList.ItemsSource = _libraryTiles;
         _libraryWatcher.RefreshRequested += OnLibraryRefreshRequested;
         ConsoleList.ItemsSource = _consoleLines;
-        _consoleMirror = GuiConsoleMirror.Install((line, isError) =>
-            _pendingLines.Enqueue((line, isError)));
+        _consoleMirror = GuiConsoleMirror.Install(_pendingLines.Enqueue);
         _consoleFlushTimer = new DispatcherTimer
         {
             Interval = TimeSpan.FromMilliseconds(80),
@@ -2599,7 +2603,7 @@ public partial class MainWindow : Window
 
     private void OnEmulatorOutput(string line, bool isError)
     {
-        _pendingLines.Enqueue((line, isError));
+        _pendingLines.Enqueue(line, isError);
     }
 
     private void OpenFileLog(string? titleId)
@@ -2683,17 +2687,29 @@ public partial class MainWindow : Window
 
     private void FlushPendingConsoleLines()
     {
-        if (_pendingLines.IsEmpty)
+        var dropped = _pendingLines.ExchangeDroppedCount();
+        if (dropped == 0 && _pendingLines.IsEmpty)
         {
             return;
         }
 
         var incoming = new List<LogLine>();
-        while (incoming.Count < MaxConsoleLinesPerFlush &&
-               _pendingLines.TryDequeue(out var pending))
+        if (dropped > 0)
         {
-            WriteFileLog(pending.Line);
-            incoming.Add(new LogLine(pending.Line, BrushForLine(pending.Line)));
+            // What was dropped was the oldest still queued, so the notice belongs ahead of
+            // whatever survived. Recording the gap matters: without it a title that outruns the
+            // console looks like one that simply stopped logging.
+            var notice =
+                $"[GUI][WARN] Console output is arriving faster than it can be shown; dropped {dropped} line(s).";
+            WriteFileLog(notice);
+            incoming.Add(new LogLine(notice, BrushForLine(notice)));
+        }
+
+        while (incoming.Count < MaxConsoleLinesPerFlush &&
+               _pendingLines.TryDequeue(out var line, out _))
+        {
+            WriteFileLog(line);
+            incoming.Add(new LogLine(line, BrushForLine(line)));
         }
 
         FlushFileLog();

--- a/tests/SharpEmu.Libs.Tests/GUI/ConsoleLineBufferTests.cs
+++ b/tests/SharpEmu.Libs.Tests/GUI/ConsoleLineBufferTests.cs
@@ -1,0 +1,154 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.GUI;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.GUI;
+
+public sealed class ConsoleLineBufferTests
+{
+    [Fact]
+    public void EnqueueAndDequeuePreserveOrderAndTheErrorFlag()
+    {
+        var buffer = new ConsoleLineBuffer(capacity: 4);
+
+        buffer.Enqueue("first", isError: false);
+        buffer.Enqueue("second", isError: true);
+
+        Assert.Equal(2, buffer.Count);
+        Assert.True(buffer.TryDequeue(out var line, out var isError));
+        Assert.Equal("first", line);
+        Assert.False(isError);
+        Assert.True(buffer.TryDequeue(out line, out isError));
+        Assert.Equal("second", line);
+        Assert.True(isError);
+        Assert.False(buffer.TryDequeue(out _, out _));
+        Assert.True(buffer.IsEmpty);
+    }
+
+    /// <summary>
+    /// The point of the whole class: a producer that outruns the drain must cost a bounded amount
+    /// of memory rather than retaining everything it ever wrote.
+    /// </summary>
+    [Fact]
+    public void ProducerThatOutrunsTheDrainNeverExceedsCapacity()
+    {
+        var buffer = new ConsoleLineBuffer(capacity: 100);
+
+        for (var i = 0; i < 100_000; i++)
+        {
+            buffer.Enqueue($"line {i}", isError: false);
+            Assert.True(buffer.Count <= buffer.Capacity);
+        }
+
+        Assert.Equal(100, buffer.Count);
+    }
+
+    /// <summary>
+    /// Oldest-first, because the newest output is what someone watching a stuck title needs.
+    /// </summary>
+    [Fact]
+    public void OverflowDropsTheOldestLinesAndKeepsTheNewest()
+    {
+        var buffer = new ConsoleLineBuffer(capacity: 3);
+
+        buffer.Enqueue("a", isError: false);
+        buffer.Enqueue("b", isError: false);
+        buffer.Enqueue("c", isError: false);
+        buffer.Enqueue("d", isError: false);
+        buffer.Enqueue("e", isError: false);
+
+        Assert.Equal(3, buffer.Count);
+        Assert.True(buffer.TryDequeue(out var line, out _));
+        Assert.Equal("c", line);
+        Assert.True(buffer.TryDequeue(out line, out _));
+        Assert.Equal("d", line);
+        Assert.True(buffer.TryDequeue(out line, out _));
+        Assert.Equal("e", line);
+    }
+
+    [Fact]
+    public void DroppedCountIsReportedOnceAndThenReset()
+    {
+        var buffer = new ConsoleLineBuffer(capacity: 2);
+
+        buffer.Enqueue("a", isError: false);
+        buffer.Enqueue("b", isError: false);
+        Assert.Equal(0, buffer.ExchangeDroppedCount());
+
+        buffer.Enqueue("c", isError: false);
+        buffer.Enqueue("d", isError: false);
+
+        Assert.Equal(2, buffer.ExchangeDroppedCount());
+        Assert.Equal(0, buffer.ExchangeDroppedCount());
+    }
+
+    [Fact]
+    public void NothingIsDroppedWhileTheDrainKeepsUp()
+    {
+        var buffer = new ConsoleLineBuffer(capacity: 2);
+
+        for (var i = 0; i < 1_000; i++)
+        {
+            buffer.Enqueue($"line {i}", isError: false);
+            Assert.True(buffer.TryDequeue(out var line, out _));
+            Assert.Equal($"line {i}", line);
+        }
+
+        Assert.Equal(0, buffer.ExchangeDroppedCount());
+        Assert.True(buffer.IsEmpty);
+    }
+
+    /// <summary>
+    /// Production has several writers (the emulator's stdout and stderr readers, plus the mirrored
+    /// in-process console) against one drain, so the bookkeeping has to survive that. A negative or
+    /// over-capacity Count here would mean the counter had drifted from the queue.
+    /// </summary>
+    [Fact]
+    public async Task CountStaysConsistentUnderConcurrentProducersAndOneConsumer()
+    {
+        var buffer = new ConsoleLineBuffer(capacity: 64);
+        using var stop = new CancellationTokenSource();
+        var consumed = 0;
+
+        var producers = Enumerable.Range(0, 4).Select(producer => Task.Run(() =>
+        {
+            for (var i = 0; i < 20_000; i++)
+            {
+                buffer.Enqueue($"p{producer}:{i}", isError: false);
+            }
+        })).ToArray();
+
+        var consumer = Task.Run(() =>
+        {
+            while (!stop.Token.IsCancellationRequested)
+            {
+                while (buffer.TryDequeue(out _, out _))
+                {
+                    consumed++;
+                }
+            }
+        });
+
+        await Task.WhenAll(producers);
+        stop.Cancel();
+        await consumer;
+
+        while (buffer.TryDequeue(out _, out _))
+        {
+            consumed++;
+        }
+
+        Assert.True(buffer.IsEmpty);
+        Assert.Equal(0, buffer.Count);
+        // Every line either reached the consumer or was counted as dropped; none vanished.
+        Assert.Equal(4 * 20_000, consumed + buffer.ExchangeDroppedCount());
+    }
+
+    [Fact]
+    public void CapacityMustBePositive()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ConsoleLineBuffer(capacity: 0));
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

Part of #619 — the unbounded host memory growth reported on Demon's Souls (17 GB → 40.9 GB in one session).

The issue frames this as "each retry appears to allocate", and the two open PRs on it attack that side: #694 samples the repeated warnings, #704 caches the `Missing HLE export for NID:` string. Both are worth having. But in the CLI process those log strings are transient garbage — nothing retains them — so neither explains growth into the tens of gigabytes.

The retention is in the GUI, in the hand-off between the threads reading the emulator child process's output and the timer that renders it:

```csharp
private readonly ConcurrentQueue<(string Line, bool IsError)> _pendingLines = new();
```

`FlushPendingConsoleLines` drains at most `MaxConsoleLinesPerFlush` (500) per tick, and the tick is 80 ms — about **6,000 lines a second**. Both lists that queue eventually feeds are capped at `MaxConsoleLines` (4,000). The queue itself was not capped at all, so anything produced faster than 6k lines/s accumulated in full, indefinitely. #619's own trace shows the import counter past 73 million dispatches in one session, which is orders of magnitude past what the console can draw.

That is the part that grows without bound, and it is independent of *why* the emulator is noisy: rate-limiting today's noisiest path leaves the same failure reachable from the next one.

## What changed

- **`ConsoleLineBuffer`** (new) — the queue with a ceiling. Past capacity it drops from the front and counts what it dropped. Oldest-first because the newest output is the part worth keeping when a title is stuck.
- **`MainWindow`** uses it with a capacity of 20,000 lines (~40 flushes' worth — deep enough to ride out a burst without losing anything, small enough that a runaway logger costs a few megabytes instead of the process), and emits one notice per flush when lines were dropped:

```
[GUI][WARN] Console output is arriving faster than it can be shown; dropped N line(s).
```

Recording the gap matters. Silently discarding output would make a title that outruns the console look like one that simply stopped logging, which is exactly the wrong signal when someone is diagnosing a hang.

The logic moved out of `MainWindow` into its own class rather than staying inline, matching how `GameLibraryReconciler`, `GameLibraryWatcher` and `LibraryTileCollection` are already factored — that is what makes it directly testable.

**Known trade-off, stated plainly:** dropped lines do not reach the file log either, since `WriteFileLog` is called from the flush. The alternative is unbounded memory, and the notice records exactly how many were lost and where. If maintainers would rather the file log stay complete, writing it from the reader thread instead of the flush would do it, but that is a bigger change than this one and I did not want to fold it in.

## Testing

**N/A** — this is GUI plumbing; there is no title-specific behaviour to report.

`ConsoleLineBufferTests.cs` (new, 7 tests) covers the behaviour directly:

- order and the error flag survive a round trip
- **a producer that outruns the drain never exceeds capacity** — 100,000 enqueues against a capacity of 100, asserting the bound holds on every single one. This is the assertion that fails on current `main`'s unbounded queue and is the whole point of the change.
- overflow drops the *oldest* and keeps the newest
- the dropped tally is reported once and then resets, so a flush cannot double-count it
- nothing is dropped while the drain keeps up
- the count stays consistent under 4 concurrent producers against 1 consumer (80,000 lines), with every line either consumed or counted as dropped and none unaccounted for — production really does have several writers against one drain
- capacity must be positive

Verified as CI does, on Windows with .NET SDK 10.0.302:

```
dotnet build SharpEmu.slnx -c Release
dotnet test SharpEmu.slnx -c Release --no-build
```

`Build succeeded`, 896 tests pass, 0 failures (889 before this branch, +7 new).

## Relationship to the other #619 PRs

Complementary, not overlapping. #694 and #704 reduce how many lines get written; this bounds what is retained when something still writes faster than the UI can draw them. All three can land independently — they touch different files and neither of the others caps the queue.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
