### PR TITLE
[CPU] Fix REX.B on the VEH spinlock compare-exchange (#779)

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -2929,7 +2929,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int hostPauseJump = offset;
 		EmitUInt32(code, ref offset, 0u);
-		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4C);
+		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4D);
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0xB1); EmitByte(code, ref offset, 0x11); // lock cmpxchg [r9], r10
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int hostRetryJump = offset;
@@ -3012,7 +3012,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int guestPauseJump = offset;
 		EmitUInt32(code, ref offset, 0u);
-		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4C);
+		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4D);
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0xB1); EmitByte(code, ref offset, 0x11);
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int guestRetryJump = offset;

--- a/tests/SharpEmu.Libs.Tests/Cpu/VehTrampolineSpinlockEncodingTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/VehTrampolineSpinlockEncodingTests.cs
@@ -1,0 +1,100 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Iced.Intel;
+using SharpEmu.Core.Cpu.Native;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+/// <summary>
+/// The VEH trampoline is hand-emitted machine code, so a wrong bit in a REX prefix is a silent
+/// hang rather than a compile error. The recursive managed-entry spinlock addressed its lock word
+/// through <c>[rcx]</c> instead of <c>[r9]</c> because REX.B was clear, and in a vectored handler
+/// <c>rcx</c> is the <c>EXCEPTION_POINTERS*</c> argument - so the compare-exchange tested the
+/// exception-record pointer against the free-lock value, never matched, and spun forever with the
+/// managed handler never entered.
+///
+/// These decode the bytes the emitter actually produces rather than asserting on the source, so
+/// the guarantee survives any future re-ordering of the emission code.
+/// </summary>
+public sealed unsafe class VehTrampolineSpinlockEncodingTests
+{
+    [Fact]
+    public void EmittedSpinlockCompareExchangesAgainstTheLockRegisterNotTheHandlerArgument()
+    {
+        if (!OperatingSystem.IsWindows() ||
+            RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            return;
+        }
+
+        var exchanges = DecodeTrampoline()
+            .Where(instruction => instruction.Mnemonic == Mnemonic.Cmpxchg)
+            .ToArray();
+
+        Assert.NotEmpty(exchanges);
+        foreach (var exchange in exchanges)
+        {
+            // The lock pointer is held in r9 for the whole acquire sequence.
+            Assert.Equal(OpKind.Memory, exchange.Op0Kind);
+            Assert.Equal(Register.R9, exchange.MemoryBase);
+            Assert.Equal(Register.R10, exchange.Op1Register);
+            Assert.True(exchange.HasLockPrefix, "the acquire must be atomic");
+        }
+    }
+
+    /// <summary>
+    /// Pins the specific encoding, so the failure message names the defect if it ever returns.
+    /// </summary>
+    [Theory]
+    [InlineData(new byte[] { 0xF0, 0x4D, 0x0F, 0xB1, 0x11 }, "R9")]
+    [InlineData(new byte[] { 0xF0, 0x4C, 0x0F, 0xB1, 0x11 }, "RCX")]
+    public void RexBSelectsWhichRegisterTheCompareExchangeAddresses(byte[] encoding, string expectedBase)
+    {
+        var decoder = Decoder.Create(64, encoding);
+        var instruction = decoder.Decode();
+
+        Assert.Equal(Mnemonic.Cmpxchg, instruction.Mnemonic);
+        Assert.Equal(expectedBase, instruction.MemoryBase.ToString());
+    }
+
+    /// <summary>
+    /// Builds a trampoline the way SetupExceptionHandler does. The constructor is skipped - it
+    /// installs process-wide handlers - and only the fields the emitter reads are supplied.
+    /// </summary>
+    private static Instruction[] DecodeTrampoline()
+    {
+        var backend = RuntimeHelpers.GetUninitializedObject(typeof(DirectExecutionBackend));
+        SetField(backend, "_vehManagedEntryLock", (nint)0x1000);
+        SetField(backend, "_hostRspSlotTlsIndex", uint.MaxValue);
+
+        var create = typeof(DirectExecutionBackend).GetMethod(
+            "CreateExceptionHandlerTrampoline",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var trampoline = (nint)create.Invoke(backend, [(nint)0x2000])!;
+        Assert.NotEqual((nint)0, trampoline);
+
+        // The emitter seals the page execute-read; re-open it so the decoder can read the bytes.
+        var code = new byte[2048];
+        Marshal.Copy(trampoline, code, 0, code.Length);
+
+        var decoder = Decoder.Create(64, code);
+        decoder.IP = (ulong)trampoline;
+        var decoded = new List<Instruction>();
+        while (decoder.IP - (ulong)trampoline < (ulong)code.Length)
+        {
+            decoded.Add(decoder.Decode());
+        }
+
+        return [.. decoded];
+    }
+
+    private static void SetField(object target, string name, object value) =>
+        typeof(DirectExecutionBackend)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(target, value);
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

#779 — every guest fault hangs the emulator at 100% CPU with no vectored handler entered and nothing logged.

**Two bytes.** The recursive managed-entry spinlock in the VEH trampoline emits:

```
F0 4C 0F B1 11
```

for what the comment on the very same line calls `lock cmpxchg [r9], r10`.

REX `0x4C` is `W=1 R=1 X=0 B=0`. With **REX.B clear**, ModRM `0x11` (`mod=00 rm=001`) addresses **`[rcx]`**, not `[r9]`. And in a vectored exception handler, `rcx` is the `EXCEPTION_POINTERS*` argument.

So the acquire did this:

```asm
mov  rax, [r9]        ; rax = lock owner  (0 when free)
cmp  rax, r10
je   mine
test rax, rax
jnz  pause            ; owner != 0 -> spin
lock cmpxchg [rcx], r10   ; <-- compares the EXCEPTION_POINTERS* against 0
jnz  retry            ; never equal -> always retry
```

It compared the exception-record pointer against the free-lock value, never matched, and jumped back to the top of the spin loop. Forever.

**The lock could therefore never be acquired, on any host.** Not a race, not timing — deterministic. No fault ever reached the managed handler, so every guest exception became a silent 100% CPU hang. That takes out everything built on `VectoredHandler`: unresolved-import sentinels, lazily-committed page demand-paging, the guest-allocator hole recovery, and the BMI/ABM and SSE4a instruction fallbacks.

REX.B belongs set, so the prefix is `0x4D`. Every other `[r9]` reference in the sequence already encodes it correctly — `mov rax, [r9]` is `49 8B 01`, `dec dword [r9+8]` is `41 FF 49 08`, `mov qword [r9], 0` is `49 C7 01 …`. This was the one that did not, in both the host-stack and guest-stack copies of the acquire.

## How I found it

Both handlers were instrumented with unconditional entry counters and never fired once, which ruled out the managed side. CET was ruled out by `Get-ProcessMitigation` (the mitigated child correctly reports `UserShadowStack: OFF`), and an uninitialised lock was ruled out by logging the pointer at build time (valid, `owner=0 depth=0`).

That left the emitted trampoline. Rather than reach for a debugger I emitted flag-preserving counter bumps at eight points inside the trampoline itself and read them back from the stall watchdog:

```
entry=2  host-path=1  host-lock=0  host-returned=0
         guest-path=1 guest-stack-switched=1  guest-lock=0  guest-returned=0
lock owner=0x0 depth=0
```

Both paths reach the acquire and neither gets past it, **while the lock is free**. That is impossible for a correct spinlock and pointed straight at the compare-exchange. The probes were removed; only the two-byte fix remains.

## Testing

**N/A** for game testing — I have no PS5 title. But this one is directly measurable with a 2-byte guest, and the before/after is unambiguous.

Using a synthetic bare ELF whose entire payload is `ud2`:

```
before:  [LOADER][INFO] Calling guest entry...
         <nothing, ~100% of one core, forever>

after:   [LOADER][INFO] NATIVE EXCEPTION CAUGHT!
         [LOADER][INFO]   Code: 0xC000001D
         [LOADER][INFO]   Exception Address: 0x0000000800001000
```

Across four synthetic guests on an Intel i7-11370H / Windows 11:

| guest | before | after |
|---|---|---|
| `xor eax,eax ; ret` | returns cleanly | returns cleanly (unchanged) |
| `ud2` | hangs at 100% CPU | fault reported, `0xC000001D` |
| `mov rax,[0] ; ret` | hangs at 100% CPU | fault reported, `0xC0000005` |
| `extrq xmm1, xmm2` | hangs at 100% CPU | fault reported, `0xC000001D` |

`VehTrampolineSpinlockEncodingTests.cs` (new, 3 tests) locks this down by **decoding the bytes the emitter actually produces** rather than asserting on the source, so the guarantee survives any re-ordering of the emission code:

- every `cmpxchg` in the emitted trampoline addresses `[r9]`, exchanges `r10`, and carries a `LOCK` prefix
- a theory pinning both encodings, so the failure message names the defect: `F0 4D 0F B1 11` → base `R9`, `F0 4C 0F B1 11` → base `RCX`

Confirmed load-bearing: reverting the two bytes and re-running fails with `Assert.Equal() Failure: Values differ`.

Verified as CI does, on Windows with .NET SDK 10.0.302:

```
dotnet build SharpEmu.slnx -c Release
dotnet test SharpEmu.slnx -c Release --no-build
```

`Build succeeded`, 892 tests pass, 0 failures (889 before this branch, +3 new).

## Scope

Deliberately just the two bytes plus the test.

**Correction to an earlier revision of this description.** I first wrote that `SHARPEMU_SENTINEL_PROBE=1` still hung after this fix, implying a second defect in `TryRecoverUnresolvedSentinel`. That was wrong, and I want it struck rather than left to send someone chasing a ghost. I had grepped the output for a couple of strings, seen neither, and inferred a hang without checking the exit code or the elapsed time. Measured properly, the probe now terminates in 3-4 seconds, deterministically across runs:

```
[LOADER][INFO] Running unresolved sentinel probe...
[LOADER][TRACE] VEH_AV first-chance at 0x000000000000FFFE type=8 target=0x000000000000FFFE
[LOADER][INFO] NATIVE EXCEPTION CAUGHT!
[LOADER][INFO]   Code: 0xC0000005
[LOADER][INFO]   Exception Address: 0x000000000000FFFE
```

It reaches the managed handler, prints full diagnostics, and fails fast with a clean managed stack trace. Before this fix it spun at 100% CPU with none of that. **So this PR fixes all of #779, not half of it.**

The probe never prints its own `Sentinel probe returned.` line, but that looks correct rather than defective: it calls address `0xFFFE` from *managed* code, and the sentinel recovery searches the stack for a plausible *guest* return address, finds none on a managed stack, and properly declines. The probe is a self-test written for a guest-side sentinel, so it is arguably just unsuited to being invoked that way. I am flagging that as an observation, not proposing a change.

I would not want this merged on my say-so alone — the reasoning above is checkable against the AMD64 encoding rules in a couple of minutes, and I would rather a maintainer confirm the REX.B reading independently before it lands.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
