### PR TITLE
[CPU] Preserve the guest exit code across the TLS lookup in the return stub

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -2406,10 +2406,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 		byte* code = (byte*)ptr;
 		int offset = 0;
-		EmitByte(code, ref offset, 0x48); // sub rsp, 0x20
+		// The guest reaches this stub by returning, so rax still holds its exit code and has to
+		// survive to the ret at the bottom: ExecuteEntry reads it as the entry's result, and the
+		// TBB fault path sets CONTEXT.Rax = 0 before redirecting here so the unwind reads as a
+		// clean 0. TlsGetValue returns in rax, so park the guest value across the call and route
+		// the slot pointer through r10 - the same reason the entry-stub epilogue uses r10 rather
+		// than rax for its identical stack switch.
+		EmitByte(code, ref offset, 0x50); // push rax (guest exit code)
+		EmitByte(code, ref offset, 0x48); // sub rsp, 0x28
 		EmitByte(code, ref offset, 0x83);
 		EmitByte(code, ref offset, 0xEC);
-		EmitByte(code, ref offset, 0x20);
+		EmitByte(code, ref offset, 0x28);
 		EmitByte(code, ref offset, 0xB9); // mov ecx, tlsIndex
 		EmitUInt32(code, ref offset, _hostRspSlotTlsIndex);
 		EmitByte(code, ref offset, 0x48); // mov rax, TlsGetValue
@@ -2418,13 +2425,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		offset += sizeof(ulong);
 		EmitByte(code, ref offset, 0xFF); // call rax
 		EmitByte(code, ref offset, 0xD0);
-		EmitByte(code, ref offset, 0x48); // add rsp, 0x20
+		EmitByte(code, ref offset, 0x48); // add rsp, 0x28
 		EmitByte(code, ref offset, 0x83);
 		EmitByte(code, ref offset, 0xC4);
-		EmitByte(code, ref offset, 0x20);
-		EmitByte(code, ref offset, 0x48); // mov rsp, [rax]
+		EmitByte(code, ref offset, 0x28);
+		EmitByte(code, ref offset, 0x4C); // mov r10, [rax]
 		EmitByte(code, ref offset, 0x8B);
-		EmitByte(code, ref offset, 0x20);
+		EmitByte(code, ref offset, 0x10);
+		EmitByte(code, ref offset, 0x58); // pop rax (restore the guest exit code)
+		EmitByte(code, ref offset, 0x4C); // mov rsp, r10
+		EmitByte(code, ref offset, 0x89);
+		EmitByte(code, ref offset, 0xD4);
 		EmitHostNonvolatileXmmRestore(code, ref offset);
 		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5F);
 		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5E);

--- a/tests/SharpEmu.Libs.Tests/Cpu/GuestReturnStubEncodingTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/GuestReturnStubEncodingTests.cs
@@ -1,0 +1,164 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Iced.Intel;
+using SharpEmu.Core.Cpu.Native;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+/// <summary>
+/// The guest return stub is hand-emitted, so nothing type-checks which register holds what across
+/// the TLS lookup it performs. A guest reaches this stub by returning, so rax carries its exit
+/// code — and <c>TlsGetValue</c> returns in rax too. Calling it without parking the guest value
+/// first replaced a clean exit with the address of the host-RSP slot.
+///
+/// These decode the bytes the emitter actually produces, so the guarantee survives the emission
+/// code being re-ordered.
+/// </summary>
+public sealed unsafe class GuestReturnStubEncodingTests
+{
+    private const int StubSize = 256;
+
+    [Fact]
+    public void GuestExitCodeInRaxSurvivesTheTlsLookup()
+    {
+        if (!IsSupportedHost)
+        {
+            return;
+        }
+
+        var decoded = DecodeGuestReturnStub();
+
+        var lastCall = LastIndexOf(decoded, i => i.Mnemonic == Mnemonic.Call);
+        Assert.True(lastCall >= 0, "the stub is expected to call TlsGetValue");
+
+        // rax is volatile and holds TlsGetValue's result the moment that call returns, so
+        // something after it has to put the guest's value back.
+        var raxRestore = LastIndexOf(decoded, i =>
+            i.Mnemonic == Mnemonic.Pop && i.Op0Register == Register.RAX);
+        Assert.True(
+            raxRestore > lastCall,
+            "rax must be restored after the last call, otherwise the guest exit code is lost");
+    }
+
+    /// <summary>
+    /// The stack switch has to read the slot through a scratch register rather than rax, matching
+    /// what the entry-stub epilogue already does with r10 for the same switch.
+    /// </summary>
+    [Fact]
+    public void StackSwitchDoesNotDereferenceRax()
+    {
+        if (!IsSupportedHost)
+        {
+            return;
+        }
+
+        var switches = DecodeGuestReturnStub()
+            .Where(i => i.Mnemonic == Mnemonic.Mov && i.Op0Kind == OpKind.Register && i.Op0Register == Register.RSP)
+            .ToArray();
+
+        Assert.NotEmpty(switches);
+        Assert.All(switches, i => Assert.NotEqual(Register.RAX, i.MemoryBase));
+    }
+
+    /// <summary>
+    /// Win64 requires RSP ≡ 0 (mod 16) at every call instruction. The stub is entered by a guest
+    /// <c>ret</c>, so entry RSP is 16-aligned; walking the stack deltas keeps the added push/pop
+    /// from silently changing the phase the original frame established.
+    /// </summary>
+    [Fact]
+    public void EveryCallIsMadeOnASixteenByteAlignedStack()
+    {
+        if (!IsSupportedHost)
+        {
+            return;
+        }
+
+        long delta = 0;
+        foreach (var instruction in DecodeGuestReturnStub())
+        {
+            switch (instruction.Mnemonic)
+            {
+                case Mnemonic.Call:
+                    Assert.True(
+                        ((delta % 16) + 16) % 16 == 0,
+                        $"stack is misaligned by {((delta % 16) + 16) % 16} bytes at the call");
+                    break;
+                case Mnemonic.Push:
+                    delta -= 8;
+                    break;
+                case Mnemonic.Pop:
+                    delta += 8;
+                    break;
+                case Mnemonic.Sub when instruction.Op0Register == Register.RSP:
+                    delta -= (long)instruction.GetImmediate(1);
+                    break;
+                case Mnemonic.Add when instruction.Op0Register == Register.RSP:
+                    delta += (long)instruction.GetImmediate(1);
+                    break;
+                case Mnemonic.Ret:
+                    return;
+            }
+        }
+    }
+
+    private static bool IsSupportedHost =>
+        OperatingSystem.IsWindows() && RuntimeInformation.ProcessArchitecture == Architecture.X64;
+
+    private static int LastIndexOf(Instruction[] instructions, Func<Instruction, bool> predicate)
+    {
+        for (var i = instructions.Length - 1; i >= 0; i--)
+        {
+            if (predicate(instructions[i]))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Builds the stub the way the backend initializer does. The constructor is skipped — it
+    /// installs process-wide handlers — and only the two fields the emitter reads are supplied.
+    /// </summary>
+    private static Instruction[] DecodeGuestReturnStub()
+    {
+        var backend = RuntimeHelpers.GetUninitializedObject(typeof(DirectExecutionBackend));
+        SetField(backend, "_hostRspSlotTlsIndex", 7u);
+        SetField(backend, "_tlsGetValueAddress", (nint)0x1234_5678);
+
+        var create = typeof(DirectExecutionBackend).GetMethod(
+            "CreateGuestReturnStub",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var stub = (nint)create.Invoke(backend, null)!;
+        Assert.NotEqual((nint)0, stub);
+
+        var code = new byte[StubSize];
+        Marshal.Copy(stub, code, 0, code.Length);
+
+        var decoder = Decoder.Create(64, code);
+        decoder.IP = (ulong)stub;
+        var decoded = new List<Instruction>();
+        while (decoder.IP - (ulong)stub < (ulong)code.Length)
+        {
+            var instruction = decoder.Decode();
+            decoded.Add(instruction);
+            if (instruction.Mnemonic == Mnemonic.Ret)
+            {
+                break;
+            }
+        }
+
+        return [.. decoded];
+    }
+
+    private static void SetField(object target, string name, object value) =>
+        typeof(DirectExecutionBackend)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(target, value);
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

A guest reaches `CreateGuestReturnStub` by **returning**, so `rax` carries its exit code. The stub's first act is to find the host-RSP slot with `TlsGetValue` — which also returns in `rax` — and nothing between that call and the final `ret` puts the guest's value back:

```asm
sub  rsp, 0x20
mov  ecx, tlsIndex
mov  rax, TlsGetValue
call rax              ; <-- rax is now the slot pointer; the guest's exit code is gone
add  rsp, 0x20
mov  rsp, [rax]
<restore xmm non-volatiles>
pop r15 … pop rbx
ret                   ; returns the slot pointer
```

So anything unwinding through this stub reports the address of the host-RSP storage cell instead of what the guest returned.

**This is not a fault-only path.** `TryCompleteGuestEntryToHostStub` (`DirectExecutionBackend.Imports.cs`) patches the active return slot and `argPack+96` to `ActiveEntryReturnSentinelRip`, which is set to `_guestReturnStub`. An entry that unwinds to the host from inside an import therefore returns through here. `ExecuteEntry` reads the result, fails its `if (num6 == 0)` check, and reports what was a clean exit as:

```
[LOADER][ERROR] Guest entry point returned non-zero: <pointer>
```

with `result = ORBIS_GEN2_ERROR_CPU_TRAP`.

There is a second tell that the value is meant to survive: the TBB fault-recovery path writes `CONTEXT.Rax = 0` immediately before redirecting here, precisely so the unwind reads as a clean `0` — and the `call rax` erases it four instructions later.

## The fix

Park `rax` across the call and route the slot pointer through `r10`:

```asm
push rax              ; guest exit code
sub  rsp, 0x28
mov  ecx, tlsIndex
mov  rax, TlsGetValue
call rax
add  rsp, 0x28
mov  r10, [rax]
pop  rax              ; restore the guest exit code
mov  rsp, r10
```

This is not a new idea — **it is what the entry stub's own epilogue already does for the identical stack switch**, and the reason it uses `r10` rather than `rax` there:

```
49 BA <slot>   mov r10, <hostRspSlotStorage>
49 8B 22       mov rsp, [r10]
```

Stack phase is unchanged: `push`(8) + `0x28`(40) = 48 bytes, the same 16-byte phase the previous `0x20` frame established, so the `call` stays correctly aligned. `r10`/`r11` are volatile and dead here — the stub pops all eight Win64 non-volatiles and returns straight to managed code.

## How I found it

This came out of a systematic byte-level audit of every hand-emitted x86-64 stub in the tree, prompted by the REX.B defect in #781. **~520 instructions across nine emitters** were decoded and checked against the AMD64 encoding rules and against what the surrounding comments and logic require.

I want to be upfront about the method's noise: it produced **21 candidate findings, and 18 did not survive**. Each candidate was attacked by three independent reviewers with different lenses (re-derive the encoding; check whether the register is actually live and the path reachable; check whether the claimed consequence is contradicted by observed behaviour), and anything that any one of them could refute was dropped. This is one of the three that survived unanimously, and it is the only one I consider unambiguous enough to submit on its own.

The other two survivors are ABI-alignment arguments that depend on preconditions a reviewer has to accept, and I would rather raise those separately than bundle them with something this clear-cut.

## Testing

**N/A** for game testing — I have no PS5 title, and I would rather say so than imply otherwise.

`GuestReturnStubEncodingTests.cs` (new, 3 tests) decodes the bytes the emitter actually produces, so the guarantees survive the emission code being re-ordered:

- **the guest exit code survives** — the last write to `rax` must come after the last `call`
- **the stack switch does not dereference `rax`** — matching the entry-stub epilogue's use of a scratch register
- **every `call` is made on a 16-byte-aligned stack** — a reusable RSP-delta walker over the decoded stream, which is what proves the added `push`/`pop` did not change the frame's phase

Confirmed load-bearing: reverting the emitter change and re-running fails 2 of the 3 —

```
Failed  StackSwitchDoesNotDereferenceRax
  Assert.All() Failure: 1 out of 1 items in the collection did not pass.
Failed  GuestExitCodeInRaxSurvivesTheTlsLookup
```

Verified as CI does, on Windows with .NET SDK 10.0.302:

```
dotnet build SharpEmu.slnx -c Release
dotnet test SharpEmu.slnx -c Release --no-build
```

`Build succeeded`, 892 tests pass, 0 failures (889 before this branch, +3 new).

## One thing I could not verify

I have no title that exercises the host-stub unwind path, so I have not *observed* the wrong value in a real log — the defect is established by reading the emitted bytes and the three call sites, not by catching it in the act. My own synthetic guests return directly through the entry stub's epilogue (the `r10` path), so they never reach this stub and cannot demonstrate it either way.

If a maintainer has a title that reaches `TryCompleteGuestEntryToHostStub`, the confirming symptom is a `Guest entry point returned non-zero:` line whose value is a plausible heap pointer rather than a small integer.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
