### PR TITLE
[Shader] Decode the VOP3-encoded VOPC and VOP1 aliases

### DIFF
--- a/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.Alu.cs
@@ -664,10 +664,17 @@ public static partial class Gen5MslTranslator
             }
             else
             {
-                var target = instruction.Control is Gen5SdwaControl
-                    { ScalarDestination: { } scalarDestination }
-                    ? scalarDestination
-                    : VccLoRegister;
+                // Same rule as the SPIR-V emitter: the decoder shares this instruction stream, so
+                // a VOP3-encoded compare must reach its named SGPR pair here too. Defaulting to
+                // VCC would silently produce wrong branches with no diagnostic.
+                var target =
+                    instruction.Destinations.Count > 0 &&
+                    instruction.Destinations[0].Kind == Gen5OperandKind.ScalarRegister
+                        ? instruction.Destinations[0].Value
+                        : instruction.Control is Gen5SdwaControl
+                            { ScalarDestination: { } scalarDestination }
+                            ? scalarDestination
+                            : VccLoRegister;
                 StoreMaskBit(target, active);
             }
 

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
@@ -1662,10 +1662,19 @@ public static partial class Gen5SpirvTranslator
             }
             else
             {
-                var compareDestination = instruction.Control is Gen5SdwaControl
-                    { ScalarDestination: { } scalarDestination }
-                    ? scalarDestination
-                    : 106u;
+                // Prefer the decoded destination: a VOP3-encoded compare names an SGPR pair, and
+                // writing VCC instead would leave that pair stale while corrupting a register the
+                // shader may still be relying on. Plain VOPC leaves Destinations empty and keeps
+                // the VCC default; SDWA is subsumed because it already records a scalar
+                // destination when it is not VCC.
+                var compareDestination =
+                    instruction.Destinations.Count > 0 &&
+                    instruction.Destinations[0].Kind == Gen5OperandKind.ScalarRegister
+                        ? instruction.Destinations[0].Value
+                        : instruction.Control is Gen5SdwaControl
+                            { ScalarDestination: { } scalarDestination }
+                            ? scalarDestination
+                            : 106u;
                 StoreWaveMask(compareDestination, activeCondition);
             }
 

--- a/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler/Gen5ShaderTranslator.cs
@@ -910,7 +910,15 @@ public static class Gen5ShaderTranslator
         var src0 = word & 0x1FF;
         sizeDwords = src0 is 0xE9 or 0xEA or 0xF9 or 0xFA or 0xFF ? 2u : 1u;
         error = string.Empty;
-        name = opcode switch
+        name = Vop1Name(opcode);
+
+        return FinishDecode(name, $"unknown-vop1 op=0x{opcode:X2}", out error);
+    }
+
+    /// <summary>VOP1 opcode names, split out so the VOP3-encoded aliases (VOP3 opcode 0x180 + n) can</summary>
+    /// <summary>share the table instead of decoding to an unnamed stub.</summary>
+    private static string Vop1Name(uint opcode) =>
+        opcode switch
         {
             0x00 => "VNop",
             0x01 => "VMovB32",
@@ -949,9 +957,6 @@ public static class Gen5ShaderTranslator
             0x44 => "VMovrelsdB32",
             _ => string.Empty,
         };
-
-        return FinishDecode(name, $"unknown-vop1 op=0x{opcode:X2}", out error);
-    }
 
     private static bool DecodeVop2(uint word, out string name, out uint sizeDwords, out string error)
     {
@@ -1026,7 +1031,15 @@ public static class Gen5ShaderTranslator
         var src0 = word & 0x1FF;
         sizeDwords = src0 is 0xE9 or 0xEA or 0xF9 or 0xFA or 0xFF ? 2u : 1u;
         error = string.Empty;
-        name = opcode switch
+        name = VopcName(opcode);
+
+        return FinishDecode(name, $"unknown-vopc op=0x{opcode:X2}", out error);
+    }
+
+    /// <summary>VOPC opcode names, split out so the VOP3-encoded aliases (VOP3 opcode 0x000-0x0FF) can</summary>
+    /// <summary>share the table instead of decoding to an unnamed stub.</summary>
+    private static string VopcName(uint opcode) =>
+        opcode switch
         {
             0x00 => "VCmpFF32",
             0x01 => "VCmpLtF32",
@@ -1096,9 +1109,6 @@ public static class Gen5ShaderTranslator
             _ => string.Empty,
         };
 
-        return FinishDecode(name, $"unknown-vopc op=0x{opcode:X2}", out error);
-    }
-
     private static bool DecodeVop3(
         uint word,
         uint extra,
@@ -1113,6 +1123,29 @@ public static class Gen5ShaderTranslator
         var src2 = (extra >> 18) & 0x1FF;
         sizeDwords = src0 == 0xFF || src1 == 0xFF || src2 == 0xFF ? 3u : 2u;
         error = string.Empty;
+
+        // VOP3 re-encodes the whole VOPC and VOP1 opcode spaces so those instructions can carry
+        // the modifiers the short forms have no room for - abs/neg on a source, clamp, or a
+        // destination other than VCC. The compiler picks the _e64 form for exactly those cases, so
+        // shaders doing anything past a plain comparison land here. Without the aliases they
+        // decoded to an unnamed Vop3Raw stub, which fails translation for the whole program and
+        // silently drops every draw that binds it.
+        //
+        // The VOP3-specific message is deliberate: these tables still have holes (f64 compares,
+        // some VOP1 slots), and reporting the VOPC/VOP1 opcode there would hide which VOP3 opcode
+        // actually needs implementing.
+        if (!isVop3B && opcode <= 0xFF)
+        {
+            name = VopcName(opcode);
+            return FinishDecode(name, $"unknown-vop3 op=0x{opcode:X3}", out error);
+        }
+
+        if (!isVop3B && opcode is >= 0x180 and <= 0x1FF)
+        {
+            name = Vop1Name(opcode - 0x180);
+            return FinishDecode(name, $"unknown-vop3 op=0x{opcode:X3}", out error);
+        }
+
         name = isVop3B
             ? opcode switch
             {
@@ -2016,11 +2049,17 @@ public static class Gen5ShaderTranslator
                     Gen5Operand.Source((extra >> 18) & 0x1FF, literal),
                 ];
                 destinations = [Gen5Operand.Vector(word & 0xFF)];
-                if (opcode == "VReadlaneB32")
+                if (opcode is "VReadlaneB32" or "VReadfirstlaneB32" ||
+                    (opcode.StartsWith("VCmp", StringComparison.Ordinal) &&
+                        !opcode.StartsWith("VCmpx", StringComparison.Ordinal)))
                 {
-                    // V_READLANE uses the VOP3A vdst byte even though the
-                    // destination register is scalar. Bits 8-14 are the
-                    // distinct sdst field used by VOP3B encodings.
+                    // These use the VOP3A vdst byte even though the destination register is
+                    // scalar. Bits 8-14 are the distinct sdst field used by VOP3B encodings.
+                    //
+                    // A VOP3-encoded compare writes an SGPR pair, which is the whole reason the
+                    // compiler chose the _e64 form over the VOPC one that always targets VCC.
+                    // VCmpx is excluded because GFX10 makes it EXEC-only, and the emitters already
+                    // route it to the wave mask.
                     destinations = [Gen5Operand.Scalar(word & 0xFF)];
                 }
                 var isVop3B = IsVop3BOpcode((word >> 16) & 0x3FF);

--- a/tests/SharpEmu.Libs.Tests/Agc/Gen5Vop3AliasSpirvTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Agc/Gen5Vop3AliasSpirvTests.cs
@@ -1,0 +1,101 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Agc;
+
+// VOP3 re-encodes the VOPC and VOP1 opcode spaces so those instructions can carry the modifiers
+// the short forms have no room for: abs/neg on a source, a clamp, or a destination other than VCC.
+// The compiler emits the _e64 form for exactly those cases, which is why a shader doing anything
+// past a plain comparison hits them and a trivial UI shader does not.
+//
+// Before the aliases were decoded, one such instruction anywhere in a program produced an unnamed
+// Vop3Raw stub, translation failed for the whole shader, and every draw bound to it was dropped —
+// silently, and for the rest of the session. These compile the real thing end to end.
+public sealed class Gen5Vop3AliasSpirvTests
+{
+    private const ulong ShaderAddress = 0x2_0000_0000;
+
+    // s_endpgm
+    private const uint EndProgram = 0xBF810000u;
+
+    [Fact]
+    public void Vop3EncodedCompareCompilesToSpirv()
+    {
+        // v_cmp_lt_f32_e64 s[4:5], v0, v1
+        var spirv = Compile([0xD4010104u, 0x00020300u, EndProgram]);
+
+        Assert.NotEmpty(spirv);
+    }
+
+    [Fact]
+    public void Vop3EncodedVop1CompilesToSpirv()
+    {
+        // v_rcp_f32_e64 v2, v0
+        var spirv = Compile([0xD5AA0002u, 0x00000100u, EndProgram]);
+
+        Assert.NotEmpty(spirv);
+    }
+
+    [Fact]
+    public void BothAliasFormsCompileTogether()
+    {
+        var spirv = Compile(
+        [
+            0xD4010104u, 0x00020300u, // v_cmp_lt_f32_e64 s[4:5], v0, v1
+            0xD5AA0002u, 0x00000100u, // v_rcp_f32_e64 v2, v0
+            EndProgram,
+        ]);
+
+        Assert.NotEmpty(spirv);
+    }
+
+    /// <summary>
+    /// The destination has to reach the emitter, not just the decoder. Two compares that differ
+    /// only in which SGPR pair they name must produce different modules — if the emitter still
+    /// hardcoded VCC they would be identical, which is the failure mode of landing the decoder
+    /// change without the emitter change.
+    /// </summary>
+    [Fact]
+    public void CompareDestinationSelectsTheNamedScalarPair()
+    {
+        var toS4 = Compile([0xD4010104u, 0x00020300u, EndProgram]);
+        var toS6 = Compile([0xD4010106u, 0x00020300u, EndProgram]);
+
+        Assert.NotEqual(toS4, toS6);
+    }
+
+    private static byte[] Compile(uint[] programWords)
+    {
+        var memory = new FakeCpuMemory(ShaderAddress, 0x2000);
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Gen5ShaderAtomicDecodeTests.WriteProgram(memory, ShaderAddress, programWords);
+        var shaderRegisters = new Dictionary<uint, uint>
+        {
+            [Gen5ShaderAtomicDecodeTests.ComputePgmRsrc2Register] = 16u << 1,
+        };
+
+        Assert.True(
+            Gen5ShaderTranslator.TryCreateState(
+                ctx,
+                ShaderAddress,
+                0,
+                shaderRegisters,
+                Gen5ShaderAtomicDecodeTests.ComputeUserDataRegister,
+                out var state,
+                out var error),
+            error);
+        Assert.True(
+            Gen5ShaderScalarEvaluator.TryEvaluate(ctx, state, out var evaluation, out error),
+            error);
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileComputeShader(
+                state, evaluation, 1, 1, 1, out var shader, out error),
+            error);
+        return shader.Spirv;
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/ShaderCompiler/Gen5ShaderTranslatorTests.cs
+++ b/tests/SharpEmu.Libs.Tests/ShaderCompiler/Gen5ShaderTranslatorTests.cs
@@ -49,4 +49,118 @@ public sealed class Gen5ShaderTranslatorTests
         Assert.Equal(Gen5OperandKind.ScalarRegister, instruction.Sources[1].Kind);
         Assert.Equal(2u, instruction.Sources[1].Value);
     }
+
+    /// <summary>
+    /// VOP3 re-encodes the whole VOPC opcode space so a compare can carry source modifiers, a
+    /// clamp, or a destination other than VCC. Before these were decoded they produced an unnamed
+    /// stub, which failed translation for the entire shader and silently dropped every draw
+    /// bound to it.
+    /// </summary>
+    [Fact]
+    public void Vop3EncodedCompareDecodesThroughTheVopcTable()
+    {
+        // v_cmp_lt_f32_e64 s[4:5], v0, v1
+        var instruction = DecodeSingle(0xD4010104u, 0x00020300u);
+
+        Assert.Equal("VCmpLtF32", instruction.Opcode);
+        Assert.Equal(Gen5ShaderEncoding.Vop3, instruction.Encoding);
+
+        // The _e64 form exists precisely so the result can go somewhere other than VCC.
+        var destination = Assert.Single(instruction.Destinations);
+        Assert.Equal(Gen5OperandKind.ScalarRegister, destination.Kind);
+        Assert.Equal(4u, destination.Value);
+    }
+
+    /// <summary>
+    /// The VOP1 space is aliased at VOP3 opcode 0x180 + n, and unlike a compare it keeps a vector
+    /// destination.
+    /// </summary>
+    [Fact]
+    public void Vop3EncodedVop1DecodesThroughTheVop1Table()
+    {
+        // v_rcp_f32_e64 v2, v0
+        var instruction = DecodeSingle(0xD5AA0002u, 0x00000100u);
+
+        Assert.Equal("VRcpF32", instruction.Opcode);
+        Assert.Equal(Gen5ShaderEncoding.Vop3, instruction.Encoding);
+
+        var destination = Assert.Single(instruction.Destinations);
+        Assert.Equal(Gen5OperandKind.VectorRegister, destination.Kind);
+        Assert.Equal(2u, destination.Value);
+    }
+
+    /// <summary>
+    /// VCMPX is EXEC-only on GFX10, so it must keep the vector-destination path and be routed to
+    /// the wave mask by the emitters rather than picking up an SGPR destination.
+    /// </summary>
+    [Fact]
+    public void Vop3EncodedCmpxKeepsItsVectorDestination()
+    {
+        // v_cmpx_lt_f32_e64 with vdst byte 0x04
+        var instruction = DecodeSingle(0xD4110104u, 0x00020300u);
+
+        Assert.StartsWith("VCmpx", instruction.Opcode, StringComparison.Ordinal);
+        Assert.Equal(Gen5OperandKind.VectorRegister, Assert.Single(instruction.Destinations).Kind);
+    }
+
+    /// <summary>
+    /// Both alias ranges must resolve through their tables rather than falling through to the
+    /// unnamed stub. Opcodes the tables do not cover are expected to fail decode, and the error
+    /// has to name the VOP3 opcode — reporting the aliased VOPC/VOP1 number instead would hide
+    /// which opcode actually needs implementing.
+    /// </summary>
+    [Theory]
+    [InlineData(0x001u)] // VOPC alias  -> v_cmp_lt_f32
+    [InlineData(0x0C1u)] // VOPC alias  -> v_cmp_lt_u32
+    [InlineData(0x1AAu)] // VOP1 alias  -> v_rcp_f32
+    [InlineData(0x1A1u)] // VOP1 alias  -> v_cvt_f32_i32
+    public void AliasRangesNeverDecodeToAnUnnamedStub(uint vop3Opcode)
+    {
+        var word = 0xD4000000u | (vop3Opcode << 16);
+        var memory = new FakeCpuMemory(ProgramAddress, 0x100);
+        Span<byte> code = stackalloc byte[3 * sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(code, word);
+        BinaryPrimitives.WriteUInt32LittleEndian(code[sizeof(uint)..], 0x00020300u);
+        BinaryPrimitives.WriteUInt32LittleEndian(code[(2 * sizeof(uint))..], 0xBF810000u);
+        Assert.True(memory.TryWrite(ProgramAddress, code));
+
+        var context = new CpuContext(memory, Generation.Gen5);
+        var decoded = Gen5ShaderTranslator.TryDecodeProgram(
+            context,
+            ProgramAddress,
+            out var program,
+            out var error);
+
+        if (decoded)
+        {
+            Assert.DoesNotContain(
+                program.Instructions,
+                static item => item.Opcode.StartsWith("Vop3Raw", StringComparison.Ordinal));
+        }
+        else
+        {
+            Assert.Contains("unknown-vop3", error, StringComparison.Ordinal);
+        }
+    }
+
+    private static Gen5ShaderInstruction DecodeSingle(uint word, uint extra)
+    {
+        var memory = new FakeCpuMemory(ProgramAddress, 0x100);
+        Span<byte> code = stackalloc byte[3 * sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(code, word);
+        BinaryPrimitives.WriteUInt32LittleEndian(code[sizeof(uint)..], extra);
+        BinaryPrimitives.WriteUInt32LittleEndian(code[(2 * sizeof(uint))..], 0xBF810000u);
+        Assert.True(memory.TryWrite(ProgramAddress, code));
+
+        var context = new CpuContext(memory, Generation.Gen5);
+        Assert.True(
+            Gen5ShaderTranslator.TryDecodeProgram(
+                context,
+                ProgramAddress,
+                out var program,
+                out var error),
+            error);
+
+        return program.Instructions[0];
+    }
 }


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

VOP3 re-encodes the **entire VOPC opcode space at `0x000-0x0FF`** and the **entire VOP1 space at `0x180-0x1FF`**, so those instructions can carry what the short forms have no room for: abs/neg on a source, a clamp, or a destination other than VCC. The compiler picks the `_e64` form for precisely those cases.

Neither range was decoded. The VOP3 table's lowest key is `0x101`, and it has no entries at all in `0x180-0x1FF`, so all of them fell through to:

```csharp
_ => $"Vop3Raw{opcode:X3}",
```

On current `main`, a three-instruction program:

```asm
v_cmp_lt_f32_e64 s[4:5], |v0|, v1
v_rcp_f32_e64    v2, v0
s_endpgm
```

fails with:

```
block=0x0: pc=0x0 Vop3Raw001: unsupported vector opcode Vop3Raw001
```

That is a hard fail with no fallback. `AgcExports.TryTranslateGuestDraw` leaves `state.TranslatedDraw = null` and the draw is dropped, deduplicated to one `[COMPAT][SHADER]` line per distinct failure. **One such instruction anywhere in a pixel shader deletes every draw that binds it, for the rest of the session, with no crash and no log spam.**

There is corroborating evidence inside the tree that this range is real and reachable: VOP3 opcode `0x101` (`VCndmaskB32`, the VOP2-in-VOP3 alias) was already added by hand, one opcode at a time, rather than by fixing the range.

## What changed

Four edits. They are **not separable** — see the note below.

1. **`Gen5ShaderTranslator.DecodeVop1` / `DecodeVopc`** — the name tables are hoisted into `Vop1Name` / `VopcName` so they can be shared. No behaviour change.
2. **`DecodeVop3`** — both alias ranges route through those tables. The VOP3-specific `unknown-vop3 op=0x%03X` message is kept deliberately: both tables still have holes (f64 compares, several VOP1 slots), and reporting the aliased VOPC/VOP1 number would hide *which VOP3 opcode actually needs implementing* — the one piece of information needed to fix the next title.
3. **`CreateInstruction`** — a VOP3-encoded compare writes an SGPR pair, which is the whole reason the compiler chose the long form, so `VCmp*` now takes a scalar destination from the vdst byte. `VCmpx` is excluded: GFX10 makes it EXEC-only and both emitters already route it to the wave mask. `VReadfirstlaneB32` is included because `TryEmitVectorAlu` requires a scalar destination and would otherwise start failing the moment edit 2 made the `_e64` form decodable.
4. **Both emitters** (`Gen5SpirvTranslator.Alu.cs`, `Gen5MslTranslator.Alu.cs`) — prefer the decoded destination over the hardcoded VCC fallback.

### Why this cannot be split

Landing the decoding without the emitter changes is **strictly worse than today**. It converts a loud, deduplicated hard failure into silent register corruption: the compare result goes to VCC while the named SGPR pair keeps a stale mask, producing wrong branches and wrong pixels with zero diagnostics.

The Metal edit is part of that, not an optional macOS extra — the decoder is shared, so shipping without it corrupts that backend in exactly the same way.

## Testing

**N/A** for game testing — I have no PS5 title, and I want to be straight about what that means for this PR (see the honest assessment below).

`Gen5ShaderTranslatorTests.cs` (+5):

- `v_cmp_lt_f32_e64` decodes to `VCmpLtF32` with a **ScalarRegister** destination of `s4`
- `v_rcp_f32_e64` decodes to `VRcpF32` with a **VectorRegister** destination
- a VOP3-encoded `VCmpx` keeps its vector destination, pinning edit 3's exclusion
- a theory over both alias ranges asserting nothing decodes to a `Vop3Raw` stub, and that opcodes the tables do not cover fail with an error containing `unknown-vop3` (pins the error-message contract)

`Gen5Vop3AliasSpirvTests.cs` (new, 4) compiles the real thing end to end through `TryCreateState` → `Gen5ShaderScalarEvaluator.TryEvaluate` → `Gen5SpirvTranslator.TryCompileComputeShader`:

- each alias form compiles to SPIR-V, and both together
- **two compares differing only in which SGPR pair they name produce different modules** — if the emitter still hardcoded VCC they would be byte-identical, so this test specifically catches edits 1+2 landing without 3+4

Confirmed load-bearing. Reverting all three source files and re-running gives exactly the stubs:

```
Vop3EncodedCompareDecodesThroughTheVopcTable   Actual: "Vop3Raw001"
AliasRangesNeverDecodeToAnUnnamedStub(1)       Opcode = Vop3Raw001
AliasRangesNeverDecodeToAnUnnamedStub(193)     Opcode = Vop3Raw0C1
AliasRangesNeverDecodeToAnUnnamedStub(417)     Opcode = Vop3Raw1A1
AliasRangesNeverDecodeToAnUnnamedStub(426)     Opcode = Vop3Raw1AA
Vop3EncodedCmpxKeepsItsVectorDestination       String: "Vop3Raw011"
```

Verified as CI does, on Windows with .NET SDK 10.0.302:

```
dotnet build SharpEmu.slnx -c Release
dotnet test SharpEmu.slnx -c Release --no-build
```

`Build succeeded`, 900 tests pass, 0 failures (889 before this branch, +11 new). That includes the Metal suite (27) and the ShaderCompiler suite (30), both green.

## Honest assessment

**I am not claiming this makes any title playable, and I would rather say so than have this oversold.**

What is established: these encodings hard-fail today, the failure silently deletes draws, and after this they compile. That is measured, not argued.

What is **not** established: that any specific title emits them. The structural case is reasonable — AMD's backend selects `_e64` when a compare carries source modifiers, a clamp, or a non-VCC SGPR destination, and non-VCC destinations come from nested or short-circuited conditionals, which trivial UI shaders do not have — and the hand-added `0x101` entry suggests someone hit this range already. But "structurally motivated" is not "measured on a title I ran".

The realistic shape of success is that some previously-vanished geometry appears and the `[COMPAT][SHADER]` log starts naming a *different* missing opcode. `v_alignbit_b32` (VOP3 `0x14E`) is the strongest candidate for what shows up next — grepping the tree for `Alignbit` returns nothing, so it is missing from the decoder table *and* both emitters and needs real emitter work rather than a table entry. I have deliberately left that out of scope.

If someone with a title can run this and paste the resulting `[COMPAT][SHADER]` lines, that would be far more valuable than my speculation about which opcode is next.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
