### PR TITLE
[AGC] Report compute shader translation failures on a default run

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -11034,13 +11034,27 @@ public static partial class AgcExports
                 out var evaluation,
                 out error))
         {
+            var firstComputeFailure = false;
             lock (_submitTraceGate)
             {
-                if (_tracedComputeShaders.Add(shaderAddress))
+                firstComputeFailure = _tracedComputeShaders.Add(shaderAddress);
+                if (firstComputeFailure)
                 {
                     TraceAgcShader(
                         $"agc.compute_shader cs=0x{shaderAddress:X16} error={error}");
                 }
+            }
+
+            // Same reasoning as the graphics path: a compute shader that fails to translate is a
+            // compatibility issue, not verbose shader tracing. The dispatch is dropped silently,
+            // so without this a title that reaches gameplay and starts dispatching compute
+            // produces no output at all for the work it lost - and the missing opcode, which is
+            // the one thing needed to fix it, is only visible with SHARPEMU_LOG_AGC_SHADER=1.
+            // Deduplicated per shader address, so a dispatch loop cannot turn this into spam.
+            if (firstComputeFailure)
+            {
+                Console.Error.WriteLine(
+                    $"[COMPAT][SHADER] cs=0x{shaderAddress:X16} error={error}");
             }
 
             return;


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

An asymmetry between the graphics and compute shader paths.

The graphics path already treats a translation failure as a compatibility issue rather than verbose tracing, and explains why in its own comment:

```csharp
// Translation failures are compatibility issues, not merely verbose
// shader diagnostics. Report each distinct failure once even when AGC
// tracing is disabled so normal runs preserve the missing opcode or
// unsupported translation reason needed to fix the game.
if (firstFailure)
{
    Console.Error.WriteLine(
        $"[COMPAT][SHADER] ps=0x{pixelShaderAddress:X16} " +
        $"es=0x{exportShaderAddress:X16} error={translationError}");
}
```

`ObserveComputeDispatch` does not. When a compute shader fails to translate it `return`s — dropping the dispatch — and reports only through `TraceAgcShader`, which is gated behind `SHARPEMU_LOG_AGC_SHADER=1`.

So on a default run, a title that reaches gameplay and starts dispatching compute loses that work with **no output at all**. The missing opcode — the one thing needed to fix it — is invisible unless the user already knew to set an environment variable they have no reason to know about.

That matters more than it looks, because compute is disproportionately a *gameplay* feature. Menus do not dispatch compute; culling, skinning, particle simulation and post-processing do. A title can therefore render its menu perfectly, reach gameplay, silently lose every compute dispatch, and produce a bug report that says only "black screen".

## What changed

One `Console.Error.WriteLine`, deduplicated by shader address using the `_tracedComputeShaders` set that already guards the existing trace, so a dispatch loop cannot turn it into spam:

```
[COMPAT][SHADER] cs=0x0000000800123456 error=block=0x0: pc=0x0 Vop3Raw001: unsupported vector opcode Vop3Raw001
```

The `cs=` prefix distinguishes it from the graphics line's `ps=` / `es=`. No behaviour changes — the dispatch is dropped exactly as before; it is now merely visible.

I kept the existing `TraceAgcShader` call rather than replacing it, so `SHARPEMU_LOG_AGC_SHADER=1` output is unchanged for anyone parsing it.

## On logging policy

`CONTRIBUTING.md` asks for logging only where it provides meaningful diagnostic value, and I think this clears that bar on the project's own stated reasoning — this is the same judgement the graphics path already made, applied to the path that was missed. It is bounded to one line per distinct shader address for the lifetime of the process, and a title with no failing compute shaders prints nothing.

If maintainers would rather this be gated behind a compatibility-logging flag that also covers the graphics line, I am happy to rework it that way instead — the important part is that the two paths agree.

## Testing

**N/A** — I have no PS5 title, and this changes only diagnostics on a path that already dropped the work.

Verified as CI does, on Windows with .NET SDK 10.0.302:

```
dotnet build SharpEmu.slnx -c Release
dotnet test SharpEmu.slnx -c Release --no-build
```

`Build succeeded`, 889 tests pass, 0 failures — unchanged, as expected for a diagnostics-only change.

I have not added a unit test. The failure site needs a live `SubmittedGpuState` and a guest shader that fails translation, and the existing compute-dispatch paths have no test harness to hang that off; a test asserting on `Console.Error` alone would pin the string without pinning the behaviour. Happy to add one if a maintainer can point me at the right seam.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
