### PR TITLE
[Kernel] Implement scePthreadAttrSet/Getsolosched (FF7 Rebirth startup)

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelPthreadExtendedCompatExports.cs
@@ -19,6 +19,9 @@ public static class KernelPthreadExtendedCompatExports
     private const ulong DefaultStackSize = 0x1_00000UL;
     private const ulong NativeGuestStackSize = 0x20_0000UL;
     private const ulong NativeGuestStackStride = 0x100_0000UL;
+    // Solo scheduling is off on a default-initialised pthread_attr_t; a title has to ask for it.
+    private const int DefaultSoloSched = 0;
+
     private const int DefaultInheritSched = 4;
     private const int DefaultSchedPolicy = 1;
     private const int DefaultSchedPriority = DefaultThreadPriority;
@@ -189,7 +192,8 @@ public static class KernelPthreadExtendedCompatExports
         ulong GuardSize,
         int InheritSched,
         int SchedPolicy,
-        int SchedPriority)
+        int SchedPriority,
+        int SoloSched)
     {
         public static PthreadAttrState Default =>
             new(
@@ -200,7 +204,8 @@ public static class KernelPthreadExtendedCompatExports
                 DefaultGuardSize,
                 DefaultInheritSched,
                 DefaultSchedPolicy,
-                DefaultSchedPriority);
+                DefaultSchedPriority,
+                DefaultSoloSched);
     }
 
     [SysAbiExport(
@@ -833,6 +838,66 @@ public static class KernelPthreadExtendedCompatExports
         }
 
         ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    /// <summary>
+    /// Solo scheduling asks the kernel to give the thread a core to itself. SharpEmu maps guest
+    /// threads onto host threads and does not reserve cores, so the attribute has no scheduling
+    /// effect here - but it is a real attribute with a getter, and a title that sets it and reads
+    /// it back must see what it wrote. Storing it is what makes that true; returning a bare
+    /// success without recording the value would leave the getter reporting the default.
+    /// </summary>
+    [SysAbiExport(
+        Nid = "Dk6FC-TI+7Q",
+        ExportName = "scePthreadAttrSetsolosched",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PthreadAttrSetsolosched(CpuContext ctx)
+    {
+        var attrAddress = ctx[CpuRegister.Rdi];
+        var soloSched = unchecked((int)ctx[CpuRegister.Rsi]);
+        if (attrAddress == 0)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        lock (_stateGate)
+        {
+            var state = GetOrCreateAttrStateLocked(attrAddress);
+            _attrStates[attrAddress] = state with { SoloSched = soloSched };
+        }
+
+        ctx[CpuRegister.Rax] = 0;
+        return (int)OrbisGen2Result.ORBIS_GEN2_OK;
+    }
+
+    [SysAbiExport(
+        Nid = "9RnL-m0+diQ",
+        ExportName = "scePthreadAttrGetsolosched",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libKernel")]
+    public static int PthreadAttrGetsolosched(CpuContext ctx)
+    {
+        var attrAddress = ctx[CpuRegister.Rdi];
+        var outSoloSchedAddress = ctx[CpuRegister.Rsi];
+        if (attrAddress == 0 || outSoloSchedAddress == 0)
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
+        }
+
+        PthreadAttrState state;
+        lock (_stateGate)
+        {
+            state = GetOrCreateAttrStateLocked(attrAddress);
+        }
+
+        if (!TryWriteInt32(ctx, outSoloSchedAddress, state.SoloSched))
+        {
+            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT;
+        }
+
+        ctx[CpuRegister.Rax] = unchecked((uint)state.SoloSched);
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 

--- a/tests/SharpEmu.Libs.Tests/Pthread/PthreadAttrSoloSchedTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Pthread/PthreadAttrSoloSchedTests.cs
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Pthread;
+
+/// <summary>
+/// scePthreadAttrSetsolosched was unimplemented, so a title calling it got
+/// ORBIS_GEN2_ERROR_NOT_FOUND and "Missing HLE export for NID: Dk6FC-TI+7Q" during thread setup.
+///
+/// Solo scheduling asks the kernel to give a thread a core to itself. SharpEmu maps guest threads
+/// onto host threads and reserves no cores, so the attribute has no scheduling effect - but it is
+/// a real attribute with a getter, and the contract a title relies on is that reading it back
+/// returns what was written. These pin that, so the pair cannot decay into a bare success that
+/// discards the value.
+/// </summary>
+public sealed class PthreadAttrSoloSchedTests
+{
+    private const ulong MemoryBase = 0x5_0000_0000;
+    private const ulong AttrAddress = MemoryBase + 0x100;
+    private const ulong OutAddress = MemoryBase + 0x200;
+
+    /// <summary>
+    /// The reported failure was a resolution failure, not a behavioural one: the loader logged
+    /// "Missing HLE export for NID: Dk6FC-TI+7Q" and returned ORBIS_GEN2_ERROR_NOT_FOUND. This is
+    /// the test that pins it fixed.
+    /// </summary>
+    [Theory]
+    [InlineData("Dk6FC-TI+7Q", "scePthreadAttrSetsolosched")]
+    [InlineData("9RnL-m0+diQ", "scePthreadAttrGetsolosched")]
+    public void RegistryResolvesTheSoloSchedExports(string nid, string exportName)
+    {
+        var manager = new ModuleManager();
+        manager.RegisterExports(SharpEmu.Generated.SysAbiExportRegistry.CreateExports(
+            Generation.Gen4 | Generation.Gen5));
+
+        Assert.True(manager.TryGetExport(nid, out var export));
+        Assert.Equal(exportName, export.Name);
+        Assert.Equal("libKernel", export.LibraryName);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(0)]
+    [InlineData(0x7FFF)]
+    public void SoloSchedRoundTripsThroughTheAttribute(int value)
+    {
+        var context = CreateContext();
+
+        context[CpuRegister.Rdi] = AttrAddress;
+        context[CpuRegister.Rsi] = unchecked((ulong)(long)value);
+        Assert.Equal(0, KernelPthreadExtendedCompatExports.PthreadAttrSetsolosched(context));
+
+        Assert.Equal(value, GetSoloSched(context));
+    }
+
+    /// <summary>
+    /// A freshly seen attribute reports solo scheduling off rather than whatever a previous
+    /// attribute at another address happened to set.
+    /// </summary>
+    [Fact]
+    public void UnsetAttributeReportsSoloSchedulingDisabled()
+    {
+        var context = CreateContext();
+
+        context[CpuRegister.Rdi] = AttrAddress;
+        context[CpuRegister.Rsi] = 1;
+        Assert.Equal(0, KernelPthreadExtendedCompatExports.PthreadAttrSetsolosched(context));
+
+        // A different attribute object must not inherit the value.
+        context[CpuRegister.Rdi] = AttrAddress + 0x40;
+        context[CpuRegister.Rsi] = OutAddress;
+        Assert.Equal(0, KernelPthreadExtendedCompatExports.PthreadAttrGetsolosched(context));
+        Assert.Equal(0, ReadInt32(context, OutAddress));
+    }
+
+    [Fact]
+    public void SetterRejectsANullAttribute()
+    {
+        var context = CreateContext();
+
+        context[CpuRegister.Rdi] = 0;
+        context[CpuRegister.Rsi] = 1;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            KernelPthreadExtendedCompatExports.PthreadAttrSetsolosched(context));
+    }
+
+    [Fact]
+    public void GetterRejectsANullOutputPointer()
+    {
+        var context = CreateContext();
+
+        context[CpuRegister.Rdi] = AttrAddress;
+        context[CpuRegister.Rsi] = 0;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            KernelPthreadExtendedCompatExports.PthreadAttrGetsolosched(context));
+    }
+
+    /// <summary>
+    /// Setting solo scheduling must not disturb the other attributes sharing the record.
+    /// </summary>
+    [Fact]
+    public void SettingSoloSchedLeavesDetachStateIntact()
+    {
+        var context = CreateContext();
+
+        context[CpuRegister.Rdi] = AttrAddress;
+        context[CpuRegister.Rsi] = 1; // PTHREAD_CREATE_DETACHED
+        Assert.Equal(0, KernelPthreadExtendedCompatExports.PthreadAttrSetdetachstate(context));
+
+        context[CpuRegister.Rdi] = AttrAddress;
+        context[CpuRegister.Rsi] = 1;
+        Assert.Equal(0, KernelPthreadExtendedCompatExports.PthreadAttrSetsolosched(context));
+
+        context[CpuRegister.Rdi] = AttrAddress;
+        context[CpuRegister.Rsi] = OutAddress;
+        Assert.Equal(0, KernelPthreadExtendedCompatExports.PthreadAttrGetdetachstate(context));
+        Assert.Equal(1, ReadInt32(context, OutAddress));
+
+        Assert.Equal(1, GetSoloSched(context));
+    }
+
+    private static int GetSoloSched(CpuContext context)
+    {
+        context[CpuRegister.Rdi] = AttrAddress;
+        context[CpuRegister.Rsi] = OutAddress;
+        Assert.Equal(0, KernelPthreadExtendedCompatExports.PthreadAttrGetsolosched(context));
+        return ReadInt32(context, OutAddress);
+    }
+
+    private static CpuContext CreateContext() =>
+        new(new FakeCpuMemory(MemoryBase, 0x1000), Generation.Gen5);
+
+    private static int ReadInt32(CpuContext context, ulong address)
+    {
+        var bytes = new byte[sizeof(int)];
+        Assert.True(context.Memory.TryRead(address, bytes));
+        return BitConverter.ToInt32(bytes);
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

**Final Fantasy VII Rebirth** stops during startup with:

```
[LOADER][ERROR] Missing HLE export for NID: Dk6FC-TI+7Q
```

That NID is `scePthreadAttrSetsolosched`. The paired getter `scePthreadAttrGetsolosched` (`9RnL-m0+diQ`) was missing too.

I found this by mining the compatibility reports in `sharpemu/sharpemu-site` rather than guessing. Across all 46 reports, `Dk6FC-TI+7Q` is the **most frequently named missing export** — five occurrences of `Missing HLE export for NID`, more than any other. Every other unresolved NID I extracted from those reports (`sceKernelGetOpenPsId`, `sceKernelIsTrinityMode`, `sceKernelConfiguredFlexibleMemorySize`, `sceNpEntitlementAccessGetSkuFlag`, `sceGameLiveStreamingInitialize`, `sceAgcCbBranch`) is already implemented — this was the only genuine gap in that set.

## What changed

Both exports, in `KernelPthreadExtendedCompatExports.cs`, following the existing attribute pattern (`scePthreadAttrSetinheritsched` / `scePthreadAttrGetdetachstate`) exactly:

- `PthreadAttrState` gains a `SoloSched` field, defaulted to `0` (off) like a default-initialised `pthread_attr_t`.
- The setter validates the attr pointer and records the value under `_stateGate`.
- The getter validates both pointers, writes the value out, and mirrors it into RAX as the sibling getters do.

## On not faking it

`CONTRIBUTING.md` is explicit that returning success without modelling the expected state is not acceptable, so I want to be clear about what this does and does not do.

Solo scheduling asks the kernel to give a thread a core to itself. SharpEmu maps guest threads onto host threads and reserves no cores, so **the attribute has no scheduling effect here, and I am not claiming otherwise.**

What a title *can* observe is the attribute itself. Storing the value is what makes `set` followed by `get` return what was written; a bare `return OK` would leave the getter reporting the default and quietly contradict the title. That round trip is the real contract, and it is what the tests pin.

If maintainers would rather solo scheduling also influence host thread affinity, that is a separate change and I would want a title to measure it against first.

## Testing

**N/A** — I do not have FF7 Rebirth (PPSA08668), so I cannot confirm it now gets further. What I can confirm is that the specific error it reported is gone: the NID resolves.

`PthreadAttrSoloSchedTests.cs` (new, 9 tests):

- **`RegistryResolvesTheSoloSchedExports`** — the one that matters. Both NIDs resolve through `SysAbiExportRegistry` to the right name and `libKernel`. This is the direct regression guard for `Missing HLE export for NID: Dk6FC-TI+7Q`.
- `SoloSchedRoundTripsThroughTheAttribute` over three values — the anti-fake-success test
- an unset attribute reports `0`, and does not inherit another attribute's value
- null attr / null out-pointer are rejected with `ORBIS_GEN2_ERROR_INVALID_ARGUMENT`
- setting solo scheduling leaves `DetachState` intact, since they share one record

The build also validates the naming: the `SHEM006` export-name analyser accepts both against `scripts/ps5_names.txt` without a warning, which independently confirms the NID/name pairing.

Verified as CI does, on Windows with .NET SDK 10.0.302:

```
dotnet build SharpEmu.slnx -c Release
dotnet test SharpEmu.slnx -c Release --no-build
```

`Build succeeded`, 898 tests pass, 0 failures (889 before this branch, +9 new).

## Honest scope

This unblocks one specific startup failure. FF7 Rebirth's report also shows a PS5 out-of-memory fatal while allocating ~2.9 GB, which this does not touch — so I would expect it to get *further*, not to boot. Anyone with the title who can post the next error would be doing me a favour.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
