### PR TITLE
[Kernel] Stop rejecting PRT apertures that lie outside a fictional window (Code Violet)

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelRuntimeCompatExports.cs
@@ -39,8 +39,6 @@ public static class KernelRuntimeCompatExports
     private const ulong ModuleInfoExSegmentCountOffset = 0x1A0;
     private const int ModuleInfoSegmentSize = 16;
     private const ulong DefaultKernelTscFrequency = 10_000_000UL;
-    private const ulong PrtAreaStartAddress = 0x0000001000000000UL;
-    private const ulong PrtAreaSize = 0x000000EC00000000UL;
     private const int MapFlagFixed = 0x10;
     private const ulong DefaultVirtualRangeAlignment = 0x4000UL;
     private const int AioInitParamSize = 0x3C;
@@ -891,22 +889,24 @@ public static class KernelRuntimeCompatExports
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
-        if ((apertureBase & 0xFFFUL) != 0)
+        if (apertureBase == 0 || (apertureBase & 0xFFFUL) != 0)
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }
 
-        if (apertureBase < PrtAreaStartAddress)
-        {
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
-        }
-
-        if (apertureSize > PrtAreaSize)
-        {
-            return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
-        }
-
-        if (apertureBase - PrtAreaStartAddress > PrtAreaSize - apertureSize)
+        // The aperture range is not checked against a fixed window any more. A title obtains the
+        // range from sceKernelReserveVirtualRange and hands the result straight back here, and that
+        // allocator searches free host VA from _nextReservedVirtualBase (0x6_0000_0000) upwards -
+        // below where the old window began and, in practice, far past where it ended. Guest and
+        // host share one address space because guest code executes natively, so a reserved range
+        // is a legitimate aperture wherever it landed; the old window described a region nothing
+        // in the emulator ever allocates from, so a correct call was rejected on arrival.
+        //
+        // Rejecting it is not only a wrong error code. On success the import dispatcher calls
+        // RegisterPrtLazyCommitRange for this range, which is what makes later guest accesses to
+        // the aperture demand-page instead of faulting, so the failure also left the range
+        // unbacked.
+        if (apertureBase > ulong.MaxValue - apertureSize)
         {
             return (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT;
         }

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelPrtApertureTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelPrtApertureTests.cs
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+/// <summary>
+/// sceKernelSetPrtAperture used to validate the aperture against a fixed window at 0x1000000000
+/// spanning 0xEC00000000. Nothing in the emulator allocates from that window:
+/// sceKernelReserveVirtualRange - which is exactly how a title obtains a PRT aperture - searches
+/// free host VA from 0x6_0000_0000 upwards, below where the window began and in practice far past
+/// where it ended. Guest and host share one address space because guest code executes natively,
+/// so a reserved range is a legitimate aperture wherever it landed.
+///
+/// The consequence was not only a wrong error code. On success the import dispatcher registers the
+/// range for lazy commit, so a rejected call also left the aperture unbacked for later accesses.
+/// </summary>
+public sealed class KernelPrtApertureTests
+{
+    private const ulong MemoryBase = 0x6_0000_0000;
+
+    /// <summary>
+    /// The exact arguments Code Violet (PPSA26528) passes, taken from its compatibility report:
+    /// aperture 0, a 256 GiB range at the address sceKernelReserveVirtualRange had just returned.
+    /// This returned 0x80020003 and the title stopped during module init.
+    /// </summary>
+    [Fact]
+    public void AcceptsTheRangeAReservationActuallyReturned()
+    {
+        var context = CreateContext();
+        context[CpuRegister.Rdi] = 0;                      // aperture id
+        context[CpuRegister.Rsi] = 0x00000289AC740000UL;   // base, as reserved
+        context[CpuRegister.Rdx] = 0x0000004000000000UL;   // 256 GiB
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            KernelRuntimeCompatExports.KernelSetPrtAperture(context));
+    }
+
+    /// <summary>
+    /// A range low in the address space is equally valid — the reservation allocator starts at
+    /// 0x6_0000_0000, below the old window entirely.
+    /// </summary>
+    [Fact]
+    public void AcceptsARangeBelowTheOldWindowStart()
+    {
+        var context = CreateContext();
+        context[CpuRegister.Rdi] = 1;
+        context[CpuRegister.Rsi] = 0x0000000600000000UL;
+        context[CpuRegister.Rdx] = 0x0000000040000000UL;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_OK,
+            KernelRuntimeCompatExports.KernelSetPrtAperture(context));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(3)]
+    [InlineData(99)]
+    public void RejectsAnApertureIdOutsideTheTable(int apertureId)
+    {
+        var context = CreateContext();
+        context[CpuRegister.Rdi] = unchecked((ulong)(long)apertureId);
+        context[CpuRegister.Rsi] = 0x0000000600000000UL;
+        context[CpuRegister.Rdx] = 0x0000000040000000UL;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            KernelRuntimeCompatExports.KernelSetPrtAperture(context));
+    }
+
+    [Fact]
+    public void RejectsAMisalignedBase()
+    {
+        var context = CreateContext();
+        context[CpuRegister.Rdi] = 0;
+        context[CpuRegister.Rsi] = 0x0000000600000001UL; // not 4 KiB aligned
+        context[CpuRegister.Rdx] = 0x0000000040000000UL;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            KernelRuntimeCompatExports.KernelSetPrtAperture(context));
+    }
+
+    [Fact]
+    public void RejectsANullBase()
+    {
+        var context = CreateContext();
+        context[CpuRegister.Rdi] = 0;
+        context[CpuRegister.Rsi] = 0;
+        context[CpuRegister.Rdx] = 0x0000000040000000UL;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            KernelRuntimeCompatExports.KernelSetPrtAperture(context));
+    }
+
+    /// <summary>
+    /// The one range check that survives: base + size must not wrap. The old window checks
+    /// happened to prevent this as a side effect, so removing them without this would have opened
+    /// a hole rather than closed one.
+    /// </summary>
+    [Fact]
+    public void RejectsARangeThatWrapsTheAddressSpace()
+    {
+        var context = CreateContext();
+        context[CpuRegister.Rdi] = 0;
+        context[CpuRegister.Rsi] = 0xFFFFFFFFFFFFF000UL;
+        context[CpuRegister.Rdx] = 0x0000000000010000UL;
+
+        Assert.Equal(
+            (int)OrbisGen2Result.ORBIS_GEN2_ERROR_INVALID_ARGUMENT,
+            KernelRuntimeCompatExports.KernelSetPrtAperture(context));
+    }
+
+    private static CpuContext CreateContext() =>
+        new(new FakeCpuMemory(MemoryBase, 0x1000), Generation.Gen5);
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this fixes

**Code Violet (PPSA26528)** stops during module init:

```
sceKernelSetPrtAperture failed with error code: 0x80020003
```

Its compatibility report has the call and, crucially, the one immediately before it:

```
[LOADER][TRACE] Import#6: libKernel:sceKernelReserveVirtualRange (7oxv3PPCumo)
[LOADER][TRACE] Import#7: libKernel:sceKernelSetPrtAperture (BohYr-F7-is)
[LOADER][WARN]  Import#7 result: ORBIS_GEN2_ERROR_INVALID_ARGUMENT (BohYr-F7-is)
                rdi=0x0000000000000000 rsi=0x00000289AC740000 rdx=0x0000004000000000
```

The title reserves a 256 GiB range and hands the result straight to `sceKernelSetPrtAperture` — the normal way to establish a PRT aperture. The arguments decode as aperture `0`, base `0x289AC740000`, size 256 GiB.

Working the five validation checks against those values, the failing one is:

```csharp
if (apertureBase - PrtAreaStartAddress > PrtAreaSize - apertureSize)
```

`0x289AC740000 - 0x1000000000` = `0x279AC740000` (~2.5 TiB) against `0xEC00000000 - 0x4000000000` = `0xAC00000000` (~688 GiB). Rejected.

## Why the window is the bug, not the address

**Nothing in the emulator allocates from that window.** `sceKernelReserveVirtualRange` — which is exactly how a title obtains a PRT aperture — searches free host VA from:

```csharp
private static ulong _nextReservedVirtualBase = 0x6000_0000_0UL;
```

That start is *below* `PrtAreaStartAddress` (`0x1000000000`), and the search then lands wherever the host has room — here `0x289AC740000`, far past the window's end. Guest and host share one address space because guest code executes natively, so a reserved range is a legitimate aperture wherever it landed.

So the window described a region no allocator in the tree ever produces, and a correct call was rejected on arrival. The two constants had no other reader; I grepped, and their only uses were the checks being removed.

## It cost more than an error code

On success, the import dispatcher does this:

```csharp
if (dispatchResolved &&
    orbisGen2Result == OrbisGen2Result.ORBIS_GEN2_OK &&
    string.Equals(importStubEntry.Nid, "BohYr-F7-is", StringComparison.Ordinal))
{
    RegisterPrtLazyCommitRange(value2, num3);
}
```

That registration is what makes later guest accesses to the aperture demand-page instead of faulting. So the rejection also left a 256 GiB range unbacked — a second failure waiting for the first access, on a path that only became reachable at all once #781 fixed the VEH spinlock.

## What changed

Kept the structural checks and dropped the fictional one:

- aperture id within the table — kept
- base non-zero and 4 KiB aligned — kept (base `0` was previously rejected only as a side effect of `base < PrtAreaStartAddress`, so it is now explicit)
- **base + size must not wrap** — added. The window checks had been providing this incidentally, so removing them without it would have opened a hole rather than closed one.

## Testing

**N/A** — I do not have Code Violet, so I cannot confirm it now gets past module init. What I can confirm is that the exact call it makes is accepted.

`KernelPrtApertureTests.cs` (new, 8 tests):

- **`AcceptsTheRangeAReservationActuallyReturned`** — Code Violet's literal arguments from the report
- `AcceptsARangeBelowTheOldWindowStart` — the reservation allocator's own starting region
- aperture id `-1`, `3`, `99` rejected
- misaligned base rejected, null base rejected
- **`RejectsARangeThatWrapsTheAddressSpace`** — pins the overflow guard that replaces the window's incidental protection

Confirmed load-bearing: reverting the source and re-running fails exactly the two acceptance tests, including Code Violet's arguments.

Verified as CI does, on Windows with .NET SDK 10.0.302:

```
dotnet build SharpEmu.slnx -c Release
dotnet test SharpEmu.slnx -c Release --no-build
```

`Build succeeded`, 897 tests pass, 0 failures (889 before this branch, +8 new).

## The alternative I considered

The other reading is that `sceKernelReserveVirtualRange` should be honouring a PRT-window address the title requested, and relocating it is the real defect. I could not settle that: the report's `Import#6` line does not include its arguments, so I cannot tell whether the title requested a specific address or passed `0` and let the system choose.

I went with this fix because it does not depend on that unknown — the emulator's own allocator is the authority on which addresses are valid, and it demonstrably produces addresses the check rejected. If a maintainer knows the PS5 genuinely constrains apertures to a fixed window, then the correct fix is instead to make the reservation allocator honour it, and I would rather that than guess.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
