### PR TITLE
Detect FS/GS segment prefixes that are not the first byte of the faulting instruction

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
@@ -76,6 +76,45 @@ public sealed partial class DirectExecutionBackend
 		SetUnhandledExceptionFilter(_unhandledFilterStub);
 	}
 
+	/// <summary>
+	/// Finds an FS/GS segment override at the start of a faulting instruction, skipping any
+	/// operand-size prefixes in front of it.
+	///
+	/// The override is not necessarily the first byte. LLVM's TLS general-dynamic relaxation pads
+	/// the sequence, so a guest thread-pointer load arrives as
+	/// <c>66 66 66 64 48 8B 04 25 00 00 00 00</c> — the <c>0x64</c> sits at index 3. Matching only
+	/// the first byte meant this never fired for the encoding shipping titles actually emit, and
+	/// an unpatched TLS access was reported as an ordinary unmapped-memory read instead.
+	/// </summary>
+	internal static bool TryDetectSegmentOverride(
+		ReadOnlySpan<byte> code,
+		out string segment,
+		out int prefixIndex)
+	{
+		prefixIndex = 0;
+		while (prefixIndex < code.Length && code[prefixIndex] == 0x66)
+		{
+			prefixIndex++;
+		}
+
+		if (prefixIndex < code.Length)
+		{
+			switch (code[prefixIndex])
+			{
+				case 0x64:
+					segment = "FS";
+					return true;
+				case 0x65:
+					segment = "GS";
+					return true;
+			}
+		}
+
+		segment = string.Empty;
+		prefixIndex = -1;
+		return false;
+	}
+
 	private unsafe int UnhandledExceptionFilter(void* exceptionInfo)
 	{
 		try
@@ -362,13 +401,11 @@ public sealed partial class DirectExecutionBackend
 					if (TryReadHostBytes(rip, code))
 					{
 						Console.Error.WriteLine("[LOADER][INFO]   Code at RIP: " + BitConverter.ToString(code).Replace("-", " "));
-						if (code[0] == 100)
+						if (TryDetectSegmentOverride(code, out var segment, out var segmentPrefixIndex))
 						{
-							Console.Error.WriteLine("[LOADER][ERROR]   Detected FS segment prefix - TLS access not patched!");
-						}
-						else if (code[0] == 101)
-						{
-							Console.Error.WriteLine("[LOADER][ERROR]   Detected GS segment prefix - TLS access not patched!");
+							Console.Error.WriteLine(
+								$"[LOADER][ERROR]   Detected {segment} segment prefix at byte {segmentPrefixIndex} - " +
+								"TLS access not patched!");
 						}
 						else if (code[0] == 197 || code[0] == 196)
 						{

--- a/tests/SharpEmu.Libs.Tests/Cpu/SegmentOverrideDetectionTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/SegmentOverrideDetectionTests.cs
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Native;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+/// <summary>
+/// When guest code faults on an unpatched TLS access the crash dump is supposed to say so. The
+/// check matched only the first byte of the instruction, so it never fired for the encoding
+/// shipping titles actually emit — LLVM's TLS general-dynamic relaxation pads the sequence with
+/// operand-size prefixes, putting the segment override at index 3.
+///
+/// The consequence was not cosmetic: every such crash in every user-submitted log was reported as
+/// an ordinary unmapped-memory read, which is why the underlying patcher defect went unnoticed.
+/// </summary>
+public sealed class SegmentOverrideDetectionTests
+{
+    /// <summary>
+    /// The exact bytes from God of War Ragnarök, EA UFC 5 and Minecraft — all three crash on a
+    /// byte-identical <c>mov rax, fs:[0]</c>.
+    /// </summary>
+    [Fact]
+    public void DetectsTheFsPrefixInTheEncodingRealTitlesEmit()
+    {
+        byte[] code =
+        [
+            0x66, 0x66, 0x66, 0x64, 0x48, 0x8B, 0x04, 0x25,
+            0x00, 0x00, 0x00, 0x00, 0x48, 0x8B, 0x0D, 0x00,
+        ];
+
+        Assert.True(DirectExecutionBackend.TryDetectSegmentOverride(code, out var segment, out var index));
+        Assert.Equal("FS", segment);
+        Assert.Equal(3, index);
+    }
+
+    [Fact]
+    public void DetectsAnUnpaddedFsPrefix()
+    {
+        byte[] code = [0x64, 0x48, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0];
+
+        Assert.True(DirectExecutionBackend.TryDetectSegmentOverride(code, out var segment, out var index));
+        Assert.Equal("FS", segment);
+        Assert.Equal(0, index);
+    }
+
+    [Fact]
+    public void DetectsAPaddedGsPrefix()
+    {
+        byte[] code = [0x66, 0x65, 0x48, 0x8B, 0x04, 0x25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+        Assert.True(DirectExecutionBackend.TryDetectSegmentOverride(code, out var segment, out var index));
+        Assert.Equal("GS", segment);
+        Assert.Equal(1, index);
+    }
+
+    /// <summary>
+    /// An ordinary instruction must not be misreported as a TLS fault — the dump would then send
+    /// the next person chasing a patcher bug that is not there.
+    /// </summary>
+    [Theory]
+    [InlineData(new byte[] { 0x48, 0x8B, 0x04, 0x25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 })] // mov rax,[abs]
+    [InlineData(new byte[] { 0xC5, 0xF8, 0x57, 0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 })] // vxorps (AVX)
+    [InlineData(new byte[] { 0x66, 0x66, 0x66, 0x90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 })] // padded nop
+    public void DoesNotReportASegmentOverrideThatIsNotThere(byte[] code)
+    {
+        Assert.False(DirectExecutionBackend.TryDetectSegmentOverride(code, out var segment, out var index));
+        Assert.Equal(string.Empty, segment);
+        Assert.Equal(-1, index);
+    }
+
+    /// <summary>All-prefix input must not run off the end of the buffer.</summary>
+    [Fact]
+    public void HandlesAnInstructionWindowThatIsEntirelyPrefixes()
+    {
+        var code = new byte[16];
+        Array.Fill(code, (byte)0x66);
+
+        Assert.False(DirectExecutionBackend.TryDetectSegmentOverride(code, out _, out var index));
+        Assert.Equal(-1, index);
+    }
+}


### PR DESCRIPTION
## Problem

`DirectExecutionBackend.Exceptions.cs` has a check meant to tell you when a guest access violation is really an unpatched TLS access rather than a null dereference:

```csharp
if (code[0] == 100)      // 0x64 = FS
{
    Console.Error.WriteLine("[LOADER][ERROR]   Detected FS segment prefix - TLS access not patched!");
}
else if (code[0] == 101) // 0x65 = GS
```

It only looks at `code[0]`. LLVM's TLS general-dynamic relaxation pads the sequence with operand-size prefixes, so a guest thread-pointer load actually arrives as:

```
66 66 66 64 48 8B 04 25 00 00 00 00     mov rax, fs:[0]
```

The `0x64` is at index **3**. `code[0]` is `0x66`, so the check falls through — first to the `code[0] == 197 || code[0] == 196` AVX branch, then to the generic path.

## Why it matters

The hint has not fired for the encoding shipping titles actually emit. Three of the "Nothing" entries on the compatibility list terminate on that byte-identical instruction:

```
Minecraft      Code at RIP: 66 66 66 64 48 8B 04 25 00 00 00 00 48 8B 7B ...
EA UFC 5       Code at RIP: 66 66 66 64 48 8B 04 25 00 00 00 00 C5 F8 57 ...
God of War     Code at RIP: 66 66 66 64 48 8B 04 25 00 00 00 00 48 8B 0D ...
```

FS base is 0 in the host process, so the load reads linear address 0 and each log reports:

```
[LOADER][INFO]   AV access: read
[LOADER][INFO]   AV target: 0x0000000000000000
```

with no TLS line. That reads as a null pointer returned from an HLE call — I read it that way myself at first, and filed a wrong diagnosis before the byte pattern made it obvious. The diagnostic that exists specifically to prevent that misreading has been silent the whole time.

## Change

Skip `0x66` prefixes before testing for the override, and report the index so a padded form is distinguishable from a bare one:

```
[LOADER][ERROR]   Detected FS segment prefix at byte 3 - TLS access not patched!
```

The check is pulled into `internal static bool TryDetectSegmentOverride(ReadOnlySpan<byte> code, out string segment, out int prefixIndex)` — no native state, no page patching, so it is testable against handcrafted byte sequences directly. Same reason `Sse4aExtrqBlendPatch` is factored that way.

Scope is deliberately narrow: **diagnostic only, no recovery behaviour changes.** The underlying patcher defect (`PatchTlsPatterns` scan coverage and handler locality) is discussed in #789 and is a separate, larger change — I am holding it for maintainer direction rather than bundling it here.

## Tests

`tests/SharpEmu.Libs.Tests/Cpu/SegmentOverrideDetectionTests.cs`, 7 cases:

- the exact padded `66 66 66 64 ...` bytes from the three logs above → `FS` at index 3
- bare `64 ...` → `FS` at index 0 (the form that already worked)
- padded `66 65 ...` → `GS` at index 1
- three negatives: `mov rax,[abs]`, an AVX `vxorps` (so the `code[0] == 197` branch is not regressed), and a padded `nop`
- an all-`0x66` window, so the prefix walk cannot run off the end of the buffer

Verified load-bearing: reverting the prefix skip in the source fails exactly the two padded cases and leaves the other five passing — the change adds coverage without altering what already worked.

`dotnet build SharpEmu.slnx -c Release` clean, `dotnet test SharpEmu.slnx -c Release --no-build` → **896 passed, 0 failed**.
