### PR TITLE
[CPU] Recover guest TLS thread-pointer loads the load-time patcher did not reach

### DIFF
--- a/src/SharpEmu.Core/Cpu/Emulation/TlsThreadPointerLoad.cs
+++ b/src/SharpEmu.Core/Cpu/Emulation/TlsThreadPointerLoad.cs
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+namespace SharpEmu.Core.Cpu.Emulation;
+
+/// <summary>
+/// Decoder for the guest thread-pointer load <c>mov reg, fs:[0]</c>.
+///
+/// On the PS5 this reads the thread's TCB self-pointer. The host process has no guest FS base -
+/// on Windows the FS base is zero - so the instruction cannot run natively: it would read linear
+/// address 0 and fault. The backend therefore rewrites every occurrence it finds at load time
+/// into a call to the TLS handler, which returns the guest TLS base for the calling thread.
+///
+/// The same encoding has to be recognised in two places: by the ahead-of-time patcher walking
+/// module bytes, and by the access-violation handler when an occurrence reaches the CPU
+/// unrewritten. Keeping one decoder means the fault-time path accepts exactly what the patcher
+/// accepts, and the two can never drift apart.
+///
+/// The decoder works on a plain byte span with no native state, so it can be unit-tested against
+/// the instruction bytes captured in crash logs.
+/// </summary>
+public static class TlsThreadPointerLoad
+{
+    /// <summary>
+    /// Longest form this decoder accepts: three operand-size prefixes, the segment override, a
+    /// REX byte, the opcode, ModRM, SIB and a 32-bit displacement.
+    /// </summary>
+    public const int MaxLength = 12;
+
+    /// <summary>
+    /// Decodes <c>mov reg, fs:[0]</c> at the start of <paramref name="code"/>.
+    ///
+    /// The accepted shape is any number of <c>0x66</c> operand-size prefixes (LLVM's TLS
+    /// general-dynamic relaxation emits three), the <c>0x64</c> FS override, an optional REX,
+    /// then <c>8B /r</c> with <c>mod=00</c>, <c>rm=100</c>, <c>SIB=0x25</c> and a zero
+    /// displacement - the absolute-address form that names offset 0 in the segment.
+    /// </summary>
+    /// <param name="destinationRegister">
+    /// The x86 register number the thread pointer is loaded into, 0-15 in encoding order
+    /// (rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi, r8-r15).
+    /// </param>
+    /// <param name="length">Total instruction length in bytes, prefixes included.</param>
+    public static bool TryDecode(ReadOnlySpan<byte> code, out int destinationRegister, out int length)
+    {
+        destinationRegister = 0;
+        length = 0;
+
+        var offset = 0;
+        while (offset < code.Length && code[offset] == 0x66)
+        {
+            offset++;
+        }
+
+        if (offset >= code.Length || code[offset] != 0x64)
+        {
+            return false;
+        }
+
+        offset++;
+        if (offset >= code.Length)
+        {
+            return false;
+        }
+
+        var rex = (byte)0;
+        if (code[offset] >= 0x40 && code[offset] <= 0x4F)
+        {
+            rex = code[offset];
+            offset++;
+        }
+
+        // opcode + ModRM + SIB + disp32
+        if (offset + 7 > code.Length || code[offset] != 0x8B)
+        {
+            return false;
+        }
+
+        var modRm = code[offset + 1];
+        var sib = code[offset + 2];
+        if ((modRm >> 6) != 0 || (modRm & 7) != 4 || sib != 0x25)
+        {
+            return false;
+        }
+
+        var displacement =
+            code[offset + 3] |
+            (code[offset + 4] << 8) |
+            (code[offset + 5] << 16) |
+            (code[offset + 6] << 24);
+        if (displacement != 0)
+        {
+            return false;
+        }
+
+        destinationRegister = ((modRm >> 3) & 7) | (((rex & 4) != 0) ? 8 : 0);
+        length = offset + 7;
+        return true;
+    }
+}

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 SharpEmu Emulator Project
+﻿// Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System;
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using SharpEmu.Core.Cpu.Disasm;
+using SharpEmu.Core.Cpu.Emulation;
 using SharpEmu.HLE;
 
 namespace SharpEmu.Core.Cpu.Native;
@@ -18,6 +19,11 @@ public sealed partial class DirectExecutionBackend
 	private const ulong LazyCommitWindowBytes = 0x0200_0000UL;
 	private static int _lazyCommitTraceCount;
 	private static int _guestAllocatorHoleRecoveries;
+	private static int _unpatchedTlsLoadRecoveries;
+	private static readonly bool _disableTlsLoadFaultRecovery = string.Equals(
+		Environment.GetEnvironmentVariable("SHARPEMU_DISABLE_TLS_LOAD_FAULT_RECOVERY"),
+		"1",
+		StringComparison.Ordinal);
 	private static int _auxiliaryThreadExecuteFaultRecoveries;
 	private static int _auxiliaryThreadExecuteFaultSkips;
 	private nint _workerAbortStack;
@@ -145,6 +151,11 @@ public sealed partial class DirectExecutionBackend
 			}
 			if (exceptionCode == 3221225477u &&
 				TryRecoverGuestAllocatorHole(exceptionRecord, contextRecord, rip))
+			{
+				return -1;
+			}
+			if (exceptionCode == 3221225477u &&
+				TryRecoverUnpatchedTlsLoad(exceptionRecord, contextRecord, rip))
 			{
 				return -1;
 			}
@@ -663,6 +674,123 @@ public sealed partial class DirectExecutionBackend
 			Console.Error.WriteLine(
 				$"[LOADER][WARN] Guest allocator empty-node adapter recovery #{recovery}: " +
 				$"rip=0x{rip:X16} -> 0x{rip + emptyPoolFallbackDelta:X16}");
+			Console.Error.Flush();
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	/// Finishes a guest <c>mov reg, fs:[0]</c> that reached the CPU without being rewritten.
+	///
+	/// The ahead-of-time pass rewrites these into a call to the TLS handler, but anything it does
+	/// not reach - code outside the scanned range, or mapped after the scan ran - executes as
+	/// written. The host FS base is zero, so the instruction reads linear address 0 and dies, and
+	/// with no fallback the title is over: this is the terminal fault in the God of War Ragnarok,
+	/// Minecraft and EA UFC 5 logs, all three on a byte-identical instruction.
+	///
+	/// Recovery is the same result the rewrite produces - the destination register receives the
+	/// calling thread's guest TLS base - so a recovered load is indistinguishable from a patched
+	/// one, only slower. Deliberately a backstop, not a replacement for patching.
+	/// </summary>
+	/// <summary>
+	/// Decides whether an access violation is a recoverable unpatched thread-pointer load, and if
+	/// so where in the CONTEXT to write the thread pointer and where to resume.
+	///
+	/// Separated from the CONTEXT plumbing so the decision can be driven directly in tests: every
+	/// guard here is a reason the emulator would rather report an honest crash than resume the
+	/// guest on a guess.
+	/// </summary>
+	/// <param name="accessType">
+	/// EXCEPTION_RECORD parameter 0: 0 read, 1 write, 8 execute.
+	/// </param>
+	/// <param name="faultAddress">EXCEPTION_RECORD parameter 1.</param>
+	/// <param name="guestTlsBase">The calling thread's guest TLS base, 0 if it has none.</param>
+	/// <param name="contextOffset">Byte offset of the destination register in the CONTEXT.</param>
+	internal static bool TryPlanUnpatchedTlsLoadRecovery(
+		ReadOnlySpan<byte> code,
+		ulong rip,
+		ulong accessType,
+		ulong faultAddress,
+		ulong guestTlsBase,
+		out int contextOffset,
+		out ulong resumeRip,
+		out int destinationRegister)
+	{
+		contextOffset = 0;
+		resumeRip = 0;
+		destinationRegister = 0;
+
+		// The host FS base is zero, so an unrewritten fs:[0] reads linear address 0. Anything
+		// else is a different fault. An ordinary null dereference lands here too - only the
+		// instruction bytes tell the two apart.
+		if (accessType != 0 || faultAddress != 0)
+		{
+			return false;
+		}
+
+		if (!TlsThreadPointerLoad.TryDecode(code, out destinationRegister, out var length))
+		{
+			return false;
+		}
+
+		if (guestTlsBase == 0)
+		{
+			// This thread has no guest TLS block. Resuming would hand the guest a null thread
+			// pointer and move the crash somewhere that says far less about the cause.
+			return false;
+		}
+
+		// The Win64 CONTEXT lays its integer registers out in x86 encoding order from Rax, so the
+		// register number indexes straight off CTX_RAX; ContextOffsetsAreLaidOutInEncodingOrderFromRax
+		// pins that down.
+		contextOffset = CTX_RAX + (8 * destinationRegister);
+		resumeRip = rip + (ulong)length;
+		return true;
+	}
+
+	private unsafe bool TryRecoverUnpatchedTlsLoad(
+		EXCEPTION_RECORD* exceptionRecord,
+		void* contextRecord,
+		ulong rip)
+	{
+		if (_disableTlsLoadFaultRecovery ||
+			exceptionRecord->NumberParameters < 2 ||
+			_guestTlsBaseTlsIndex == uint.MaxValue)
+		{
+			return false;
+		}
+
+		Span<byte> code = stackalloc byte[TlsThreadPointerLoad.MaxLength];
+		if (!TryReadHostBytes(rip, code))
+		{
+			return false;
+		}
+
+		var tlsBase = (ulong)TlsGetValue(_guestTlsBaseTlsIndex);
+		if (!TryPlanUnpatchedTlsLoadRecovery(
+				code,
+				rip,
+				*exceptionRecord->ExceptionInformation,
+				exceptionRecord->ExceptionInformation[1],
+				tlsBase,
+				out var contextOffset,
+				out var resumeRip,
+				out var destinationRegister))
+		{
+			return false;
+		}
+
+		WriteCtxU64(contextRecord, contextOffset, tlsBase);
+		WriteCtxU64(contextRecord, CTX_RIP, resumeRip);
+
+		var recovery = Interlocked.Increment(ref _unpatchedTlsLoadRecoveries);
+		if (recovery <= 16 || (recovery & (recovery - 1)) == 0)
+		{
+			Console.Error.WriteLine(
+				$"[LOADER][WARN] Unpatched TLS thread-pointer load recovery #{recovery}: " +
+				$"rip=0x{rip:X16} reg={destinationRegister} tls=0x{tlsBase:X16} " +
+				$"resume=0x{resumeRip:X16} (the load-time patcher did not cover this address)");
 			Console.Error.Flush();
 		}
 
@@ -1255,7 +1383,10 @@ public sealed partial class DirectExecutionBackend
 		}
 	}
 
-	private unsafe static bool TryReadHostBytes(ulong address, byte[] buffer)
+	private unsafe static bool TryReadHostBytes(ulong address, byte[] buffer) =>
+		TryReadHostBytes(address, buffer.AsSpan());
+
+	private unsafe static bool TryReadHostBytes(ulong address, Span<byte> buffer)
 	{
 		if (address < 65536)
 		{
@@ -1279,7 +1410,7 @@ public sealed partial class DirectExecutionBackend
 
 		try
 		{
-			Marshal.Copy((nint)address, buffer, 0, buffer.Length);
+			new ReadOnlySpan<byte>((void*)address, buffer.Length).CopyTo(buffer);
 			return true;
 		}
 		catch

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 SharpEmu Emulator Project
+﻿// Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System;
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using SharpEmu.Core.Cpu;
 using SharpEmu.Core.Cpu.Debugging;
+using SharpEmu.Core.Cpu.Emulation;
 using SharpEmu.Core.Loader;
 using SharpEmu.Core.Memory;
 using SharpEmu.HLE;
@@ -3321,50 +3322,16 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			return false;
 		}
 
-		var offset = 0;
-		while (offset < availableLength && source[offset] == 0x66)
-		{
-			offset++;
-		}
-
-		if (offset >= availableLength || source[offset] != 0x64)
+		if (!TlsThreadPointerLoad.TryDecode(
+				new ReadOnlySpan<byte>(source, availableLength),
+				out var destinationRegister,
+				out var instructionLength))
 		{
 			return false;
 		}
 
-		offset++;
-		if (offset >= availableLength)
-		{
-			return false;
-		}
-
-		var rex = (byte)0;
-		if (source[offset] >= 0x40 && source[offset] <= 0x4F)
-		{
-			rex = source[offset];
-			offset++;
-		}
-
-		if (offset + 7 > availableLength || source[offset] != 0x8B)
-		{
-			return false;
-		}
-
-		var modRm = source[offset + 1];
-		var sib = source[offset + 2];
-		if ((modRm >> 6) != 0 || (modRm & 7) != 4 || sib != 0x25)
-		{
-			return false;
-		}
-
-		var displacement = *(int*)(source + offset + 3);
-		if (displacement != 0)
-		{
-			return false;
-		}
-
-		var destinationRegister = ((modRm >> 3) & 7) | (((rex & 4) != 0) ? 8 : 0);
-		var instructionLength = offset + 7;
+		// A rewrite needs room for the call plus the register move; the decoder itself has no
+		// such constraint, so the length floor stays here with the patcher that requires it.
 		if (instructionLength < MinTlsPatchInstructionBytes)
 		{
 			return false;

--- a/tests/SharpEmu.Libs.Tests/Cpu/TlsThreadPointerLoadTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/TlsThreadPointerLoadTests.cs
@@ -1,0 +1,180 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Reflection;
+using SharpEmu.Core.Cpu.Emulation;
+using SharpEmu.Core.Cpu.Native;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+/// <summary>
+/// Covers the decoder shared by the load-time TLS patcher and the access-violation fallback that
+/// finishes a <c>mov reg, fs:[0]</c> the patcher did not reach.
+/// </summary>
+public sealed class TlsThreadPointerLoadTests
+{
+    /// <summary>
+    /// The instruction God of War Ragnarök, EA UFC 5 and Minecraft all die on, byte for byte.
+    /// LLVM's TLS general-dynamic relaxation leaves three operand-size prefixes in front.
+    /// </summary>
+    [Fact]
+    public void DecodesTheInstructionShippingTitlesActuallyFaultOn()
+    {
+        byte[] code =
+        [
+            0x66, 0x66, 0x66, 0x64, 0x48, 0x8B, 0x04, 0x25,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+
+        Assert.True(TlsThreadPointerLoad.TryDecode(code, out var register, out var length));
+        Assert.Equal(0, register); // rax
+        Assert.Equal(12, length);
+    }
+
+    /// <summary>Unpadded <c>mov rax, fs:[0]</c> — no prefixes, still the same instruction.</summary>
+    [Fact]
+    public void DecodesTheUnpaddedForm()
+    {
+        byte[] code = [0x64, 0x48, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00];
+
+        Assert.True(TlsThreadPointerLoad.TryDecode(code, out var register, out var length));
+        Assert.Equal(0, register);
+        Assert.Equal(9, length);
+    }
+
+    /// <summary>No REX at all: <c>mov eax, fs:[0]</c> is eight bytes.</summary>
+    [Fact]
+    public void DecodesTheFormWithNoRexByte()
+    {
+        byte[] code = [0x64, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00];
+
+        Assert.True(TlsThreadPointerLoad.TryDecode(code, out var register, out var length));
+        Assert.Equal(0, register);
+        Assert.Equal(8, length);
+    }
+
+    /// <summary>
+    /// The destination comes from ModRM.reg extended by REX.R. Getting this wrong writes the
+    /// thread pointer into the wrong register, which corrupts the guest silently rather than
+    /// crashing it.
+    /// </summary>
+    [Theory]
+    [InlineData(0x48, 0x04, 0)]  //             rax
+    [InlineData(0x48, 0x0C, 1)]  //             rcx
+    [InlineData(0x48, 0x14, 2)]  //             rdx
+    [InlineData(0x48, 0x1C, 3)]  //             rbx
+    [InlineData(0x48, 0x24, 4)]  //             rsp
+    [InlineData(0x48, 0x2C, 5)]  //             rbp
+    [InlineData(0x48, 0x34, 6)]  //             rsi
+    [InlineData(0x48, 0x3C, 7)]  //             rdi
+    [InlineData(0x4C, 0x04, 8)]  // REX.R set → r8
+    [InlineData(0x4C, 0x2C, 13)] // REX.R set → r13
+    [InlineData(0x4C, 0x3C, 15)] // REX.R set → r15
+    public void ExtractsTheDestinationRegisterFromModRmAndRex(byte rex, byte modRm, int expected)
+    {
+        byte[] code = [0x64, rex, 0x8B, modRm, 0x25, 0x00, 0x00, 0x00, 0x00];
+
+        Assert.True(TlsThreadPointerLoad.TryDecode(code, out var register, out var length));
+        Assert.Equal(expected, register);
+        Assert.Equal(9, length);
+    }
+
+    /// <summary>
+    /// Only offset 0 is the thread pointer. A non-zero displacement is a different TLS access
+    /// whose value is not the base, so accepting it would resume the guest with a wrong value —
+    /// worse than the fault it replaces.
+    /// </summary>
+    [Fact]
+    public void RejectsANonZeroDisplacement()
+    {
+        byte[] code = [0x64, 0x48, 0x8B, 0x04, 0x25, 0x08, 0x00, 0x00, 0x00];
+
+        Assert.False(TlsThreadPointerLoad.TryDecode(code, out _, out _));
+    }
+
+    [Theory]
+    [InlineData(new byte[] { 0x65, 0x48, 0x8B, 0x04, 0x25, 0, 0, 0, 0 })]       // GS, not FS
+    [InlineData(new byte[] { 0x48, 0x8B, 0x04, 0x25, 0, 0, 0, 0, 0 })]          // no segment override
+    [InlineData(new byte[] { 0x64, 0x48, 0x89, 0x04, 0x25, 0, 0, 0, 0 })]       // store, not load
+    [InlineData(new byte[] { 0x64, 0x48, 0x8B, 0x44, 0x25, 0, 0, 0, 0 })]       // mod=01, not mod=00
+    [InlineData(new byte[] { 0x64, 0x48, 0x8B, 0x00, 0x25, 0, 0, 0, 0 })]       // rm=000, no SIB
+    [InlineData(new byte[] { 0x64, 0x48, 0x8B, 0x04, 0x24, 0, 0, 0, 0 })]       // SIB names a base
+    [InlineData(new byte[] { 0x64, 0xC7, 0x04, 0x25, 0, 0, 0, 0, 0 })]          // immediate TLS store
+    public void RejectsInstructionsThatAreNotAThreadPointerLoad(byte[] code)
+    {
+        Assert.False(TlsThreadPointerLoad.TryDecode(code, out _, out _));
+    }
+
+    /// <summary>
+    /// The handler reads a fixed-size window that can end mid-instruction at a page boundary.
+    /// Every truncation must be rejected rather than read past the end.
+    /// </summary>
+    [Fact]
+    public void RejectsEveryTruncationOfAValidInstruction()
+    {
+        byte[] code =
+        [
+            0x66, 0x66, 0x66, 0x64, 0x48, 0x8B, 0x04, 0x25,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+
+        for (var take = 0; take < code.Length; take++)
+        {
+            Assert.False(
+                TlsThreadPointerLoad.TryDecode(code.AsSpan(0, take), out _, out _),
+                $"accepted a {take}-byte prefix of a {code.Length}-byte instruction");
+        }
+
+        Assert.True(TlsThreadPointerLoad.TryDecode(code, out _, out _));
+    }
+
+    /// <summary>An empty window must not fault.</summary>
+    [Fact]
+    public void RejectsAnEmptyWindow()
+    {
+        Assert.False(TlsThreadPointerLoad.TryDecode(ReadOnlySpan<byte>.Empty, out _, out _));
+    }
+
+    /// <summary>Trailing bytes after the instruction are the next instruction, not a mismatch.</summary>
+    [Fact]
+    public void ReportsOnlyTheLengthOfTheLoadItself()
+    {
+        byte[] code =
+        [
+            0x66, 0x66, 0x66, 0x64, 0x48, 0x8B, 0x04, 0x25,
+            0x00, 0x00, 0x00, 0x00, 0x48, 0x8B, 0x0D, 0x00,
+        ];
+
+        Assert.True(TlsThreadPointerLoad.TryDecode(code, out _, out var length));
+        Assert.Equal(12, length);
+    }
+
+    /// <summary>
+    /// The fault handler writes the recovered thread pointer with
+    /// <c>CTX_RAX + 8 * destinationRegister</c>. That shortcut is only valid because the Win64
+    /// CONTEXT stores its integer registers in x86 encoding order; if a future edit reorders the
+    /// offsets, the recovery would write the value into the wrong register — including RSP.
+    /// </summary>
+    [Fact]
+    public void ContextOffsetsAreLaidOutInEncodingOrderFromRax()
+    {
+        string[] encodingOrder =
+        [
+            "CTX_RAX", "CTX_RCX", "CTX_RDX", "CTX_RBX",
+            "CTX_RSP", "CTX_RBP", "CTX_RSI", "CTX_RDI",
+            "CTX_R8", "CTX_R9", "CTX_R10", "CTX_R11",
+            "CTX_R12", "CTX_R13", "CTX_R14", "CTX_R15",
+        ];
+
+        var baseOffset = ContextOffset("CTX_RAX");
+        for (var register = 0; register < encodingOrder.Length; register++)
+        {
+            Assert.Equal(baseOffset + (8 * register), ContextOffset(encodingOrder[register]));
+        }
+    }
+
+    private static int ContextOffset(string name) => (int)typeof(DirectExecutionBackend)
+        .GetField(name, BindingFlags.Static | BindingFlags.NonPublic)!
+        .GetRawConstantValue()!;
+}

--- a/tests/SharpEmu.Libs.Tests/Cpu/UnpatchedTlsLoadRecoveryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/UnpatchedTlsLoadRecoveryTests.cs
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Native;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+/// <summary>
+/// Drives the access-violation recovery for a guest <c>mov reg, fs:[0]</c> that reached the CPU
+/// unrewritten, over the exception parameters the OS would supply.
+/// </summary>
+public sealed class UnpatchedTlsLoadRecoveryTests
+{
+    private const int CtxRax = 120;
+    private const ulong Rip = 0x0000_0008_0028_4106UL;
+    private const ulong TlsBase = 0x0000_0008_1234_5000UL;
+
+    /// <summary>Access violation, read, target 0 — what the OS reports for this fault.</summary>
+    private const ulong Read = 0;
+
+    /// <summary>
+    /// The instruction and the exception parameters from the God of War Ragnarök log, which are
+    /// the same in the Minecraft and EA UFC 5 logs.
+    /// </summary>
+    private static readonly byte[] RealFault =
+    [
+        0x66, 0x66, 0x66, 0x64, 0x48, 0x8B, 0x04, 0x25,
+        0x00, 0x00, 0x00, 0x00,
+    ];
+
+    [Fact]
+    public void RecoversTheFaultThreeShippingTitlesTerminateOn()
+    {
+        Assert.True(DirectExecutionBackend.TryPlanUnpatchedTlsLoadRecovery(
+            RealFault, Rip, Read, faultAddress: 0, TlsBase,
+            out var contextOffset, out var resumeRip, out var register));
+
+        Assert.Equal(0, register);              // rax
+        Assert.Equal(CtxRax, contextOffset);
+        Assert.Equal(Rip + 12, resumeRip);      // past the whole padded instruction
+    }
+
+    /// <summary>
+    /// Resuming has to land exactly one instruction on. Short of that the guest re-executes the
+    /// load and faults forever; past it, it skips real work.
+    /// </summary>
+    [Theory]
+    [InlineData(new byte[] { 0x64, 0x8B, 0x04, 0x25, 0, 0, 0, 0 }, 8)]
+    [InlineData(new byte[] { 0x64, 0x48, 0x8B, 0x04, 0x25, 0, 0, 0, 0 }, 9)]
+    [InlineData(new byte[] { 0x66, 0x64, 0x48, 0x8B, 0x04, 0x25, 0, 0, 0, 0 }, 10)]
+    [InlineData(new byte[] { 0x66, 0x66, 0x66, 0x64, 0x48, 0x8B, 0x04, 0x25, 0, 0, 0, 0 }, 12)]
+    public void ResumesExactlyPastTheInstruction(byte[] code, int length)
+    {
+        Assert.True(DirectExecutionBackend.TryPlanUnpatchedTlsLoadRecovery(
+            code, Rip, Read, faultAddress: 0, TlsBase, out _, out var resumeRip, out _));
+
+        Assert.Equal(Rip + (ulong)length, resumeRip);
+    }
+
+    /// <summary>
+    /// The thread pointer must reach the register the instruction names. Writing the right value
+    /// to the wrong register corrupts the guest without crashing it.
+    /// </summary>
+    [Theory]
+    [InlineData(0x48, 0x04, 0, 120)]   // rax
+    [InlineData(0x48, 0x0C, 1, 128)]   // rcx
+    [InlineData(0x48, 0x14, 2, 136)]   // rdx
+    [InlineData(0x48, 0x1C, 3, 144)]   // rbx
+    [InlineData(0x48, 0x24, 4, 152)]   // rsp
+    [InlineData(0x48, 0x2C, 5, 160)]   // rbp
+    [InlineData(0x48, 0x34, 6, 168)]   // rsi
+    [InlineData(0x48, 0x3C, 7, 176)]   // rdi
+    [InlineData(0x4C, 0x04, 8, 184)]   // r8
+    [InlineData(0x4C, 0x2C, 13, 224)]  // r13
+    [InlineData(0x4C, 0x3C, 15, 240)]  // r15
+    public void TargetsTheContextSlotForTheEncodedRegister(
+        byte rex, byte modRm, int expectedRegister, int expectedOffset)
+    {
+        byte[] code = [0x64, rex, 0x8B, modRm, 0x25, 0x00, 0x00, 0x00, 0x00];
+
+        Assert.True(DirectExecutionBackend.TryPlanUnpatchedTlsLoadRecovery(
+            code, Rip, Read, faultAddress: 0, TlsBase,
+            out var contextOffset, out _, out var register));
+
+        Assert.Equal(expectedRegister, register);
+        Assert.Equal(expectedOffset, contextOffset);
+    }
+
+    /// <summary>
+    /// A thread with no guest TLS block gets no recovery. Resuming it with a null thread pointer
+    /// trades a crash that names the cause for one that happens later somewhere unrelated.
+    /// </summary>
+    [Fact]
+    public void DeclinesWhenTheThreadHasNoGuestTlsBase()
+    {
+        Assert.False(DirectExecutionBackend.TryPlanUnpatchedTlsLoadRecovery(
+            RealFault, Rip, Read, faultAddress: 0, guestTlsBase: 0, out _, out _, out _));
+    }
+
+    /// <summary>
+    /// A genuine null dereference reaches this handler with identical exception parameters. Only
+    /// the instruction bytes separate the two, so anything that is not the load must fall
+    /// through and be reported.
+    /// </summary>
+    [Theory]
+    [InlineData(new byte[] { 0x48, 0x8B, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0 })]        // mov rax,[rax]
+    [InlineData(new byte[] { 0x48, 0x8B, 0x04, 0x25, 0, 0, 0, 0, 0, 0, 0, 0 })]     // mov rax,[0] — no FS
+    [InlineData(new byte[] { 0x65, 0x48, 0x8B, 0x04, 0x25, 0, 0, 0, 0, 0, 0, 0 })]  // GS, not FS
+    [InlineData(new byte[] { 0x64, 0x48, 0x89, 0x04, 0x25, 0, 0, 0, 0, 0, 0, 0 })]  // a store
+    public void DeclinesFaultsThatOnlyLookLikeTheTlsLoad(byte[] code)
+    {
+        Assert.False(DirectExecutionBackend.TryPlanUnpatchedTlsLoadRecovery(
+            code, Rip, Read, faultAddress: 0, TlsBase, out _, out _, out _));
+    }
+
+    /// <summary>
+    /// Writes and execute faults are not this instruction, whatever the bytes at RIP decode to.
+    /// </summary>
+    [Theory]
+    [InlineData(1UL)] // write
+    [InlineData(8UL)] // execute
+    public void DeclinesAccessTypesOtherThanRead(ulong accessType)
+    {
+        Assert.False(DirectExecutionBackend.TryPlanUnpatchedTlsLoadRecovery(
+            RealFault, Rip, accessType, faultAddress: 0, TlsBase, out _, out _, out _));
+    }
+
+    /// <summary>
+    /// <c>fs:[0]</c> faults at linear address 0 and nowhere else. A fault at any other address is
+    /// a different problem that must not be silently resumed.
+    /// </summary>
+    [Theory]
+    [InlineData(0x8UL)]
+    [InlineData(0x1000UL)]
+    [InlineData(0xFFFF_FFFF_FFFF_FFF0UL)]
+    public void DeclinesFaultsAtAnyAddressOtherThanZero(ulong faultAddress)
+    {
+        Assert.False(DirectExecutionBackend.TryPlanUnpatchedTlsLoadRecovery(
+            RealFault, Rip, Read, faultAddress, TlsBase, out _, out _, out _));
+    }
+
+    /// <summary>
+    /// The handler reads a fixed window that can stop at a page boundary mid-instruction. A
+    /// truncated decode must decline rather than resume at a wrong offset.
+    /// </summary>
+    [Fact]
+    public void DeclinesATruncatedInstructionWindow()
+    {
+        for (var take = 0; take < RealFault.Length; take++)
+        {
+            Assert.False(
+                DirectExecutionBackend.TryPlanUnpatchedTlsLoadRecovery(
+                    RealFault.AsSpan(0, take), Rip, Read, faultAddress: 0, TlsBase,
+                    out _, out _, out _),
+                $"recovered from a {take}-byte window");
+        }
+    }
+}


### PR DESCRIPTION
Implements direction (2) from #789.

## Problem

A guest `mov reg, fs:[0]` cannot execute natively — the host FS base is zero, so it reads linear address 0 and dies. The backend handles this by rewriting every occurrence it finds at load time into a call to the TLS handler. Anything the load-time pass does not reach runs as written, and there is **no fallback**, so the first one a title executes ends the run.

That is the terminal fault in three logs, on a byte-identical instruction:

```
Minecraft      Code at RIP: 66 66 66 64 48 8B 04 25 00 00 00 00 48 8B 7B ...
EA UFC 5       Code at RIP: 66 66 66 64 48 8B 04 25 00 00 00 00 C5 F8 57 ...
God of War     Code at RIP: 66 66 66 64 48 8B 04 25 00 00 00 00 48 8B 0D ...
```

`66 66 66` is LLVM's TLS general-dynamic relaxation padding, `64` the FS override, `48 8B 04 25 00000000` is `mov rax, fs:[0]`. All three titles are at **Nothing** on the compatibility list. The logs report a read of address 0 and nothing more, which reads as a null pointer coming back from an HLE call rather than as a TLS access.

## Change

Adds the recovery to the access-violation ladder, next to the existing lazily-committed-page and allocator-hole cases. On a read fault at address 0 whose instruction decodes as the thread-pointer load, the destination register receives the calling thread's guest TLS base and execution resumes past the instruction — the same result the load-time rewrite produces, so a recovered load is indistinguishable from a patched one.

The decoder moves to `Cpu/Emulation/TlsThreadPointerLoad`, and `TryPatchTlsLoadInstruction` now uses it too. One decoder, two consumers: the fault path accepts exactly what the patcher accepts, and they cannot drift.

**Where it declines rather than guesses** — an ordinary null dereference arrives with identical exception parameters, so only the instruction bytes separate the two:

- the thread has no guest TLS block (resuming would hand the guest a null thread pointer and move the crash somewhere less informative)
- the fault is not a read, or not at address 0
- the bytes are not the thread-pointer load — including GS, a store, a non-zero displacement, or a different addressing form
- the instruction window is truncated at a page boundary

`SHARPEMU_DISABLE_TLS_LOAD_FAULT_RECOVERY=1` turns it off.

## Verification on hardware

A synthetic bare ELF reproduces the miss the way it actually happens. `PatchTlsPatterns` walks *forward* from the entry point, so anything mapped below the entry is never examined — Minecraft's case verbatim (entry `0x811950010`, fault at `0x80D104AA0`). So the guest puts the load in a function below the entry and calls back to it, and loads it into **r13** rather than rax, so recovering into the wrong register would still be caught:

```
0x1000  low:    66 66 66 64 4C 8B 2C 25 00000000   mov r13, fs:[0]
                31 C0                              xor eax, eax
                4D 85 ED                           test r13, r13
                0F 95 C0                           setnz al
                C3                                 ret
0x2000  entry:  E8 <rel32 to low>                  call low
                C3                                 ret
```

Same build, same guest, one environment variable:

```
[LOADER][INFO] Patched 0 TLS loads, 0 TLS stores, ...
[LOADER][WARN] Unpatched TLS thread-pointer load recovery #1: rip=0x0000000800001000
               reg=13 tls=0x00007FFE00000000 resume=0x000000080000100C
               (the load-time patcher did not cover this address)
[LOADER][INFO] Guest returned: 1
```

```
SHARPEMU_DISABLE_TLS_LOAD_FAULT_RECOVERY=1

[LOADER][INFO] NATIVE EXCEPTION CAUGHT!
[LOADER][INFO]   RIP: 0x0000000800001000
[LOADER][INFO]   AV access: read
[LOADER][INFO]   AV target: 0x0000000000000000
[LOADER][INFO]   Code at RIP: 66 66 66 64 4C 8B 2C 25 00 00 00 00 31 C0 4D 85
-> exit 139 (segmentation fault)
```

`Patched 0 TLS loads` confirms the load-time pass genuinely missed it, and the crash with recovery off is the same shape as the three title logs.

A control guest with the identical layout and PT_TLS but a harmless low function returns cleanly either way, so the layout is not doing the work.

## Depends on #781

Before that fix, the VEH spinlock's compare-exchange had REX.B clear, so no guest fault reached the managed handler at all. On current `main` this same guest produces a 20-second stall with no exception report whatsoever, with the recovery enabled or disabled — the handler is never reached. The hardware runs above are on `main` + #781. **This PR is correct but inert until #781 lands.** It is based on `main` and does not include that change.

## Tests

39 cases across two files.

`TlsThreadPointerLoadTests` — the decoder: the exact bytes from the three logs; the unpadded and no-REX forms; all 16 destination registers through ModRM.reg and REX.R; rejection of non-zero displacement, GS, stores, `mod=01`, `rm=000`, a SIB naming a base, and the immediate TLS store; every truncation of a valid instruction; an empty window.

It also pins the assumption the recovery's `CTX_RAX + 8 * register` shortcut rests on — that the Win64 CONTEXT stores its integer registers in x86 encoding order. If a future edit reorders those offsets, the recovery would write the thread pointer into the wrong register, including RSP, and that test is what catches it.

`UnpatchedTlsLoadRecoveryTests` — the recovery decision driven over the exception parameters the OS supplies: the God of War fault recovering to the right register and resume address; resume landing exactly one instruction on for each encoding length (8/9/10/12 bytes); the CONTEXT offset for all 16 registers; and each decline path above.

Verified load-bearing throughout — reverting a guard fails the case that covers it.

`dotnet build SharpEmu.slnx -c Release` clean, `dotnet test SharpEmu.slnx -c Release --no-build` → **942 passed, 0 failed**.

## Scope

Deliberately a backstop, not a replacement for patching — recovery costs a kernel round trip per load, so the load-time pass is still where coverage should come from. Direction (1) in #789 (scan coverage and handler locality) is the larger change and I am holding it for maintainer direction as offered there; the two are independent and this one helps regardless of what that pass ends up covering.
