### PR TITLE
[Diagnostics] Report live registers in the stall watchdog instead of the entry context

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 SharpEmu Emulator Project
+﻿// Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System;
@@ -912,6 +912,13 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	}
 
 	private bool HasActiveExecutionThread => ReferenceEquals(_activeExecutionBackend, this);
+
+	/// <summary>
+	/// Host thread id currently inside a guest execution call, 0 when none is. Read by the stall
+	/// watchdog from its own thread, which is why this is an ordinary field rather than one of the
+	/// [ThreadStatic] execution-state slots above.
+	/// </summary>
+	private int _executingHostThreadId;
 
 	/// <summary>
 	/// Binds the debug frame view the dispatcher created for the frame about to
@@ -5653,6 +5660,11 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		var previousYieldRequested = _activeGuestThreadYieldRequested;
 		var previousYieldReason = _activeGuestThreadYieldReason;
 		nint previousHostRspSlotValue = TlsGetValue(_hostRspSlotTlsIndex);
+		// Guest code runs natively on this thread; the managed CpuContext keeps whatever it was
+		// entered with. The stall watchdog runs elsewhere, so record the host thread id here or it
+		// has no way to reach the live registers.
+		var previousExecutingHostThreadId = Interlocked.Exchange(
+			ref _executingHostThreadId, unchecked((int)GetCurrentThreadId()));
 		try
 		{
 			_activeExecutionBackend = this;
@@ -5828,6 +5840,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		finally
 		{
 			TlsSetValue(_hostRspSlotTlsIndex, previousHostRspSlotValue);
+			Volatile.Write(ref _executingHostThreadId, previousExecutingHostThreadId);
 			RestoreActiveExecutionThread(
 				previousActiveBackend,
 				previousActiveContext,
@@ -5876,6 +5889,11 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		var previousYieldRequested = _activeGuestThreadYieldRequested;
 		var previousYieldReason = _activeGuestThreadYieldReason;
 		nint previousHostRspSlotValue = TlsGetValue(_hostRspSlotTlsIndex);
+		// Guest code runs natively on this thread; the managed CpuContext keeps whatever it was
+		// entered with. The stall watchdog runs elsewhere, so record the host thread id here or it
+		// has no way to reach the live registers.
+		var previousExecutingHostThreadId = Interlocked.Exchange(
+			ref _executingHostThreadId, unchecked((int)GetCurrentThreadId()));
 		try
 		{
 			_activeExecutionBackend = this;
@@ -5991,6 +6009,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		finally
 		{
 			TlsSetValue(_hostRspSlotTlsIndex, previousHostRspSlotValue);
+			Volatile.Write(ref _executingHostThreadId, previousExecutingHostThreadId);
 			RestoreActiveExecutionThread(
 				previousActiveBackend,
 				previousActiveContext,
@@ -6146,6 +6165,11 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		var previousYieldRequested = _activeGuestThreadYieldRequested;
 		var previousYieldReason = _activeGuestThreadYieldReason;
 		nint previousHostRspSlotValue = TlsGetValue(_hostRspSlotTlsIndex);
+		// Guest code runs natively on this thread; the managed CpuContext keeps whatever it was
+		// entered with. The stall watchdog runs elsewhere, so record the host thread id here or it
+		// has no way to reach the live registers.
+		var previousExecutingHostThreadId = Interlocked.Exchange(
+			ref _executingHostThreadId, unchecked((int)GetCurrentThreadId()));
 		try
 		{
 			_activeExecutionBackend = this;
@@ -6349,6 +6373,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			StopStallWatchdog();
 			ActiveEntryReturnSentinelRip = 0uL;
 			TlsSetValue(_hostRspSlotTlsIndex, previousHostRspSlotValue);
+			Volatile.Write(ref _executingHostThreadId, previousExecutingHostThreadId);
 			if (_hostRspSlotStorage != 0)
 			{
 				*(long*)_hostRspSlotStorage = 0L;
@@ -6726,9 +6751,35 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			{
 				return;
 			}
-			ulong rsp = cpuContext[CpuRegister.Rsp];
-			Console.Error.WriteLine($"[LOADER][ERROR] Stall snapshot: rip=0x{cpuContext.Rip:X16} rsp=0x{rsp:X16} rbp=0x{cpuContext[CpuRegister.Rbp]:X16} rax=0x{cpuContext[CpuRegister.Rax]:X16} rbx=0x{cpuContext[CpuRegister.Rbx]:X16} rcx=0x{cpuContext[CpuRegister.Rcx]:X16} rdx=0x{cpuContext[CpuRegister.Rdx]:X16} rsi=0x{cpuContext[CpuRegister.Rsi]:X16} rdi=0x{cpuContext[CpuRegister.Rdi]:X16}");
-			ulong num = cpuContext.Rip & 0xFFFFFFFFFFFFFFF0uL;
+			// Guest code executes natively, so the managed context still holds the values execution
+			// was entered with - reporting its RIP names the entry point, not where the guest is
+			// stuck. Suspend the executing host thread and read the live registers instead; fall
+			// back to the managed context only when that thread cannot be reached.
+			ulong rip;
+			ulong rsp;
+			var executingHostThreadId = Volatile.Read(ref _executingHostThreadId);
+			if (TryCaptureHostThreadContext(executingHostThreadId, out var live))
+			{
+				rip = live.Rip;
+				rsp = live.Rsp;
+				Console.Error.WriteLine(
+					$"[LOADER][ERROR] Stall snapshot: rip=0x{rip:X16} rsp=0x{rsp:X16} rbp=0x{live.Rbp:X16} " +
+					$"rax=0x{live.Rax:X16} rbx=0x{live.Rbx:X16} rcx=0x{live.Rcx:X16} rdx=0x{live.Rdx:X16} " +
+					$"source=live host_tid={executingHostThreadId} entry_rip=0x{cpuContext.Rip:X16}");
+			}
+			else
+			{
+				rip = cpuContext.Rip;
+				rsp = cpuContext[CpuRegister.Rsp];
+				Console.Error.WriteLine(
+					$"[LOADER][ERROR] Stall snapshot: rip=0x{rip:X16} rsp=0x{rsp:X16} rbp=0x{cpuContext[CpuRegister.Rbp]:X16} " +
+					$"rax=0x{cpuContext[CpuRegister.Rax]:X16} rbx=0x{cpuContext[CpuRegister.Rbx]:X16} " +
+					$"rcx=0x{cpuContext[CpuRegister.Rcx]:X16} rdx=0x{cpuContext[CpuRegister.Rdx]:X16} " +
+					$"rsi=0x{cpuContext[CpuRegister.Rsi]:X16} rdi=0x{cpuContext[CpuRegister.Rdi]:X16} " +
+					$"source=entry-context host_tid={executingHostThreadId} " +
+					"(registers are as execution was entered, not where it is stopped)");
+			}
+			ulong num = rip & 0xFFFFFFFFFFFFFFF0uL;
 			for (int i = 0; i < _importEntries.Length; i++)
 			{
 				if (_importEntries[i].Address != num)
@@ -6747,7 +6798,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				break;
 			}
 			Span<byte> destination = stackalloc byte[16];
-			if (cpuContext.Memory.TryRead(cpuContext.Rip, destination))
+			if (cpuContext.Memory.TryRead(rip, destination))
 			{
 				Console.Error.WriteLine($"[LOADER][ERROR] Stall bytes @rip: {BitConverter.ToString(destination.ToArray()).Replace("-", " ")}");
 			}

--- a/tests/SharpEmu.Libs.Tests/Cpu/HostThreadContextCaptureTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/HostThreadContextCaptureTests.cs
@@ -1,0 +1,118 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Reflection;
+using System.Threading;
+using SharpEmu.Core.Cpu.Native;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+/// <summary>
+/// The stall watchdog reads the live registers of the thread executing guest code by suspending
+/// it. Guest code runs natively, so the managed CpuContext still holds whatever execution was
+/// entered with — reporting its RIP names the entry point rather than where the guest is stuck.
+///
+/// Suspending the thread it is diagnosing is the risk in that: a capture that fails to resume
+/// would freeze the emulator at exactly the moment someone is trying to find out why it stopped.
+/// </summary>
+public sealed class HostThreadContextCaptureTests
+{
+    private static readonly MethodInfo Capture = typeof(DirectExecutionBackend).GetMethod(
+        "TryCaptureHostThreadContext",
+        BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    /// <summary>
+    /// A running thread must keep running afterwards. This is the property that keeps the
+    /// watchdog from deadlocking the process it reports on.
+    /// </summary>
+    [Fact]
+    public void LeavesTheCapturedThreadRunning()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var progress = 0L;
+        var stop = false;
+        var started = new ManualResetEventSlim();
+        var threadId = 0;
+
+        var worker = new Thread(() =>
+        {
+            threadId = GetCurrentThreadId();
+            started.Set();
+            while (!Volatile.Read(ref stop))
+            {
+                Interlocked.Increment(ref progress);
+            }
+        })
+        { IsBackground = true };
+
+        worker.Start();
+        try
+        {
+            Assert.True(started.Wait(TimeSpan.FromSeconds(10)));
+
+            Assert.True(TryCapture(threadId, out var rip, out var rsp));
+            Assert.NotEqual(0UL, rip);
+            Assert.NotEqual(0UL, rsp);
+
+            var afterCapture = Interlocked.Read(ref progress);
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+            while (Interlocked.Read(ref progress) == afterCapture && DateTime.UtcNow < deadline)
+            {
+                Thread.Sleep(1);
+            }
+
+            Assert.True(
+                Interlocked.Read(ref progress) > afterCapture,
+                "the captured thread made no progress afterwards - it was left suspended");
+        }
+        finally
+        {
+            Volatile.Write(ref stop, true);
+            worker.Join(TimeSpan.FromSeconds(10));
+        }
+    }
+
+    /// <summary>
+    /// Capturing the calling thread would suspend the watchdog itself, which never returns. It
+    /// has to decline instead.
+    /// </summary>
+    [Fact]
+    public void DeclinesToCaptureTheCallingThread()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Assert.False(TryCapture(GetCurrentThreadId(), out _, out _));
+    }
+
+    /// <summary>
+    /// Thread id 0 is what the watchdog reads when no guest execution is in progress. It must
+    /// fall back to the managed context rather than reporting invented registers.
+    /// </summary>
+    [Fact]
+    public void DeclinesWhenNoThreadIsExecuting()
+    {
+        Assert.False(TryCapture(0, out _, out _));
+    }
+
+    private static bool TryCapture(int hostThreadId, out ulong rip, out ulong rsp)
+    {
+        object?[] args = [hostThreadId, null];
+        var captured = (bool)Capture.Invoke(null, args)!;
+        var snapshot = args[1]!;
+        var type = snapshot.GetType();
+        rip = (ulong)type.GetProperty("Rip")!.GetValue(snapshot)!;
+        rsp = (ulong)type.GetProperty("Rsp")!.GetValue(snapshot)!;
+        return captured;
+    }
+
+    [System.Runtime.InteropServices.DllImport("kernel32.dll")]
+    private static extern int GetCurrentThreadId();
+}


### PR DESCRIPTION
## Problem

The stall watchdog's headline line reads the managed `CpuContext`:

```csharp
Console.Error.WriteLine($"[LOADER][ERROR] Stall snapshot: rip=0x{cpuContext.Rip:X16} ...");
```

Guest code executes natively, so that object still holds whatever execution was *entered* with. The RIP it prints is the entry point, not where the guest is stuck, and the general registers are the ones execution started with. `Stall bytes @rip` is then dumped from that same stale RIP, so the report also shows the wrong instruction.

A synthetic guest makes it unambiguous — entry at `0x800002000` calls a function at `0x800001000` that spins forever. On current `main`:

```
[LOADER][ERROR] Stall snapshot: rip=0x0000000800002000 rsp=0x00007FFFF01FFF98 rbp=0x00007FFFF01FFFE0
                rax=0x0 rbx=0x0 rcx=0x0 rdx=0x0 rsi=0x00007FFDD0000000 rdi=0x00007FFFF01FFFA0
[LOADER][ERROR] Stall bytes @rip: E8 FB EF FF FF C3
```

`E8 FB EF FF FF C3` is the `call` at the entry point. The guest is spinning 0x1000 bytes away, and every general register reads zero.

This affects every stall capture attached to a compatibility report, so anyone reading one — including anyone triaging the "Boots"/"Menus" titles that stall rather than crash — starts from the wrong address. I hit it myself while verifying #791: the report pointed at the entry while the guest was actually dead at a completely different RIP, and it cost real time before I stopped trusting the number.

## Change

The machinery to do better already exists. `TryCaptureHostThreadContext` suspends a host thread and reads its live registers — but it is only applied to threads in the guest-thread registry, and the thread running the entry is not one of them, so in practice the live path never covers the interesting thread. (In the run above there were zero `Stall guest-thread:` lines at all.)

Record the host thread id on entry to each of the three guest execution paths, and have the watchdog capture that thread's live context. Same guest, same build, after:

```
[LOADER][ERROR] Stall snapshot: rip=0x0000000800001000 rsp=0x00007FFFF01FFF80 rbp=0x00007FFFF01FFFE0
                rax=0x0000000800002000 rbx=0x000000A11557EC00 rcx=0x0 rdx=0x0
                source=live host_tid=6180 entry_rip=0x0000000800002000
[LOADER][ERROR] Stall bytes @rip: 90 90 EB FC
```

`90 90 EB FC` is `nop; nop; jmp -4` — the loop it is actually spinning in.

Two details worth calling out:

- **The entry RIP is kept**, as `entry_rip=`, since it is still useful — it just is not the stall location.
- **The fallback says so.** When the executing thread cannot be reached the report still uses the managed context, but now tags itself `source=entry-context` and states that the registers are as execution was entered. Silently presenting entry registers as a snapshot is what caused the problem in the first place.

The new field is an ordinary instance field rather than one of the `[ThreadStatic]` execution-state slots, because the watchdog reads it from its own thread — that is the whole point.

## Tests

The capture suspends the thread it reports on, which is the real risk here: a capture that fails to resume would freeze the emulator at exactly the moment someone is trying to find out why it stopped. So the test covers that property directly — a captured thread must still be making progress afterwards — plus the two decline paths (the calling thread, which would suspend the watchdog itself; and thread id 0, when no guest execution is in progress).

Verified load-bearing: removing the `ResumeThread` call fails `LeavesTheCapturedThreadRunning` with *"the captured thread made no progress afterwards - it was left suspended"*.

`dotnet build SharpEmu.slnx -c Release` clean, `dotnet test SharpEmu.slnx -c Release --no-build` → **892 passed, 0 failed**.

## Scope

Diagnostics only — no execution behaviour changes, and the watchdog's threshold and triggering are untouched. Independent of #790 and #791.
