### PR TITLE
[Kernel] Write the full 64-bit handle in sceKernelCreateSema

### DIFF
--- a/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelSemaphoreCompatExports.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 SharpEmu Emulator Project
+﻿// Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Buffers.Binary;
@@ -71,7 +71,11 @@ public static class KernelSemaphoreCompatExports
             Count = initialCount,
         };
 
-        if (!TryWriteUInt32(ctx, semaphoreAddress, handle))
+        // SceKernelSema is a 64-bit opaque pointer, so the whole variable has to be written.
+        // Writing only the low half leaves the guest's upper four bytes holding whatever was
+        // there, which every other kernel-object creator here avoids: sceKernelCreateEventFlag
+        // and sceKernelCreateEqueue both write 64 bits.
+        if (!ctx.TryWriteUInt64(semaphoreAddress, handle))
         {
             _semaphores.TryRemove(handle, out _);
             return SetReturn(ctx, OrbisGen2Result.ORBIS_GEN2_ERROR_MEMORY_FAULT);

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelCreateSemaOutParameterTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelCreateSemaOutParameterTests.cs
@@ -1,0 +1,100 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+/// <summary>
+/// <c>SceKernelSema</c> is a 64-bit opaque pointer, so <c>sceKernelCreateSema</c> has to write the
+/// guest's whole variable. Writing only the low half leaves the upper four bytes holding whatever
+/// was there before the call — the sibling creators (<c>sceKernelCreateEventFlag</c>,
+/// <c>sceKernelCreateEqueue</c>) both write 64 bits.
+/// </summary>
+public sealed class KernelCreateSemaOutParameterTests
+{
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong SemaphoreAddress = MemoryBase + 0x100;
+    private const ulong NameAddress = MemoryBase + 0x200;
+
+    /// <summary>
+    /// The guest's variable is uninitialised in practice. Pre-fill it so a partial write is
+    /// visible as surviving garbage rather than hiding behind zeroed memory.
+    /// </summary>
+    [Fact]
+    public void WritesTheWholeSixtyFourBitHandleVariable()
+    {
+        var context = CreateContext();
+        Assert.True(context.TryWriteUInt64(SemaphoreAddress, 0xDEAD_BEEF_DEAD_BEEFUL));
+
+        Assert.Equal(0, CreateSema(context, "sema-full-width"));
+
+        Assert.True(context.TryReadUInt64(SemaphoreAddress, out var written));
+        Assert.Equal(0UL, written >> 32);
+        Assert.NotEqual(0UL, written & 0xFFFF_FFFFUL);
+    }
+
+    /// <summary>
+    /// The handle written out has to be the one the semaphore calls answer to, or the guest holds
+    /// a token nothing accepts.
+    /// </summary>
+    [Fact]
+    public void WritesAHandleTheSemaphoreCallsAccept()
+    {
+        var context = CreateContext();
+        Assert.Equal(0, CreateSema(context, "sema-round-trip", initialCount: 1));
+        Assert.True(context.TryReadUInt64(SemaphoreAddress, out var handle));
+
+        context[CpuRegister.Rdi] = handle;
+        context[CpuRegister.Rsi] = 1;
+        context[CpuRegister.Rdx] = 0;
+        Assert.Equal(0, KernelSemaphoreCompatExports.KernelWaitSema(context));
+
+        context[CpuRegister.Rdi] = handle;
+        Assert.Equal(0, KernelSemaphoreCompatExports.KernelDeleteSema(context));
+    }
+
+    /// <summary>Two semaphores must not come back with the same handle.</summary>
+    [Fact]
+    public void HandsOutDistinctHandles()
+    {
+        var context = CreateContext();
+
+        Assert.Equal(0, CreateSema(context, "sema-a"));
+        Assert.True(context.TryReadUInt64(SemaphoreAddress, out var first));
+
+        Assert.Equal(0, CreateSema(context, "sema-b"));
+        Assert.True(context.TryReadUInt64(SemaphoreAddress, out var second));
+
+        Assert.NotEqual(first, second);
+
+        foreach (var handle in new[] { first, second })
+        {
+            context[CpuRegister.Rdi] = handle;
+            Assert.Equal(0, KernelSemaphoreCompatExports.KernelDeleteSema(context));
+        }
+    }
+
+    private static int CreateSema(CpuContext context, string name, int initialCount = 0)
+    {
+        WriteName(context, name);
+        context[CpuRegister.Rdi] = SemaphoreAddress;
+        context[CpuRegister.Rsi] = NameAddress;
+        context[CpuRegister.Rdx] = 0;
+        context[CpuRegister.Rcx] = unchecked((ulong)initialCount);
+        context[CpuRegister.R8] = 4;
+        context[CpuRegister.R9] = 0;
+        return KernelSemaphoreCompatExports.KernelCreateSema(context);
+    }
+
+    private static void WriteName(CpuContext context, string name)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(name + "\0");
+        Assert.True(context.Memory.TryWrite(NameAddress, bytes));
+    }
+
+    private static CpuContext CreateContext() =>
+        new(new FakeCpuMemory(MemoryBase, 0x1000), Generation.Gen5);
+}


### PR DESCRIPTION
## Problem

`SceKernelSema` is a 64-bit opaque pointer, so `sceKernelCreateSema`'s out-parameter is eight bytes. It writes four:

```csharp
if (!TryWriteUInt32(ctx, semaphoreAddress, handle))
```

The guest's upper half keeps whatever was in that variable beforehand — in practice, uninitialised stack or struct padding.

It is the odd one out among the kernel-object creators in this tree:

| export | out-parameter write |
|---|---|
| `sceKernelCreateEventFlag` | `ctx.TryWriteUInt64(outAddress, handle)` |
| `sceKernelCreateEqueue` | `ctx.TryWriteUInt64(outAddress, handle)` |
| `scePthreadMutexInit` | `TryWriteUInt64Compat(ctx, mutexAddress, handle)` |
| **`sceKernelCreateSema`** | **`TryWriteUInt32(ctx, semaphoreAddress, handle)`** |

## Severity, honestly

**No title is known to break on this today.** Every semaphore export here takes the handle in RDI and masks it back to 32 bits, so the value round-trips through our own HLE regardless of what the upper half holds. I checked each consumer before writing this.

So the deviation is from the ABI, not from our internal consistency. What it leaves behind is a guest variable that is half-initialised: a guest that copies it, compares two of them, or null-checks the full 64 bits is reading uninitialised data, and the resulting bug would be nondeterministic and extremely unpleasant to trace back to here. I would rather not leave that for whoever hits it.

I am flagging the severity plainly rather than dressing this up as a fix for a specific title, because it isn't one.

## Change

One line, plus a comment recording why the width matters and which siblings it now matches.

**The POSIX side is deliberately unchanged.** `sem_init` writes a 32-bit cookie into an opaque `sem_t` and `TryGetPosixSemaphoreHandle` reads it back at the same width — that is a consistent pair, and a legitimate design for a struct the guest never inspects. Only the Orbis entry point is wrong.

## Tests

`KernelCreateSemaOutParameterTests`, three cases:

- the out-parameter is pre-filled with `0xDEADBEEFDEADBEEF` before the call, so a partial write shows up as surviving garbage rather than hiding behind zeroed memory
- the handle written out is one `sceKernelWaitSema` and `sceKernelDeleteSema` actually accept — a wider write is no good if it writes the wrong thing
- two semaphores get distinct handles

Verified load-bearing: restoring the 32-bit write fails `WritesTheWholeSixtyFourBitHandleVariable` and leaves the other two passing, which is the correct signature for a change that adds width without altering the handle.

`dotnet build SharpEmu.slnx -c Release` clean, `dotnet test SharpEmu.slnx -c Release --no-build` → **892 passed, 0 failed**.
