### PR TITLE
Fix VEH trampoline lock register encoding

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -2929,7 +2929,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int hostPauseJump = offset;
 		EmitUInt32(code, ref offset, 0u);
-		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4C);
+		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4D);
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0xB1); EmitByte(code, ref offset, 0x11); // lock cmpxchg [r9], r10
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int hostRetryJump = offset;
@@ -3012,7 +3012,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int guestPauseJump = offset;
 		EmitUInt32(code, ref offset, 0u);
-		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4C);
+		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4D);
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0xB1); EmitByte(code, ref offset, 0x11);
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int guestRetryJump = offset;

--- a/tests/SharpEmu.Libs.Tests/Cpu/ImportTrampolineAbiTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/ImportTrampolineAbiTests.cs
@@ -60,6 +60,22 @@ public sealed class ImportTrampolineAbiTests
         }
     }
 
+    [Fact]
+    public unsafe void ExceptionHandlerTrampoline_UsesR9ForBothManagedEntryLocks()
+    {
+        if (!OperatingSystem.IsWindows() || RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            return;
+        }
+
+        var code = CreateExceptionHandlerTrampolineBytes();
+        var expected = new byte[] { 0xF0, 0x4D, 0x0F, 0xB1, 0x11 };
+        var incorrect = new byte[] { 0xF0, 0x4C, 0x0F, 0xB1, 0x11 };
+
+        Assert.Equal(2, CountOccurrences(code, expected));
+        Assert.Equal(0, CountOccurrences(code, incorrect));
+    }
+
     private static unsafe byte[] CreateTrampolineBytes()
     {
         var backend = (DirectExecutionBackend)RuntimeHelpers.GetUninitializedObject(
@@ -85,6 +101,41 @@ public sealed class ImportTrampolineAbiTests
         {
             Assert.True(HostMemory.Free((void*)trampoline, 0, HostMemory.MEM_RELEASE));
         }
+    }
+
+    private static unsafe byte[] CreateExceptionHandlerTrampolineBytes()
+    {
+        var backend = (DirectExecutionBackend)RuntimeHelpers.GetUninitializedObject(
+            typeof(DirectExecutionBackend));
+        var createTrampoline = typeof(DirectExecutionBackend).GetMethod(
+            "CreateExceptionHandlerTrampoline",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(createTrampoline);
+        var trampoline = (nint)createTrampoline.Invoke(backend, [nint.Zero])!;
+        Assert.NotEqual(0, trampoline);
+
+        try
+        {
+            return new ReadOnlySpan<byte>((void*)trampoline, 2048).ToArray();
+        }
+        finally
+        {
+            Assert.True(HostMemory.Free((void*)trampoline, 0, HostMemory.MEM_RELEASE));
+        }
+    }
+
+    private static int CountOccurrences(ReadOnlySpan<byte> code, ReadOnlySpan<byte> pattern)
+    {
+        var count = 0;
+        for (var offset = 0; offset <= code.Length - pattern.Length; offset++)
+        {
+            if (code.Slice(offset, pattern.Length).SequenceEqual(pattern))
+            {
+                count++;
+            }
+        }
+
+        return count;
     }
 
     private static void AssertContains(ReadOnlySpan<byte> code, ReadOnlySpan<byte> expected)

--- a/tests/SharpEmu.Libs.Tests/Cpu/WindowsVehRegressionTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/WindowsVehRegressionTests.cs
@@ -1,0 +1,239 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+public sealed class WindowsVehRegressionTests
+{
+    private const int RegressionTimeoutMilliseconds = 30_000;
+#if DEBUG
+    private const string BuildConfiguration = "Debug";
+#else
+    private const string BuildConfiguration = "Release";
+#endif
+
+    private static readonly byte[] RetGuest = [0x31, 0xC0, 0xC3];
+    private static readonly byte[] Ud2Guest = [0x0F, 0x0B];
+    private static readonly byte[] AccessViolationGuest =
+        [0x48, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00, 0xC3];
+
+    [Fact]
+    public void RetGuest_StillReturnsNormally()
+    {
+        if (!CanRunNativeWindowsGuest())
+        {
+            return;
+        }
+
+        var result = RunGuest("ret", RetGuest);
+
+        AssertCompleted(result, "RET");
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Guest returned: 0", result.Output);
+    }
+
+    [Fact]
+    public void Ud2Guest_ReachesManagedVehWithoutCpuSpin()
+    {
+        if (!CanRunNativeWindowsGuest())
+        {
+            return;
+        }
+
+        var result = RunGuest("ud2", Ud2Guest);
+
+        AssertFaultReachedManagedPathWithoutSpin(result, "UD2", "0xC000001D");
+    }
+
+    [Fact]
+    public void AccessViolationGuest_ReachesManagedVehWithoutCpuSpin()
+    {
+        if (!CanRunNativeWindowsGuest())
+        {
+            return;
+        }
+
+        var result = RunGuest("access-violation", AccessViolationGuest);
+
+        AssertFaultReachedManagedPathWithoutSpin(result, "access violation", "0xC0000005");
+    }
+
+    private static bool CanRunNativeWindowsGuest() =>
+        OperatingSystem.IsWindows() && RuntimeInformation.ProcessArchitecture == Architecture.X64;
+
+    private static GuestProcessResult RunGuest(string name, ReadOnlySpan<byte> guestCode)
+    {
+        var appHost = FindAppHost();
+        var tempDirectory = Directory.CreateTempSubdirectory($"sharpemu-779-{name}-");
+        try
+        {
+            var imagePath = Path.Combine(tempDirectory.FullName, "eboot.bin");
+            File.WriteAllBytes(imagePath, BuildElfImage(guestCode));
+            return RunAppHost(appHost, imagePath, name);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    private static string FindAppHost()
+    {
+        var repository = FindRepositoryRoot();
+        var appHost = Path.Combine(
+            repository,
+            "artifacts",
+            "bin",
+            BuildConfiguration,
+            "net10.0",
+            "win-x64",
+            "SharpEmu.exe");
+
+        if (File.Exists(appHost))
+        {
+            return appHost;
+        }
+
+        throw new FileNotFoundException(
+            $"The Windows CLI test host was not built for {BuildConfiguration}. " +
+            $"Build SharpEmu.slnx with -c {BuildConfiguration} before running this regression test.",
+            appHost);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "SharpEmu.slnx")))
+            {
+                return directory.FullName;
+            }
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the SharpEmu repository root.");
+    }
+
+    private static GuestProcessResult RunAppHost(string appHost, string imagePath, string name)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = appHost,
+            WorkingDirectory = Path.GetDirectoryName(appHost)!,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        startInfo.ArgumentList.Add("--cpu-engine=native");
+        startInfo.ArgumentList.Add("--log-level=info");
+        startInfo.ArgumentList.Add(imagePath);
+        // The test's external timeout must be the only hang detector.
+        startInfo.Environment["SHARPEMU_STALL_WATCHDOG_SECONDS"] = "0";
+
+        using var process = Process.Start(startInfo) ??
+            throw new InvalidOperationException($"Could not start the SharpEmu CLI for {name}.");
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(RegressionTimeoutMilliseconds);
+        var cpuSampleMilliseconds = 0.0;
+
+        if (!exited)
+        {
+            process.Refresh();
+            var cpuBefore = process.TotalProcessorTime;
+            Thread.Sleep(250);
+            process.Refresh();
+            cpuSampleMilliseconds = (process.TotalProcessorTime - cpuBefore).TotalMilliseconds;
+
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+
+            process.WaitForExit();
+        }
+        else
+        {
+            process.WaitForExit();
+        }
+
+        return new GuestProcessResult(
+            exited,
+            process.ExitCode,
+            cpuSampleMilliseconds,
+            stdout.GetAwaiter().GetResult() + stderr.GetAwaiter().GetResult());
+    }
+
+    private static void AssertCompleted(GuestProcessResult result, string caseName)
+    {
+        Assert.True(
+            result.Completed,
+            $"{caseName} did not terminate within the regression timeout; " +
+            $"the 250 ms post-timeout CPU sample was {result.CpuSampleMilliseconds:F0} ms.\n" +
+            result.Output);
+    }
+
+    private static void AssertFaultReachedManagedPathWithoutSpin(
+        GuestProcessResult result,
+        string caseName,
+        string exceptionCode)
+    {
+        AssertCompleted(result, caseName);
+        Assert.Contains("NATIVE EXCEPTION CAUGHT!", result.Output);
+        Assert.Contains($"Code: {exceptionCode}", result.Output);
+        Assert.NotEqual(0, result.ExitCode);
+    }
+
+    private static byte[] BuildElfImage(ReadOnlySpan<byte> guestCode)
+    {
+        const int fileOffset = 0x1000;
+        const ulong guestEntry = 0x1000;
+        var image = new byte[fileOffset + guestCode.Length];
+
+        image[0] = 0x7F;
+        image[1] = (byte)'E';
+        image[2] = (byte)'L';
+        image[3] = (byte)'F';
+        image[4] = 2; // ELFCLASS64
+        image[5] = 1; // little endian
+        image[6] = 1; // ELF version
+        image[7] = 9; // FreeBSD ABI, accepted by the loader
+        image[8] = 2; // ABI version
+
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0x10), 3); // ET_DYN
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0x12), 0x3E); // AMD64
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(0x14), 1);
+        BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(0x18), guestEntry);
+        BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(0x20), 0x40);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0x34), 0x40);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0x36), 0x38);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0x38), 1);
+
+        var programHeader = image.AsSpan(0x40, 0x38);
+        BinaryPrimitives.WriteUInt32LittleEndian(programHeader, 1); // PT_LOAD
+        BinaryPrimitives.WriteUInt32LittleEndian(programHeader[4..], 7); // R|W|X
+        BinaryPrimitives.WriteUInt64LittleEndian(programHeader[8..], fileOffset);
+        BinaryPrimitives.WriteUInt64LittleEndian(programHeader[16..], guestEntry);
+        BinaryPrimitives.WriteUInt64LittleEndian(programHeader[24..], guestEntry);
+        BinaryPrimitives.WriteUInt64LittleEndian(programHeader[32..], (ulong)guestCode.Length);
+        BinaryPrimitives.WriteUInt64LittleEndian(programHeader[40..], (ulong)guestCode.Length);
+        BinaryPrimitives.WriteUInt64LittleEndian(programHeader[48..], 0x1000);
+        guestCode.CopyTo(image.AsSpan(fileOffset));
+
+        return image;
+    }
+
+    private sealed record GuestProcessResult(
+        bool Completed,
+        int ExitCode,
+        double CpuSampleMilliseconds,
+        string Output);
+}


### PR DESCRIPTION
Fixes #779.

I tracked the hang down to the exception trampoline. It was supposed to emit `lock cmpxchg [r9], r10`, but the REX prefix was `0x4C`, so the memory operand ended up using `rcx` instead of `r9`.

During a guest fault, `rcx` could be something invalid like `0x8`, so the VEH would fault again inside itself before reaching the managed handler and keep looping.

The fix is just changing the two affected prefixes from `0x4C` to `0x4D`, which sets `REX.B` and makes the operand use `r9` as intended.

I also added regression tests for the emitted encoding and small synthetic RET, UD2, and access-violation guests on Windows x64.

## Testing

Synthetic RET/UD2/access-violation reproducers on Windows x64: passed.  
Full Release suite: 893 passed, 0 failed.  
Release build: 0 warnings, 0 errors.  
No commercial games were used; this is a synthetic reproducer for #779.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested or marked testing as N/A.