### PR TITLE
fix(logging): cap FileLogSink size and roll over via SHARPEMU_LOG_MAX_BYTES

### DIFF
--- a/src/SharpEmu.Logging/FileLogSink.cs
+++ b/src/SharpEmu.Logging/FileLogSink.cs
@@ -11,13 +11,18 @@ public sealed class FileLogSink : ISharpEmuLogSink, IDisposable
     private static readonly TimeSpan FlushInterval = TimeSpan.FromMilliseconds(500);
 
     private readonly object _sync = new();
-    private readonly StreamWriter _writer;
+    private readonly string _path;
+    private readonly long _maxBytes;
+    private StreamWriter _writer;
     private readonly Timer _flushTimer;
     private bool _disposed;
 
-    public FileLogSink(string path, bool append = true, bool includeTimestamp = true)
+    public FileLogSink(string path, bool append = true, bool includeTimestamp = true, long maxBytes = 0)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        _path = path;
+        _maxBytes = maxBytes > 0 ? maxBytes : 0;
 
         var directory = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
@@ -91,6 +96,11 @@ public sealed class FileLogSink : ISharpEmuLogSink, IDisposable
             {
                 _writer.Flush();
             }
+
+            if (_maxBytes > 0 && _writer.BaseStream.Position >= _maxBytes)
+            {
+                TryRollover();
+            }
         }
     }
 
@@ -104,6 +114,60 @@ public sealed class FileLogSink : ISharpEmuLogSink, IDisposable
             }
 
             _writer.Flush();
+        }
+    }
+
+    // Called inside _sync. Flushes and closes the current writer, renames
+    // the current file to <_path>.1 (overwriting any previous backup), then
+    // opens a fresh writer at _path. If the rename or create fails the catch
+    // block re-opens in append mode so subsequent writes are not silently
+    // dropped. A second failure marks the sink disposed so Write() returns
+    // immediately rather than throwing on every call.
+    private void TryRollover()
+    {
+        try
+        {
+            _writer.Flush();
+            _writer.Dispose();
+
+            File.Move(_path, _path + ".1", overwrite: true);
+
+            var fileStream = new FileStream(
+                _path,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.Read,
+                bufferSize: 65536,
+                FileOptions.SequentialScan);
+            _writer = new StreamWriter(fileStream, Encoding.UTF8, bufferSize: 65536)
+            {
+                AutoFlush = false,
+            };
+        }
+        catch
+        {
+            // Rollover failed. Re-open in append mode so the rest of the
+            // session is not silently lost.
+            try
+            {
+                var fileStream = new FileStream(
+                    _path,
+                    FileMode.Append,
+                    FileAccess.Write,
+                    FileShare.Read,
+                    bufferSize: 65536,
+                    FileOptions.SequentialScan);
+                _writer = new StreamWriter(fileStream, Encoding.UTF8, bufferSize: 65536)
+                {
+                    AutoFlush = false,
+                };
+            }
+            catch
+            {
+                // Cannot reopen either; mark disposed so Write() returns
+                // immediately instead of throwing on every subsequent call.
+                _disposed = true;
+            }
         }
     }
 

--- a/src/SharpEmu.Logging/SharpEmuLog.cs
+++ b/src/SharpEmu.Logging/SharpEmuLog.cs
@@ -195,6 +195,18 @@ public static class SharpEmuLog
         return !IsTrueLike(raw);
     }
 
+    // Reads SHARPEMU_LOG_MAX_BYTES. Plain byte count (e.g. 52428800 for 50 MiB).
+    // Returns 0 (no cap) when the variable is absent, empty, or not a positive integer.
+    private static long ResolveMaxBytesFromEnvironment()
+    {
+        var raw = Environment.GetEnvironmentVariable("SHARPEMU_LOG_MAX_BYTES");
+        return !string.IsNullOrWhiteSpace(raw) &&
+               long.TryParse(raw.Trim(), out var value) &&
+               value > 0
+            ? value
+            : 0;
+    }
+
     private static ISharpEmuLogSink ResolveSinkFromEnvironment()
     {
         var consoleSink = new ConsoleLogSink(
@@ -206,7 +218,11 @@ public static class SharpEmuLog
         {
             try
             {
-                var fileSink = new FileLogSink(logFilePath, append: true, includeTimestamp: true);
+                var fileSink = new FileLogSink(
+                    logFilePath,
+                    append: true,
+                    includeTimestamp: true,
+                    maxBytes: ResolveMaxBytesFromEnvironment());
                 // The file gets every level; the configured minimum only
                 // limits what reaches the console.
                 _fileCapturesAllLevels = true;


### PR DESCRIPTION
## Summary
`FileLogSink` (used when `SHARPEMU_LOG_FILE` is set) opened its target file
in Append mode with no size limit or rotation. Long-running sessions, or
repeated runs pointed at the same fixed log path, could grow the file
unbounded.

This does **not** affect the default logging path documented in the README
(`--log-file` / piped via `Tee-Object` or `tee`), which already creates a
fresh, timestamped log file per session
(`{titleId}-{yyyyMMdd-HHmmss}.log`) and had no unbounded growth risk.

## Change

### `FileLogSink.cs` (+64 lines)
- Added an optional `maxBytes` constructor parameter (default `0` = no cap,
  preserving existing behavior for all current call sites).
- Stores the file path so it can be renamed on rollover; `_writer` is no
  longer `readonly` so it can be replaced.
- `Write()` checks `_writer.BaseStream.Position >= _maxBytes` after the
  existing error-level eager flush, and triggers rollover when crossed —
  using the stream's actual position rather than a manual byte counter.
- `TryRollover()` flushes, disposes, moves `_path` → `_path + ".1"`
  (overwriting any previous `.1`), and opens a fresh writer. If the
  move/create fails, it falls back to re-opening in append mode; if that
  also fails, the sink marks itself disposed so subsequent `Write()` calls
  no-op instead of throwing.

### `SharpEmuLog.cs` (+14 lines)
- `ResolveMaxBytesFromEnvironment()` reads `SHARPEMU_LOG_MAX_BYTES`, parses
  it as a byte count, and returns `0` (no cap) if absent or invalid.
- `ResolveSinkFromEnvironment()` now passes `maxBytes:` through to the
  `FileLogSink` constructor.

## Scope
- Only affects file output policy — no verbosity, sink topology, or
  console-path changes.
- `--log-file` / `TeeTextWriter` path is unchanged (already per-session by
  design).
- `SHARPEMU_LOG_FILE` path now respects the cap.
- Any other `FileLogSink` call site (e.g. from the GUI) only gets capping
  if it explicitly passes `maxBytes`; existing call sites with no arg are
  unaffected.
- Retention is a single rolled backup (`foo.log` → `foo.1.log`), not a
  multi-generation history — kept intentionally simple for this fix.

## Usage
```powershell
# Cap the log at 50 MiB (52,428,800 bytes); rolls over to SharpEmu.log.1 once crossed
$env:SHARPEMU_LOG_FILE = "SharpEmu.log"
$env:SHARPEMU_LOG_MAX_BYTES = "52428800"
.\SharpEmu.exe "C:\path\to\eboot.bin"
```
Without `SHARPEMU_LOG_MAX_BYTES` set, behavior is identical to before this
change.

## Testing
[Fill in what was actually verified — e.g. "manually set
SHARPEMU_LOG_MAX_BYTES to a small value and confirmed rollover to
SharpEmu.log.1 after the threshold was crossed; confirmed default
(unset) behavior is unchanged."]

## Out of scope
- No change to what gets logged or at what verbosity.
- `SHARPEMU_LOG_FILE` itself isn't currently documented in the
  README/docs — happy to open a small follow-up to document both env vars
  if maintainers want them public-facing.