### PR TITLE
[HLE] Fix AJM/ACM no-op stubs and accept Gen5 AudioOut2 mastering/batch calls

### DIFF
--- a/src/SharpEmu.Libs/Acm/AcmExports.cs
+++ b/src/SharpEmu.Libs/Acm/AcmExports.cs
@@ -99,6 +99,50 @@ public static class AcmExports
         return CompleteBatchStart(ctx, context, infoCount, errorAddress, batchAddress);
     }
 
+    // DSP batch submission and synchronization. The emulator runs no ACM DSP
+    // jobs (FFT/panner/reverb output stays silent), but Scream's workers trap
+    // with int 0x41/0x42 asserts whenever a submission call reports failure,
+    // so the whole batch surface must report success.
+    [SysAbiExport(
+        Nid = "WeZOIm8+8WI",
+        ExportName = "sceAcmBatchInitialize",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAcm")]
+    public static int AcmBatchInitialize(CpuContext ctx) =>
+        ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+
+    [SysAbiExport(
+        Nid = "Mk1xvQXIdkk",
+        ExportName = "sceAcmBatchInitializeLite",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAcm")]
+    public static int AcmBatchInitializeLite(CpuContext ctx) =>
+        ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+
+    [SysAbiExport(
+        Nid = "A5NXCXK5Gfc",
+        ExportName = "sceAcmBatchStart",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAcm")]
+    public static int AcmBatchStart(CpuContext ctx) =>
+        ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+
+    [SysAbiExport(
+        Nid = "S3BPrjCfZ90",
+        ExportName = "sceAcmBatchStartMultiple",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAcm")]
+    public static int AcmBatchStartMultiple(CpuContext ctx) =>
+        ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+
+    [SysAbiExport(
+        Nid = "uqDIauipRbo",
+        ExportName = "sceAcmBatchProcess",
+        Target = Generation.Gen4 | Generation.Gen5,
+        LibraryName = "libSceAcm")]
+    public static int AcmBatchProcess(CpuContext ctx) =>
+        ctx.SetReturn(OrbisGen2Result.ORBIS_GEN2_OK);
+
     [SysAbiExport(
         Nid = "RLN3gRlXJLE",
         ExportName = "sceAcmBatchWait",

--- a/src/SharpEmu.Libs/Audio/AjmExports.cs
+++ b/src/SharpEmu.Libs/Audio/AjmExports.cs
@@ -21,7 +21,12 @@ public static class AjmExports
     private const int OrbisAjmErrorJobCreation = unchecked((int)0x80930012);
     private const ulong MaxSilentPcmBytes = 1 << 20;
     private const uint Atrac9CodecType = 1;
-    private const uint MaxCodecType = 25;
+    // Registration is pure bookkeeping (a HashSet.Add), so the only real
+    // constraint is that codecType << 14 must not overflow the 32-bit
+    // instanceId it gets packed into (see AjmInstanceCreate) -- not any
+    // hardcoded list of known Sony codec ids, which a retail title's Gen5
+    // codec type (e.g. 24) can legitimately fall outside of.
+    private const uint MaxCodecType = 1u << 18;
     private const int MaxInstanceIndex = 0x2FFF;
     private const int MaxDecodeBufferBytes = 64 * 1024 * 1024;
 
@@ -119,9 +124,12 @@ public static class AjmExports
         LibraryName = "libSceAjm")]
     public static int AjmFinalize(CpuContext ctx)
     {
-        Contexts.TryRemove(unchecked((uint)ctx[CpuRegister.Rdi]), out _);
-        ctx[CpuRegister.Rax] = 0;
-        return 0;
+        if (!Contexts.TryRemove(unchecked((uint)ctx[CpuRegister.Rdi]), out _))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidContext);
+        }
+
+        return ctx.SetReturn(0);
     }
 
     [SysAbiExport(
@@ -334,8 +342,20 @@ public static class AjmExports
         LibraryName = "libSceAjm")]
     public static int AjmModuleUnregister(CpuContext ctx)
     {
-        ctx[CpuRegister.Rax] = 0;
-        return 0;
+        var contextId = unchecked((uint)ctx[CpuRegister.Rdi]);
+        var codecType = unchecked((uint)ctx[CpuRegister.Rsi]);
+        if (!Contexts.TryGetValue(contextId, out var state))
+        {
+            return ctx.SetReturn(OrbisAjmErrorInvalidContext);
+        }
+
+        lock (state.Gate)
+        {
+            state.RegisteredCodecs.Remove(codecType);
+        }
+
+        Trace($"module_unregister context={contextId} codec={codecType}");
+        return ctx.SetReturn(0);
     }
 
     [SysAbiExport(

--- a/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
+++ b/src/SharpEmu.Libs/Audio/AudioOut2Exports.cs
@@ -163,6 +163,33 @@ public static class AudioOut2Exports
         return (int)OrbisGen2Result.ORBIS_GEN2_OK;
     }
 
+    // Ghost of Yotei calls this with flags=0 during Scream startup and never
+    // checks the result before continuing into its mastering path; the actual
+    // mastering chain lives in the host mixer, so accepting the request is
+    // sufficient.
+    [SysAbiExport(
+        Nid = "XHl38ZNknbs",
+        ExportName = "sceAudioOut2MasteringInit",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2MasteringInit(CpuContext ctx)
+    {
+        return SetReturn(ctx, 0);
+    }
+
+    // 3D-audio object latency hint; the host mixer has no object pipeline to
+    // tune, but failure here makes Yotei tear down its whole ACM context and
+    // abort audio arena bring-up.
+    [SysAbiExport(
+        Nid = "TViD1EZXkNI",
+        ExportName = "sceAudioOut2Set3DLatency",
+        Target = Generation.Gen5,
+        LibraryName = "libSceAudioOut2")]
+    public static int AudioOut2Set3DLatency(CpuContext ctx)
+    {
+        return SetReturn(ctx, 0);
+    }
+
     [SysAbiExport(
         Nid = "t5YrizufpQc",
         ExportName = "sceAudioOut2ContextResetParam",

--- a/tests/SharpEmu.Libs.Tests/Audio/AjmExportsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Audio/AjmExportsTests.cs
@@ -353,6 +353,13 @@ public sealed class AjmExportsTests : IDisposable
         return AjmExports.AjmModuleRegister(_ctx);
     }
 
+    private int UnregisterCodec(uint contextId, uint codecType)
+    {
+        _ctx[CpuRegister.Rdi] = contextId;
+        _ctx[CpuRegister.Rsi] = codecType;
+        return AjmExports.AjmModuleUnregister(_ctx);
+    }
+
     private int RegisterMemory(uint contextId, ulong address, ulong pages)
     {
         _ctx[CpuRegister.Rdi] = contextId;


### PR DESCRIPTION
## Summary
- `AjmModuleUnregister`/`AjmFinalize` were pure no-ops (always returned success without touching state); they now validate the context and actually remove the codec registration / context entry, returning a real error when the context is unknown.
- `MaxCodecType` was hardcoded to 25 based on known Sony codec ids, incorrectly rejecting valid Gen5 codec types (e.g. 24). Registration is pure bookkeeping (`HashSet.Add`); the only real constraint is that `codecType << 14` must not overflow the 32-bit `instanceId` it gets packed into, i.e. `codecType < 2^18`.
- Accept `sceAcmBatchInitialize`/`InitializeLite`/`Start`/`StartMultiple`/`Process` as successful no-ops — the emulator runs no ACM DSP jobs, but Scream's workers trap on `int 0x41`/`0x42` asserts whenever a submission call reports failure.
- Accept `sceAudioOut2MasteringInit`/`Set3DLatency` as no-ops — the host mixer has no mastering/object pipeline to tune, but returning failure makes titles tear down their whole ACM context and abort audio arena bring-up.

## Testing

Tested on Ghost of Yotei (PPSA26344). Compared against `upstream/main`, without this PR. 60s run:

- `sceAudioOut2MasteringInit`/`Set3DLatency` unresolved-import warnings: 2 → 0
- New audio-related guest threads unblocked (never spawned on baseline, reproducible 2/2 runs): `MovieDecoder`, `snd_stream_parsing_thread`, `snd_stream_reader_thread`, `Psn`, `NCA::PumpThread`
- Watchdog stall errors: 1 → 0
- Crashes: 0 → 0

This PR alone gets the title past its Scream audio-init stall into further boot (splash presented, ~40k imports dispatched vs ~30k before), but still hits an unrelated infinite retry loop in `sceVideoOutGetFlipStatus` (ret site `0x800CD1335`) shortly after — fixed by the separate `videoout-agc-hle-misc` PR. Combined with that PR, the title renders and presents a real GPU frame (reproducible 2/2 runs); neither PR alone reaches that point.

Regression check — same 60s harness on Demon's Souls, Astro Bot, Outer Wilds, Cult of the Lamb, Ghost of Tsushima, GTA, Minecraft, Quake: **0 calls** to any of the exports touched by this PR on any of them (grepped per-NID), so behavior is byte-for-byte identical to baseline on all 8 — this PR only activates on titles that actually exercise the Gen5 ACM/AudioOut2 batch surface.