### PR TITLE
Filesystem: encode Windows-invalid guest filename characters (#683)

### DIFF
--- a/src/SharpEmu.Libs/HostFsName.cs
+++ b/src/SharpEmu.Libs/HostFsName.cs
@@ -1,0 +1,221 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text;
+
+namespace SharpEmu.Libs;
+
+/// <summary>
+/// Reversible mapping of a single <em>guest</em> path segment to a name the host
+/// filesystem can actually hold, and back.
+/// <para>
+/// The guest filesystem is FreeBSD-flavoured: every byte except <c>/</c> and NUL
+/// is a legal filename character. Windows is far narrower, and its failure mode
+/// is silent rather than loud — <c>rg_ac_Arcade Spirits: The New Challengers.dat</c>
+/// does not fail to open, it opens the alternate data stream
+/// <c>" The New Challengers.dat"</c> on a file called <c>rg_ac_Arcade Spirits</c>.
+/// The title writes its save, sees success, and finds nothing on the next boot;
+/// the reopen faults instead of returning ENOENT. Trailing dots and spaces are
+/// silently trimmed the same way, and a name whose stem is a DOS device
+/// (<c>nul</c>, <c>aux</c>, <c>com1</c>...) opens the device rather than a file.
+/// </para>
+/// <para>
+/// Percent-encoding the offending characters keeps the mapping one-to-one, which
+/// replacing them with <c>_</c> would not: <c>foo:bar</c> and <c>foo_bar</c> are
+/// distinct guest names that must stay distinct on the host.
+/// </para>
+/// <para>
+/// The cost of that is one ambiguity, and it is deliberately kept as small as
+/// possible: a literal <c>%</c> is escaped only when two hex digits follow it,
+/// so the one class of host name this cannot represent is a pre-existing file
+/// that already looks like an escape (<c>Assets%20Big.pak</c> in a dump, say).
+/// Every other name containing a percent sign maps to itself. Escaping <c>%</c>
+/// unconditionally would trade that rare case for a common one; not escaping it
+/// at all would let <c>foo%3Abar</c> and <c>foo:bar</c> collide.
+/// </para>
+/// <para>
+/// Only Windows needs this; Linux and macOS hosts accept the guest names as-is
+/// and encoding there would break dumps that legitimately use these characters.
+/// Both directions are therefore the identity outside Windows, which also means
+/// a save directory is not portable between a Windows host and a POSIX one —
+/// that was already true, since the Windows copy never held the real name.
+/// </para>
+/// </summary>
+internal static class HostFsName
+{
+    // Everything Path.GetInvalidFileNameChars() reports on Windows except the
+    // separators, which callers have already consumed by splitting the path, and
+    // the control characters handled below. Hard-coded rather than queried so a
+    // guest name encodes identically no matter which host produced it.
+    private const string AlwaysEscaped = "\"*:<>?|";
+
+    private const string HexDigits = "0123456789ABCDEF";
+
+    /// <summary>
+    /// Encodes one guest path segment for use as a host filename. Returns
+    /// <paramref name="segment"/> unchanged on non-Windows hosts, and for the
+    /// overwhelming majority of names on Windows too.
+    /// </summary>
+    public static string EncodeSegment(string segment) =>
+        OperatingSystem.IsWindows() ? EncodeWindowsSegment(segment) : segment;
+
+    /// <summary>
+    /// Recovers the guest name from a host filename produced by
+    /// <see cref="EncodeSegment"/>. Used when handing host directory entries back
+    /// to the guest, so a name the guest wrote survives a round trip through
+    /// <c>getdents</c> and the <c>open</c> that follows it.
+    /// </summary>
+    public static string DecodeSegment(string segment) =>
+        OperatingSystem.IsWindows() ? DecodeWindowsSegment(segment) : segment;
+
+    /// <summary>
+    /// The encoding itself, with the host check lifted out so the mapping can be
+    /// tested — and reasoned about — on any platform.
+    /// </summary>
+    public static string EncodeWindowsSegment(string segment)
+    {
+        if (!NeedsEncoding(segment))
+        {
+            return segment;
+        }
+
+        // A name whose stem is a DOS device is unusable whatever its extension
+        // ("nul.dat" is still the null device), and the stem is not made of
+        // escapable characters. Escaping its first letter is enough to stop the
+        // match and stays reversible.
+        var escapeFirstChar = HasReservedDeviceStem(segment);
+        var trailingRunStart = TrailingDotSpaceRunStart(segment);
+
+        var builder = new StringBuilder(segment.Length + 8);
+        for (var i = 0; i < segment.Length; i++)
+        {
+            var ch = segment[i];
+            if (i >= trailingRunStart ||
+                (i == 0 && escapeFirstChar) ||
+                MustEscape(segment, i))
+            {
+                // Every escapable character is ASCII — the invalid set, the
+                // control range, '.', ' ', '%' and the letter starting a device
+                // stem — so two hex digits always suffice. Non-ASCII characters
+                // are legal on both filesystems and pass through untouched.
+                builder.Append('%').Append(HexDigits[(ch >> 4) & 0xF]).Append(HexDigits[ch & 0xF]);
+                continue;
+            }
+
+            builder.Append(ch);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// The inverse of <see cref="EncodeWindowsSegment"/>, likewise unconditional.
+    /// </summary>
+    public static string DecodeWindowsSegment(string segment)
+    {
+        if (!segment.Contains('%', StringComparison.Ordinal))
+        {
+            return segment;
+        }
+
+        var builder = new StringBuilder(segment.Length);
+        for (var i = 0; i < segment.Length; i++)
+        {
+            if (segment[i] == '%' && IsEscapeSequenceAt(segment, i))
+            {
+                builder.Append((char)((HexValue(segment[i + 1]) << 4) | HexValue(segment[i + 2])));
+                i += 2;
+                continue;
+            }
+
+            builder.Append(segment[i]);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool NeedsEncoding(string segment)
+    {
+        if (segment.Length == 0)
+        {
+            return false;
+        }
+
+        if (TrailingDotSpaceRunStart(segment) < segment.Length || HasReservedDeviceStem(segment))
+        {
+            return true;
+        }
+
+        for (var i = 0; i < segment.Length; i++)
+        {
+            if (MustEscape(segment, i))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MustEscape(string segment, int index)
+    {
+        var ch = segment[index];
+        return AlwaysEscaped.Contains(ch, StringComparison.Ordinal) ||
+               ch < ' ' ||
+               (ch == '%' && IsEscapeSequenceAt(segment, index));
+    }
+
+    // A literal '%' only has to be escaped when it would otherwise read back as
+    // an escape, i.e. when two hex digits follow it. Leaving the rest alone keeps
+    // names like "100% Complete.sav" — and every dump file containing a percent
+    // sign — mapping to themselves.
+    private static bool IsEscapeSequenceAt(string segment, int index) =>
+        index + 2 < segment.Length &&
+        IsHexDigit(segment[index + 1]) &&
+        IsHexDigit(segment[index + 2]);
+
+    private static bool IsHexDigit(char ch) =>
+        ch is (>= '0' and <= '9') or (>= 'A' and <= 'F') or (>= 'a' and <= 'f');
+
+    private static int HexValue(char ch) =>
+        ch <= '9' ? ch - '0' : (char.ToUpperInvariant(ch) - 'A') + 10;
+
+    // Index at which the trailing run of '.' / ' ' that CreateFile would strip
+    // begins, or the segment length when there is none. "." and ".." never reach
+    // here: callers resolve them as directory navigation before splitting.
+    private static int TrailingDotSpaceRunStart(string segment)
+    {
+        var start = segment.Length;
+        while (start > 0 && (segment[start - 1] == '.' || segment[start - 1] == ' '))
+        {
+            start--;
+        }
+
+        return start;
+    }
+
+    // Whether the part before the first '.' names a DOS device, matched
+    // case-insensitively as Windows does.
+    private static bool HasReservedDeviceStem(string segment)
+    {
+        var stemLength = segment.IndexOf('.');
+        var stem = stemLength < 0 ? segment.AsSpan() : segment.AsSpan(0, stemLength);
+        if (stem.Length is not (3 or 4))
+        {
+            return false;
+        }
+
+        var prefix = stem[..3];
+        if (stem.Length == 3)
+        {
+            return prefix.Equals("CON", StringComparison.OrdinalIgnoreCase) ||
+                   prefix.Equals("PRN", StringComparison.OrdinalIgnoreCase) ||
+                   prefix.Equals("AUX", StringComparison.OrdinalIgnoreCase) ||
+                   prefix.Equals("NUL", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return stem[3] is >= '0' and <= '9' &&
+               (prefix.Equals("COM", StringComparison.OrdinalIgnoreCase) ||
+                prefix.Equals("LPT", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
+++ b/src/SharpEmu.Libs/Kernel/KernelMemoryCompatExports.cs
@@ -208,7 +208,10 @@ public static partial class KernelMemoryCompatExports
     private sealed class OpenDirectory
     {
         public required string Path { get; init; }
+
+        // Child names in GUEST form, not host form: see EnumerateDirectoryEntries.
         public required string[] Entries { get; init; }
+
         public int NextIndex { get; set; }
     }
 
@@ -5241,6 +5244,12 @@ public static partial class KernelMemoryCompatExports
     // prefixes that land back inside /app0 on real hardware. Combining those
     // raw against the app0 root walked out of the game folder entirely, so the
     // title enumerated an unrelated host directory and never found its .pak files.
+    //
+    // Each surviving segment is then encoded for the host filesystem. This is a
+    // no-op except on Windows, where a guest name the host cannot represent (a
+    // ':' in a save filename, say) would otherwise be silently rewritten by the
+    // Win32 layer instead of rejected — see HostFsName. EnumerateDirectoryEntries
+    // decodes on the way back out.
     private static string NormalizeMountRelativePath(string relativePath)
     {
         var segments = relativePath.Split(
@@ -5264,7 +5273,7 @@ public static partial class KernelMemoryCompatExports
                 continue;
             }
 
-            resolved.Add(segment);
+            resolved.Add(HostFsName.EncodeSegment(segment));
         }
 
         return string.Join(Path.DirectorySeparatorChar, resolved);
@@ -7379,7 +7388,11 @@ public static partial class KernelMemoryCompatExports
 
         var entryBytes = Encoding.UTF8.GetBytes(entryName);
         var nameLength = Math.Min(entryBytes.Length, 255);
-        var entryPath = Path.Combine(directory.Path, entryName);
+        // Entries are held in guest form (see EnumerateDirectoryEntries), so the
+        // name has to go back through the encoder to name a host path again;
+        // otherwise an encoded subdirectory probes as missing and is reported to
+        // the guest as a regular file.
+        var entryPath = Path.Combine(directory.Path, HostFsName.EncodeSegment(entryName));
         var entryType = Directory.Exists(entryPath) ? (byte)4 : (byte)8;
 
         var payload = new byte[512];
@@ -7404,9 +7417,13 @@ public static partial class KernelMemoryCompatExports
         // host dir previously returned EOF on the first call (rax=0), which
         // sent GTA's fiWriteAsyncDataWorker down a path that treated the fd as
         // a pointer (AV at 0xB1 on /download0/cloudcache/).
+        // Names go back out in guest form: the guest re-encodes whatever it reads
+        // here when it opens the entry, so an unencoded host name would resolve
+        // to a different file (or to nothing) on the very next syscall.
         var children = Directory.EnumerateFileSystemEntries(hostPath)
             .Select(Path.GetFileName)
             .Where(static name => !string.IsNullOrEmpty(name))
+            .Select(static name => HostFsName.DecodeSegment(name!))
             .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase);
 
         return new[] { ".", ".." }.Concat(children).ToArray()!;

--- a/tests/SharpEmu.Libs.Tests/Kernel/HostFsNameTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/HostFsNameTests.cs
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Text;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+/// <summary>
+/// The guest names files with FreeBSD rules; Windows silently rewrites the ones
+/// it cannot hold, so a save is written under a name the reopen never finds.
+/// These pin the encoding that makes the mapping total and reversible. The
+/// <c>WindowsSegment</c> entry points skip the host check so the mapping is
+/// exercised on every CI platform, not just Windows.
+/// </summary>
+public sealed class HostFsNameTests
+{
+    [Theory]
+    // Ordinary names are their own encoding — the common case must not churn.
+    [InlineData("SAVE0000", "SAVE0000")]
+    [InlineData("param.json", "param.json")]
+    // The reported failure: a ':' makes Windows write an alternate data stream
+    // on a truncated file rather than the file the guest asked for.
+    [InlineData(
+        "rg_ac_Arcade Spirits: The New Challengers_0.dat",
+        "rg_ac_Arcade Spirits%3A The New Challengers_0.dat")]
+    [InlineData("a*b", "a%2Ab")]
+    [InlineData("a?b", "a%3Fb")]
+    [InlineData("a\"b", "a%22b")]
+    [InlineData("a<b>c", "a%3Cb%3Ec")]
+    [InlineData("a|b", "a%7Cb")]
+    [InlineData("tab\there", "tab%09here")]
+    // Trailing dots and spaces are stripped by CreateFile, which is the same
+    // silent-rename failure by another route.
+    [InlineData("save.", "save%2E")]
+    [InlineData("save ", "save%20")]
+    [InlineData("save. .", "save%2E%20%2E")]
+    // A DOS device stem opens the device whatever the extension, so break the
+    // match on the first letter.
+    [InlineData("nul", "%6Eul")]
+    [InlineData("AUX.dat", "%41UX.dat")]
+    [InlineData("com1.sav", "%63om1.sav")]
+    [InlineData("lpt9", "%6Cpt9")]
+    // ...but only for the real device names.
+    [InlineData("con.dat", "%63on.dat")]
+    [InlineData("conf.dat", "conf.dat")]
+    [InlineData("com.dat", "com.dat")]
+    [InlineData("comA", "comA")]
+    // A literal '%' is escaped only when it would otherwise read back as an
+    // escape, so real dump filenames containing one map to themselves.
+    [InlineData("100% Complete.sav", "100% Complete.sav")]
+    [InlineData("50%", "50%")]
+    [InlineData("a%3Ab", "a%253Ab")]
+    [InlineData("a%zzb", "a%zzb")]
+    public void EncodeRewritesOnlyWhatWindowsCannotHold(string guestName, string expectedHostName)
+    {
+        Assert.Equal(expectedHostName, HostFsName.EncodeWindowsSegment(guestName));
+        Assert.Equal(guestName, HostFsName.DecodeWindowsSegment(expectedHostName));
+    }
+
+    [Fact]
+    public void EncodedNamesAreValidWindowsFilenames()
+    {
+        // Path.GetInvalidFileNameChars() is the host's own answer on Windows and
+        // the superset (POSIX reports only '/' and NUL) elsewhere, so assert
+        // against the Windows set directly to keep the check meaningful on CI.
+        const string windowsInvalid = "\"<>|:*?\\/";
+        foreach (var guestName in Corpus())
+        {
+            var encoded = HostFsName.EncodeWindowsSegment(guestName);
+            foreach (var ch in encoded)
+            {
+                Assert.False(windowsInvalid.Contains(ch) || ch < ' ', encoded);
+            }
+
+            Assert.False(encoded.EndsWith('.') || encoded.EndsWith(' '), encoded);
+
+            var stem = encoded.Split('.', 2)[0];
+            Assert.DoesNotContain(
+                stem,
+                new[] { "CON", "PRN", "AUX", "NUL" },
+                StringComparer.OrdinalIgnoreCase);
+            Assert.False(
+                stem.Length == 4 &&
+                stem[3] is >= '0' and <= '9' &&
+                (stem.StartsWith("COM", StringComparison.OrdinalIgnoreCase) ||
+                 stem.StartsWith("LPT", StringComparison.OrdinalIgnoreCase)),
+                encoded);
+        }
+    }
+
+    [Fact]
+    public void EncodeRoundTripsAndStaysOneToOne()
+    {
+        // Injectivity is the whole reason for percent-encoding over replacing
+        // with '_': "foo:bar" and "foo_bar" are different saves. A successful
+        // round trip for every name proves no two of them collide.
+        var seen = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var guestName in Corpus())
+        {
+            var encoded = HostFsName.EncodeWindowsSegment(guestName);
+            Assert.Equal(guestName, HostFsName.DecodeWindowsSegment(encoded));
+
+            Assert.False(
+                seen.TryGetValue(encoded, out var previous),
+                $"'{guestName}' and '{previous}' both encode to '{encoded}'");
+            seen[encoded] = guestName;
+        }
+    }
+
+    [Fact]
+    public void HostGatedEntryPointsAreIdentityOffWindows()
+    {
+        const string guestName = "rg_ac_Arcade Spirits: The New Challengers_0.dat";
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal(HostFsName.EncodeWindowsSegment(guestName), HostFsName.EncodeSegment(guestName));
+            return;
+        }
+
+        // POSIX hosts hold the guest name as-is, and encoding there would break
+        // dumps that legitimately use these characters.
+        Assert.Equal(guestName, HostFsName.EncodeSegment(guestName));
+        Assert.Equal(guestName, HostFsName.DecodeSegment(guestName));
+        Assert.Equal("a%3Ab", HostFsName.DecodeSegment("a%3Ab"));
+    }
+
+    // Names built from the awkward characters in every position, plus the
+    // literals the theory above calls out by hand.
+    private static IEnumerable<string> Corpus()
+    {
+        string[] pieces = ["a", ":", "%", "%25", "%3A", ".", " ", "*", "", "|", "nul", "1"];
+        foreach (var first in pieces)
+        {
+            foreach (var second in pieces)
+            {
+                foreach (var third in pieces)
+                {
+                    var candidate = string.Concat(first, second, third);
+                    // "", "." and ".." never reach the encoder: empty segments are
+                    // dropped by the split and the dot segments are resolved as
+                    // directory navigation first.
+                    if (candidate is "" or "." or "..")
+                    {
+                        continue;
+                    }
+
+                    yield return candidate;
+                }
+            }
+        }
+
+        yield return "SAVE0000";
+        yield return "rg_ac_Arcade Spirits: The New Challengers_0.dat";
+        yield return "100% Complete.sav";
+        yield return new string('.', 8);
+        yield return new StringBuilder().Append('x', 200).Append(':').ToString();
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Kernel/KernelGuestFilenameEncodingTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Kernel/KernelGuestFilenameEncodingTests.cs
@@ -1,0 +1,240 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using System.Text;
+using SharpEmu.HLE;
+using SharpEmu.Libs.Kernel;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Kernel;
+
+// A guest filename that Windows cannot hold used to reach CreateFile unchanged.
+// Windows does not fail those: "save: 0.dat" writes the alternate data stream
+// ": 0.dat" on a file named "save", so the title's write succeeds, the file is
+// not there on the next boot, and the reopen faults. These drive the real
+// open/getdents syscalls end to end, so they assert the property that actually
+// matters — whatever name the guest writes under, it can read back and
+// enumerate — on every host rather than pinning a Windows-only spelling.
+[Collection(KernelMemoryCompatStateCollection.Name)]
+public sealed class KernelGuestFilenameEncodingTests : IDisposable
+{
+    private const int O_RDONLY = 0x0;
+    private const int O_WRONLY = 0x1;
+    private const int O_CREAT = 0x0200;
+    private const int O_DIRECTORY = 0x00020000;
+
+    private const string GuestMount = "/sharpemu_encoding_mnt";
+    private const ulong MemoryBase = 0x1_0000_0000;
+    private const ulong PathAddress = MemoryBase + 0x100;
+    private const ulong BufferAddress = MemoryBase + 0x800;
+
+    private readonly string _tempRoot;
+    private readonly string _mountRoot;
+
+    public KernelGuestFilenameEncodingTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), $"sharpemu-fsname-{Guid.NewGuid():N}");
+        _mountRoot = Path.Combine(_tempRoot, "mnt");
+        Directory.CreateDirectory(_mountRoot);
+        KernelMemoryCompatExports.RegisterGuestPathMount(GuestMount, _mountRoot);
+    }
+
+    public void Dispose()
+    {
+        KernelMemoryCompatExports.UnregisterGuestPathMount(GuestMount);
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    [Theory]
+    // The name from the Arcade Spirits report, and the rest of the characters
+    // Windows rejects or rewrites.
+    [InlineData("rg_ac_Arcade Spirits: The New Challengers_0.dat")]
+    [InlineData("progress?.sav")]
+    [InlineData("chapter*final.dat")]
+    [InlineData("say \"hello\".txt")]
+    [InlineData("a<b>c|d.bin")]
+    [InlineData("trailing dot.")]
+    [InlineData("nul.dat")]
+    // Names that are already legal must keep working untouched.
+    [InlineData("ordinary.sav")]
+    [InlineData("100% Complete.sav")]
+    public void GuestWrittenFileIsReadableAndEnumerableUnderItsOwnName(string guestName)
+    {
+        var guestPath = $"{GuestMount}/{guestName}";
+        var payload = "slot"u8.ToArray();
+
+        var writeFd = Open(guestPath, O_WRONLY | O_CREAT);
+        Assert.True(writeFd > 0, $"open for write failed with {writeFd}");
+        Assert.Equal(payload.Length, Write(writeFd, payload));
+        Close(writeFd);
+
+        // The name the guest used must resolve back to the same bytes. Before the
+        // encoding this failed on Windows: the data landed in an alternate data
+        // stream and the reopen found a truncated, empty file.
+        var readFd = Open(guestPath, O_RDONLY);
+        Assert.True(readFd > 0, $"reopen failed with {readFd}");
+        Assert.Equal(payload, Read(readFd, payload.Length));
+        Close(readFd);
+
+        // ...and a directory listing must hand that same name back, since the
+        // guest turns straight around and opens what it read.
+        Assert.Contains(guestName, ReadDirectory(GuestMount));
+    }
+
+    [Fact]
+    public void EncodedSubdirectoryIsReportedAsADirectory()
+    {
+        // The dirent type byte is derived by re-joining the entry name to the
+        // host path, so an entry handed back in guest form has to be re-encoded
+        // before it is probed; otherwise every encoded directory reports as a
+        // regular file (DT_REG) and the guest never descends into it.
+        const string guestName = "slot: 1";
+        Assert.True(Mkdir($"{GuestMount}/{guestName}"), "mkdir failed");
+
+        var entries = ReadDirectoryEntries(GuestMount);
+        var entry = Assert.Single(entries, e => e.Name == guestName);
+        Assert.Equal(4, entry.Type); // DT_DIR
+
+        // A file inside it is reachable through the guest name of both segments.
+        var nestedFd = Open($"{GuestMount}/{guestName}/data:0.bin", O_WRONLY | O_CREAT);
+        Assert.True(nestedFd > 0, $"nested open failed with {nestedFd}");
+        Close(nestedFd);
+        Assert.Contains("data:0.bin", ReadDirectory($"{GuestMount}/{guestName}"));
+    }
+
+    [Fact]
+    public void DistinctGuestNamesDoNotShareAHostFile()
+    {
+        // Replacing invalid characters with '_' would alias these two saves onto
+        // one host file, quietly destroying the first.
+        var colonFd = Open($"{GuestMount}/slot:0.sav", O_WRONLY | O_CREAT);
+        Assert.True(colonFd > 0);
+        Assert.Equal(5, Write(colonFd, "colon"u8.ToArray()));
+        Close(colonFd);
+
+        var underscoreFd = Open($"{GuestMount}/slot_0.sav", O_WRONLY | O_CREAT);
+        Assert.True(underscoreFd > 0);
+        Assert.Equal(5, Write(underscoreFd, "under"u8.ToArray()));
+        Close(underscoreFd);
+
+        Assert.Equal("colon"u8.ToArray(), ReadAll($"{GuestMount}/slot:0.sav"));
+        Assert.Equal("under"u8.ToArray(), ReadAll($"{GuestMount}/slot_0.sav"));
+        Assert.Equal(2, Directory.GetFiles(_mountRoot).Length);
+    }
+
+    private static CpuContext NewContext(out FakeCpuMemory memory)
+    {
+        memory = new FakeCpuMemory(MemoryBase, 0x2000);
+        return new CpuContext(memory, Generation.Gen5);
+    }
+
+    private static int Open(string guestPath, int flags)
+    {
+        var context = NewContext(out var memory);
+        memory.WriteCString(PathAddress, guestPath);
+        context[CpuRegister.Rdi] = PathAddress;
+        context[CpuRegister.Rsi] = unchecked((ulong)(long)flags);
+        context[CpuRegister.Rdx] = 0x1B6; // 0666
+        var result = KernelMemoryCompatExports.KernelOpenUnderscore(context);
+        return result < 0 ? result : unchecked((int)context[CpuRegister.Rax]);
+    }
+
+    private static void Close(int fd)
+    {
+        var context = NewContext(out _);
+        context[CpuRegister.Rdi] = unchecked((ulong)(long)fd);
+        Assert.Equal(0, KernelMemoryCompatExports.KernelClose(context));
+    }
+
+    private static int Write(int fd, byte[] payload)
+    {
+        var context = NewContext(out var memory);
+        Assert.True(memory.TryWrite(BufferAddress, payload));
+        context[CpuRegister.Rdi] = unchecked((ulong)(long)fd);
+        context[CpuRegister.Rsi] = BufferAddress;
+        context[CpuRegister.Rdx] = (ulong)payload.Length;
+        Assert.Equal(0, KernelMemoryCompatExports.KernelWrite(context));
+        return unchecked((int)context[CpuRegister.Rax]);
+    }
+
+    private static byte[] Read(int fd, int length)
+    {
+        var context = NewContext(out var memory);
+        context[CpuRegister.Rdi] = unchecked((ulong)(long)fd);
+        context[CpuRegister.Rsi] = BufferAddress;
+        context[CpuRegister.Rdx] = (ulong)length;
+        Assert.Equal(0, KernelMemoryCompatExports.KernelRead(context));
+
+        var read = unchecked((int)context[CpuRegister.Rax]);
+        var buffer = new byte[read];
+        Assert.True(memory.TryRead(BufferAddress, buffer));
+        return buffer;
+    }
+
+    private static byte[] ReadAll(string guestPath)
+    {
+        var fd = Open(guestPath, O_RDONLY);
+        Assert.True(fd > 0, $"open failed with {fd}");
+        var bytes = Read(fd, 64);
+        Close(fd);
+        return bytes;
+    }
+
+    private static bool Mkdir(string guestPath)
+    {
+        var context = NewContext(out var memory);
+        memory.WriteCString(PathAddress, guestPath);
+        context[CpuRegister.Rdi] = PathAddress;
+        context[CpuRegister.Rsi] = 0x1FF; // 0777
+        return KernelMemoryCompatExports.KernelMkdir(context) == 0;
+    }
+
+    private static List<string> ReadDirectory(string guestPath) =>
+        ReadDirectoryEntries(guestPath).ConvertAll(static entry => entry.Name);
+
+    // Drains getdents, which yields one 512-byte dirent per call: u32 fileno,
+    // u16 reclen, u8 type, u8 namlen, then the name.
+    private static List<(string Name, byte Type)> ReadDirectoryEntries(string guestPath)
+    {
+        var fd = Open(guestPath, O_RDONLY | O_DIRECTORY);
+        Assert.True(fd > 0, $"opendir failed with {fd}");
+
+        var entries = new List<(string, byte)>();
+        try
+        {
+            for (var guard = 0; guard < 256; guard++)
+            {
+                var context = NewContext(out var memory);
+                context[CpuRegister.Rdi] = unchecked((ulong)(long)fd);
+                context[CpuRegister.Rsi] = BufferAddress;
+                context[CpuRegister.Rdx] = 512;
+                Assert.Equal(0, KernelMemoryCompatExports.KernelGetdents(context));
+                if (context[CpuRegister.Rax] == 0)
+                {
+                    return entries;
+                }
+
+                var dirent = new byte[512];
+                Assert.True(memory.TryRead(BufferAddress, dirent));
+                var type = dirent[6];
+                var nameLength = dirent[7];
+                var name = Encoding.UTF8.GetString(dirent, 8, nameLength);
+                Assert.Equal(512, BinaryPrimitives.ReadUInt16LittleEndian(dirent.AsSpan(4, 2)));
+                if (name is not ("." or ".."))
+                {
+                    entries.Add((name, type));
+                }
+            }
+
+            throw new InvalidOperationException("getdents never reported end of directory");
+        }
+        finally
+        {
+            Close(fd);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #683.

## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## The problem

The guest filesystem follows FreeBSD naming rules, so a title can create a file whose name Windows cannot hold. Path translation handed those segments straight to `CreateFile`, and the failure is silent rather than loud:

- A `:` makes the write land in an **alternate data stream** on a truncated file. `rg_ac_Arcade Spirits: The New Challengers_0.dat` becomes the stream `": The New Challengers_0.dat"` on a file named `rg_ac_Arcade Spirits`.
- Trailing dots and spaces are stripped by `CreateFile`.
- A name whose stem is a DOS device (`nul.dat`) opens the device instead of a file.

In each case the write **succeeds**, so the title never notices. The file is not there on the next boot, and the reopen faults instead of returning `ENOENT`. This is what #683 reports for Arcade Spirits: The New Challengers (PPSA08576).

## The change

New `HostFsName` — a reversible percent-encoding of a single guest path segment — applied at the three points where names cross the guest/host boundary in `KernelMemoryCompatExports`:

| Site | Direction |
| --- | --- |
| `NormalizeMountRelativePath` | encodes each segment; it is the choke point every real file syscall reaches (open/stat/unlink/mkdir/rename/…), for built-in and registered mounts alike |
| `EnumerateDirectoryEntries` | decodes, so `getdents` hands names back in guest form — the guest re-encodes what it read on the following `open` |
| dirent type probe | re-encodes before touching the host path |

That third one is not cosmetic: without it an encoded subdirectory probes as missing and is reported as `DT_REG`, so the guest never descends into it. It is covered by a test.

Design points worth review:

- **Percent-encoding rather than `_`**, as the issue argues: `foo:bar` and `foo_bar` are distinct saves that must stay distinct. Injectivity is asserted over a generated corpus.
- **A literal `%` is escaped only when two hex digits follow it.** Escaping unconditionally would break any dump file containing a percent sign (`100% Complete.sav` maps to itself); not escaping at all would let `foo%3Abar` collide with `foo:bar`. The residual cost is one rare case — a pre-existing host file that already looks like an escape, e.g. `Assets%20Big.pak` — documented in the class comment.
- **Windows only.** POSIX hosts hold the guest names as-is, and encoding there would break dumps that legitimately use these characters. Both directions are the identity off Windows.

Existing saves written under the old truncated names are not migrated.

## Testing

Not yet verified against a game. The change is derived from Win32 filename semantics and the reproduction in #683, and is covered by automated tests rather than a play session:

- `HostFsNameTests` pins the mapping itself: round-trip, injectivity over a generated corpus, and that encoded output is in fact a legal Windows filename (no invalid characters, no trailing dot/space, no device stem).
- `KernelGuestFilenameEncodingTests` drives the real `open`/`write`/`getdents` syscalls end to end and asserts the property that matters — whatever name the guest writes under, it can read back and enumerate.

Full solution builds clean and the whole suite is green: 839 `SharpEmu.Libs` tests, 90 across the other three projects.

One coverage caveat worth stating up front: this was developed on **macOS**, where the encoder is the identity, so local runs exercise the syscall plumbing but not the Windows mapping through it. The platform gate is split out (`EncodeWindowsSegment` / `DecodeWindowsSegment`) specifically so the mapping is still tested on every platform, and the end-to-end tests assert behaviour rather than a Windows-only spelling — so the `windows-latest` CI job, which runs the whole suite, is what exercises the wired-up encoding path.

Arcade Spirits: The New Challengers (PPSA08576) is the title to verify against; before/after results will be added here once it has been run on Windows.

Happy to rework the approach if maintainers prefer a different scheme, or to confine encoding to writable mounts only (`/savedata0`, `/temp0`, `/download0`) rather than applying it uniformly at the shared choke point.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [ ] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [ ] I listed the game(s) I tested (or marked the testing section as `N/A`).

> **Note for maintainers:** this description was drafted with AI assistance (Claude Code), so the third box is deliberately left unticked rather than ticked untruthfully. The checklist is the submitting contributor's to complete.

