### PR TITLE
fix(cpu): align RSP at Win64 call sites in hand-emitted stubs (#783)

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -2477,7 +2477,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		byte* code = (byte*)ptr;
 		int offset = 0;
 		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83);
-		EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x28); // sub rsp, 0x28
+		EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x20); // sub rsp, 0x20 (entry RSP is 16-aligned via RIP redirect, not a call)
 		EmitByte(code, ref offset, 0xB9);
 		EmitUInt32(code, ref offset, _workerDoneEventTlsIndex); // mov ecx, tls
 		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xB8);
@@ -2652,7 +2652,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x51);
 			EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x52); // push r10 (Rip)
 			EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83);
-			EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x40); // sub rsp, 0x40 (hex buf @ +0x30)
+			EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x48); // sub rsp, 0x48: entry RSP ≡ 8 (VEH call) + 6 pushes (48, ≡ 0) ⇒ 0x48 (72, ≡ 8) lands calls at ≡ 0
 			EmitByte(code, ref offset, 0xB9); EmitUInt32(code, ref offset, unchecked((uint)-12));
 			EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xB8);
 			*(nint*)(code + offset) = getStdHandle;
@@ -2683,10 +2683,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			offset += sizeof(nint);
 			EmitByte(code, ref offset, 0xFF); EmitByte(code, ref offset, 0xD0);
 
-			// Hex-encode Rip. Stack after sub 0x40: [rsp+0x40]=saved Rip (push r10).
+			// Hex-encode Rip. Stack after sub 0x48: [rsp+0x48]=saved Rip (push r10).
 			EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x8B);
 			EmitByte(code, ref offset, 0x54); EmitByte(code, ref offset, 0x24);
-			EmitByte(code, ref offset, 0x40); // mov r10, [rsp+0x40]
+			EmitByte(code, ref offset, 0x48); // mov r10, [rsp+0x48]
 			EmitByte(code, ref offset, 0x49); EmitByte(code, ref offset, 0xB8);
 			var hexDigitsAbsSlot = offset;
 			*(nint*)(code + offset) = 0;
@@ -2725,9 +2725,6 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xC7);
 			EmitByte(code, ref offset, 0x44); EmitByte(code, ref offset, 0x24);
 			EmitByte(code, ref offset, 0x20); EmitUInt32(code, ref offset, 0);
-			EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xC7);
-			EmitByte(code, ref offset, 0x44); EmitByte(code, ref offset, 0x24);
-			EmitByte(code, ref offset, 0x38); EmitUInt32(code, ref offset, 0);
 			EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xB8);
 			*(nint*)(code + offset) = writeFile;
 			offset += sizeof(nint);
@@ -2747,7 +2744,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			}
 
 			EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83);
-			EmitByte(code, ref offset, 0xC4); EmitByte(code, ref offset, 0x40);
+			EmitByte(code, ref offset, 0xC4); EmitByte(code, ref offset, 0x48); // add rsp, 0x48 (match sub)
 			EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5A); // pop r10
 			EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x59);
 			EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x58);

--- a/src/SharpEmu.Core/Cpu/Native/Windows/WindowsFaultHandling.cs
+++ b/src/SharpEmu.Core/Cpu/Native/Windows/WindowsFaultHandling.cs
@@ -95,7 +95,7 @@ internal sealed unsafe partial class WindowsFaultHandling : IHostFaultHandling
             EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x51); // push r9
             EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x52); // push r10
             EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83);
-            EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x40); // sub rsp, 0x40
+            EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x48); // sub rsp, 0x48: entry RSP ≡ 8 (VEH call) + 6 pushes (48, ≡ 0) ⇒ 0x48 (72, ≡ 8) lands calls at ≡ 0
             EmitByte(code, ref offset, 0xB9); EmitUInt32(code, ref offset, unchecked((uint)-12));
             EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xB8);
             *(nint*)(code + offset) = getStdHandle;
@@ -128,7 +128,7 @@ internal sealed unsafe partial class WindowsFaultHandling : IHostFaultHandling
 
             EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x8B);
             EmitByte(code, ref offset, 0x54); EmitByte(code, ref offset, 0x24);
-            EmitByte(code, ref offset, 0x40); // mov r10, [rsp+0x40]
+            EmitByte(code, ref offset, 0x48); // mov r10, [rsp+0x48]
             EmitByte(code, ref offset, 0x49); EmitByte(code, ref offset, 0xB8);
             var hexDigitsAbsSlot = offset;
             *(nint*)(code + offset) = 0;
@@ -167,16 +167,13 @@ internal sealed unsafe partial class WindowsFaultHandling : IHostFaultHandling
             EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xC7);
             EmitByte(code, ref offset, 0x44); EmitByte(code, ref offset, 0x24);
             EmitByte(code, ref offset, 0x20); EmitUInt32(code, ref offset, 0);
-            EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xC7);
-            EmitByte(code, ref offset, 0x44); EmitByte(code, ref offset, 0x24);
-            EmitByte(code, ref offset, 0x38); EmitUInt32(code, ref offset, 0);
             EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xB8);
             *(nint*)(code + offset) = writeFile;
             offset += sizeof(nint);
             EmitByte(code, ref offset, 0xFF); EmitByte(code, ref offset, 0xD0);
 
             EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83);
-            EmitByte(code, ref offset, 0xC4); EmitByte(code, ref offset, 0x40);
+            EmitByte(code, ref offset, 0xC4); EmitByte(code, ref offset, 0x48); // add rsp, 0x48 (match sub)
             EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5A);
             EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x59);
             EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x58);


### PR DESCRIPTION
## Summary

Fixes #783. Three hand-emitted x86-64 stubs make Win64 calls with RSP ≡ 8 (mod 16) at the `call` instruction, where the ABI requires ≡ 0. The fix is a one-byte immediate per site (plus the two matching frame offsets in the breadcrumb blocks), derived from the entry invariant at each site:

**Site 1 — `CreateWorkerAbortStub` (live)**
Entered by RIP redirect, never by `call`. Both entry paths force a 16-aligned RSP before redirecting: the managed path writes `hostRsp & ~0xF` to `CONTEXT.Rsp` (`DirectExecutionBackend.Exceptions.cs`), and the native VEH trampoline path does `and r8, ~0xF` before storing `Context.Rsp`. So entry is RSP ≡ 0, and the prologue `sub rsp, 0x28` (40 ≡ 8) leaves every later call (TlsGetValue, SetEvent, GetStdHandle, WriteFile, FlushFileBuffers) at ≡ 8. Changed to `sub rsp, 0x20` (32 ≡ 0) — still supplies the full 32 bytes of shadow space; the balanced `sub/add rsp, 0x20` pair around the breadcrumb already covers WriteFile's fifth-argument slot.

**Site 2 — FastFail breadcrumb in `CreateExceptionHandlerTrampoline` (live)**
A VEH handler *is* entered by `call`, so entry is RSP ≡ 8. Six pushes (48 ≡ 0) and `sub rsp, 0x40` (64 ≡ 0) preserve that phase, leaving GetStdHandle/WriteFile/FlushFileBuffers at ≡ 8. Changed the sub to `0x48` (72 ≡ 8) so the calls land at ≡ 0, and updated the matching saved-Rip load (`[rsp+0x40]` → `[rsp+0x48]`) and the epilogue `add rsp, 0x48` to keep the frame balanced.

**Site 3 — `WindowsFaultHandling.CreateHandlerThunk` (unreachable today)**
Same construction, same fix — keeps the "keep in sync" contract with Site 2's trampoline.

**Bonus fix in both breadcrumbs**
The second `WriteFile`'s `mov qword [rsp+0x38], 0` lands inside the 16-byte hex buffer (built at `[rsp+0x30]`) *after* the nibble loop, so the FastFail `rip=0x…` line lost its low eight hex digits to NUL bytes. Removed that store in both breadcrumbs. (The identical store before the *first* WriteFile, which runs before the buffer is built, is harmless and left untouched.)

## Why this matters

The misalignment is currently benign on the paths taken (multiple reviewers ran the same sequences without faulting), but it is a latent ABI trap: the next call added to these stubs, or a future CRT/kernel32 build that spills with aligned moves, would fault. The Site 2 breadcrumb is the only place `0xC0000409` is ever logged — if it ever did fault, the breadcrumb itself would be one of the misaligned calls and the failure would be silent.

## Verification

- **Byte-level audit**: re-derived the stack arithmetic at each site against the actual emitted instruction stream and both entry paths (managed CONTEXT write + native asm redirect). Entry invariants confirmed from source: abort stub = RIP redirect at RSP ≡ 0; VEH trampoline = call entry at RSP ≡ 8.
- `dotnet build SharpEmu.slnx -c Release` → clean (0 errors; 3 pre-existing unrelated warnings).
- `dotnet test SharpEmu.slnx -c Release --no-build` → **891 passed, 0 failed**.
- No runtime behavior change on guest titles: this is a conformance correction to Windows-only stubs (same instructions, corrected stack phase).

## Testing

N/A — no game testing; the change alters only the stack phase of Windows-only hand-emitted stubs that no title can distinguish before/after. Static audit + full build/test suite instead.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
