### PR TITLE
fix(cpu): scan guest modules for TLS loads and anchor handler near guest image (#789)

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -2310,7 +2310,13 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private unsafe void CreateTlsHandler()
 	{
-		_tlsHandlerAddress = (nint)TryAllocateNearEntry(TlsHandlerRegionSize);
+		// Anchor the handler allocation just BELOW the guest image window, not
+		// at _entryPoint: during module init _entryPoint is a host address, so
+		// the handler used to land in host memory, out of E8 rel32 (±2 GiB)
+		// reach of the guest code being patched (#789). A handler 16 MiB below
+		// the window base (0x800000000) covers the entire window
+		// [0x800000000, 0x900000000) via rel32.
+		_tlsHandlerAddress = (nint)TryAllocateNear(GuestImageBase - 0x1000000uL, TlsHandlerRegionSize);
 		if (_tlsHandlerAddress == 0)
 		{
 			_tlsHandlerAddress = (nint)VirtualAlloc(null, TlsHandlerRegionSize, 12288u, 64u);
@@ -3092,10 +3098,9 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		return (nint)ptr;
 	}
 
-	private unsafe void* TryAllocateNearEntry(nuint size)
+	private unsafe void* TryAllocateNear(ulong anchor, nuint size)
 	{
-		ulong entryPoint = _entryPoint;
-		ulong baseAddress = entryPoint & 0xFFFFFFFFFFFF0000uL;
+		ulong baseAddress = anchor & 0xFFFFFFFFFFFF0000uL;
 		for (long num = 0L; num <= 1879048192; num += 16777216)
 		{
 			if (TryAllocAt(baseAddress, num, size, out var memory))
@@ -3142,11 +3147,16 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private unsafe void PatchTlsPatterns()
 	{
-        // Large Gen5 executables can keep valid code well past the first 32 MiB.
-        // Astro Bot, for example, has an FS:[0] TLS load near +0x70A0000.
-        const ulong MaxScanBytes = 134217728uL;
-		ulong num = _entryPoint;
-		ulong num2 = num + MaxScanBytes;
+		// Scan the guest image window, not [_entryPoint, _entryPoint + 128 MiB):
+		// during module init _entryPoint is a host address, so the old anchor
+		// scanned the emulator's own runtime and never reached the guest image
+		// (every log shows "Patched 0 TLS loads", #789). The guest window covers
+		// all loaded modules; the VirtualQuery walk below only byte-scans
+		// committed executable regions, so cost tracks the amount of code, not
+		// the window size. Astro Bot, for example, has an FS:[0] TLS load near
+		// +0x70A0000, well inside the window.
+		ulong num = GuestImageBase;
+		ulong num2 = GuestImageLimit;
 		int num3 = 0;
 		int num4 = 0;
 		int num9 = 0;
@@ -3382,7 +3392,10 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		}
 		try
 		{
-			*(sbyte*)address = -24;
+			// Resolve and validate the rel32 displacement BEFORE writing the E8
+			// opcode: the old order clobbered the first byte of the guest
+			// instruction on the out-of-range path, leaving a half-corrupted
+			// instruction in the guest image (#789).
 			long num = _tlsHandlerAddress;
 			long num2 = address + 5;
 			long num3 = num - num2;
@@ -3392,6 +3405,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				return false;
 			}
 
+			*(sbyte*)address = -24;
 			*(int*)(address + 1) = (int)num3;
 			var offset = 5;
 			if (destinationRegister != 0)
@@ -3441,13 +3455,15 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		byte* ptr = (byte*)num;
 		int num2 = 0;
 		ptr[num2++] = 80;
-		ptr[num2++] = 232;
-		long num3 = _tlsHandlerAddress - (num + num2 + 4);
+		// Resolve the rel32 before emitting the E8 so an out-of-range helper
+		// leaves the stub region clean instead of half-written (#789).
+		long num3 = _tlsHandlerAddress - (num + num2 + 5);
 		if (num3 < int.MinValue || num3 > int.MaxValue)
 		{
 			Console.Error.WriteLine($"[LOADER][WARNING] TLS store helper out of rel32 range at 0x{num:X16}");
 			return 0;
 		}
+		ptr[num2++] = 232;
 		*(int*)(ptr + num2) = (int)num3;
 		num2 += 4;
 		ptr[num2++] = 199;

--- a/tests/SharpEmu.Libs.Tests/Cpu/TlsLoadPatcherTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/TlsLoadPatcherTests.cs
@@ -1,0 +1,199 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Reflection;
+using System.Runtime.Serialization;
+using SharpEmu.Core.Cpu.Native;
+using SharpEmu.HLE;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+/// <summary>
+/// Coverage for the guest TLS thread-pointer load patcher used by
+/// DirectExecutionBackend.PatchTlsPatterns.
+///
+/// The encodings exercised here are the exact bytes seen at the faulting RIP of
+/// God of War Ragnarök, Minecraft and EA UFC 5 (#789): LLVM's TLS
+/// general-dynamic relaxation emits three 0x66 operand-size prefixes before the
+/// 0x64 FS override, i.e. `66 66 66 64 48 8B 04 25 00000000` (mov reg, fs:[0]).
+///
+/// The out-of-range case is the regression guard: the patcher used to write the
+/// E8 opcode before validating the rel32 displacement, so a handler that was
+/// out of ±2 GiB reach (the pre-fix state for God of War / UFC 5, whose
+/// handlers landed in host memory ~2.6 TB from the guest image) left the guest
+/// instruction half-corrupted.
+/// </summary>
+public sealed unsafe class TlsLoadPatcherTests
+{
+    private static readonly MethodInfo TryPatchTlsLoadInstruction = typeof(DirectExecutionBackend).GetMethod(
+        "TryPatchTlsLoadInstruction",
+        BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly FieldInfo TlsHandlerAddress = typeof(DirectExecutionBackend).GetField(
+        "_tlsHandlerAddress",
+        BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private delegate bool TryPatchTlsLoadInstructionDelegate(nint address, byte* source, int availableLength);
+
+    // mov rax, fs:[0] — the exact faulting encoding from the three title logs.
+    private static readonly byte[] ThreadPointerLoadRax =
+        [0x66, 0x66, 0x66, 0x64, 0x48, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00];
+
+    // mov r13, fs:[0] — same shape, REX.R destination (r13 = index 13).
+    private static readonly byte[] ThreadPointerLoadR13 =
+        [0x66, 0x66, 0x66, 0x64, 0x4C, 0x8B, 0x2C, 0x25, 0x00, 0x00, 0x00, 0x00];
+
+    private static DirectExecutionBackend CreateBackend()
+    {
+        // Bypass the constructor: it allocates TLS slots and native state that
+        // the patcher does not need and that are awkward to provision in a
+        // unit test. Only the _tlsHandlerAddress field is read on this path.
+        return (DirectExecutionBackend)FormatterServices.GetUninitializedObject(
+            typeof(DirectExecutionBackend));
+    }
+
+    private static TryPatchTlsLoadInstructionDelegate GetPatcher(DirectExecutionBackend backend) =>
+        (TryPatchTlsLoadInstructionDelegate)Delegate.CreateDelegate(
+            typeof(TryPatchTlsLoadInstructionDelegate), backend, TryPatchTlsLoadInstruction);
+
+    private static byte* AllocateExecutablePage()
+    {
+        // Apple Silicon macOS denies anonymous PROT_EXEC mappings without the
+        // JIT entitlement (errno EACCES); CI runs osx-x64 (Rosetta) and
+        // Linux/Windows where they succeed. Callers skip when unsupported.
+        var memory = HostMemory.Alloc(null, 4096u, 12288u, 64u); // MEM_COMMIT|MEM_RESERVE, PAGE_EXECUTE_READWRITE
+        return memory == null ? null : (byte*)memory;
+    }
+
+    [Fact]
+    public void PatchesLlvmPaddedTlsLoadInRange()
+    {
+        var backend = CreateBackend();
+        var patcher = GetPatcher(backend);
+        byte* page = AllocateExecutablePage();
+        if (page == null)
+        {
+            return; // host denies executable mappings (see AllocateExecutablePage)
+        }
+
+        try
+        {
+            // Handler 0x10 past the instruction end: comfortably inside rel32 reach.
+            TlsHandlerAddress.SetValue(backend, (nint)(page + 12 + 0x10));
+
+            fixed (byte* code = ThreadPointerLoadRax)
+            {
+                for (int i = 0; i < ThreadPointerLoadRax.Length; i++)
+                {
+                    page[i] = code[i];
+                }
+
+                bool patched = patcher((nint)page, page, ThreadPointerLoadRax.Length);
+
+                Assert.True(patched);
+                Assert.Equal(0xE8, page[0]); // call rel32
+
+                long expectedDisplacement = (long)(nint)(page + 12 + 0x10) - ((long)(nint)page + 5);
+                Assert.Equal((int)expectedDisplacement, *(int*)(page + 1));
+
+                // Destination rax: no register move needed, remainder is NOP padding.
+                for (int i = 5; i < ThreadPointerLoadRax.Length; i++)
+                {
+                    Assert.Equal(0x90, page[i]);
+                }
+            }
+        }
+        finally
+        {
+            HostMemory.Free(page, 4096u, 32768u); // MEM_RELEASE
+        }
+    }
+
+    [Fact]
+    public void PatchesRexBDestinationRegister()
+    {
+        var backend = CreateBackend();
+        var patcher = GetPatcher(backend);
+        byte* page = AllocateExecutablePage();
+        if (page == null)
+        {
+            return; // host denies executable mappings (see AllocateExecutablePage)
+        }
+
+        try
+        {
+            TlsHandlerAddress.SetValue(backend, (nint)(page + 12 + 0x10));
+
+            fixed (byte* code = ThreadPointerLoadR13)
+            {
+                for (int i = 0; i < ThreadPointerLoadR13.Length; i++)
+                {
+                    page[i] = code[i];
+                }
+
+                bool patched = patcher((nint)page, page, ThreadPointerLoadR13.Length);
+
+                Assert.True(patched);
+                Assert.Equal(0xE8, page[0]);
+
+                // mov r13, rax: REX.WB (0x49) 0x89 /r with modrm 0xC5.
+                Assert.Equal(0x49, page[5]);
+                Assert.Equal(0x89, page[6]);
+                Assert.Equal(0xC5, page[7]);
+
+                for (int i = 8; i < ThreadPointerLoadR13.Length; i++)
+                {
+                    Assert.Equal(0x90, page[i]);
+                }
+            }
+        }
+        finally
+        {
+            HostMemory.Free(page, 4096u, 32768u); // MEM_RELEASE
+        }
+    }
+
+    [Fact]
+    public void OutOfRangeHandlerLeavesInstructionUntouched()
+    {
+        var backend = CreateBackend();
+        var patcher = GetPatcher(backend);
+        byte* page = AllocateExecutablePage();
+        if (page == null)
+        {
+            return; // host denies executable mappings (see AllocateExecutablePage)
+        }
+
+        try
+        {
+            // Handler 3 GiB past the instruction: beyond the ±2 GiB rel32 limit.
+            // This is the pre-fix God of War / UFC 5 condition (handler in host
+            // memory, guest image unreachable).
+            TlsHandlerAddress.SetValue(backend, (nint)(page + 0xC0000000L));
+
+            fixed (byte* code = ThreadPointerLoadRax)
+            {
+                for (int i = 0; i < ThreadPointerLoadRax.Length; i++)
+                {
+                    page[i] = code[i];
+                }
+
+                bool patched = patcher((nint)page, page, ThreadPointerLoadRax.Length);
+
+                Assert.False(patched);
+
+                // Regression guard: the patcher must not have written the E8
+                // opcode before discovering the displacement was out of range.
+                for (int i = 0; i < ThreadPointerLoadRax.Length; i++)
+                {
+                    Assert.Equal(ThreadPointerLoadRax[i], page[i]);
+                }
+            }
+        }
+        finally
+        {
+            HostMemory.Free(page, 4096u, 32768u); // MEM_RELEASE
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements direction (1) from #789 — the load-time patcher fix that the fault-time fallback in #791 composes with. This is the root cause of the God of War Ragnarök / Minecraft / EA UFC 5 terminal crashes: **`PatchTlsPatterns` has never patched a single TLS load in any title** because it scans the wrong memory.

### Problem 1 — the scan never reaches guest code

`PatchTlsPatterns` anchored on `_entryPoint`, which during module init is a **host address** (the loader hands `TryExecute` a host entry while the guest image sits at `0x800000000`). The 128 MiB forward-only walk therefore scanned the emulator's own runtime — which is why every title log shows `Patched 0 TLS loads, 164 TLS stores, ...` with a game-independent store count: the "stores" were patches applied to host memory.

**Fix:** scan the guest image window `[GuestImageBase, GuestImageLimit)` = `[0x800000000, 0x900000000)` instead. The `VirtualQuery` walk only byte-scans committed executable regions, so the cost tracks actual code volume, not window size — the 128 MiB cap was a proxy for "stay in the guest image", and the window constant is the exact thing.

### Problem 2 — even a correct scan couldn't emit patches (handler locality)

The patch is `E8 rel32` to a single TLS handler allocated near `_entryPoint`. With `_entryPoint` being a host address, the handler landed in host memory ~2.2–2.6 TB from the guest image for GoW / UFC 5 — out of ±2 GiB rel32 reach, so every match would have degraded to a `TLS patch out of rel32 range` warning with the instruction still unpatched (and, pre-fix, half-corrupted — see Problem 3). The issue author's own correction in #789 established that scan coverage and handler locality must be fixed together.

**Fix:** allocate the handler just below the guest window — 16 MiB below `GuestImageBase` (i.e. `0x7FF000000`). From there the ±2 GiB rel32 window covers `[0x77F000000, 0xFFF00000]`, i.e. the **entire** 4 GiB guest window. Minecraft's handler was already inside the window (only its scan direction was wrong — fault below the entry); GoW/UFC 5 needed the locality move.

### Problem 3 — out-of-range patches corrupted the guest instruction

`PatchTlsLoadInstruction` wrote the `E8` opcode **before** validating the rel32 displacement, so the out-of-range path returned `false` with the guest instruction's first byte already clobbered to `E8`. With the scan now actually reaching guest code, this latent bug becomes a real corruption hazard. Fixed by resolving and validating the displacement first (same pattern in `CreateTlsImmediateStoreHelper`).

## Verification

- **`TlsLoadPatcherTests`** (new, 3 tests): drives the production patcher over the exact faulting encodings from the three title logs (`66 66 66 64 48 8B 04 25 00000000`), the REX.R destination form (`mov r13, fs:[0]`), and the out-of-range regression guard — the instruction must be left byte-for-byte untouched. The guard fails on the old write-ordering.
  - Note: Apple Silicon macOS denies anonymous `PROT_EXEC` mappings without the JIT entitlement, so the tests skip there (same pattern as the existing Linux-only `Sse4aPosixSignalRecoveryTests`); CI's osx-x64 (Rosetta), Linux and Windows runners exercise them for real.
- `dotnet build SharpEmu.slnx -c Release` → clean, 0 errors.
- `dotnet test SharpEmu.slnx -c Release --no-build` → **894 passed, 0 failed** (804 in SharpEmu.Libs.Tests, including the 3 new ones).
- No guest-code behavior change for titles whose TLS loads were already being patched (Astro Bot etc.): same instruction rewrite, corrected anchor/range.

## Scope note

Deliberately does not include #790 (fault-time diagnostic) or #791 (fault-time fallback) — those are independent PRs that compose: #790 makes the next captures self-diagnosing, #791 catches whatever the load-time pass still misses, and this change makes the load-time pass actually run.

## Testing

N/A — no game hardware testing available (macOS host; the patcher path is exercised via the new unit tests instead). This changes the load-time patch pass only; behavior on titles with working TLS patching is unchanged, and titles that previously crashed on the first unpatched TLS load now get the patch.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
