### PR TITLE
fix(cpu): report native import session statistics

### DIFF
--- a/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
+++ b/src/SharpEmu.Core/Cpu/CpuDispatcher.cs
@@ -155,7 +155,10 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
         LastRecentInstructionWindow = null;
         LastRecentControlTransferTrace = null;
         LastSessionSummary = default;
-        OrbisGen2Result FailEarly(OrbisGen2Result result, CpuExitReason reason = CpuExitReason.UnhandledException)
+        OrbisGen2Result FailEarly(
+            OrbisGen2Result result,
+            CpuExitReason reason = CpuExitReason.UnhandledException,
+            NativeCpuSessionStatistics nativeStatistics = default)
         {
             LastSessionSummary = new CpuSessionSummary(
                 result,
@@ -164,8 +167,8 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
                 lastGuestRip: entryPoint,
                 lastStubRip: 0,
                 totalInstructions: 0,
-                importsHit: 0,
-                uniqueNidsHit: 0);
+                importsHit: nativeStatistics.ImportsHit,
+                uniqueNidsHit: nativeStatistics.UniqueNidsHit);
             return result;
         }
 
@@ -290,14 +293,18 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
         _nativeCpuBackend ??= new DirectExecutionBackend(_moduleManager);
         // Let backend stall reports reference the same frame as entry.
         (_nativeCpuBackend as DirectExecutionBackend)?.SetActiveDebugFrame(debugFrame);
-        if (_nativeCpuBackend.TryExecute(
+        var nativeSucceeded = _nativeCpuBackend.TryExecute(
                 context,
                 entryPoint,
                 generation,
                 effectiveImportStubs,
                 runtimeSymbols ?? new Dictionary<string, ulong>(StringComparer.Ordinal),
                 executionOptions,
-                out var nativeResult))
+                out var nativeResult);
+        var nativeStatistics = _nativeCpuBackend is INativeCpuSessionStatisticsProvider statisticsProvider
+            ? statisticsProvider.LastSessionStatistics
+            : default;
+        if (nativeSucceeded)
         {
             debugHook?.OnFrameExit(debugFrame!, nativeResult);
             LastSessionSummary = new CpuSessionSummary(
@@ -309,8 +316,8 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
                 lastGuestRip: context.Rip,
                 lastStubRip: 0,
                 totalInstructions: 0,
-                importsHit: 0,
-                uniqueNidsHit: 0);
+                importsHit: nativeStatistics.ImportsHit,
+                uniqueNidsHit: nativeStatistics.UniqueNidsHit);
             return nativeResult;
         }
 
@@ -336,7 +343,8 @@ public sealed class CpuDispatcher : ICpuDispatcher, IDisposable
         Console.Error.WriteLine($"[DISPATCHER] Native backend FAILED: {backendError}");
         return FailEarly(
             OrbisGen2Result.ORBIS_GEN2_ERROR_NOT_IMPLEMENTED,
-            CpuExitReason.NativeBackendUnavailable);
+            CpuExitReason.NativeBackendUnavailable,
+            nativeStatistics);
     }
 
     private ulong TryMapStackRegion()

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Imports.cs
@@ -200,6 +200,7 @@ public sealed partial class DirectExecutionBackend
 			return 18446744071562199042uL;
 		}
 		ImportStubEntry importStubEntry = _importEntries[importIndex];
+		Volatile.Read(ref _activeImportSessionCounters)?.Record(importStubEntry.Nid);
 		if (_perfHleHistogram)
 		{
 			RecordPerfHleCall(importStubEntry.Export?.Name ?? importStubEntry.Nid);

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -17,7 +17,11 @@ using SharpEmu.Libs.Diagnostics;
 
 namespace SharpEmu.Core.Cpu.Native;
 
-public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, IGuestThreadScheduler, IDisposable
+public sealed unsafe partial class DirectExecutionBackend :
+	INativeCpuBackend,
+	INativeCpuSessionStatisticsProvider,
+	IGuestThreadScheduler,
+	IDisposable
 {
 	private static readonly SharpEmu.Logging.SharpEmuLogger Log = SharpEmu.Logging.SharpEmuLog.For("Native");
 
@@ -299,6 +303,12 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	private nint _guestContextTransferStub;
 
 	private long _importDispatchCount;
+
+	private NativeImportSessionCounters? _activeImportSessionCounters;
+
+	private int _lastSessionImportsHit;
+
+	private int _lastSessionUniqueNidsHit;
 
 	private const int ImportDispatchBlockSize = 256;
 
@@ -1127,7 +1137,31 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		PrewarmNativeGuestWorkers(Math.Max(NativeWorkerMaxConcurrent, 4));
 	}
 
+	NativeCpuSessionStatistics INativeCpuSessionStatisticsProvider.LastSessionStatistics =>
+		new(
+			Volatile.Read(ref _lastSessionImportsHit),
+			Volatile.Read(ref _lastSessionUniqueNidsHit));
+
 	public bool TryExecute(CpuContext context, ulong entryPoint, Generation generation, IReadOnlyDictionary<ulong, string> importStubs, IReadOnlyDictionary<string, ulong> runtimeSymbols, CpuExecutionOptions executionOptions, out OrbisGen2Result result)
+	{
+		var sessionCounters = new NativeImportSessionCounters();
+		Volatile.Write(ref _lastSessionImportsHit, 0);
+		Volatile.Write(ref _lastSessionUniqueNidsHit, 0);
+		Volatile.Write(ref _activeImportSessionCounters, sessionCounters);
+		try
+		{
+			return TryExecuteCore(context, entryPoint, generation, importStubs, runtimeSymbols, executionOptions, out result);
+		}
+		finally
+		{
+			Interlocked.CompareExchange(ref _activeImportSessionCounters, null, sessionCounters);
+			var statistics = sessionCounters.Snapshot();
+			Volatile.Write(ref _lastSessionImportsHit, statistics.ImportsHit);
+			Volatile.Write(ref _lastSessionUniqueNidsHit, statistics.UniqueNidsHit);
+		}
+	}
+
+	private bool TryExecuteCore(CpuContext context, ulong entryPoint, Generation generation, IReadOnlyDictionary<ulong, string> importStubs, IReadOnlyDictionary<string, ulong> runtimeSymbols, CpuExecutionOptions executionOptions, out OrbisGen2Result result)
 	{
 		Console.Error.WriteLine("[LOADER][INFO] === Execute START ===");
 		Console.Error.WriteLine($"[LOADER][INFO] EntryPoint: 0x{entryPoint:X16}, ImportStubs: {importStubs.Count}");

--- a/src/SharpEmu.Core/Cpu/Native/NativeCpuSessionStatistics.cs
+++ b/src/SharpEmu.Core/Cpu/Native/NativeCpuSessionStatistics.cs
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Collections.Concurrent;
+
+namespace SharpEmu.Core.Cpu.Native;
+
+internal readonly record struct NativeCpuSessionStatistics(int ImportsHit, int UniqueNidsHit);
+
+internal interface INativeCpuSessionStatisticsProvider
+{
+    NativeCpuSessionStatistics LastSessionStatistics { get; }
+}
+
+internal sealed class NativeImportSessionCounters
+{
+    private readonly ConcurrentDictionary<string, byte> _uniqueNids = new(StringComparer.Ordinal);
+    private int _importsHit;
+
+    public void Record(string nid)
+    {
+        Interlocked.Increment(ref _importsHit);
+        _uniqueNids.TryAdd(nid, 0);
+    }
+
+    public NativeCpuSessionStatistics Snapshot() =>
+        new(Volatile.Read(ref _importsHit), _uniqueNids.Count);
+}

--- a/tests/SharpEmu.Libs.Tests/Cpu/NativeCpuSessionStatisticsTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/NativeCpuSessionStatisticsTests.cs
@@ -1,0 +1,136 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu;
+using SharpEmu.Core.Cpu.Native;
+using SharpEmu.Core.Memory;
+using SharpEmu.HLE;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+public sealed class NativeCpuSessionStatisticsTests
+{
+    [Fact]
+    public void Snapshot_WithoutImports_IsEmpty()
+    {
+        var counters = new NativeImportSessionCounters();
+
+        Assert.Equal(new NativeCpuSessionStatistics(0, 0), counters.Snapshot());
+    }
+
+    [Fact]
+    public void Snapshot_AfterOneImport_ReportsOneImportAndOneNid()
+    {
+        var counters = new NativeImportSessionCounters();
+
+        counters.Record("first-nid");
+
+        Assert.Equal(new NativeCpuSessionStatistics(1, 1), counters.Snapshot());
+    }
+
+    [Fact]
+    public void Snapshot_AfterRepeatedNid_CountsEveryImportOnce()
+    {
+        var counters = new NativeImportSessionCounters();
+
+        counters.Record("same-nid");
+        counters.Record("same-nid");
+
+        Assert.Equal(new NativeCpuSessionStatistics(2, 1), counters.Snapshot());
+    }
+
+    [Fact]
+    public void Snapshot_AfterDistinctNids_CountsBothNids()
+    {
+        var counters = new NativeImportSessionCounters();
+
+        counters.Record("first-nid");
+        counters.Record("second-nid");
+
+        Assert.Equal(new NativeCpuSessionStatistics(2, 2), counters.Snapshot());
+    }
+
+    [Fact]
+    public void Snapshot_AfterConcurrentImports_IsExact()
+    {
+        const int dispatchCount = 10_000;
+        const int uniqueNidCount = 17;
+        var counters = new NativeImportSessionCounters();
+
+        Parallel.For(0, dispatchCount, index => counters.Record($"nid-{index % uniqueNidCount}"));
+
+        Assert.Equal(
+            new NativeCpuSessionStatistics(dispatchCount, uniqueNidCount),
+            counters.Snapshot());
+    }
+
+    [Fact]
+    public void DispatchEntry_CopiesNativeStatisticsIntoSessionSummary()
+    {
+        var memory = new VirtualMemory();
+        var moduleManager = new ModuleManager();
+        var backend = new StatisticsBackend(new NativeCpuSessionStatistics(2, 1));
+        using var dispatcher = new CpuDispatcher(memory, moduleManager, backend);
+
+        var result = dispatcher.DispatchEntry(
+            0x1_0000,
+            Generation.Gen5,
+            executionOptions: new CpuExecutionOptions { CpuEngine = CpuExecutionEngine.NativeOnly });
+
+        Assert.Equal(OrbisGen2Result.ORBIS_GEN2_OK, result);
+        Assert.Equal(2, dispatcher.LastSessionSummary.ImportsHit);
+        Assert.Equal(1, dispatcher.LastSessionSummary.UniqueNidsHit);
+    }
+
+    [Fact]
+    public void DispatchEntry_PreservesNativeStatisticsWhenBackendFails()
+    {
+        var memory = new VirtualMemory();
+        var moduleManager = new ModuleManager();
+        var backend = new StatisticsBackend(
+            new NativeCpuSessionStatistics(2, 2),
+            succeeds: false);
+        using var dispatcher = new CpuDispatcher(memory, moduleManager, backend);
+
+        _ = dispatcher.DispatchEntry(
+            0x1_0000,
+            Generation.Gen5,
+            executionOptions: new CpuExecutionOptions { CpuEngine = CpuExecutionEngine.NativeOnly });
+
+        Assert.Equal(2, dispatcher.LastSessionSummary.ImportsHit);
+        Assert.Equal(2, dispatcher.LastSessionSummary.UniqueNidsHit);
+    }
+
+    private sealed class StatisticsBackend(
+        NativeCpuSessionStatistics statistics,
+        bool succeeds = true) : INativeCpuBackend, INativeCpuSessionStatisticsProvider
+    {
+        public string BackendName => "statistics-test";
+
+        public string? LastError => succeeds ? null : "expected test failure";
+
+        public NativeCpuSessionStatistics LastSessionStatistics => statistics;
+
+        public bool TryExecute(
+            CpuContext context,
+            ulong entryPoint,
+            Generation generation,
+            IReadOnlyDictionary<ulong, string> importStubs,
+            IReadOnlyDictionary<string, ulong> runtimeSymbols,
+            CpuExecutionOptions executionOptions,
+            out OrbisGen2Result result)
+        {
+            _ = context;
+            _ = entryPoint;
+            _ = generation;
+            _ = importStubs;
+            _ = runtimeSymbols;
+            _ = executionOptions;
+            result = succeeds
+                ? OrbisGen2Result.ORBIS_GEN2_OK
+                : OrbisGen2Result.ORBIS_GEN2_ERROR_CPU_TRAP;
+            return succeeds;
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Count native HLE import dispatches with a fresh, per-execution counter.
- Track unique dispatched NIDs in a session-local concurrent set.
- Copy the final snapshot into `CpuDispatcher.LastSessionSummary` on successful and failed native backend exits.
- Add focused contract tests for zero, repeated, distinct, concurrent, successful, and failed dispatch cases.

No import resolution, ABI, trampoline, HLE implementation, or guest execution behavior is changed.

## Testing

N/A for game testing; this change only populates native-session diagnostics. Automated validation:

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release --filter "FullyQualifiedName~NativeCpuSessionStatisticsTests|FullyQualifiedName~Gen5NativeReturnSmokeTests" --verbosity normal` (8 passed)
- Temporary counter sabotage made the one-import contract test fail with `ImportsHit` 0 instead of 1; the production line was restored before the final runs.
- `dotnet build SharpEmu.slnx -c Release` (0 warnings, 0 errors)
- `dotnet test SharpEmu.slnx -c Release --no-build --verbosity minimal` (899 passed)
- `git diff --check`

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

The description was prepared with AI assistance and reviewed by the submitter; the authorship checkbox is intentionally left unchecked.
