### PR TITLE
fix(vmem): use ConcurrentDictionary for _pageProtections

### DIFF
--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 SharpEmu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using SharpEmu.Core.Loader;
 using SharpEmu.HLE;
@@ -18,7 +19,7 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
     private readonly object _allocationSearchHintGate = new();
     private readonly List<MemoryRegion> _regions = new();
     private readonly Dictionary<(ulong DesiredAddress, ulong Alignment, bool Executable), ulong> _allocationSearchHints = new();
-    private readonly Dictionary<ulong, ProgramHeaderFlags> _pageProtections = new();
+    private readonly ConcurrentDictionary<ulong, ProgramHeaderFlags> _pageProtections = new();
     private bool _disposed;
 
     [ThreadStatic]


### PR DESCRIPTION
### What this does

Fixes a startup hang where `PhysicalVirtualMemory` can get stuck in `Dictionary.TryGetValue`.

### Details

While debugging a multi-threaded boot with 20+ guest worker threads, the process would hang during startup with one CPU core at 100%.

A WinDbg dump showed the thread stuck in the .NET `Dictionary.cs` lookup:

    00 System_Private_CoreLib!Dictionary<ulong, ProgramHeaderFlags>.TryGetValue

    01 SharpEmu_Core!PhysicalVirtualMemory.CanAccessWithoutProtectionChange

    02 SharpEmu_Core!PhysicalVirtualMemory.CanWriteWithoutProtectionChange

    03 SharpEmu_Core!PhysicalVirtualMemory.TryWrite

`_pageProtections` was using a regular `Dictionary<ulong, ProgramHeaderFlags>`. It is accessed by multiple guest worker threads while memory segments and their protections are being set up.

The dictionary was being corrupted under concurrent access, resulting in a circular bucket chain and leaving `TryGetValue` stuck in its lookup loop.

Changed `_pageProtections` to a `ConcurrentDictionary<ulong, ProgramHeaderFlags>` so it can be accessed safely from multiple worker threads.

## Testing

- Ghost of Yōtei (PPSA26344) – Confirmed that the multi-threaded startup hang in `PhysicalVirtualMemory` is resolved. Also verified with a WinDbg process dump that the `Dictionary.TryGetValue` hang no longer occurs.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.

- [x] I tested my changes or marked the testing section as `N/A`.

- [x] I wrote this pull request description myself and did not paste AI-generated explanations.

- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).