### PR TITLE
Fix unaligned BufferLoad/GlobalLoad dword access

### DIFF
--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.cs
@@ -2366,17 +2366,16 @@ public static partial class Gen5SpirvTranslator
                         return;
                     }
 
+                    // GLOBAL_STORE/LOAD_DWORD(x2/x3/x4) are dword-aligned by the GCN ISA, so read/write dwords directly instead of the per-byte loop.
                     for (uint index = 0; index < control.DwordCount; index++)
                     {
-                        var address = index == 0
-                            ? byteAddress
-                            : IAdd(byteAddress, UInt(index * sizeof(uint)));
-                        StoreBufferBytes(
+                        var indexedDwordAddress = index == 0
+                            ? dwordAddress
+                            : IAdd(dwordAddress, UInt(index));
+                        StoreBufferWord(
                             bindingIndex,
-                            address,
-                            LoadV(control.VectorData + index),
-                            sizeof(uint),
-                            0);
+                            indexedDwordAddress,
+                            LoadV(control.VectorData + index));
                     }
                 });
                 return true;
@@ -2404,12 +2403,12 @@ public static partial class Gen5SpirvTranslator
 
             for (uint index = 0; index < control.DwordCount; index++)
             {
-                var address = index == 0
-                    ? byteAddress
-                    : IAdd(byteAddress, UInt(index * sizeof(uint)));
+                var indexedDwordAddress = index == 0
+                    ? dwordAddress
+                    : IAdd(dwordAddress, UInt(index));
                 StoreV(
                     control.VectorData + index,
-                    LoadUnalignedBufferWord(bindingIndex, address));
+                    LoadBufferWord(bindingIndex, indexedDwordAddress));
             }
 
             return true;
@@ -2510,17 +2509,16 @@ public static partial class Gen5SpirvTranslator
                         return;
                     }
 
+                    // BUFFER_STORE/LOAD_DWORD(x2/x3/x4) are dword-aligned by the GCN ISA, same as the GLOBAL case above — no per-byte reassembly needed.
                     for (uint index = 0; index < control.DwordCount; index++)
                     {
-                        var address = index == 0
-                            ? byteAddress
-                            : IAdd(byteAddress, UInt(index * sizeof(uint)));
-                        StoreBufferBytes(
+                        var indexedDwordAddress = index == 0
+                            ? dwordAddress
+                            : IAdd(dwordAddress, UInt(index));
+                        StoreBufferWord(
                             bindingIndex,
-                            address,
-                            LoadV(control.VectorData + index),
-                            sizeof(uint),
-                            0);
+                            indexedDwordAddress,
+                            LoadV(control.VectorData + index));
                     }
                 });
 
@@ -2576,12 +2574,12 @@ public static partial class Gen5SpirvTranslator
 
             for (uint index = 0; index < control.DwordCount; index++)
             {
-                var address = index == 0
-                    ? byteAddress
-                    : IAdd(byteAddress, UInt(index * sizeof(uint)));
+                var indexedDwordAddress = index == 0
+                    ? dwordAddress
+                    : IAdd(dwordAddress, UInt(index));
                 StoreV(
                     control.VectorData + index,
-                    LoadUnalignedBufferWord(bindingIndex, address));
+                    LoadBufferWord(bindingIndex, indexedDwordAddress));
             }
 
             return true;


### PR DESCRIPTION
Fix a generic GPU-buffer translation inefficiency where dword-aligned BufferLoad/GlobalLoad instructions were paying the cost of unaligned byte-by-byte access:

Route BufferLoadDword/x2/x3/x4, BufferStoreDword/x2/x3/x4, and their GLOBAL counterparts through the existing aligned LoadBufferWord/StoreBufferWord helpers instead of LoadUnalignedBufferWord/StoreBufferBytes.

The GCN ISA guarantees these opcodes are always dword-aligned — only the byte/short/D16 variants legitimately need unaligned reconstruction, and those already have their own dedicated path. The generic dword-count loop was reconstructing every dword one byte at a time (4 bounds-checked accesses per dword, each with its own OpArrayLength/OpSelect/OpAccessChain/OpLoad-OpStore, plus shift/mask/or reassembly) for opcodes that never needed it.

Testing
Ghost of Yōtei (compared against upstream/main without this PR)
- Compute shader 0x800036E100 (4K / 8.3M-thread dispatch, 6 BufferLoadDwordx4 instructions in its hottest block).
- GPU dispatch time: 429 ms vs86 ms (~5× faster).
- Generated SPIR-V size: 526 KB vs 402 KB.
- Output unchanged

Astro Bot
- Found two shaders (0x000000050056A900 and 0x0000000555F4F500) using the same aligned BufferLoadDword pattern.
- Improvement is much smaller (≤0.3 ms) because these shaders contain far fewer occurrences of the pattern and are much lighter overall.
- Output unchanged.

Demon's Souls
- Found five shaders using the same pattern.
- Performed a clean A/B comparison (7-minute run before the fix, 7-minute run after).
- No measurable performance difference beyond normal run-to-run noise (within ±5–7%), consistent with those shaders only containing one or two occurrences of the pattern.
- Output unchanged.
