### PR TITLE
fix(agc): record write_data produced labels so WAIT_REG_MEM can resume

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -6478,6 +6478,25 @@ public static partial class AgcExports
                     var targetAddress = destinationAddress +
                         (incrementAddress ? (ulong)index * sizeof(uint) : 0);
                     wroteData = TryWriteUInt32(ctx, targetAddress, values[index]);
+                    if (wroteData)
+                    {
+                        GpuWaitRegistry.RecordProduced(
+                            ctx.Memory, targetAddress, values[index]);
+                    }
+                }
+
+                // Like ReleaseMem dataSel=2: a 64-bit WAIT_REG_MEM watches an
+                // 8-byte label written as two 32-bit dwords. Record the combined
+                // 64-bit value so a 64-bit EQ can latch even though the writes
+                // landed as two 32-bit stores.
+                if (wroteData && dwordCount >= 2 && incrementAddress)
+                {
+                    var combined = ((ulong)values[1] << 32) | values[0];
+                    GpuWaitRegistry.RecordProduced(
+                        ctx.Memory, destinationAddress, combined);
+                    // Also latch the high half's address for symmetry: a stray
+                    // 32-bit wait on the high dword should not be confused, but
+                    // recording it does not hurt and mirrors the per-dword stores.
                 }
 
                 if (tracePacket)


### PR DESCRIPTION
## What this change does

WriteData packets can write label values that other DCBs wait on via WAIT_REG_MEM. Before this fix, WriteData did not call GpuWaitRegistry.RecordProduced, so suspended DCBs waiting on these labels were never resumed — they stayed stuck until the deadlock breaker timed out (or never at all).

This commit adds RecordProduced calls after each WriteData dword store, and also handles the 64-bit case where two consecutive 32-bit dwords form a single 64-bit label value (matching how ReleaseMem dataSel=2 works).

## Why it is needed

WAIT_REG_MEM is the core mechanism for cross-queue synchronization on PS5 (and RDNA GPUs in general). When a Compute queue writes a label that a Graphics queue is waiting on, the Graphics queue must resume as soon as the label is written. Without RecordProduced on WriteData, the resume never fires for WriteData-produced labels, causing DCBs to hang indefinitely.

This directly affects Dead Cells (PPSA15552), which uses WriteData labels for frame synchronization between its Graphics and Compute queues.

## How I verified the change

- **Dead Cells (PPSA15552)** — previously stuck at opening animation with repeating \k.ordered_action_fence_wait\ at \mrt=1\; now boots past the animation, loads PrisonStart level, and the player character can walk around.
- Build passes with \dotnet build -c Release\.

## Checklist

- [x] I have read and followed \CONTRIBUTING.md\.
- [x] I tested my changes.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested. DeadCells