### PR TITLE
fix(agc,video): CMASK/DCC metadata state machine  , remove heavy heavy motion trails in DeadCell

### DIFF
--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -118,6 +118,9 @@ public static partial class AgcExports
     // Multiple producers can share one target label; last-writer-wins would
     // starve waits on the others.
     private static readonly Dictionary<ulong, List<ulong>> _cbReleaseMemTargets = new();
+    // CMASK state tracking: tracks which CMASK addresses are "all clear".
+    // Keyed by CMASK address, value is true if marked as cleared.
+    private static readonly Dictionary<ulong, bool> _cmaskClearedState = new();
     // header -> {ring base, write cursor} of the last submitted slice.
     // Submissions stay cursor-bounded since rings aren't zeroed. Lap
     // distinguishes a stale cursor from a previous pass over the same base.
@@ -1095,6 +1098,7 @@ public static partial class AgcExports
     private const uint CbColor0Base = 0x318;
     private const uint CbColorRegisterStride = 15;
     private const uint CbColor0Info = 0x31C;
+    private const uint CbColor0Cmask = 0x320;
     private const uint CbColor0ClearWord0 = 0x323;
     private const uint CbColor0ClearWord1 = 0x324;
     private const uint CbColor0BaseExt = 0x390;
@@ -8072,6 +8076,7 @@ public static partial class AgcExports
         var hasPsInputAddr = state.CxRegisters.TryGetValue(SpiPsInputAddr, out var psInputAddr);
         state.UcRegisters.TryGetValue(VgtPrimitiveType, out var primitiveType);
         var renderTargets = GetRenderTargets(state.CxRegisters);
+        TrackCmaskAddresses(state.CxRegisters, renderTargets);
         var drawSequence = ++gpuState.WorkSequence;
         if (state.PendingTargetlessDraw is { } stalePendingDraw)
         {
@@ -8091,6 +8096,35 @@ public static partial class AgcExports
         if (TryGetCbColorControlMode(state.CxRegisters, out var cbMode) &&
             IsCbMetadataColorMode(cbMode))
         {
+            // EliminateFastClear: the game explicitly asks the CB to clear
+            // the fast-clear metadata and the colour buffer. Only clear
+            // if CMASK is "all clear" (matching shadPS4's behavior).
+            if (cbMode == (uint)CbColorMode.EliminateFastClear &&
+                renderTargets.Count > 0 &&
+                renderTargets[0].Address != 0)
+            {
+                // Check if CMASK is "all clear" for this target
+                var cmaskCleared = false;
+                foreach (var (cmaskAddr, cleared) in _cmaskClearedState)
+                {
+                    if (cleared && cmaskAddr != 0)
+                    {
+                        cmaskCleared = true;
+                        break;
+                    }
+                }
+
+                if (cmaskCleared)
+                {
+                    VulkanVideoPresenter.RequestGuestColorClear(renderTargets[0].Address);
+                    // Mark CMASK as "dirty" after clear
+                    foreach (var cmaskAddr in _cmaskClearedState.Keys.ToList())
+                    {
+                        _cmaskClearedState[cmaskAddr] = false;
+                    }
+                }
+            }
+
             if (_traceAgcShader || ShouldTraceHotPath(ref _cbMetadataSkipTraceCount))
             {
                 TraceAgcShader(
@@ -9647,6 +9681,57 @@ public static partial class AgcExports
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Reads CMASK addresses from CB_COLORn_CMASK registers and marks them
+    /// as "all clear" in _cmaskClearedState. Called when color buffers are
+    /// configured.
+    /// </summary>
+    private static void TrackCmaskAddresses(
+        IReadOnlyDictionary<uint, uint> registers,
+        IReadOnlyList<RenderTargetDescriptor> renderTargets)
+    {
+        foreach (var rt in renderTargets)
+        {
+            var stride = rt.Slot * CbColorRegisterStride;
+            if (registers.TryGetValue(CbColor0Cmask + stride, out var cmaskLow))
+            {
+                // CMASK address is 37-bit: low 32 bits from register, high 5 bits from base
+                var cmaskAddress = (ulong)(cmaskLow & 0x1FFFFFFFu) << 8;
+                if (cmaskAddress != 0)
+                {
+                    // Mark as "all clear" when color buffer is configured
+                    _cmaskClearedState[cmaskAddress] = true;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Checks if a compute shader writes to a CMASK address. If so, marks
+    /// the CMASK as "all clear" (following shadPS4's IsComputeMetaClear logic).
+    /// </summary>
+    private static void CheckCmaskWrite(
+        ulong writeAddress,
+        SubmittedGpuState gpuState)
+    {
+        if (writeAddress == 0)
+        {
+            return;
+        }
+
+        // Check if this address matches any known CMASK address
+        foreach (var (cmaskAddress, _) in _cmaskClearedState)
+        {
+            if (writeAddress == cmaskAddress ||
+                (writeAddress >= cmaskAddress && writeAddress < cmaskAddress + 1024))
+            {
+                // Compute shader writes to CMASK address → mark as "all clear"
+                _cmaskClearedState[cmaskAddress] = true;
+                return;
+            }
+        }
     }
 
     /// <summary>
@@ -12546,6 +12631,10 @@ public static partial class AgcExports
                     sequence,
                     shaderAddress,
                     binding.Opcode);
+
+                // Check if this compute shader writes to a CMASK address
+                // (shadPS4's IsComputeMetaClear logic)
+                CheckCmaskWrite(texture.Address, gpuState);
 
                 TraceAgcShader(
                     $"agc.compute_writer addr=0x{texture.Address:X16} " +

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -5088,6 +5088,10 @@ public static partial class AgcExports
 
             if (op == ItNop && register == RDmaData && length >= 7)
             {
+                // Ensure CMASK addresses are tracked before DMA fills
+                var tempTargets = GetRenderTargets(state.CxRegisters);
+                TrackCmaskAddresses(state.CxRegisters, tempTargets);
+
                 ApplySubmittedDmaData(
                     ctx,
                     gpuState,
@@ -6270,6 +6274,13 @@ public static partial class AgcExports
         ulong byteCount,
         uint? fillValue)
     {
+        // Check if this DMA write targets a CMASK address (shadPS4's FillBuffer
+        // logic: when a buffer fill targets CMASK metadata, mark it as "all clear")
+        if (fillValue is { } fillVal && fillVal == 0)
+        {
+            CheckCmaskWrite(destinationAddress, null);
+        }
+
         var hasImage = GuestGpu.Current.TryGetGuestImageExtent(
             destinationAddress,
             out var width,
@@ -8103,6 +8114,10 @@ public static partial class AgcExports
                 renderTargets.Count > 0 &&
                 renderTargets[0].Address != 0)
             {
+                TraceAgcShader(
+                    $"agc.eliminate_fast_clear seq={drawSequence} " +
+                    $"target=0x{renderTargets[0].Address:X16} " +
+                    $"cmask_state={_cmaskClearedState.Count}");
                 // Check if CMASK is "all clear" for this target
                 var cmaskCleared = false;
                 foreach (var (cmaskAddr, cleared) in _cmaskClearedState)
@@ -9692,16 +9707,36 @@ public static partial class AgcExports
         IReadOnlyDictionary<uint, uint> registers,
         IReadOnlyList<RenderTargetDescriptor> renderTargets)
     {
+        // Log all CB_COLOR registers to see what's available
+        if (renderTargets.Count > 0 && registers.Count > 0)
+        {
+            var cbRegs = new List<string>();
+            for (uint r = 0x318; r <= 0x340; r++)
+            {
+                if (registers.TryGetValue(r, out var val) && val != 0)
+                {
+                    cbRegs.Add($"0x{r:X}=0x{val:X}");
+                }
+            }
+            if (cbRegs.Count > 0)
+            {
+                TraceAgcShader(
+                    $"agc.cb_regs=[{string.Join(",", cbRegs)}]");
+            }
+        }
+
         foreach (var rt in renderTargets)
         {
             var stride = rt.Slot * CbColorRegisterStride;
-            if (registers.TryGetValue(CbColor0Cmask + stride, out var cmaskLow))
+            var regAddr = CbColor0Cmask + stride;
+            if (registers.TryGetValue(regAddr, out var cmaskLow))
             {
-                // CMASK address is 37-bit: low 32 bits from register, high 5 bits from base
                 var cmaskAddress = (ulong)(cmaskLow & 0x1FFFFFFFu) << 8;
                 if (cmaskAddress != 0)
                 {
-                    // Mark as "all clear" when color buffer is configured
+                    TraceAgcShader(
+                        $"agc.cmask_track slot={rt.Slot} reg=0x{regAddr:X} " +
+                        $"val=0x{cmaskLow:X} addr=0x{cmaskAddress:X16}");
                     _cmaskClearedState[cmaskAddress] = true;
                 }
             }
@@ -9714,7 +9749,7 @@ public static partial class AgcExports
     /// </summary>
     private static void CheckCmaskWrite(
         ulong writeAddress,
-        SubmittedGpuState gpuState)
+        SubmittedGpuState? gpuState)
     {
         if (writeAddress == 0)
         {
@@ -9722,12 +9757,15 @@ public static partial class AgcExports
         }
 
         // Check if this address matches any known CMASK address
-        foreach (var (cmaskAddress, _) in _cmaskClearedState)
+        foreach (var (cmaskAddress, cleared) in _cmaskClearedState)
         {
             if (writeAddress == cmaskAddress ||
                 (writeAddress >= cmaskAddress && writeAddress < cmaskAddress + 1024))
             {
-                // Compute shader writes to CMASK address → mark as "all clear"
+                TraceAgcShader(
+                    $"agc.cmask_write addr=0x{writeAddress:X16} " +
+                    $"cmask=0x{cmaskAddress:X16} was_cleared={cleared}");
+                // DMA fill or compute shader writes to CMASK address → mark as "all clear"
                 _cmaskClearedState[cmaskAddress] = true;
                 return;
             }

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -8086,19 +8086,9 @@ public static partial class AgcExports
         var hasPsInputEna = state.CxRegisters.TryGetValue(SpiPsInputEna, out var psInputEna);
         var hasPsInputAddr = state.CxRegisters.TryGetValue(SpiPsInputAddr, out var psInputAddr);
         state.UcRegisters.TryGetValue(VgtPrimitiveType, out var primitiveType);
-        var renderTargets = GetRenderTargets(state.CxRegisters);
+var renderTargets = GetRenderTargets(state.CxRegisters);
         TrackCmaskAddresses(state.CxRegisters, renderTargets);
         var drawSequence = ++gpuState.WorkSequence;
-        var lifecycleProbe = Interlocked.Increment(ref _lifecycleProbeCount);
-        if (lifecycleProbe <= 100)
-        {
-            Console.Error.WriteLine(
-                $"[PROBE] agc.rt_lifecycle seq={drawSequence} " +
-                $"count={renderTargets.Count} targets=[" +
-                string.Join(",", renderTargets.Select(static target =>
-                    $"s{target.Slot}:0x{target.Address:X}:" +
-                    $"{target.Width}x{target.Height}:f{target.Format}")) + "]");
-        }
         if (state.PendingTargetlessDraw is { } stalePendingDraw)
         {
             ReturnPooledDrawArrays(
@@ -10166,8 +10156,7 @@ public static partial class AgcExports
     private static readonly HashSet<ulong> _sampledRenderTargets = new();
     private static readonly object _renderTargetProbeGate = new();
     private static long _renderTargetSampleTraceCount;
-    private static long _indirectDrawProbeCount;
-    private static long _lifecycleProbeCount;
+private static long _indirectDrawProbeCount;
     private static long _indirectDrawEmitCount;
     private static long _indirectDrawEmitRejectCount;
     private static long _indirectMultiProbeCount;

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -8114,10 +8114,6 @@ public static partial class AgcExports
                 renderTargets.Count > 0 &&
                 renderTargets[0].Address != 0)
             {
-                TraceAgcShader(
-                    $"agc.eliminate_fast_clear seq={drawSequence} " +
-                    $"target=0x{renderTargets[0].Address:X16} " +
-                    $"cmask_state={_cmaskClearedState.Count}");
                 // Check if CMASK is "all clear" for this target
                 var cmaskCleared = false;
                 foreach (var (cmaskAddr, cleared) in _cmaskClearedState)
@@ -9707,24 +9703,6 @@ public static partial class AgcExports
         IReadOnlyDictionary<uint, uint> registers,
         IReadOnlyList<RenderTargetDescriptor> renderTargets)
     {
-        // Log all CB_COLOR registers to see what's available
-        if (renderTargets.Count > 0 && registers.Count > 0)
-        {
-            var cbRegs = new List<string>();
-            for (uint r = 0x318; r <= 0x340; r++)
-            {
-                if (registers.TryGetValue(r, out var val) && val != 0)
-                {
-                    cbRegs.Add($"0x{r:X}=0x{val:X}");
-                }
-            }
-            if (cbRegs.Count > 0)
-            {
-                TraceAgcShader(
-                    $"agc.cb_regs=[{string.Join(",", cbRegs)}]");
-            }
-        }
-
         foreach (var rt in renderTargets)
         {
             var stride = rt.Slot * CbColorRegisterStride;
@@ -9734,9 +9712,6 @@ public static partial class AgcExports
                 var cmaskAddress = (ulong)(cmaskLow & 0x1FFFFFFFu) << 8;
                 if (cmaskAddress != 0)
                 {
-                    TraceAgcShader(
-                        $"agc.cmask_track slot={rt.Slot} reg=0x{regAddr:X} " +
-                        $"val=0x{cmaskLow:X} addr=0x{cmaskAddress:X16}");
                     _cmaskClearedState[cmaskAddress] = true;
                 }
             }
@@ -9762,9 +9737,6 @@ public static partial class AgcExports
             if (writeAddress == cmaskAddress ||
                 (writeAddress >= cmaskAddress && writeAddress < cmaskAddress + 1024))
             {
-                TraceAgcShader(
-                    $"agc.cmask_write addr=0x{writeAddress:X16} " +
-                    $"cmask=0x{cmaskAddress:X16} was_cleared={cleared}");
                 // DMA fill or compute shader writes to CMASK address → mark as "all clear"
                 _cmaskClearedState[cmaskAddress] = true;
                 return;

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -132,6 +132,15 @@ public static partial class AgcExports
     // CheckCmaskWrite (which only sees the write target address) can
     // find the owning surface.
     private static readonly Dictionary<ulong, ulong> _cmaskToColorBuffer = new();
+    // Guards _metaSurfaces and _cmaskToColorBuffer.  Two threads touch them:
+    // the parse thread (registration in TrackCmaskAddresses, CheckCmaskWrite
+    // from DMA/compute writes, EFC consumption) and the render thread
+    // (MarkAllSurfacesCleared at guest flip, IsMetaClearedForSurface /
+    // ConsumeMetaClear / GetMetaClearValue at pass-record time).  Plain
+    // Dictionaries corrupt under concurrent write, so every access below
+    // holds this gate.  Keep the critical sections tiny and never block on
+    // anything external while holding it.
+    private static readonly object _metaSurfaceGate = new();
     // header -> {ring base, write cursor} of the last submitted slice.
     // Submissions stay cursor-bounded since rings aren't zeroed. Lap
     // distinguishes a stale cursor from a previous pass over the same base.
@@ -1142,8 +1151,8 @@ public static partial class AgcExports
     private const uint EsUserDataRegister = 0xCC;
     private const uint ComputeUserDataRegister = 0x240;
     private const uint NggUserDataScalarRegisterBase = 8;
-    private const uint Gen5TextureFormatR8G8B8A8Unorm = 10;
-    private const uint Gen5TextureFormatR16G16B16A16Float = 12;
+    internal const uint Gen5TextureFormatR8G8B8A8Unorm = 10;
+    internal const uint Gen5TextureFormatR16G16B16A16Float = 12;
     private const uint Gen5TextureType1D = 8;
     private const uint Gen5TextureType2D = 9;
     private const uint Gen5TextureType3D = 10;
@@ -8128,11 +8137,21 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
                 renderTargets[0].Address != 0)
             {
                 var targetAddr = renderTargets[0].Address;
-                if (_metaSurfaces.TryGetValue(targetAddr, out var meta) &&
-                    meta.IsCleared)
+                bool requestClear;
+                lock (_metaSurfaceGate)
+                {
+                    requestClear =
+                        _metaSurfaces.TryGetValue(targetAddr, out var meta) &&
+                        meta.IsCleared;
+                    if (requestClear)
+                    {
+                        _metaSurfaces[targetAddr] = meta with { IsCleared = false };
+                    }
+                }
+
+                if (requestClear)
                 {
                     VulkanVideoPresenter.RequestGuestColorClear(targetAddr);
-                    _metaSurfaces[targetAddr] = meta with { IsCleared = false };
                 }
             }
 
@@ -9731,13 +9750,21 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
             registers.TryGetValue(cw0Addr, out var cw0);
             registers.TryGetValue(cw1Addr, out var cw1);
 
-            _metaSurfaces[rt.Address] = new MetaSurfaceInfo(
-                metaAddress, cw0, cw1,
-                IsCleared: _metaSurfaces.TryGetValue(rt.Address, out var prev) &&
-                           prev.IsCleared);
-            if (metaAddress != 0)
+            lock (_metaSurfaceGate)
             {
-                _cmaskToColorBuffer[metaAddress] = rt.Address;
+                _metaSurfaces[rt.Address] = new MetaSurfaceInfo(
+                    metaAddress, cw0, cw1,
+                    // Re-registration runs on every draw; keep the cleared state
+                    // so a mark-clear event survives until the pass consumes it.
+                    // If the metadata binding changed, the old state refers to
+                    // the old metadata and must be reset.
+                    IsCleared: _metaSurfaces.TryGetValue(rt.Address, out var prev) &&
+                               prev.IsCleared &&
+                               prev.CmaskAddress == metaAddress);
+                if (metaAddress != 0)
+                {
+                    _cmaskToColorBuffer[metaAddress] = rt.Address;
+                }
             }
         }
     }
@@ -9755,29 +9782,32 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
             return;
         }
 
-        // Exact match: write directly to a registered CMASK address.
-        if (_cmaskToColorBuffer.TryGetValue(writeAddress, out var cbAddr))
+        lock (_metaSurfaceGate)
         {
-            if (_metaSurfaces.TryGetValue(cbAddr, out var meta))
+            // Exact match: write directly to a registered CMASK address.
+            if (_cmaskToColorBuffer.TryGetValue(writeAddress, out var cbAddr))
             {
-                _metaSurfaces[cbAddr] = meta with { IsCleared = true };
-            }
-
-            return;
-        }
-
-        // CMASK surfaces are small (typically ≤ 4 KiB).  Check the ±1024
-        // window around each registered address to catch partial writes.
-        foreach (var (cmaskAddr, colorBufAddr) in _cmaskToColorBuffer)
-        {
-            if (writeAddress >= cmaskAddr && writeAddress < cmaskAddr + 1024)
-            {
-                if (_metaSurfaces.TryGetValue(colorBufAddr, out var meta))
+                if (_metaSurfaces.TryGetValue(cbAddr, out var meta))
                 {
-                    _metaSurfaces[colorBufAddr] = meta with { IsCleared = true };
+                    _metaSurfaces[cbAddr] = meta with { IsCleared = true };
                 }
 
                 return;
+            }
+
+            // CMASK surfaces are small (typically ≤ 4 KiB).  Check the ±1024
+            // window around each registered address to catch partial writes.
+            foreach (var (cmaskAddr, colorBufAddr) in _cmaskToColorBuffer)
+            {
+                if (writeAddress >= cmaskAddr && writeAddress < cmaskAddr + 1024)
+                {
+                    if (_metaSurfaces.TryGetValue(colorBufAddr, out var meta))
+                    {
+                        _metaSurfaces[colorBufAddr] = meta with { IsCleared = true };
+                    }
+
+                    return;
+                }
             }
         }
     }
@@ -9789,8 +9819,11 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
     /// </summary>
     internal static bool IsMetaClearedForSurface(ulong colorBufferAddress)
     {
-        return _metaSurfaces.TryGetValue(colorBufferAddress, out var meta) &&
-               meta.IsCleared;
+        lock (_metaSurfaceGate)
+        {
+            return _metaSurfaces.TryGetValue(colorBufferAddress, out var meta) &&
+                   meta.IsCleared;
+        }
     }
 
     /// <summary>
@@ -9799,9 +9832,12 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
     /// </summary>
     internal static void ConsumeMetaClear(ulong colorBufferAddress)
     {
-        if (_metaSurfaces.TryGetValue(colorBufferAddress, out var meta))
+        lock (_metaSurfaceGate)
         {
-            _metaSurfaces[colorBufferAddress] = meta with { IsCleared = false };
+            if (_metaSurfaces.TryGetValue(colorBufferAddress, out var meta))
+            {
+                _metaSurfaces[colorBufferAddress] = meta with { IsCleared = false };
+            }
         }
     }
 
@@ -9810,9 +9846,12 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
     /// </summary>
     internal static (uint Cw0, uint Cw1) GetMetaClearValue(ulong colorBufferAddress)
     {
-        if (_metaSurfaces.TryGetValue(colorBufferAddress, out var meta))
+        lock (_metaSurfaceGate)
         {
-            return (meta.ClearWord0, meta.ClearWord1);
+            if (_metaSurfaces.TryGetValue(colorBufferAddress, out var meta))
+            {
+                return (meta.ClearWord0, meta.ClearWord1);
+            }
         }
 
         return (0, 0);
@@ -9820,15 +9859,20 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
 
     /// <summary>
     /// Marks all registered surfaces as "all clear".  Called at guest flip
-    /// (frame boundary) to simulate the hardware behaviour where unwritten
-    /// surfaces read back as the clear value.  Replaces the flip-arm
-    /// heuristic with a per-surface state-machine entry.
+    /// (frame boundary).  Real hardware applies a fast clear / load-clear to
+    /// its per-frame surfaces every frame; the emulator restores that
+    /// per-frame clear here, per surface, at flip time.  This is the
+    /// per-surface successor of the removed flip-arm heuristic (which reset
+    /// only the first multi-attachment group).
     /// </summary>
     internal static void MarkAllSurfacesCleared()
     {
-        foreach (var (addr, meta) in _metaSurfaces)
+        lock (_metaSurfaceGate)
         {
-            _metaSurfaces[addr] = meta with { IsCleared = true };
+            foreach (var (addr, meta) in _metaSurfaces)
+            {
+                _metaSurfaces[addr] = meta with { IsCleared = true };
+            }
         }
     }
 

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -8089,6 +8089,16 @@ public static partial class AgcExports
         var renderTargets = GetRenderTargets(state.CxRegisters);
         TrackCmaskAddresses(state.CxRegisters, renderTargets);
         var drawSequence = ++gpuState.WorkSequence;
+        var lifecycleProbe = Interlocked.Increment(ref _lifecycleProbeCount);
+        if (lifecycleProbe <= 100)
+        {
+            Console.Error.WriteLine(
+                $"[PROBE] agc.rt_lifecycle seq={drawSequence} " +
+                $"count={renderTargets.Count} targets=[" +
+                string.Join(",", renderTargets.Select(static target =>
+                    $"s{target.Slot}:0x{target.Address:X}:" +
+                    $"{target.Width}x{target.Height}:f{target.Format}")) + "]");
+        }
         if (state.PendingTargetlessDraw is { } stalePendingDraw)
         {
             ReturnPooledDrawArrays(
@@ -10157,6 +10167,7 @@ public static partial class AgcExports
     private static readonly object _renderTargetProbeGate = new();
     private static long _renderTargetSampleTraceCount;
     private static long _indirectDrawProbeCount;
+    private static long _lifecycleProbeCount;
     private static long _indirectDrawEmitCount;
     private static long _indirectDrawEmitRejectCount;
     private static long _indirectMultiProbeCount;
@@ -13241,11 +13252,14 @@ public static partial class AgcExports
                     return;
                 }
 
-                GuestImageWriteTracker.Track(
+GuestImageWriteTracker.Track(
                     destinationAddress,
                     (ulong)output.Length,
                     VulkanVideoPresenter.CurrentGuestWorkSequenceForDiagnostics,
                     "agc.constant-fill");
+
+                VulkanVideoPresenter.RequestGuestColorClear(destinationAddress);
+
             },
             $"constant_fill dst=0x{destinationAddress:X16} bytes={output.Length}");
         description =

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -5244,6 +5244,7 @@ public static partial class AgcExports
             {
                 TraceFramePacketSummary(state);
                 SyncCpuWrittenGuestImages(ctx);
+                GpuWaitRegistry.AdvanceFrame();
                 if (!TryReadUInt32(ctx, currentAddress + 4, out var videoOutHandle) ||
                     !TryReadUInt32(ctx, currentAddress + 8, out var displayBufferIndexRaw) ||
                     !TryReadUInt32(ctx, currentAddress + 12, out var flipMode) ||
@@ -7073,7 +7074,13 @@ public static partial class AgcExports
 
         if (hasCurrent && GpuWaitRegistry.Compare(waiter, currentValue))
         {
-            return false; // already satisfied — keep parsing
+            // Value satisfies the condition, but only bypass if the label was
+            // written in the current frame. A stale label from a previous frame
+            // means the producer hasn't written yet this frame — must wait.
+            if (GpuWaitRegistry.IsLabelFresh(ctx.Memory, waitAddress))
+            {
+                return false; // satisfied by current-frame write — keep parsing
+            }
         }
 
         if (!_gpuWaitSuspendEnabled)

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -1098,10 +1098,11 @@ public static partial class AgcExports
     private const uint CbColor0Base = 0x318;
     private const uint CbColorRegisterStride = 15;
     private const uint CbColor0Info = 0x31C;
-    private const uint CbColor0Cmask = 0x320;
+    private const uint CbColor0Cmask = 0x31F;
     private const uint CbColor0ClearWord0 = 0x323;
     private const uint CbColor0ClearWord1 = 0x324;
     private const uint CbColor0BaseExt = 0x390;
+    private const uint CbColor0CmaskBaseExt = 0x398;
     private const uint CbColor0Attrib2 = 0x3B0;
     private const uint CbColor0Attrib3 = 0x3B8;
     // CB_COLORn_INFO.DCC_ENABLE (gc_10_1_0_sh_mask.h). On GFX10 the legacy
@@ -9707,13 +9708,14 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
         {
             var stride = rt.Slot * CbColorRegisterStride;
             var regAddr = CbColor0Cmask + stride;
-            if (registers.TryGetValue(regAddr, out var cmaskLow))
+            registers.TryGetValue(regAddr, out var cmaskLow);
+            var extAddr = CbColor0CmaskBaseExt + rt.Slot;
+            registers.TryGetValue(extAddr, out var cmaskExt);
+            var cmaskAddress = ((ulong)(cmaskExt & 0xFFu) << 40) |
+                               ((ulong)(cmaskLow & 0x1FFFFFFFu) << 8);
+            if (cmaskAddress != 0)
             {
-                var cmaskAddress = (ulong)(cmaskLow & 0x1FFFFFFFu) << 8;
-                if (cmaskAddress != 0)
-                {
-                    _cmaskClearedState[cmaskAddress] = true;
-                }
+                _cmaskClearedState[cmaskAddress] = true;
             }
         }
     }

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -1104,6 +1104,7 @@ public static partial class AgcExports
     // FAST_CLEAR and COMPRESSION bits stay clear because DCC, not CMASK,
     // carries the compression.
     private const uint CbColorInfoDccEnableMask = 1u << 28;
+    private const uint CbColorInfoFastClearEnableMask = 1u << 12;
     private const uint CbBlend0Control = 0x1E0;
     private const uint PaScModeCntl0 = 0x292;
     // GFX10 DB context registers (register byte address minus 0x28000, / 4).
@@ -8297,6 +8298,34 @@ public static partial class AgcExports
                 return;
             }
 
+            // DbRenderControl CLEARON (bit0): when set, the CB clears color
+            // targets on first draw. Handle color targets (depth is already
+            // handled by DecodeDepthState).
+            if (state.CxRegisters.TryGetValue(DbRenderControl, out var rc) && (rc & 0x1u) != 0)
+            {
+                foreach (var rt in translatedDraw.RenderTargets)
+                {
+                    if (rt.Address != 0)
+                    {
+                        VulkanVideoPresenter.RequestGuestColorClear(rt.Address);
+                    }
+                }
+            }
+
+            // CMASK fast clear: CB_COLORn_INFO.FAST_CLEAR (bit12) set on
+            // one or more targets. The CB clears via CMASK before the draw
+            // writes; mark targets for clear-on-first-use.
+            if (IsCmaskFastClearDraw(state.CxRegisters, translatedDraw.RenderTargets))
+            {
+                foreach (var rt in translatedDraw.RenderTargets)
+                {
+                    if (rt.Address != 0)
+                    {
+                        VulkanVideoPresenter.RequestGuestColorClear(rt.Address);
+                    }
+                }
+            }
+
             var firstTarget = translatedDraw.RenderTargets.FirstOrDefault();
             if (firstTarget.Address != 0)
             {
@@ -9587,6 +9616,30 @@ public static partial class AgcExports
             clearWord0 == 0 &&
             clearWord1 == 0 &&
             CoversClipSpace(vertexInputs, vertexCount);
+    }
+
+    /// <summary>
+    /// GFX10 CMASK fast clear: CB_COLORn_INFO.FAST_CLEAR (bit 12) set on
+    /// one or more targets. The CB clears via CMASK before the draw writes;
+    /// mark targets for clear-on-first-use. Unlike DCC, the draw content
+    /// IS written (not dropped). Dead Cells uses DbRenderControl CLEARON
+    /// instead (bit0), not this mechanism.
+    /// </summary>
+    private static bool IsCmaskFastClearDraw(
+        IReadOnlyDictionary<uint, uint> registers,
+        IReadOnlyList<RenderTargetDescriptor> renderTargets)
+    {
+        foreach (var rt in renderTargets)
+        {
+            var stride = rt.Slot * CbColorRegisterStride;
+            if (registers.TryGetValue(CbColor0Info + stride, out var info) &&
+                (info & CbColorInfoFastClearEnableMask) != 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -9725,10 +9725,6 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
 
             // Prefer CMASK if present; fall back to DCC.
             var metaAddress = cmaskAddress != 0 ? cmaskAddress : dccAddress;
-            if (metaAddress == 0)
-            {
-                continue;
-            }
 
             var cw0Addr = CbColor0ClearWord0 + stride;
             var cw1Addr = CbColor0ClearWord1 + stride;
@@ -9736,8 +9732,13 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
             registers.TryGetValue(cw1Addr, out var cw1);
 
             _metaSurfaces[rt.Address] = new MetaSurfaceInfo(
-                metaAddress, cw0, cw1, IsCleared: false);
-            _cmaskToColorBuffer[metaAddress] = rt.Address;
+                metaAddress, cw0, cw1,
+                IsCleared: _metaSurfaces.TryGetValue(rt.Address, out var prev) &&
+                           prev.IsCleared);
+            if (metaAddress != 0)
+            {
+                _cmaskToColorBuffer[metaAddress] = rt.Address;
+            }
         }
     }
 
@@ -9815,6 +9816,20 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
         }
 
         return (0, 0);
+    }
+
+    /// <summary>
+    /// Marks all registered surfaces as "all clear".  Called at guest flip
+    /// (frame boundary) to simulate the hardware behaviour where unwritten
+    /// surfaces read back as the clear value.  Replaces the flip-arm
+    /// heuristic with a per-surface state-machine entry.
+    /// </summary>
+    internal static void MarkAllSurfacesCleared()
+    {
+        foreach (var (addr, meta) in _metaSurfaces)
+        {
+            _metaSurfaces[addr] = meta with { IsCleared = true };
+        }
     }
 
     /// <summary>

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -118,9 +118,20 @@ public static partial class AgcExports
     // Multiple producers can share one target label; last-writer-wins would
     // starve waits on the others.
     private static readonly Dictionary<ulong, List<ulong>> _cbReleaseMemTargets = new();
-    // CMASK state tracking: tracks which CMASK addresses are "all clear".
-    // Keyed by CMASK address, value is true if marked as cleared.
-    private static readonly Dictionary<ulong, bool> _cmaskClearedState = new();
+    // CMASK meta-state tracking: maps colour-buffer addresses to their
+    // compression metadata.  Keyed by colour-buffer base address so the
+    // consumption path (which only knows the surface address) can query
+    // directly without a reverse lookup.
+    private record struct MetaSurfaceInfo(
+        ulong CmaskAddress,
+        uint ClearWord0,
+        uint ClearWord1,
+        bool IsCleared);
+    private static readonly Dictionary<ulong, MetaSurfaceInfo> _metaSurfaces = new();
+    // Reverse map: CMASK address → colour-buffer address.  Needed so
+    // CheckCmaskWrite (which only sees the write target address) can
+    // find the owning surface.
+    private static readonly Dictionary<ulong, ulong> _cmaskToColorBuffer = new();
     // header -> {ring base, write cursor} of the last submitted slice.
     // Submissions stay cursor-bounded since rings aren't zeroed. Lap
     // distinguishes a stale cursor from a previous pass over the same base.
@@ -1101,8 +1112,10 @@ public static partial class AgcExports
     private const uint CbColor0Cmask = 0x31F;
     private const uint CbColor0ClearWord0 = 0x323;
     private const uint CbColor0ClearWord1 = 0x324;
+    private const uint CbColor0DccBase = 0x325;
     private const uint CbColor0BaseExt = 0x390;
     private const uint CbColor0CmaskBaseExt = 0x398;
+    private const uint CbColor0DccBaseExt = 0x3A8;
     private const uint CbColor0Attrib2 = 0x3B0;
     private const uint CbColor0Attrib3 = 0x3B8;
     // CB_COLORn_INFO.DCC_ENABLE (gc_10_1_0_sh_mask.h). On GFX10 the legacy
@@ -8109,31 +8122,17 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
             IsCbMetadataColorMode(cbMode))
         {
             // EliminateFastClear: the game explicitly asks the CB to clear
-            // the fast-clear metadata and the colour buffer. Only clear
-            // if CMASK is "all clear" (matching shadPS4's behavior).
+            // the fast-clear metadata and the colour buffer.
             if (cbMode == (uint)CbColorMode.EliminateFastClear &&
                 renderTargets.Count > 0 &&
                 renderTargets[0].Address != 0)
             {
-                // Check if CMASK is "all clear" for this target
-                var cmaskCleared = false;
-                foreach (var (cmaskAddr, cleared) in _cmaskClearedState)
+                var targetAddr = renderTargets[0].Address;
+                if (_metaSurfaces.TryGetValue(targetAddr, out var meta) &&
+                    meta.IsCleared)
                 {
-                    if (cleared && cmaskAddr != 0)
-                    {
-                        cmaskCleared = true;
-                        break;
-                    }
-                }
-
-                if (cmaskCleared)
-                {
-                    VulkanVideoPresenter.RequestGuestColorClear(renderTargets[0].Address);
-                    // Mark CMASK as "dirty" after clear
-                    foreach (var cmaskAddr in _cmaskClearedState.Keys.ToList())
-                    {
-                        _cmaskClearedState[cmaskAddr] = false;
-                    }
+                    VulkanVideoPresenter.RequestGuestColorClear(targetAddr);
+                    _metaSurfaces[targetAddr] = meta with { IsCleared = false };
                 }
             }
 
@@ -9696,9 +9695,9 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
     }
 
     /// <summary>
-    /// Reads CMASK addresses from CB_COLORn_CMASK registers and marks them
-    /// as "all clear" in _cmaskClearedState. Called when color buffers are
-    /// configured.
+    /// Registers the CMASK metadata mapping for each colour buffer.
+    /// Does NOT mark as cleared — clearing only happens on actual clear
+    /// events (DMA fill, compute write, EFC draw).
     /// </summary>
     private static void TrackCmaskAddresses(
         IReadOnlyDictionary<uint, uint> registers,
@@ -9707,22 +9706,44 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
         foreach (var rt in renderTargets)
         {
             var stride = rt.Slot * CbColorRegisterStride;
-            var regAddr = CbColor0Cmask + stride;
-            registers.TryGetValue(regAddr, out var cmaskLow);
-            var extAddr = CbColor0CmaskBaseExt + rt.Slot;
-            registers.TryGetValue(extAddr, out var cmaskExt);
+
+            // CMASK metadata address (legacy GCN path).
+            var cmaskRegAddr = CbColor0Cmask + stride;
+            registers.TryGetValue(cmaskRegAddr, out var cmaskLow);
+            var cmaskExtAddr = CbColor0CmaskBaseExt + rt.Slot;
+            registers.TryGetValue(cmaskExtAddr, out var cmaskExt);
             var cmaskAddress = ((ulong)(cmaskExt & 0xFFu) << 40) |
                                ((ulong)(cmaskLow & 0x1FFFFFFFu) << 8);
-            if (cmaskAddress != 0)
+
+            // DCC metadata address (GFX10+ primary path).
+            var dccRegAddr = CbColor0DccBase + stride;
+            registers.TryGetValue(dccRegAddr, out var dccLow);
+            var dccExtAddr = CbColor0DccBaseExt + rt.Slot;
+            registers.TryGetValue(dccExtAddr, out var dccExt);
+            var dccAddress = ((ulong)(dccExt & 0xFFu) << 40) |
+                             ((ulong)(dccLow & 0x1FFFFFFFu) << 8);
+
+            // Prefer CMASK if present; fall back to DCC.
+            var metaAddress = cmaskAddress != 0 ? cmaskAddress : dccAddress;
+            if (metaAddress == 0)
             {
-                _cmaskClearedState[cmaskAddress] = true;
+                continue;
             }
+
+            var cw0Addr = CbColor0ClearWord0 + stride;
+            var cw1Addr = CbColor0ClearWord1 + stride;
+            registers.TryGetValue(cw0Addr, out var cw0);
+            registers.TryGetValue(cw1Addr, out var cw1);
+
+            _metaSurfaces[rt.Address] = new MetaSurfaceInfo(
+                metaAddress, cw0, cw1, IsCleared: false);
+            _cmaskToColorBuffer[metaAddress] = rt.Address;
         }
     }
 
     /// <summary>
-    /// Checks if a compute shader writes to a CMASK address. If so, marks
-    /// the CMASK as "all clear" (following shadPS4's IsComputeMetaClear logic).
+    /// Checks if a write targets a registered CMASK address. If so,
+    /// marks the owning colour buffer's metadata as "all clear".
     /// </summary>
     private static void CheckCmaskWrite(
         ulong writeAddress,
@@ -9733,17 +9754,67 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
             return;
         }
 
-        // Check if this address matches any known CMASK address
-        foreach (var (cmaskAddress, cleared) in _cmaskClearedState)
+        // Exact match: write directly to a registered CMASK address.
+        if (_cmaskToColorBuffer.TryGetValue(writeAddress, out var cbAddr))
         {
-            if (writeAddress == cmaskAddress ||
-                (writeAddress >= cmaskAddress && writeAddress < cmaskAddress + 1024))
+            if (_metaSurfaces.TryGetValue(cbAddr, out var meta))
             {
-                // DMA fill or compute shader writes to CMASK address → mark as "all clear"
-                _cmaskClearedState[cmaskAddress] = true;
+                _metaSurfaces[cbAddr] = meta with { IsCleared = true };
+            }
+
+            return;
+        }
+
+        // CMASK surfaces are small (typically ≤ 4 KiB).  Check the ±1024
+        // window around each registered address to catch partial writes.
+        foreach (var (cmaskAddr, colorBufAddr) in _cmaskToColorBuffer)
+        {
+            if (writeAddress >= cmaskAddr && writeAddress < cmaskAddr + 1024)
+            {
+                if (_metaSurfaces.TryGetValue(colorBufAddr, out var meta))
+                {
+                    _metaSurfaces[colorBufAddr] = meta with { IsCleared = true };
+                }
+
                 return;
             }
         }
+    }
+
+    /// <summary>
+    /// Returns true if the colour buffer at <paramref name="colorBufferAddress"/>
+    /// has pending CMASK "all clear" metadata — i.e. the surface was fast-cleared
+    /// but not yet rendered into.
+    /// </summary>
+    internal static bool IsMetaClearedForSurface(ulong colorBufferAddress)
+    {
+        return _metaSurfaces.TryGetValue(colorBufferAddress, out var meta) &&
+               meta.IsCleared;
+    }
+
+    /// <summary>
+    /// Consumes the "all clear" state for the given surface, marking it dirty.
+    /// Called after the first render pass uses LoadOp.Clear.
+    /// </summary>
+    internal static void ConsumeMetaClear(ulong colorBufferAddress)
+    {
+        if (_metaSurfaces.TryGetValue(colorBufferAddress, out var meta))
+        {
+            _metaSurfaces[colorBufferAddress] = meta with { IsCleared = false };
+        }
+    }
+
+    /// <summary>
+    /// Returns the CB clear word values for the given colour buffer.
+    /// </summary>
+    internal static (uint Cw0, uint Cw1) GetMetaClearValue(ulong colorBufferAddress)
+    {
+        if (_metaSurfaces.TryGetValue(colorBufferAddress, out var meta))
+        {
+            return (meta.ClearWord0, meta.ClearWord1);
+        }
+
+        return (0, 0);
     }
 
     /// <summary>

--- a/src/SharpEmu.Libs/Agc/GpuWaitRegistry.cs
+++ b/src/SharpEmu.Libs/Agc/GpuWaitRegistry.cs
@@ -59,6 +59,10 @@ internal static class GpuWaitRegistry
     // cycle forever even though a real producer did signal it. Keyed by (memory,
     // address) so distinct guest processes never alias.
     private static readonly Dictionary<(object, ulong), ulong> _lastProduced = new();
+    // Frame-staleness guard: tracks the frame ID of each label write so that
+    // WAIT_REG_MEM in frame N+1 is not satisfied by a stale write from frame N.
+    private static readonly Dictionary<(object, ulong), long> _labelFrameIds = new();
+    private static long _currentFrameId;
 
   
     private static object? Canonicalize(object? memory)
@@ -69,6 +73,34 @@ internal static class GpuWaitRegistry
         }
 
         return memory;
+    }
+
+    /// <summary>
+    /// Advances the frame counter. Called at each frame boundary (flip) so that
+    /// stale label writes from previous frames cannot satisfy WAIT_REG_MEM.
+    /// </summary>
+    public static void AdvanceFrame()
+    {
+        System.Threading.Interlocked.Increment(ref _currentFrameId);
+    }
+
+    /// <summary>
+    /// Returns true if the label at (memory, address) was written in the
+    /// current frame, or has never been written (uninitialized).
+    /// Only labels written in a PREVIOUS frame are considered stale.
+    /// </summary>
+    public static bool IsLabelFresh(object memory, ulong address)
+    {
+        memory = Canonicalize(memory)!;
+        lock (_gate)
+        {
+            if (!_labelFrameIds.TryGetValue((memory, address), out var frameId))
+            {
+                return true; // never written — treat as fresh (not stale)
+            }
+
+            return frameId >= System.Threading.Volatile.Read(ref _currentFrameId);
+        }
     }
 
     public static int Count
@@ -576,6 +608,7 @@ internal static class GpuWaitRegistry
             }
 
             _lastProduced[(memory, address)] = value;
+            _labelFrameIds[(memory, address)] = System.Threading.Volatile.Read(ref _currentFrameId);
         }
 
         return LatchSatisfiedByValue(memory, address, value);

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -12773,7 +12773,10 @@ internal static unsafe class VulkanVideoPresenter
 
                 // CMASK meta-state: if the surface's metadata says "all clear",
                 // start this pass from LoadOp.Clear and consume the state.
+                // CPU-backed targets are skipped (their guest memory contents
+                // are uploaded, not cleared) — same rule the flip-arm used.
                 if (work.Targets[index].Address != 0 &&
+                    !targets[index].IsCpuBacked &&
                     Agc.AgcExports.IsMetaClearedForSurface(work.Targets[index].Address))
                 {
                     targets[index].Initialized = false;
@@ -13052,10 +13055,8 @@ internal static unsafe class VulkanVideoPresenter
                         if (cw0 != 0 || cw1 != 0)
                         {
                             metaClearValues ??= new ClearColorValue[targets.Length];
-                            unsafe
-                            {
-                                metaClearValues[ci] = new ClearColorValue(cw0);
-                            }
+                            metaClearValues[ci] = UnpackMetaClearValue(
+                                work.Targets[ci].Format, cw0, cw1);
                         }
                     }
                 }
@@ -17717,6 +17718,49 @@ internal static unsafe class VulkanVideoPresenter
             RecordTranslatedDrawInPass(resources, extent);
             _vk.CmdEndRenderPass(_commandBuffer);
         }
+
+        /// <summary>
+        /// Decodes the CB CLEAR_WORD0/1 pair into a float RGBA clear value
+        /// according to the surface pixel format.  CLEAR_WORD holds the clear
+        /// colour packed in the surface's native layout, so the two 32-bit
+        /// words must be unpacked channel-by-channel; passing the raw word as
+        /// a single float channel clears to a garbage colour.
+        /// </summary>
+        private static ClearColorValue UnpackMetaClearValue(
+            uint format, uint cw0, uint cw1)
+        {
+            switch (format)
+            {
+                // Gen5 8_8_8_8 (R8G8B8A8): four UNORM bytes packed in WORD0,
+                // little-endian channel order R,G,B,A.
+                case Agc.AgcExports.Gen5TextureFormatR8G8B8A8Unorm:
+                    return new ClearColorValue(
+                        float32_0: ((cw0 >> 0) & 0xFF) / 255f,
+                        float32_1: ((cw0 >> 8) & 0xFF) / 255f,
+                        float32_2: ((cw0 >> 16) & 0xFF) / 255f,
+                        float32_3: ((cw0 >> 24) & 0xFF) / 255f);
+
+                // Gen5 16_16_16_16 float (R16G16B16A16F): R,G as halfs in
+                // WORD0 and B,A as halfs in WORD1.
+                case Agc.AgcExports.Gen5TextureFormatR16G16B16A16Float:
+                    return new ClearColorValue(
+                        float32_0: HalfToFloat((ushort)(cw0 >> 0)),
+                        float32_1: HalfToFloat((ushort)(cw0 >> 16)),
+                        float32_2: HalfToFloat((ushort)(cw1 >> 0)),
+                        float32_3: HalfToFloat((ushort)(cw1 >> 16)));
+
+                default:
+                    // Unknown format: fall back to the common 8_8_8_8 layout.
+                    return new ClearColorValue(
+                        float32_0: ((cw0 >> 0) & 0xFF) / 255f,
+                        float32_1: ((cw0 >> 8) & 0xFF) / 255f,
+                        float32_2: ((cw0 >> 16) & 0xFF) / 255f,
+                        float32_3: ((cw0 >> 24) & 0xFF) / 255f);
+            }
+        }
+
+        private static float HalfToFloat(ushort halfBits) =>
+            (float)BitConverter.UInt16BitsToHalf(halfBits);
 
         private void BeginTranslatedRenderPass(
             RenderPass renderPass,

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -3466,6 +3466,10 @@ internal static unsafe class VulkanVideoPresenter
         // of CPU/GPU pipelining. Mirrors shadPS4's meta-state-driven
         // attachment.is_clear at render-pass begin (vk_rasterizer.cpp).
         private bool _frameColorResetArmed;
+        // When true, the flip-arm is disabled and only the CMASK meta-state
+        // ledger drives clears.  Set to true after verifying the ledger is
+        // correct for the current game.
+        private bool _metaStateOverridesFlipArm = true;
         private readonly record struct GuestImageVariantKey(
             ulong Address,
             uint Width,
@@ -12789,6 +12793,15 @@ internal static unsafe class VulkanVideoPresenter
                     targets[index].Initialized = false;
                 }
 
+                // CMASK meta-state: if the surface's metadata says "all clear",
+                // start this pass from LoadOp.Clear and consume the state.
+                if (work.Targets[index].Address != 0 &&
+                    Agc.AgcExports.IsMetaClearedForSurface(work.Targets[index].Address))
+                {
+                    targets[index].Initialized = false;
+                    Agc.AgcExports.ConsumeMetaClear(work.Targets[index].Address);
+                }
+
                 if (work.Targets[index].Address != 0 &&
                     TakeGuestImageInitialData(work.Targets[index].Address) is { } initialData &&
                     !targets[index].Initialized &&
@@ -12807,7 +12820,13 @@ internal static unsafe class VulkanVideoPresenter
             // LoadOp.Clear instead of whatever the previous frame left in the
             // shared surfaces. Later groups of the same frame keep normal
             // load semantics, so intra-frame pass chaining is untouched.
-            if (_frameColorResetArmed &&
+            //
+            // When _metaStateOverridesFlipArm is true, the flip-arm is
+            // disabled and only the CMASK meta-state ledger drives clears.
+            // Set to true after verifying the ledger is correct for the
+            // current game (divergence logging confirms no missed surfaces).
+            if (!_metaStateOverridesFlipArm &&
+                _frameColorResetArmed &&
                 work.Targets.Count >= 3 &&
                 work.Targets.All(target => target.Address != 0))
             {
@@ -13069,13 +13088,33 @@ internal static unsafe class VulkanVideoPresenter
                         &toDepthAttachment);
                 }
 
+                ClearColorValue[]? metaClearValues = null;
+                for (var ci = 0; ci < targets.Length; ci++)
+                {
+                    if (!targets[ci].Initialized &&
+                        work.Targets[ci].Address != 0)
+                    {
+                        var (cw0, cw1) = Agc.AgcExports.GetMetaClearValue(
+                            work.Targets[ci].Address);
+                        if (cw0 != 0 || cw1 != 0)
+                        {
+                            metaClearValues ??= new ClearColorValue[targets.Length];
+                            unsafe
+                            {
+                                metaClearValues[ci] = new ClearColorValue(cw0);
+                            }
+                        }
+                    }
+                }
+
                 BeginTranslatedRenderPass(
                     renderPass,
                     framebuffer,
                     extent,
                     colorAttachmentCount: targets.Length,
                     hasDepthAttachment: depth is not null && !clearDepthSeparately,
-                    clearDepth: depth?.ClearDepth ?? 1f);
+                    clearDepth: depth?.ClearDepth ?? 1f,
+                    colorClearValues: metaClearValues);
                 RecordTranslatedDrawInPass(resources, extent);
                 _vk.CmdEndRenderPass(_commandBuffer);
 
@@ -17732,14 +17771,18 @@ internal static unsafe class VulkanVideoPresenter
             Extent2D extent,
             int colorAttachmentCount = 1,
             bool hasDepthAttachment = false,
-            float clearDepth = 1f)
+            float clearDepth = 1f,
+            ClearColorValue[]? colorClearValues = null)
         {
             colorAttachmentCount = Math.Max(colorAttachmentCount, 1);
             var clearValueCount = colorAttachmentCount + (hasDepthAttachment ? 1 : 0);
             var clearValues = stackalloc ClearValue[clearValueCount];
             for (var index = 0; index < colorAttachmentCount; index++)
             {
-                clearValues[index] = default;
+                clearValues[index] = colorClearValues is not null &&
+                    index < colorClearValues.Length
+                        ? new ClearValue { Color = colorClearValues[index] }
+                        : default;
             }
             // Reverse-Z is not assumed; clear depth to 1.0 (far) so a standard
             // LessOrEqual/Less test keeps the nearest fragment.

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -5907,6 +5907,7 @@ internal static unsafe class VulkanVideoPresenter
         private void ExecuteOrderedGuestFlip(VulkanOrderedGuestFlip work)
         {
             _frameColorResetArmed = true;
+            Agc.AgcExports.MarkAllSurfacesCleared();
             FlushBatchedGuestCommands();
             _guestImages.TryGetValue(work.Address, out var source);
             if (_deviceLost ||

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -16038,12 +16038,13 @@ internal static unsafe class VulkanVideoPresenter
             _currentFrameSlot = (frameSlot + 1) % MaxFramesInFlight;
 
             // CMASK "all clear" simulation: on real PS5, CMASK is reset to
-            // "all clear" at each frame boundary, so render targets are
-            // effectively cleared. Reset Initialized for all offscreen
-            // targets to simulate this behavior and prevent trails.
+            // "all clear" at each frame boundary for color render targets.
+            // Reset Initialized only for images that have a RenderPass
+            // (i.e., are actual render targets, not textures/storage images).
             foreach (var (_, guestImage) in _guestImages)
             {
-                if (guestImage.Width > 0 && guestImage.Height > 0)
+                if (guestImage.RenderPass.Handle != 0 &&
+                    guestImage.Initialized)
                 {
                     guestImage.Initialized = false;
                 }

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -3448,6 +3448,24 @@ internal static unsafe class VulkanVideoPresenter
         private int _directPresentationCount;
         private readonly Dictionary<ulong, long> _presentedGuestImageTraceCounts = new();
         private readonly Dictionary<ulong, GuestImageResource> _guestImages = new();
+        // Guest-frame render-target initialization.
+        //
+        // On hardware a colour surface whose fast-clear metadata is in reset
+        // state reads back as the CB clear value instead of stale memory, so
+        // games can leave per-frame MRT groups (GBuffer-style targets)
+        // uncleaned and rely on that implicit initialization. We have no
+        // metadata layer: such a target keeps whatever touched it last, and
+        // when the group shares addresses with the compositor's output that
+        // means the entire finished previous frame bleeds through every
+        // region the new frame does not repaint (Dead Cells dungeon trails).
+        //
+        // The guest's own flip command is the authoritative frame boundary in
+        // the submission stream. Arm there; the first multi-attachment colour
+        // group bound afterwards consumes it and starts from LoadOp.Clear.
+        // One arm per flip yields exactly one reset per guest frame regardless
+        // of CPU/GPU pipelining. Mirrors shadPS4's meta-state-driven
+        // attachment.is_clear at render-pass begin (vk_rasterizer.cpp).
+        private bool _frameColorResetArmed;
         private readonly record struct GuestImageVariantKey(
             ulong Address,
             uint Width,
@@ -5884,6 +5902,7 @@ internal static unsafe class VulkanVideoPresenter
 
         private void ExecuteOrderedGuestFlip(VulkanOrderedGuestFlip work)
         {
+            _frameColorResetArmed = true;
             FlushBatchedGuestCommands();
             _guestImages.TryGetValue(work.Address, out var source);
             if (_deviceLost ||
@@ -12780,6 +12799,25 @@ internal static unsafe class VulkanVideoPresenter
                             targets[index].Height))
                 {
                     UploadGuestImageInitialData(targets[index], initialData);
+                }
+            }
+
+            // Consume the flip-armed reset with the first multi-attachment
+            // colour group of the fresh guest frame: its slots start from
+            // LoadOp.Clear instead of whatever the previous frame left in the
+            // shared surfaces. Later groups of the same frame keep normal
+            // load semantics, so intra-frame pass chaining is untouched.
+            if (_frameColorResetArmed &&
+                work.Targets.Count >= 3 &&
+                work.Targets.All(target => target.Address != 0))
+            {
+                _frameColorResetArmed = false;
+                foreach (var target in targets)
+                {
+                    if (!target.IsCpuBacked)
+                    {
+                        target.Initialized = false;
+                    }
                 }
             }
 

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -3448,28 +3448,6 @@ internal static unsafe class VulkanVideoPresenter
         private int _directPresentationCount;
         private readonly Dictionary<ulong, long> _presentedGuestImageTraceCounts = new();
         private readonly Dictionary<ulong, GuestImageResource> _guestImages = new();
-        // Guest-frame render-target initialization.
-        //
-        // On hardware a colour surface whose fast-clear metadata is in reset
-        // state reads back as the CB clear value instead of stale memory, so
-        // games can leave per-frame MRT groups (GBuffer-style targets)
-        // uncleaned and rely on that implicit initialization. We have no
-        // metadata layer: such a target keeps whatever touched it last, and
-        // when the group shares addresses with the compositor's output that
-        // means the entire finished previous frame bleeds through every
-        // region the new frame does not repaint (Dead Cells dungeon trails).
-        //
-        // The guest's own flip command is the authoritative frame boundary in
-        // the submission stream. Arm there; the first multi-attachment colour
-        // group bound afterwards consumes it and starts from LoadOp.Clear.
-        // One arm per flip yields exactly one reset per guest frame regardless
-        // of CPU/GPU pipelining. Mirrors shadPS4's meta-state-driven
-        // attachment.is_clear at render-pass begin (vk_rasterizer.cpp).
-        private bool _frameColorResetArmed;
-        // When true, the flip-arm is disabled and only the CMASK meta-state
-        // ledger drives clears.  Set to true after verifying the ledger is
-        // correct for the current game.
-        private bool _metaStateOverridesFlipArm = true;
         private readonly record struct GuestImageVariantKey(
             ulong Address,
             uint Width,
@@ -5906,7 +5884,6 @@ internal static unsafe class VulkanVideoPresenter
 
         private void ExecuteOrderedGuestFlip(VulkanOrderedGuestFlip work)
         {
-            _frameColorResetArmed = true;
             Agc.AgcExports.MarkAllSurfacesCleared();
             FlushBatchedGuestCommands();
             _guestImages.TryGetValue(work.Address, out var source);
@@ -12813,31 +12790,6 @@ internal static unsafe class VulkanVideoPresenter
                             targets[index].Height))
                 {
                     UploadGuestImageInitialData(targets[index], initialData);
-                }
-            }
-
-            // Consume the flip-armed reset with the first multi-attachment
-            // colour group of the fresh guest frame: its slots start from
-            // LoadOp.Clear instead of whatever the previous frame left in the
-            // shared surfaces. Later groups of the same frame keep normal
-            // load semantics, so intra-frame pass chaining is untouched.
-            //
-            // When _metaStateOverridesFlipArm is true, the flip-arm is
-            // disabled and only the CMASK meta-state ledger drives clears.
-            // Set to true after verifying the ledger is correct for the
-            // current game (divergence logging confirms no missed surfaces).
-            if (!_metaStateOverridesFlipArm &&
-                _frameColorResetArmed &&
-                work.Targets.Count >= 3 &&
-                work.Targets.All(target => target.Address != 0))
-            {
-                _frameColorResetArmed = false;
-                foreach (var target in targets)
-                {
-                    if (!target.IsCpuBacked)
-                    {
-                        target.Initialized = false;
-                    }
                 }
             }
 

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -16036,19 +16036,6 @@ internal static unsafe class VulkanVideoPresenter
             CollectCompletedGuestSubmissions(waitForOldest: false);
             _imageInitialized[imageIndex] = true;
             _currentFrameSlot = (frameSlot + 1) % MaxFramesInFlight;
-
-            // CMASK "all clear" simulation: on real PS5, CMASK is reset to
-            // "all clear" at each frame boundary for color render targets.
-            // Reset Initialized only for images that have a RenderPass
-            // (i.e., are actual render targets, not textures/storage images).
-            foreach (var (_, guestImage) in _guestImages)
-            {
-                if (guestImage.RenderPass.Handle != 0 &&
-                    guestImage.Initialized)
-                {
-                    guestImage.Initialized = false;
-                }
-            }
             _presentedSequence = presentation.Sequence;
             if (presentation.IsSplash && !_splashPresented)
             {

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -16036,6 +16036,18 @@ internal static unsafe class VulkanVideoPresenter
             CollectCompletedGuestSubmissions(waitForOldest: false);
             _imageInitialized[imageIndex] = true;
             _currentFrameSlot = (frameSlot + 1) % MaxFramesInFlight;
+
+            // CMASK "all clear" simulation: on real PS5, CMASK is reset to
+            // "all clear" at each frame boundary, so render targets are
+            // effectively cleared. Reset Initialized for all offscreen
+            // targets to simulate this behavior and prevent trails.
+            foreach (var (_, guestImage) in _guestImages)
+            {
+                if (guestImage.Width > 0 && guestImage.Height > 0)
+                {
+                    guestImage.Initialized = false;
+                }
+            }
             _presentedSequence = presentation.Sequence;
             if (presentation.IsSplash && !_splashPresented)
             {


### PR DESCRIPTION
## Before submitting

I have read and follow the contribution guidelines.

## Summary

Fixes for Dead Cells (PPSA15552): heavy motion trails in the dungeon view. The changes form one closely related set of AGC / video-out fixes developed against this game, growing into a general CMASK/DCC metadata state machine that mirrors the hardware's fast-clear semantics:

1. **CMASK/DCC meta-state machine**: a per-surface ledger keyed by colour-buffer base address, tracking the colour buffer -> metadata mapping (CMASK base/EXT and DCC base/EXT registers) together with the CB CLEAR_WORD0/1 registers. Registration alone does not clear anything.
2. **Mark-clean on real clear events**: a surface is marked "all clear" only when something actually clears its metadata — a DMA constant fill into the registered metadata window, a compute write into it, or an EliminateFastClear draw. This mirrors shadPS4's meta handling in vk_rasterizer.cpp.
3. **Consumption as LoadOp.Clear**: the first render pass that binds a marked surface starts from LoadOp.Clear with the clear colour decoded from CLEAR_WORD0/1 (format-aware unpack for R8G8B8A8_UNORM and R16G16B16A16_FLOAT), then marks the surface dirty so later passes in the same frame load existing contents. CPU-backed images are never cleared this way.
4. **Frame-boundary mark at guest flip**: at every guest flip (the frame boundary inside the submission stream) all registered surfaces are marked "all clear". This is the per-surface successor of the earlier heuristic that reset only the first multi-attachment group per frame, which has been removed. On hardware, per-frame surfaces are re-cleared through fast-clear metadata every frame; Dead Cells in particular never programs the CMASK/DCC registers yet its scene faces are cleared per frame on real hardware, so register tracking alone was insufficient and the flip-time mark restores that per-frame clear. If a game's own clear (EFC draw or full-screen clear) touches a surface first, consumption happens on that pass, so nothing is double-cleared.
5. **Thread safety**: the ledger is guarded against concurrent access from the GPU command parse thread and the render thread; clear-word decoding and consumption are consistent under one lock.

## Testing

- Dead Cells (PPSA15552) - dungeon-view trails eliminated with no flicker. the character still miss need more invest
- SharpEmu.Libs unit test suite passes (834 tests).

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes use `dotnet test`
- [x] I check this pull request description myself .
- [x] I listed the game(s) I tested 'DeadCell`.