### PR TITLE
Fix TLS patcher scanning inside short jumps

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -3200,7 +3200,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				{
 					nint address = (nint)(ptr + i);
 					int remainingBytes = scanBytes - i;
-					if (TryPatchTlsLoadInstruction(address, ptr + i, remainingBytes))
+					if (TryPatchTlsLoadInstruction(address, ptr + i, remainingBytes, i))
 					{
 						num3++;
 					}
@@ -3343,9 +3343,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		return true;
 	}
 
-	private unsafe bool TryPatchTlsLoadInstruction(nint address, byte* source, int availableLength)
+	private unsafe bool TryPatchTlsLoadInstruction(nint address, byte* source, int availableLength, int regionOffset)
 	{
 		if (availableLength < MinTlsPatchInstructionBytes)
+		{
+			return false;
+		}
+
+		// A bare 0xEB (JMP rel8) always owns a disp8 after it, so it can
+		// never be the last byte of a valid instruction. If it precedes our
+		// candidate, we're mid-instruction: reject and let the scan retry.
+		if (regionOffset >= 1 && source[-1] == 0xEB)
 		{
 			return false;
 		}


### PR DESCRIPTION
Before this change, the TLS patcher scanned executable memory byte by byte and attempted to match a TLS load from every position. It only validated the bytes after the candidate, without checking whether that position was actually the start of an instruction.

This could make the scanner start inside a previous instruction. In GTA V, a short jump with a 0x66 displacement appears immediately before a 66-prefixed FS:[0] load. The scanner interpreted the jump displacement as part of the TLS instruction and patched from the wrong byte, corrupting the jump and creating an infinite loop during the AGC resource-destructor path.

This change gives the TLS matcher enough context to detect that case and reject candidates immediately following a short-jump opcode. The scan then continues to the actual TLS instruction boundary and patches it normally..


### Testing

Tested for 75 seconds without diagnostic flags:

- GTA V: boot-time hang vs boots and presents the intro
- Astro Bot : no regression.
- Cult of the Lamb: no regression.
- Ghost of Yōtei: no regression.