### PR TITLE
test(loader): cover synthetic Gen5 SELF runtime path

### DIFF
--- a/tests/SharpEmu.Libs.Tests/Cpu/Gen5NativeReturnSmokeTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/Gen5NativeReturnSmokeTests.cs
@@ -9,6 +9,7 @@ using SharpEmu.Core.Cpu.Native;
 using SharpEmu.Core.Loader;
 using SharpEmu.Core.Memory;
 using SharpEmu.HLE;
+using SharpEmu.Libs.Tests.Loader;
 using Xunit;
 
 namespace SharpEmu.Libs.Tests.Cpu;
@@ -16,10 +17,11 @@ namespace SharpEmu.Libs.Tests.Cpu;
 public sealed class Gen5NativeReturnSmokeTests
 {
     private const string WorkerEnvironmentVariable = "SHARPEMU_NATIVE_RETURN_SMOKE_WORKER";
+    private const string WorkerCompletionMarker = "SHARPEMU_NATIVE_RETURN_SMOKE_COMPLETED";
     private static readonly TimeSpan WorkerTimeout = TimeSpan.FromSeconds(30);
 
     [Fact]
-    public async Task SyntheticGen5Entry_ReturnsToHost()
+    public async Task SyntheticGen5ElfAndMinimalSelfEntries_ReturnToHost()
     {
         if (!IsSupportedHost)
         {
@@ -31,7 +33,8 @@ public sealed class Gen5NativeReturnSmokeTests
                 "1",
                 StringComparison.Ordinal))
         {
-            ExecuteSyntheticGuest();
+            ExecuteSyntheticGuests();
+            Console.Error.WriteLine(WorkerCompletionMarker);
             return;
         }
 
@@ -43,16 +46,30 @@ public sealed class Gen5NativeReturnSmokeTests
         Assert.True(
             result.ExitCode == 0,
             $"native return worker exited with code {result.ExitCode}\n{result.Output}");
+        Assert.True(
+            result.Output.Contains(WorkerCompletionMarker, StringComparison.Ordinal),
+            $"native return worker exited without confirming both guest executions\n{result.Output}");
     }
 
     private static bool IsSupportedHost =>
         RuntimeInformation.ProcessArchitecture == Architecture.X64 &&
         (OperatingSystem.IsWindows() || OperatingSystem.IsLinux() || OperatingSystem.IsMacOS());
 
-    private static void ExecuteSyntheticGuest()
+    private static void ExecuteSyntheticGuests()
+    {
+        ExecuteSyntheticGuest(BuildSyntheticElf(), expectedIsSelf: false);
+
+        ReadOnlySpan<byte> payload = [0x31, 0xC0, 0xC3]; // xor eax, eax; ret
+        ExecuteSyntheticGuest(
+            SyntheticGen5SelfImageBuilder.BuildMinimalSelfSegmentTableImage(payload),
+            expectedIsSelf: true);
+    }
+
+    private static void ExecuteSyntheticGuest(byte[] imageData, bool expectedIsSelf)
     {
         using var memory = new PhysicalVirtualMemory();
-        var image = new SelfLoader().Load(BuildSyntheticElf(), memory);
+        var image = new SelfLoader().Load(imageData, memory);
+        Assert.Equal(expectedIsSelf, image.IsSelf);
         Assert.Equal((byte)2, image.ElfHeader.AbiVersion);
         Assert.Equal(0x0000_0008_0000_1000UL, image.EntryPoint);
 
@@ -100,7 +117,9 @@ public sealed class Gen5NativeReturnSmokeTests
         startInfo.ArgumentList.Add(typeof(Gen5NativeReturnSmokeTests).Assembly.Location);
         startInfo.ArgumentList.Add("--filter");
         startInfo.ArgumentList.Add(
-            $"FullyQualifiedName={typeof(Gen5NativeReturnSmokeTests).FullName}.{nameof(SyntheticGen5Entry_ReturnsToHost)}");
+            $"FullyQualifiedName={typeof(Gen5NativeReturnSmokeTests).FullName}.{nameof(SyntheticGen5ElfAndMinimalSelfEntries_ReturnToHost)}");
+        startInfo.ArgumentList.Add("--logger");
+        startInfo.ArgumentList.Add("console;verbosity=normal");
         startInfo.Environment[WorkerEnvironmentVariable] = "1";
         startInfo.Environment["SHARPEMU_SENTINEL_PROBE"] = null;
 

--- a/tests/SharpEmu.Libs.Tests/Loader/SyntheticGen5SelfImageBuilder.cs
+++ b/tests/SharpEmu.Libs.Tests/Loader/SyntheticGen5SelfImageBuilder.cs
@@ -1,0 +1,126 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+
+namespace SharpEmu.Libs.Tests.Loader;
+
+/// <summary>
+/// Builds a minimal synthetic PS5 SELF segment-table fixture from public ELF and SELF layouts.
+/// The fixture has a coherent minimal header, one data entry, and an embedded ELF.
+/// <c>SelfLoader</c> consumes only the recognition and segment-routing subset. The output
+/// omits extended and signing metadata, so it is not a format-complete or console-installable fSELF.
+/// </summary>
+internal static class SyntheticGen5SelfImageBuilder
+{
+    public const ulong ImageBase = 0x0000_0008_0000_0000UL;
+    public const ulong PayloadVirtualAddress = 0x1000;
+    public const int ElfPayloadFileOffset = 0x1000;
+    public const ulong DefaultMemorySize = 0x1000;
+
+    private const uint Ps5SelfMagic = 0x5414F5EE;
+    private const int SelfHeaderSize = 0x20;
+    private const int SelfSegmentSize = 0x20;
+    private const int SelfEntryCount = 1;
+    private const int ElfHeaderSize = 0x40;
+    private const int ProgramHeaderSize = 0x38;
+    private const int ElfOffset = SelfHeaderSize + (SelfEntryCount * SelfSegmentSize);
+    private const int SelfEmbeddedHeadersEnd = ElfOffset + ElfHeaderSize + ProgramHeaderSize;
+
+    public const int SelfPayloadFileOffset = (SelfEmbeddedHeadersEnd + 0xF) & ~0xF;
+
+    // Public SELF entry bitfields: has_blocks, a 16 KiB block-size exponent, and
+    // program-header index zero. SelfLoader currently exposes has_blocks as IsBlocked.
+    private const int SelfBlockSizeFieldShift = 12;
+    private const int SelfBlockSizeExponent = 2;
+    private const ulong SelfHasBlocksEntryFlag = 1UL << 11;
+    private const ulong SelfDataEntryProperties =
+        SelfHasBlocksEntryFlag |
+        ((ulong)SelfBlockSizeExponent << SelfBlockSizeFieldShift);
+
+    public static byte[] BuildMinimalSelfSegmentTableImage(
+        ReadOnlySpan<byte> payload,
+        ulong memorySize = DefaultMemorySize)
+    {
+        if (payload.IsEmpty)
+        {
+            throw new ArgumentException("Synthetic payload must not be empty.", nameof(payload));
+        }
+
+        if (memorySize < (ulong)payload.Length)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(memorySize),
+                "Memory size must be at least as large as the payload.");
+        }
+
+        var imageLength = checked((SelfPayloadFileOffset + payload.Length + 0xF) & ~0xF);
+        var image = new byte[imageLength];
+
+        WriteSelfContainer(image, payload.Length);
+        WriteElfHeader(image.AsSpan(ElfOffset, ElfHeaderSize));
+        WriteProgramHeader(
+            image.AsSpan(ElfOffset + ElfHeaderSize, ProgramHeaderSize),
+            memorySize,
+            payload.Length);
+        payload.CopyTo(image.AsSpan(SelfPayloadFileOffset));
+        return image;
+    }
+
+    private static void WriteSelfContainer(Span<byte> image, int payloadLength)
+    {
+        var header = image[..SelfHeaderSize];
+        BinaryPrimitives.WriteUInt32BigEndian(header, Ps5SelfMagic);
+        header[0x04] = 0x00;
+        header[0x05] = 0x01;
+        header[0x06] = 0x01;
+        header[0x07] = 0x12;
+        BinaryPrimitives.WriteUInt32LittleEndian(header[0x08..], 0);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[0x0C..], SelfPayloadFileOffset);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[0x0E..], 0);
+        BinaryPrimitives.WriteUInt64LittleEndian(header[0x10..], (ulong)image.Length);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[0x18..], SelfEntryCount);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[0x1A..], 0);
+
+        // The physical data offset intentionally differs from ELF p_offset so
+        // the test fails if SELF segment-table resolution regresses to fallback.
+        var dataEntry = image.Slice(SelfHeaderSize, SelfSegmentSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(dataEntry, SelfDataEntryProperties);
+        BinaryPrimitives.WriteUInt64LittleEndian(dataEntry[0x08..], SelfPayloadFileOffset);
+        BinaryPrimitives.WriteUInt64LittleEndian(dataEntry[0x10..], (ulong)payloadLength);
+        BinaryPrimitives.WriteUInt64LittleEndian(dataEntry[0x18..], (ulong)payloadLength);
+    }
+
+    private static void WriteElfHeader(Span<byte> header)
+    {
+        header[0x00] = 0x7F;
+        header[0x01] = (byte)'E';
+        header[0x02] = (byte)'L';
+        header[0x03] = (byte)'F';
+        header[0x04] = 2;
+        header[0x05] = 1;
+        header[0x06] = 1;
+        header[0x07] = 9;
+        header[0x08] = 2;
+        BinaryPrimitives.WriteUInt16LittleEndian(header[0x10..], 3);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[0x12..], 62);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[0x14..], 1);
+        BinaryPrimitives.WriteUInt64LittleEndian(header[0x18..], PayloadVirtualAddress);
+        BinaryPrimitives.WriteUInt64LittleEndian(header[0x20..], ElfHeaderSize);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[0x34..], ElfHeaderSize);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[0x36..], ProgramHeaderSize);
+        BinaryPrimitives.WriteUInt16LittleEndian(header[0x38..], 1);
+    }
+
+    private static void WriteProgramHeader(Span<byte> header, ulong memorySize, int payloadLength)
+    {
+        BinaryPrimitives.WriteUInt32LittleEndian(header, 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[0x04..], 5);
+        BinaryPrimitives.WriteUInt64LittleEndian(header[0x08..], ElfPayloadFileOffset);
+        BinaryPrimitives.WriteUInt64LittleEndian(header[0x10..], PayloadVirtualAddress);
+        BinaryPrimitives.WriteUInt64LittleEndian(header[0x18..], PayloadVirtualAddress);
+        BinaryPrimitives.WriteUInt64LittleEndian(header[0x20..], (ulong)payloadLength);
+        BinaryPrimitives.WriteUInt64LittleEndian(header[0x28..], memorySize);
+        BinaryPrimitives.WriteUInt64LittleEndian(header[0x30..], 0x1000);
+    }
+}

--- a/tests/SharpEmu.Libs.Tests/Loader/SyntheticGen5SelfImageLoadTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Loader/SyntheticGen5SelfImageLoadTests.cs
@@ -1,0 +1,55 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Loader;
+using SharpEmu.Core.Memory;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Loader;
+
+/// <summary>
+/// End-to-end loader coverage for the minimal PS5 SELF segment-table fixture.
+/// </summary>
+public sealed class SyntheticGen5SelfImageLoadTests
+{
+    [Fact]
+    public void MinimalSelfSegmentTableImage_UsesPhysicalOffsetAndZeroFillsMappedExtent()
+    {
+        ReadOnlySpan<byte> payload = [0x31, 0xC0, 0xC3];
+        var imageData = SyntheticGen5SelfImageBuilder.BuildMinimalSelfSegmentTableImage(payload);
+        var memory = new VirtualMemory();
+
+        var image = new SelfLoader().Load(imageData, memory);
+
+        Assert.True(image.IsSelf);
+        Assert.Equal((byte)2, image.ElfHeader.AbiVersion);
+        Assert.Equal(
+            SyntheticGen5SelfImageBuilder.ImageBase + SyntheticGen5SelfImageBuilder.PayloadVirtualAddress,
+            image.EntryPoint);
+
+        var programHeader = Assert.Single(image.ProgramHeaders);
+        Assert.Equal((ulong)SyntheticGen5SelfImageBuilder.ElfPayloadFileOffset, programHeader.Offset);
+        Assert.Equal(ProgramHeaderType.Load, programHeader.HeaderType);
+        Assert.Equal((ulong)payload.Length, programHeader.FileSize);
+        Assert.Equal(SyntheticGen5SelfImageBuilder.DefaultMemorySize, programHeader.MemorySize);
+
+        var mappedRegion = Assert.Single(image.MappedRegions);
+        Assert.Equal(image.EntryPoint, mappedRegion.VirtualAddress);
+        Assert.Equal((ulong)SyntheticGen5SelfImageBuilder.SelfPayloadFileOffset, mappedRegion.FileOffset);
+        Assert.NotEqual(programHeader.Offset, mappedRegion.FileOffset);
+        Assert.Equal((ulong)payload.Length, mappedRegion.FileSize);
+        Assert.Equal(SyntheticGen5SelfImageBuilder.DefaultMemorySize, mappedRegion.MemorySize);
+        Assert.Equal(ProgramHeaderFlags.Read | ProgramHeaderFlags.Execute, mappedRegion.Protection);
+
+        Span<byte> mappedBytes = stackalloc byte[8];
+        Assert.True(memory.TryRead(image.EntryPoint, mappedBytes));
+        Assert.Equal(payload.ToArray(), mappedBytes[..payload.Length].ToArray());
+        Assert.Equal(new byte[mappedBytes.Length - payload.Length], mappedBytes[payload.Length..].ToArray());
+
+        Span<byte> tailBytes = stackalloc byte[16];
+        var tailAddress =
+            image.EntryPoint + SyntheticGen5SelfImageBuilder.DefaultMemorySize - (ulong)tailBytes.Length;
+        Assert.True(memory.TryRead(tailAddress, tailBytes));
+        Assert.Equal(new byte[tailBytes.Length], tailBytes.ToArray());
+    }
+}


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this adds

PR https://github.com/sharpemu/sharpemu/pull/818 checks that a small Gen5 ELF can run and return through the native backend. This adds the same coverage for the SELF path.

The new test checks the SELF payload offset, entry point, protection flags, copied bytes, and zero-filled memory. The native smoke still runs the original ELF, then runs the SELF image before writing its completion marker.

No production code is changed.

## How it works

The SELF entry puts the payload at file offset `0xC0`. Its embedded ELF uses `p_offset = 0x1000`, which is outside the generated image. If `SelfLoader` falls back to the ELF offset instead of using the SELF entry, the test fails.

The payload is the same `xor eax, eax; ret` sequence used by the existing native-return smoke test.

## Testing

Game testing: `N/A`. The tests use generated bytes and do not load a game or firmware image.

- Windows x64, .NET SDK 10.0.103: new tests 2/2; full solution 925/925.
- Kali WSL2 x64, .NET SDK 10.0.103: new tests 2/2, including the native worker.
- Current https://github.com/sharpemu/sharpemu/pull/780 plus this branch: focused tests 7/7.

Additional sensitivity checks changed the SELF offset, flags, program-header index, memory size, guest return instruction, and nested test filter one at a time. Each change made the relevant test fail.

## Scope and limitations

- Three test files, 205 additions and 5 deletions.
- Complements https://github.com/sharpemu/sharpemu/pull/780 for https://github.com/sharpemu/sharpemu/issues/388; it does not close the issue by itself.
- The test builds a small synthetic SELF with one segment and an embedded ELF. It isn't a complete fSELF and won't run on a console.
- No Sony firmware, keys, signatures, encrypted content, or game assets are included.
- macOS x64 and the full Linux suite were not run.

## Notes

The fixture uses public SELF layout information from [self.h](https://github.com/ps5-payload-dev/ftpsrv/blob/master/self.h) and [make_fself.py](https://github.com/ps5-payload-dev/sdk/blob/master/samples/install_app/make_fself.py).

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).