### PR TITLE
fix(memory): expand the HLE guest-allocation arena

### DIFF
--- a/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
+++ b/src/SharpEmu.Core/Memory/PhysicalVirtualMemory.cs
@@ -29,7 +29,13 @@ public sealed unsafe class PhysicalVirtualMemory : IVirtualMemory, IGuestMemoryA
     private const ulong PageSize = 0x1000;
     private const ulong HostAllocationGranularity = 0x10000;
     private const ulong GuestAllocationArenaAddress = 0x00006000_0000_0000;
-    private const ulong GuestAllocationArenaSize = 0x0100_0000;
+    // Full C++ runtimes can route large numbers of HLE-backed heap allocations
+    // through this arena. The original 16 MiB capacity could be exhausted
+    // during asset setup, turning a valid allocation request into a null
+    // pointer that failed later in unrelated guest code. Keep enough capacity
+    // for those workloads. Adapted from foufouadi's allocator-exhaustion
+    // investigation.
+    private const ulong GuestAllocationArenaSize = 0x2000_0000;
     private const ulong GuestAllocationArenaStartOffset = PageSize;
     private const ulong LargeDataReserveThreshold = 0x4000_0000UL; // 1 GiB
     private const ulong FullCommitRegionLimit = 4UL << 30;

--- a/tests/SharpEmu.Libs.Tests/Memory/GuestMemoryAllocatorTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Memory/GuestMemoryAllocatorTests.cs
@@ -14,7 +14,7 @@ public sealed class GuestMemoryAllocatorTests
     public void FreedRangesAreReusedAndCoalesced()
     {
         using var memory = new PhysicalVirtualMemory(new FakeHostMemory());
-        const ulong usableArenaSize = 0x0100_0000 - 0x1000;
+        const ulong usableArenaSize = 0x2000_0000 - 0x1000;
 
         Assert.True(memory.TryAllocateGuestMemory(0x4000, 0x1000, out var first));
         Assert.True(memory.TryAllocateGuestMemory(0x8000, 0x1000, out var second));
@@ -32,6 +32,16 @@ public sealed class GuestMemoryAllocatorTests
 
         Assert.True(memory.TryAllocateGuestMemory(usableArenaSize, 0x1000, out var coalesced));
         Assert.Equal(first, coalesced);
+    }
+
+    [Fact]
+    public void ArenaSupportsAllocationsBeyondLegacySixteenMiBLimit()
+    {
+        using var memory = new PhysicalVirtualMemory(new FakeHostMemory());
+
+        Assert.True(memory.TryAllocateGuestMemory(0x0100_0000, 0x1000, out var first));
+        Assert.True(memory.TryAllocateGuestMemory(0x0020_0000, 0x1000, out var beyondLegacyLimit));
+        Assert.Equal(first + 0x0100_0000, beyondLegacyLimit);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

This expands the fixed HLE guest-allocation arena from 16 MiB to 512 MiB.

The original arena was sufficient while it only backed small opaque HLE objects. It can now also receive allocations from fuller C++ runtime paths, including `operator new` and libc mspace allocation handlers. A title can therefore exhaust 16 MiB during boot, receive a null allocation result, and fail later at an apparently unrelated guest call site.

The change:

- raises the arena's address-space capacity without changing its allocation policy;
- retains the first page as an unmapped/null guard;
- updates the allocator capacity regression test; and
- adds a test proving that allocations can safely cross the former 16 MiB boundary.

The 512 MiB range is reserved guest address space. Host pages continue to be backed according to the existing memory implementation as they are used; this does not eagerly allocate a 512 MiB managed buffer.

## Testing

- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release --filter FullyQualifiedName~GuestMemoryAllocatorTests --verbosity minimal` — 11 passed.
- Runtime testing: the larger arena removed the observed boot-time arena exhaustion in GTA V in the Fran fork. This PR only addresses that allocator-capacity failure; it does not claim to fix later unrelated guest failures.

## Credits and assistance

The allocator-exhaustion investigation and underlying arena-size change were authored by Foued Attar (Foufouadi). The commit retains Foued as co-author.

AI assistance was used to isolate the change from the experimental fork, simplify its comments, review it against current upstream, and run verification. It was not used to author the underlying implementation.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).

