### PR TITLE
fix(cpu): preserve TLS instruction boundaries after rel8 branches

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Iced.Intel;
 using SharpEmu.Core.Cpu;
 using SharpEmu.Core.Cpu.Debugging;
 using SharpEmu.Core.Loader;
@@ -3350,10 +3351,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			return false;
 		}
 
-		// A bare 0xEB (JMP rel8) always owns a disp8 after it, so it can
-		// never be the last byte of a valid instruction. If it precedes our
-		// candidate, we're mid-instruction: reject and let the scan retry.
-		if (regionOffset >= 1 && source[-1] == 0xEB)
+		var region = new ReadOnlySpan<byte>(source - regionOffset, regionOffset + availableLength);
+		if (IsTlsLoadCandidateInsideShortJump(region, regionOffset))
 		{
 			return false;
 		}
@@ -3408,6 +3407,85 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		}
 
 		return PatchTlsLoadInstruction(address, instructionLength, destinationRegister);
+	}
+
+	internal static bool IsTlsLoadCandidateInsideShortJump(ReadOnlySpan<byte> region, int candidateOffset)
+	{
+		if ((uint)candidateOffset >= (uint)region.Length ||
+			candidateOffset < 1 ||
+			region[candidateOffset - 1] != 0xEB)
+		{
+			return false;
+		}
+
+		// The byte before the candidate can be either a JMP rel8 opcode or
+		// the rel8 operand of an instruction that ends at the candidate.
+		// Dreaming Sarah has `75 EB 66 66 66 64 ...`: EB is the backward
+		// displacement of JNZ, so the first 66 is the real TLS boundary.
+		// Preserve that boundary while still rejecting GTA V's `EB 66 66
+		// 64 ...`, where the first 66 belongs to the JMP instruction.
+		if (IsRel8ControlFlowInstructionEndingAtCandidate(region, candidateOffset))
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	private static bool IsRel8ControlFlowInstructionEndingAtCandidate(
+		ReadOnlySpan<byte> region,
+		int candidateOffset)
+	{
+		if (candidateOffset < 2)
+		{
+			return false;
+		}
+
+		var branchOffset = candidateOffset - 2;
+		var opcode = region[branchOffset];
+		if (!((opcode >= 0x70 && opcode <= 0x7F) ||
+			opcode is >= 0xE0 and <= 0xE3 ||
+			opcode == 0xEB))
+		{
+			return false;
+		}
+
+		var branchTarget = candidateOffset + (sbyte)region[candidateOffset - 1];
+		if (branchTarget < 0 || branchTarget >= branchOffset)
+		{
+			return false;
+		}
+
+		// A byte pair that merely looks like Jcc/LOOP/JMP is not sufficient:
+		// decode forward from its backward target and require the stream to
+		// land exactly on the proposed branch. This makes the exception depend
+		// on an actual instruction boundary instead of another adjacent-byte
+		// guess.
+		var decoder = Decoder.Create(
+			64,
+			new ByteArrayCodeReader(region[branchTarget..candidateOffset].ToArray()));
+		decoder.IP = (ulong)branchTarget;
+		while (decoder.IP < (ulong)candidateOffset)
+		{
+			var instructionOffset = (int)decoder.IP;
+			decoder.Decode(out var instruction);
+			if (instruction.Code == Code.INVALID || instruction.Length <= 0)
+			{
+				return false;
+			}
+
+			if (instructionOffset == branchOffset)
+			{
+				return instruction.Length == 2 && decoder.IP == (ulong)candidateOffset;
+			}
+
+			if (decoder.IP > (ulong)branchOffset)
+			{
+				return false;
+			}
+		}
+
+		return false;
 	}
 
 	private unsafe bool PatchTlsLoadInstruction(nint address, int instructionLength, int destinationRegister)

--- a/tests/SharpEmu.Libs.Tests/Cpu/TlsLoadPatchBoundaryTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Cpu/TlsLoadPatchBoundaryTests.cs
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using SharpEmu.Core.Cpu.Native;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Cpu;
+
+public sealed class TlsLoadPatchBoundaryTests
+{
+    [Fact]
+    public void RejectsGtaShortJumpDisplacementAsTlsPrefix()
+    {
+        byte[] code =
+        [
+            0x90,
+            0xEB, 0x66,
+            0x66, 0x64, 0x48, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        Assert.True(DirectExecutionBackend.IsTlsLoadCandidateInsideShortJump(code, candidateOffset: 2));
+        Assert.False(DirectExecutionBackend.IsTlsLoadCandidateInsideShortJump(code, candidateOffset: 3));
+    }
+
+    [Fact]
+    public void KeepsDreamingSarahTlsInstructionAfterBackwardJnz()
+    {
+        byte[] code =
+        [
+            0x48, 0x8B, 0x1C, 0xD0,
+            0x4C, 0x39, 0x2B,
+            0x0F, 0x84, 0x10, 0x01, 0x00, 0x00,
+            0x48, 0xFF, 0xC2,
+            0x48, 0x39, 0xD1,
+            0x75, 0xEB,
+            0x66, 0x66, 0x66, 0x64, 0x48, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        Assert.False(DirectExecutionBackend.IsTlsLoadCandidateInsideShortJump(code, candidateOffset: 21));
+    }
+
+    [Theory]
+    [InlineData(0x70)]
+    [InlineData(0x7F)]
+    [InlineData(0xE0)]
+    [InlineData(0xE3)]
+    [InlineData(0xEB)]
+    public void KeepsTlsInstructionAfterRel8ControlFlow(byte opcode)
+    {
+        byte[] code =
+        [
+            0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90,
+            0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90,
+            opcode, 0xEB,
+            0x66, 0x64, 0x48, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        Assert.False(DirectExecutionBackend.IsTlsLoadCandidateInsideShortJump(code, candidateOffset: 21));
+    }
+
+    [Fact]
+    public void Rel8OpcodeByteInsidePreviousInstructionDoesNotBypassGuard()
+    {
+        byte[] code =
+        [
+            0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90,
+            0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90,
+            0x6A, 0x75,
+            0xEB, 0x66,
+            0x66, 0x64, 0x48, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        Assert.True(DirectExecutionBackend.IsTlsLoadCandidateInsideShortJump(code, candidateOffset: 21));
+    }
+}


### PR DESCRIPTION
## Summary

- keep the #838 protection against treating a short-jump displacement as a TLS prefix
- distinguish a real rel8 control-flow instruction ending at the TLS candidate by decoding forward from its backward target
- cover GTA V, Dreaming Sarah, `JMP rel8`, conditional/loop rel8 branches, and a misleading opcode byte inside another instruction

## Regression fixed

Dreaming Sarah contains this sequence near file offset `0x162975`:

```text
75 EB 66 66 66 64 48 8B 04 25 00 00 00 00
```

Here, `75 EB` is a backward `JNZ rel8`; the first `66` is the real TLS instruction boundary. #838 interpreted the displacement byte `EB` as a `JMP rel8` opcode, rejected that boundary, and patched from the following prefix. The game then remained on a black screen while loading its Construct 2 layouts.

The new check remains conservative: it only accepts the candidate when Iced decoding from the backward branch target lands exactly on the proposed two-byte rel8 branch and ends at the candidate.

## Testing

- Dreaming Sarah on the parent of #838: reaches the menu
- exact #838 merge and current upstream without this patch: black screen
- current upstream with this patch and a fresh user/cache directory: reaches the menu
- `dotnet test tests/SharpEmu.Libs.Tests/SharpEmu.Libs.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~TlsLoadPatchBoundaryTests`
  - 8 passed, 0 failed
