### PR TITLE
fix(ngs2): correct PS-ADPCM loop flag semantics

### DIFF
--- a/src/SharpEmu.Libs/Ngs2/Ngs2VagDecoder.cs
+++ b/src/SharpEmu.Libs/Ngs2/Ngs2VagDecoder.cs
@@ -96,34 +96,49 @@ public static class Ngs2VagDecoder
                 filter = 0;
             }
 
+            // Only 0-12 are meaningful shift factors; the SPU reads the reserved
+            // 13-15 as 9. Without this a frame carrying one decodes to near
+            // silence instead of the waveform the encoder intended.
+            if (shift > 12)
+            {
+                shift = 9;
+            }
+
             // Per-frame loop marker (exact PS-ADPCM values, not bit masks):
-            //   3 = loop start, 6 = loop end + jump back, 1/7 = one-shot end.
+            //   6 = loop start (save the address), 3 = loop end (jump back),
+            //   1 = end marker, 7 = end marker whose own frame decodes as silence.
             var flags = frames[offset + 1];
             var blockStart = outIndex;
-            if (flags == 0x03)
+            if (flags == 0x06)
             {
                 loopStart = blockStart;
             }
 
             var f0 = Coeff0[filter];
             var f1 = Coeff1[filter];
+            var discard = flags == 0x07;
             for (var i = 0; i < 14; i++)
             {
                 var d = frames[offset + 2 + i];
                 for (var nibble = 0; nibble < 2; nibble++)
                 {
-                    var raw = nibble == 0 ? d & 0x0F : d >> 4;
-                    // Sign-extend the 4-bit sample into the top nibble, then scale.
-                    var s = (short)(raw << 12) >> shift;
-                    var predicted = (hist1 * f0 + hist2 * f1) >> 6;
-                    var sample = Math.Clamp(s + predicted, short.MinValue, short.MaxValue);
+                    var sample = 0;
+                    if (!discard)
+                    {
+                        var raw = nibble == 0 ? d & 0x0F : d >> 4;
+                        // Sign-extend the 4-bit sample into the top nibble, then scale.
+                        var s = (short)(raw << 12) >> shift;
+                        var predicted = (hist1 * f0 + hist2 * f1) >> 6;
+                        sample = Math.Clamp(s + predicted, short.MinValue, short.MaxValue);
+                    }
+
                     samples[outIndex++] = (short)sample;
                     hist2 = hist1;
                     hist1 = sample;
                 }
             }
 
-            if (flags == 0x06)
+            if (flags == 0x03)
             {
                 loopEnd = outIndex;
             }

--- a/tests/SharpEmu.Libs.Tests/Audio/Ngs2VagDecoderTests.cs
+++ b/tests/SharpEmu.Libs.Tests/Audio/Ngs2VagDecoderTests.cs
@@ -1,0 +1,132 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.Libs.Ngs2;
+using Xunit;
+
+namespace SharpEmu.Libs.Tests.Audio;
+
+public sealed class Ngs2VagDecoderTests
+{
+    private const int SamplesPerFrame = 28;
+
+    [Fact]
+    public void LoopStartComesFromTheFrameFlaggedSix()
+    {
+        // A typical looping BGM: intro frame, loop-start frame (0x06),
+        // body, then the loop-end frame (0x03) closing the sample.
+        var frames = BuildFrames(flags: [0x00, 0x06, 0x00, 0x03]);
+
+        var waveform = Ngs2VagDecoder.Decode(frames, sampleRate: 48000);
+
+        Assert.Equal(SamplesPerFrame, waveform.LoopStart);
+        Assert.Equal(4 * SamplesPerFrame, waveform.LoopEnd);
+    }
+
+    [Fact]
+    public void LoopEndFlagDoesNotTruncateTheWaveform()
+    {
+        // Regression: flag 0x03 used to be read as "loop start", which left the
+        // loop covering only the tail frame and reduced a looping voice to a
+        // 28-sample buzz.
+        var frames = BuildFrames(flags: [0x06, 0x00, 0x03]);
+
+        var waveform = Ngs2VagDecoder.Decode(frames, sampleRate: 48000);
+
+        Assert.Equal(0, waveform.LoopStart);
+        Assert.Equal(3 * SamplesPerFrame, waveform.LoopEnd);
+    }
+
+    [Fact]
+    public void OneShotEndFlagStopsDecoding()
+    {
+        var frames = BuildFrames(flags: [0x00, 0x01, 0x00]);
+
+        var waveform = Ngs2VagDecoder.Decode(frames, sampleRate: 48000);
+
+        Assert.Equal(2 * SamplesPerFrame, waveform.Samples.Length);
+        Assert.Equal(-1, waveform.LoopStart);
+    }
+
+    [Fact]
+    public void DiscardEndFlagEmitsSilenceForItsOwnFrame()
+    {
+        // Flag 0x07 is "end marker, do not decode": the frame still occupies its
+        // 28 sample slots but the SPU outputs silence rather than the nibbles.
+        var frames = BuildFrames(flags: [0x00, 0x07]);
+
+        var waveform = Ngs2VagDecoder.Decode(frames, sampleRate: 48000);
+
+        Assert.Equal(2 * SamplesPerFrame, waveform.Samples.Length);
+        Assert.All(
+            waveform.Samples[SamplesPerFrame..].ToArray(),
+            sample => Assert.Equal(0, sample));
+    }
+
+    [Fact]
+    public void ReservedShiftFactorsDecodeAsNine()
+    {
+        // Shift factors 13-15 are out of range; the SPU treats them as 9, so a
+        // frame using one must decode identically to the same frame at shift 9.
+        var reserved = BuildFrames(flags: [0x00], shift: 15);
+        var nine = BuildFrames(flags: [0x00], shift: 9);
+
+        var reservedWaveform = Ngs2VagDecoder.Decode(reserved, sampleRate: 48000);
+        var nineWaveform = Ngs2VagDecoder.Decode(nine, sampleRate: 48000);
+
+        Assert.Equal(nineWaveform.Samples, reservedWaveform.Samples);
+    }
+
+    [Fact]
+    public void ContainerDecodeCarriesTheLoopPointsThroughToTheWaveform()
+    {
+        // The production path arms a voice from a whole "VAGp" container, so the
+        // loop markers have to survive the header/payload sizing too.
+        var container = BuildVagContainer(
+            BuildFrames(flags: [0x00, 0x06, 0x00, 0x03]),
+            sampleRate: 44100);
+
+        Assert.True(Ngs2VagDecoder.TryDecode(container, out var waveform));
+
+        Assert.Equal(44100, waveform.SampleRate);
+        Assert.Equal(SamplesPerFrame, waveform.LoopStart);
+        Assert.Equal(4 * SamplesPerFrame, waveform.LoopEnd);
+    }
+
+    [Fact]
+    public void NonVagBufferIsRejected()
+    {
+        Assert.False(Ngs2VagDecoder.TryDecode(new byte[Ngs2VagDecoder.VagHeaderSize + 16], out _));
+    }
+
+    // Wraps ADPCM frames in the 48-byte big-endian "VAGp" header the games use.
+    private static byte[] BuildVagContainer(byte[] frames, int sampleRate)
+    {
+        var container = new byte[Ngs2VagDecoder.VagHeaderSize + frames.Length];
+        BinaryPrimitives.WriteUInt32BigEndian(container, 0x56414770);
+        BinaryPrimitives.WriteUInt32BigEndian(container.AsSpan(0x0C), (uint)frames.Length);
+        BinaryPrimitives.WriteUInt32BigEndian(container.AsSpan(0x10), (uint)sampleRate);
+        frames.CopyTo(container.AsSpan(Ngs2VagDecoder.VagHeaderSize));
+        return container;
+    }
+
+    // Builds one 16-byte PS-ADPCM frame per flag, all sharing the same nibble
+    // payload so tests can compare frames purely by header.
+    private static byte[] BuildFrames(byte[] flags, int shift = 4, int filter = 0)
+    {
+        var frames = new byte[flags.Length * 16];
+        for (var frame = 0; frame < flags.Length; frame++)
+        {
+            var offset = frame * 16;
+            frames[offset] = (byte)((filter << 4) | shift);
+            frames[offset + 1] = flags[frame];
+            for (var i = 0; i < 14; i++)
+            {
+                frames[offset + 2 + i] = (byte)(0x19 + i);
+            }
+        }
+
+        return frames;
+    }
+}


### PR DESCRIPTION
## What this changes

`Ngs2VagDecoder` read PS-ADPCM frame flag `0x03` as loop start and `0x06` as loop
end. PS-ADPCM defines them the other way round — `0x06` saves the loop address
(start), `0x03` jumps back to it (end).

On a normal looping waveform (`0x06` on an early frame, `0x03` on the last) the
swap put the loop *end* 28 samples in and the loop *start* on the final frame.
The `loopEnd <= loopStart` fallback at the bottom of `Decode` then stretched the
end back out to the buffer length, leaving `loopStart` on the last frame and
`loopEnd` at the buffer end. A looping voice therefore played through once and
then repeated only its final 28-sample frame for as long as it stayed armed.

Two neighbouring frame-header defects are fixed in the same block:

- Shift factors 13–15 are reserved; the SPU reads them as 9. They were used
  verbatim, so a frame carrying one decoded to near silence.
- Flag `0x07` is "end marker, do not decode" — the frame still occupies its 28
  sample slots but outputs silence. Its nibbles were being decoded instead.

Reference used for the flag table and the shift-factor clamp: vgmstream's
`src/coding/psx_decoder.c`, which documents the values as Sony defines them and
whose own loop scanner uses `0x06` for start and `0x03` for end.

The predictor coefficients, the `>> 6` predictor scaling (no rounding constant)
and the `filter > 4 -> 0` clamp already matched that reference and are unchanged.

## Testing

> [!WARNING]
> **Not yet tested against a real game.** The decoder is only reached through
> `sceNgs2VoiceSetState`'s waveform-blocks param, and I have not run a title that
> arms an NGS2 sampler voice from a VAGp container. This needs game testing
> before it should be merged.

`Ngs2VagDecoder` had no test coverage at all, so this adds it:

- `tests/SharpEmu.Libs.Tests/Audio/Ngs2VagDecoderTests.cs` — 7 tests covering the
  loop markers, the one-shot and discard end markers, the reserved shift
  factors, and the `VAGp` container entry point that production actually calls.

Four of them fail on `main`. `LoopStartComesFromTheFrameFlaggedSix` reports
`LoopStart` = 84 (the last frame of a 4-frame waveform) instead of 28, which is
the swap reproduced directly.

Suite results with the change:

| Project | Result |
| --- | --- |
| `SharpEmu.Libs.Tests` | 857 passed (850 on `main` + 7 new) |
| `SharpEmu.ShaderCompiler.Tests` | 95 passed |
| `SharpEmu.ShaderCompiler.Metal.Tests` | 60 passed |
| `SharpEmu.SourceGenerators.Tests` | 36 passed |

`dotnet build SharpEmu.slnx` succeeds with 0 warnings.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [ ] I tested my changes or marked the testing section as `N/A`.
- [ ] I wrote this pull request description myself and did not paste AI-generated explanations.
- [ ] I listed the game(s) I tested (or marked the testing section as `N/A`).

> The last three boxes are deliberately left unticked. This change was written
> with AI assistance and the description above is AI-drafted, so per the
> "AI-Assisted Contributions" section of `CONTRIBUTING.md` it needs to be
> restated in the author's own words, and the game testing still has to be done,
> before this leaves draft.
