### PR TITLE
fix(macos): POSIX TBB workers, RGB10 present encode, DCC image publish

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.NativeWorker.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.NativeWorker.cs
@@ -180,7 +180,7 @@ public sealed partial class DirectExecutionBackend
 
 	private void PrewarmNativeGuestWorkers(int count)
 	{
-		if (!OperatingSystem.IsWindows() || NativeGuestWorkersDisabled || count <= 0)
+		if (NativeGuestWorkersDisabled || count <= 0)
 		{
 			return;
 		}
@@ -223,10 +223,10 @@ public sealed partial class DirectExecutionBackend
 
 	private NativeGuestExecutor? RentNativeGuestExecutor()
 	{
-		// NativeGuestExecutor emits a Win32 wait loop and creates it with
-		// kernel32!CreateThread. POSIX hosts use the established inline entry
-		// path until the worker loop has a pthread/eventfd implementation.
-		if (!OperatingSystem.IsWindows() || NativeGuestWorkersDisabled)
+		// Windows uses the kernel32 wait loop; POSIX uses the same emitted loop
+		// with the calls routed through Win64->SysV thunks (worker semaphores +
+		// managed UnmanagedCallersOnly stubs, see EnsureWorkerLoopImports).
+		if (NativeGuestWorkersDisabled)
 		{
 			return null;
 		}
@@ -332,6 +332,9 @@ public sealed partial class DirectExecutionBackend
 		// calls through register-shuffling thunks (shared by all workers).
 		private static nint _posixPrologueThunk;
 		private static nint _posixEpilogueThunk;
+		private static nint _posixWaitEventThunk;
+		private static nint _posixSignalEventThunk;
+		private static nint _posixExitThreadThunk;
 		private static readonly object PosixThunkGate = new();
 		private GCHandle _selfHandle;
 		private void* _controlBlock;
@@ -380,7 +383,7 @@ public sealed partial class DirectExecutionBackend
 
 		public static NativeGuestExecutor? TryCreate(DirectExecutionBackend backend)
 		{
-			if (!EnsureKernel32Exports())
+			if (!EnsureWorkerLoopImports())
 			{
 				return null;
 			}
@@ -393,21 +396,78 @@ public sealed partial class DirectExecutionBackend
 			return executor;
 		}
 
-		private static bool EnsureKernel32Exports()
+		// Resolves the three kernel32 entry points the emitted loop embeds. On
+		// POSIX the same Win64-ABI call sites are kept and each import is a
+		// Win64->SysV thunk wrapping a managed UnmanagedCallersOnly stub, so the
+		// emitter below stays byte-identical across platforms.
+		private static bool EnsureWorkerLoopImports()
 		{
 			if (_exitThreadAddress != 0)
 			{
 				return _waitForSingleObjectAddress != 0 && _setEventAddress != 0;
 			}
-			nint kernel32 = GetModuleHandle("kernel32.dll");
-			if (kernel32 == 0)
+			if (OperatingSystem.IsWindows())
 			{
-				return false;
+				nint kernel32 = GetModuleHandle("kernel32.dll");
+				if (kernel32 == 0)
+				{
+					return false;
+				}
+				_waitForSingleObjectAddress = GetProcAddress(kernel32, "WaitForSingleObject");
+				_setEventAddress = GetProcAddress(kernel32, "SetEvent");
+				_exitThreadAddress = GetProcAddress(kernel32, "ExitThread");
+				return _waitForSingleObjectAddress != 0 && _setEventAddress != 0 && _exitThreadAddress != 0;
 			}
-			_waitForSingleObjectAddress = GetProcAddress(kernel32, "WaitForSingleObject");
-			_setEventAddress = GetProcAddress(kernel32, "SetEvent");
-			_exitThreadAddress = GetProcAddress(kernel32, "ExitThread");
+
+			lock (PosixThunkGate)
+			{
+				if (_posixExitThreadThunk == 0)
+				{
+					_posixWaitEventThunk = PosixHostStubs.CreateWin64ToSysVThunk(
+						(nint)(delegate* unmanaged<nint, uint, int>)&WaitForEventPosix);
+					_posixSignalEventThunk = PosixHostStubs.CreateWin64ToSysVThunk(
+						(nint)(delegate* unmanaged<nint, int>)&SignalEventPosix);
+					_posixExitThreadThunk = PosixHostStubs.CreateWin64ToSysVThunk(
+						(nint)(delegate* unmanaged<nint, void>)&ExitThreadPosix);
+				}
+			}
+			_waitForSingleObjectAddress = _posixWaitEventThunk;
+			_setEventAddress = _posixSignalEventThunk;
+			_exitThreadAddress = _posixExitThreadThunk;
 			return _waitForSingleObjectAddress != 0 && _setEventAddress != 0 && _exitThreadAddress != 0;
+		}
+
+		// SysV stubs behind the Win64->SysV thunks. WaitForSingleObject returns
+		// WAIT_OBJECT_0 (0) on success and the emitted loop ignores the value;
+		// INFINITE (0xFFFFFFFF) maps to the wait-forever sentinel.
+		[UnmanagedCallersOnly]
+		private static int WaitForEventPosix(nint handle, uint timeoutMilliseconds)
+		{
+			_ = PosixHostStubs.WaitWorkerEvent(
+				handle,
+				timeoutMilliseconds == 0xFFFFFFFFu ? -1 : unchecked((int)timeoutMilliseconds));
+			return 0;
+		}
+
+		[UnmanagedCallersOnly]
+		private static int SignalEventPosix(nint handle)
+		{
+			_ = PosixHostStubs.SignalWorkerEvent(handle);
+			return 1;
+		}
+
+		[UnmanagedCallersOnly]
+		private static void ExitThreadPosix(nint exitCode)
+		{
+			PosixHostStubs.pthread_exit(exitCode);
+		}
+
+		// Used by the backend constructor to build the worker abort stub's
+		// SetEvent import before any executor exists.
+		internal static nint CreateSignalEventWin64Thunk()
+		{
+			return PosixHostStubs.CreateWin64ToSysVThunk(
+				(nint)(delegate* unmanaged<nint, int>)&SignalEventPosix);
 		}
 
 		private bool Initialize()
@@ -547,6 +607,45 @@ public sealed partial class DirectExecutionBackend
 
 		private bool StartWorkerThread()
 		{
+			if (!OperatingSystem.IsWindows())
+			{
+				// The loop stub ignores the pthread argument and never returns
+				// (pthread_exit), so it doubles as the start routine directly.
+				var attr = Marshal.AllocHGlobal(256);
+				try
+				{
+					if (PosixHostStubs.pthread_attr_init(attr) != 0)
+					{
+						return false;
+					}
+					if (PosixHostStubs.pthread_attr_setstacksize(attr, WorkerStackReservation) != 0)
+					{
+						_ = PosixHostStubs.pthread_attr_destroy(attr);
+						return false;
+					}
+
+					nint thread = 0;
+					var rc = PosixHostStubs.pthread_create(&thread, attr, (nint)_loopStub, 0);
+					_ = PosixHostStubs.pthread_attr_destroy(attr);
+					if (rc != 0)
+					{
+						return false;
+					}
+
+					_threadHandle = thread;
+					_nativeThreadId = 0;
+				}
+				finally
+				{
+					Marshal.FreeHGlobal(attr);
+				}
+				if (LogThreadMode)
+				{
+					TraceThreadMode($"worker_created native_tid=posix loop=0x{(ulong)_loopStub:X16}");
+				}
+				return true;
+			}
+
 			_threadHandle = CreateThread(
 				0,
 				WorkerStackReservation,
@@ -597,7 +696,22 @@ public sealed partial class DirectExecutionBackend
 			// TBB abort stub SetEvent's without ExitRun — _entered stays true.
 			if (_entered)
 			{
-				var waitRc = WaitForSingleObject(_threadHandle, 500u);
+				uint waitRc;
+				if (OperatingSystem.IsWindows())
+				{
+					waitRc = WaitForSingleObject(_threadHandle, 500u);
+				}
+				else
+				{
+					// The abort victim parks in guest code with asynchronous
+					// cancellation enabled (set in EnterRun), so cancel + join
+					// mirrors the TerminateThread+wait below. Killed-thread libc
+					// state is accepted collateral, same as Windows.
+					_ = PosixHostStubs.pthread_cancel(_threadHandle);
+					waitRc = PosixHostStubs.pthread_join(_threadHandle, null) == 0
+						? 0u
+						: 0xFFFFFFFFu;
+				}
 				Console.Error.WriteLine(
 					$"[LOADER][WARN] Native guest worker tid={_nativeThreadId} aborted during run; " +
 					$"wait_rc=0x{waitRc:X8} respawning");
@@ -612,14 +726,17 @@ public sealed partial class DirectExecutionBackend
 				_entered = false;
 				if (_threadHandle != 0)
 				{
-					// Abort stub parks (no ExitThread). Force-kill the parked OS
-					// thread so we can recreate the loop without process teardown.
-					if (waitRc != 0u)
+					if (OperatingSystem.IsWindows())
 					{
-						_ = TerminateThread(_threadHandle, unchecked((uint)(-1)));
-						_ = WaitForSingleObject(_threadHandle, 1000u);
+						// Abort stub parks (no ExitThread). Force-kill the parked OS
+						// thread so we can recreate the loop without process teardown.
+						if (waitRc != 0u)
+						{
+							_ = TerminateThread(_threadHandle, unchecked((uint)(-1)));
+							_ = WaitForSingleObject(_threadHandle, 1000u);
+						}
 					}
-					CloseHandle(_threadHandle);
+					_ = CloseHandle(_threadHandle);
 					_threadHandle = 0;
 					_nativeThreadId = 0;
 				}
@@ -730,6 +847,15 @@ public sealed partial class DirectExecutionBackend
 		private nint EnterRun()
 		{
 			var backend = _backend;
+			if (!OperatingSystem.IsWindows())
+			{
+				// Enable asynchronous cancellation on the worker thread so the
+				// abort path (Run) can kill a victim parked mid-guest-code.
+				int oldCancelType;
+				_ = PosixHostStubs.pthread_setcanceltype(
+					PosixHostStubs.PthreadCancelAsynchronous,
+					&oldCancelType);
+			}
 			_prevBackend = _activeExecutionBackend;
 			_prevContext = _activeCpuContext;
 			_prevSentinel = _activeEntryReturnSentinelRip;
@@ -841,9 +967,20 @@ public sealed partial class DirectExecutionBackend
 			var exited = _threadHandle == 0;
 			if (_threadHandle != 0)
 			{
-				exited = WaitForSingleObject(_threadHandle, 1000u) == 0u;
-				CloseHandle(_threadHandle);
+				if (OperatingSystem.IsWindows())
+				{
+					exited = WaitForSingleObject(_threadHandle, 1000u) == 0u;
+				}
+				else
+				{
+					// Teardown only happens after guest quiescence, so the worker
+					// is parked in the loop wait (not in guest code) and processes
+					// the stop flag promptly; pthread_join returns immediately.
+					exited = PosixHostStubs.pthread_join(_threadHandle, null) == 0;
+				}
+				_ = CloseHandle(_threadHandle);
 				_threadHandle = 0;
+				_nativeThreadId = 0;
 			}
 			if (!exited)
 			{

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -1054,8 +1054,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		_selfHandlePtr = GCHandle.ToIntPtr(_selfHandle);
 		_guestTlsBaseTlsIndex = TlsAlloc();
 		_hostRspSlotTlsIndex = TlsAlloc();
-		_workerDoneEventTlsIndex = OperatingSystem.IsWindows() ? TlsAlloc() : uint.MaxValue;
-		_tbbAbortEligibleTlsIndex = OperatingSystem.IsWindows() ? TlsAlloc() : uint.MaxValue;
+		_workerDoneEventTlsIndex = TlsAlloc();
+		_tbbAbortEligibleTlsIndex = TlsAlloc();
 		if (_guestTlsBaseTlsIndex == uint.MaxValue || _hostRspSlotTlsIndex == uint.MaxValue)
 		{
 			throw new OutOfMemoryException("Failed to allocate native TLS slots");
@@ -1089,6 +1089,9 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			_queryPerformanceCounterAddress = PosixHostStubs.QueryPerformanceCounterStubAddress;
 			_switchToThreadAddress = PosixHostStubs.SwitchToThreadStubAddress;
 			_sleepAddress = PosixHostStubs.SleepStubAddress;
+			// The worker abort stub needs SetEvent as well; route it through
+			// the same Win64->SysV thunk the worker loop uses.
+			_setEventAddress = NativeGuestExecutor.CreateSignalEventWin64Thunk();
 		}
 		_tlsBaseAddress = (nint)VirtualAlloc(null, 4096u, 12288u, 4u);
 		if (_tlsBaseAddress == 0)
@@ -1123,9 +1126,49 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			Console.Error.WriteLine(
 				"[LOADER][WARN] Worker abort stub unavailable; TBB execute-fault recover will use host_exit");
 		}
+		WarmUpWorkerAbortStub(_workerAbortStub);
 		SetupExceptionHandler();
 		// Cover the Astro TBB spawn storm (often 8–12 concurrent tbb_thead).
 		PrewarmNativeGuestWorkers(Math.Max(NativeWorkerMaxConcurrent, 4));
+	}
+
+	/// <summary>
+	/// Runs the worker abort stub once on a disposable thread so Rosetta 2
+	/// translates its bytes: entering never-translated code from a signal
+	/// resume silently fails under Rosetta (see WarmUpPosixSignalPath), which
+	/// would leave the TBB fault recovery parked without SetEvent and wedge
+	/// the renting thread. The warmup caller's TLS done-event slot is unset,
+	/// so the stub skips SetEvent and parks; async cancellation reclaims it.
+	/// </summary>
+	private unsafe void WarmUpWorkerAbortStub(nint stub)
+	{
+		if (stub < 0x10000 || OperatingSystem.IsWindows())
+		{
+			return;
+		}
+
+		var attr = Marshal.AllocHGlobal(256);
+		try
+		{
+			if (PosixHostStubs.pthread_attr_init(attr) != 0)
+			{
+				return;
+			}
+			_ = PosixHostStubs.pthread_attr_setstacksize(attr, 1024u * 1024u);
+			nint thread = 0;
+			if (PosixHostStubs.pthread_create(&thread, attr, stub, 0) == 0)
+			{
+				Thread.Sleep(100);
+				_ = PosixHostStubs.pthread_cancel(thread);
+				_ = PosixHostStubs.pthread_join(thread, null);
+				Console.Error.WriteLine("[LOADER][INFO] Worker abort stub warmed (translated) on a disposable thread");
+			}
+			_ = PosixHostStubs.pthread_attr_destroy(attr);
+		}
+		finally
+		{
+			Marshal.FreeHGlobal(attr);
+		}
 	}
 
 	public bool TryExecute(CpuContext context, ulong entryPoint, Generation generation, IReadOnlyDictionary<ulong, string> importStubs, IReadOnlyDictionary<string, ulong> runtimeSymbols, CpuExecutionOptions executionOptions, out OrbisGen2Result result)
@@ -2460,18 +2503,18 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 	/// </summary>
 	private unsafe nint CreateWorkerAbortStub()
 	{
-		if (!OperatingSystem.IsWindows() ||
-			_workerDoneEventTlsIndex == uint.MaxValue ||
+		if (_workerDoneEventTlsIndex == uint.MaxValue ||
 			_tlsGetValueAddress == 0 ||
 			_setEventAddress == 0)
 		{
 			return 0;
 		}
 
-		nint kernel32 = GetModuleHandle("kernel32.dll");
+		nint kernel32 = OperatingSystem.IsWindows() ? GetModuleHandle("kernel32.dll") : 0;
 		nint getStdHandle = kernel32 != 0 ? GetProcAddress(kernel32, "GetStdHandle") : 0;
 		nint writeFile = kernel32 != 0 ? GetProcAddress(kernel32, "WriteFile") : 0;
 		nint flushFileBuffers = kernel32 != 0 ? GetProcAddress(kernel32, "FlushFileBuffers") : 0;
+		nint pthreadExitPosix = OperatingSystem.IsWindows() ? 0 : PosixHostStubs.GetLibcExport("pthread_exit");
 
 		const uint stubSize = 256u;
 		void* ptr = VirtualAlloc(null, stubSize, 12288u, 4u);
@@ -2551,10 +2594,26 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		}
 
 		// Park: do not ExitThread (process-wide silent die after VEH redirect).
+		// On POSIX the stub runs after sigreturn (plain thread context), so it
+		// can terminate itself with pthread_exit right after SetEvent: the
+		// renter sees the abort, joins the dead thread and respawns — no
+		// parked thread to cancel, no async-cancel libc hazard.
 		int parkOffset = offset;
-		EmitByte(code, ref offset, 0xF3); EmitByte(code, ref offset, 0x90); // pause
-		EmitByte(code, ref offset, 0xEB);
-		EmitByte(code, ref offset, unchecked((byte)(parkOffset - (offset + 1)))); // jmp park
+		if (OperatingSystem.IsWindows())
+		{
+			EmitByte(code, ref offset, 0xF3); EmitByte(code, ref offset, 0x90); // pause
+			EmitByte(code, ref offset, 0xEB);
+			EmitByte(code, ref offset, unchecked((byte)(parkOffset - (offset + 1)))); // jmp park
+		}
+		else
+		{
+			EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x31); EmitByte(code, ref offset, 0xFF); // xor rdi, rdi
+			EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xB8);
+			*(nint*)(code + offset) = pthreadExitPosix;
+			offset += sizeof(nint);
+			EmitByte(code, ref offset, 0xFF); EmitByte(code, ref offset, 0xD0); // call pthread_exit
+			EmitByte(code, ref offset, 0xCC);                                   // int3 (never returns)
+		}
 
 		if (msgAbsSlot >= 0)
 		{

--- a/src/SharpEmu.Core/Cpu/Native/PosixHostStubs.cs
+++ b/src/SharpEmu.Core/Cpu/Native/PosixHostStubs.cs
@@ -274,7 +274,7 @@ internal static unsafe class PosixHostStubs
 
         // Linux: call pthread_getspecific, preserving the registers that are
         // volatile in SysV but non-volatile in Win64 (rsi, rdi).
-        var pthreadGetSpecific = ResolveLibcExport("pthread_getspecific");
+        var pthreadGetSpecific = GetLibcExport("pthread_getspecific");
         Emit(page, ref offset, 0x56);                                               // push rsi
         Emit(page, ref offset, 0x57);                                               // push rdi
         Emit(page, ref offset, 0x48, 0x83, 0xEC, 0x08);                             // sub rsp, 8
@@ -305,7 +305,7 @@ internal static unsafe class PosixHostStubs
 
     private static nint EmitSwitchToThread(byte* page, ref int offset)
     {
-        var schedYield = ResolveLibcExport("sched_yield");
+        var schedYield = GetLibcExport("sched_yield");
         var start = (nint)(page + offset);
         Emit(page, ref offset, 0x56);                                               // push rsi
         Emit(page, ref offset, 0x57);                                               // push rdi
@@ -323,7 +323,7 @@ internal static unsafe class PosixHostStubs
     private static nint EmitSleep(byte* page, ref int offset)
     {
         // void Sleep(DWORD milliseconds in ecx) -> usleep(microseconds in edi).
-        var usleep = ResolveLibcExport("usleep");
+        var usleep = GetLibcExport("usleep");
         var start = (nint)(page + offset);
         Emit(page, ref offset, 0x56);                                               // push rsi
         Emit(page, ref offset, 0x57);                                               // push rdi
@@ -342,7 +342,7 @@ internal static unsafe class PosixHostStubs
         return start;
     }
 
-    private static nint ResolveLibcExport(string name)
+    public static nint GetLibcExport(string name)
     {
         var libc = NativeLibrary.Load(OperatingSystem.IsMacOS() ? "libSystem.dylib" : "libc.so.6");
         return NativeLibrary.GetExport(libc, name);
@@ -422,4 +422,33 @@ internal static unsafe class PosixHostStubs
 
     [DllImport("libc")]
     private static extern int sem_destroy(nint semaphore);
+
+    // pthread primitives for native guest workers on POSIX hosts. pthread_t is
+    // pointer-sized on both macOS and Linux x86-64.
+    [DllImport("libc")]
+    public static extern int pthread_create(nint* thread, nint attr, nint startRoutine, nint arg);
+
+    [DllImport("libc")]
+    public static extern int pthread_join(nint thread, nint* retval);
+
+    [DllImport("libc")]
+    public static extern int pthread_cancel(nint thread);
+
+    [DllImport("libc")]
+    public static extern int pthread_attr_init(nint attr);
+
+    [DllImport("libc")]
+    public static extern int pthread_attr_setstacksize(nint attr, nuint stackSize);
+
+    [DllImport("libc")]
+    public static extern int pthread_attr_destroy(nint attr);
+
+    /// <summary>PTHREAD_CANCEL_ASYNCHRONOUS so a parked abort victim dies promptly.</summary>
+    public const int PthreadCancelAsynchronous = 1;
+
+    [DllImport("libc")]
+    public static extern int pthread_setcanceltype(int type, int* oldtype);
+
+    [DllImport("libc")]
+    public static extern void pthread_exit(nint value);
 }

--- a/src/SharpEmu.Libs/Agc/AgcExports.cs
+++ b/src/SharpEmu.Libs/Agc/AgcExports.cs
@@ -5292,11 +5292,22 @@ public static partial class AgcExports
                     VideoOutExports.TryGetDisplayBufferInfo(
                         handle,
                         displayBufferIndex,
-                        out var pendingDisplayBuffer) &&
-                    state.KnownRenderTargets.TryGetValue(
-                        pendingDisplayBuffer.Address,
-                        out var pendingDisplayTarget))
+                        out var pendingDisplayBuffer))
                 {
+                    if (!state.KnownRenderTargets.TryGetValue(
+                            pendingDisplayBuffer.Address,
+                            out var pendingDisplayTarget))
+                    {
+                        pendingDisplayTarget = new RenderTargetDescriptor(
+                            0,
+                            pendingDisplayBuffer.Address,
+                            pendingDisplayBuffer.Width,
+                            pendingDisplayBuffer.Height,
+                            9,
+                            0,
+                            0);
+                    }
+
                     var textures = CreateGuestDrawTextures(
                         ctx,
                         pendingComposite.Textures,
@@ -8112,15 +8123,6 @@ public static partial class AgcExports
 var renderTargets = GetRenderTargets(state.CxRegisters);
         TrackCmaskAddresses(state.CxRegisters, renderTargets);
         var drawSequence = ++gpuState.WorkSequence;
-        if (state.PendingTargetlessDraw is { } stalePendingDraw)
-        {
-            ReturnPooledDrawArrays(
-                stalePendingDraw,
-                globals: true,
-                vertex: true,
-                index: true);
-            state.PendingTargetlessDraw = null;
-        }
         state.TranslatedDraw = null;
         state.GuestDrawKind = GuestDrawKind.None;
 
@@ -8352,12 +8354,15 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
             // modelling DCC block state.
             if (translatedDraw.IsDccFastClear)
             {
-                foreach (var target in translatedDraw.GuestTargets)
+                // Still create host GPU images (zero clear). RequestGuestColorClear
+                // alone never publishes _availableGuestImages, so later composites
+                // sample empty CPU tiles (Astro title gray/black).
+                if (translatedDraw.GuestTargets.Count > 0)
                 {
-                    if (target.Address != 0)
-                    {
-                        VulkanVideoPresenter.RequestGuestColorClear(target.Address);
-                    }
+                    VulkanVideoPresenter.SubmitOffscreenColorClear(
+                        translatedDraw.GuestTargets,
+                        0f, 0f, 0f, 0f,
+                        translatedDraw.PixelShaderAddress);
                 }
 
                 ReturnPooledDrawArrays(
@@ -9037,7 +9042,7 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
         // draw a multi-render-target G-buffer (up to eight slots) in one pass.
         // Fall back to slot 0 if we cannot match any export to a bound target.
         var pixelColorExportMasks = pixelState.Program.PixelColorExportMasks;
-        var allBoundTargets = GetRenderTargets(state.CxRegisters);
+        var allBoundTargets = GetRenderTargets(state.CxRegisters, includeMaskedTargets: true);
         // At most 8 slots; a manual filter avoids the per-draw LINQ iterator/
         // closure allocations. Slots are distinct, so sorting by slot is stable.
         var selectedTargets = new List<RenderTargetDescriptor>(allBoundTargets.Count);
@@ -9051,13 +9056,7 @@ var renderTargets = GetRenderTargets(state.CxRegisters);
 
         if (selectedTargets.Count == 0)
         {
-            foreach (var target in allBoundTargets)
-            {
-                if (target.Slot == 0)
-                {
-                    selectedTargets.Add(target);
-                }
-            }
+            selectedTargets.AddRange(allBoundTargets);
         }
 
         selectedTargets.Sort(static (left, right) => left.Slot.CompareTo(right.Slot));
@@ -11628,9 +11627,14 @@ private static long _indirectDrawProbeCount;
         // With the write tracker off (Windows default), IsGuestImageUploadKnown
         // uses a cheap guest-memory probe so static UI can still skip (Dead
         // Cells menus) while changing CPU content (GTA Bink) forces a copy.
-        if (!isStorage &&
+        if (!_textureCopySkipDisabled &&
+            !isStorage &&
             !wantsArrayUpload &&
             descriptor.Address != 0 &&
+            GuestGpu.Current.IsGpuGuestImageAvailable(
+                descriptor.Address,
+                descriptor.Format,
+                descriptor.NumberType) &&
             GuestGpu.Current.IsGuestImageUploadKnown(
                 descriptor.Address,
                 descriptor.Format,

--- a/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
+++ b/src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs
@@ -1905,6 +1905,9 @@ internal static unsafe class VulkanVideoPresenter
     internal static bool IsLinearFloatPresentSource(Format format) =>
         format is Format.R16G16B16A16Sfloat or Format.R32G32B32A32Sfloat;
 
+    internal static bool IsPackedRgb10PresentSource(Format format) =>
+        format is Format.A2R10G10B10UnormPack32 or Format.A2B10G10R10UnormPack32;
+
     // A guest image accepts a request in a different Vulkan format without
     // being recreated when the two formats are the same texel layout read
     // through different transfer functions (sRGB vs UNORM counterparts).
@@ -2033,6 +2036,11 @@ internal static unsafe class VulkanVideoPresenter
         if (address == 0 || guestFormat == 0)
         {
             return;
+        }
+
+        if ((guestFormat & 0x8000_0000u) == 0)
+        {
+            guestFormat = 0x8000_0000u | ((guestFormat & 0x1FFu) << 8);
         }
 
         lock (_gate)
@@ -2339,7 +2347,8 @@ internal static unsafe class VulkanVideoPresenter
     }
 
     private static bool IsKnownGuestTextureFormat(uint format) =>
-        format is >= 1 and <= 19 or 34 or >= 169 and <= 182;
+        format is >= 1 and <= 19 or 20 or 22 or 29 or 34 or 36 or 49 or 56 or 62 or 64 or 71 or 75
+            or >= 169 and <= 182;
 
     private static byte[] CreateBlackFrame(uint width, uint height)
     {
@@ -18312,7 +18321,8 @@ internal static unsafe class VulkanVideoPresenter
                 (_presentEncodeExtent.Width != _extent.Width ||
                  _presentEncodeExtent.Height != _extent.Height))
             {
-                DestroyPresentEncodeImage();
+            DestroyPresentEncodeImage();
+            DestroyPresentUnpackImage();
             }
 
             if (_presentEncodeImage.Handle == 0)
@@ -18381,6 +18391,89 @@ internal static unsafe class VulkanVideoPresenter
             _presentEncodeExtent = default;
         }
 
+        private Image _presentUnpackImage;
+        private DeviceMemory _presentUnpackMemory;
+        private Extent2D _presentUnpackExtent;
+
+        private bool TryGetPresentUnpackImage(uint width, uint height, out Image unpackImage)
+        {
+            unpackImage = default;
+            if (width == 0 || height == 0)
+            {
+                return false;
+            }
+
+            if (_presentUnpackImage.Handle != 0 &&
+                (_presentUnpackExtent.Width != width || _presentUnpackExtent.Height != height))
+            {
+                DestroyPresentUnpackImage();
+            }
+
+            if (_presentUnpackImage.Handle == 0)
+            {
+                var imageInfo = new ImageCreateInfo
+                {
+                    SType = StructureType.ImageCreateInfo,
+                    ImageType = ImageType.Type2D,
+                    Format = Format.R16G16B16A16Sfloat,
+                    Extent = new Extent3D(width, height, 1),
+                    MipLevels = 1,
+                    ArrayLayers = 1,
+                    Samples = SampleCountFlags.Count1Bit,
+                    Tiling = ImageTiling.Optimal,
+                    Usage = ImageUsageFlags.TransferDstBit | ImageUsageFlags.TransferSrcBit,
+                    SharingMode = SharingMode.Exclusive,
+                    InitialLayout = ImageLayout.Undefined,
+                };
+                Check(
+                    _vk.CreateImage(_device, &imageInfo, null, out _presentUnpackImage),
+                    "vkCreateImage(present unpack)");
+                _vk.GetImageMemoryRequirements(
+                    _device,
+                    _presentUnpackImage,
+                    out var requirements);
+                var allocationInfo = new MemoryAllocateInfo
+                {
+                    SType = StructureType.MemoryAllocateInfo,
+                    AllocationSize = requirements.Size,
+                    MemoryTypeIndex = FindMemoryType(
+                        requirements.MemoryTypeBits,
+                        MemoryPropertyFlags.DeviceLocalBit),
+                };
+                Check(
+                    _vk.AllocateMemory(_device, &allocationInfo, null, out _presentUnpackMemory),
+                    "vkAllocateMemory(present unpack)");
+                Check(
+                    _vk.BindImageMemory(_device, _presentUnpackImage, _presentUnpackMemory, 0),
+                    "vkBindImageMemory(present unpack)");
+                _presentUnpackExtent = new Extent2D(width, height);
+                SetDebugName(
+                    ObjectType.Image,
+                    _presentUnpackImage.Handle,
+                    "SharpEmu present RGB10 unpack image");
+            }
+
+            unpackImage = _presentUnpackImage;
+            return true;
+        }
+
+        private void DestroyPresentUnpackImage()
+        {
+            if (_presentUnpackImage.Handle != 0)
+            {
+                _vk.DestroyImage(_device, _presentUnpackImage, null);
+                _presentUnpackImage = default;
+            }
+
+            if (_presentUnpackMemory.Handle != 0)
+            {
+                _vk.FreeMemory(_device, _presentUnpackMemory, null);
+                _presentUnpackMemory = default;
+            }
+
+            _presentUnpackExtent = default;
+        }
+
         private void RecordGuestImageBlit(
             uint imageIndex,
             GuestImageResource source)
@@ -18437,10 +18530,17 @@ internal static unsafe class VulkanVideoPresenter
             };
             // Linear-float flips need a linear->sRGB encode on the way to a
             // UNORM swapchain; sRGB (or unknown-counterpart) swapchains keep
-            // the direct blit.
+            // the direct blit. Packed RGB10 cannot blit directly into sRGB on
+            // MoltenVK (horizontal stripes) — unpack to RGBA16F first.
+            Image unpackImage = default;
+            var unpackForPresent = IsPackedRgb10PresentSource(source.Format) &&
+                TryGetPresentUnpackImage(source.Width, source.Height, out unpackImage);
+            var presentSourceFormat = unpackForPresent
+                ? Format.R16G16B16A16Sfloat
+                : source.Format;
             var encodeForPresent = false;
             Image encodeImage = default;
-            if (IsLinearFloatPresentSource(source.Format) &&
+            if (IsLinearFloatPresentSource(presentSourceFormat) &&
                 GetSrgbCounterpart(_swapchainFormat) != Format.Undefined)
             {
                 encodeForPresent = TryGetPresentEncodeImage(out encodeImage);
@@ -18473,6 +18573,72 @@ internal static unsafe class VulkanVideoPresenter
                 null,
                 encodeForPresent ? 3u : 2u,
                 barriers);
+
+            var blitSource = source.Image;
+            if (unpackForPresent)
+            {
+                var unpackToDst = new ImageMemoryBarrier
+                {
+                    SType = StructureType.ImageMemoryBarrier,
+                    SrcAccessMask = 0,
+                    DstAccessMask = AccessFlags.TransferWriteBit,
+                    OldLayout = ImageLayout.Undefined,
+                    NewLayout = ImageLayout.TransferDstOptimal,
+                    SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                    DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                    Image = unpackImage,
+                    SubresourceRange = ColorSubresourceRange(),
+                };
+                _vk.CmdPipelineBarrier(
+                    _commandBuffer,
+                    PipelineStageFlags.TransferBit,
+                    PipelineStageFlags.TransferBit,
+                    0, 0, null, 0, null, 1, &unpackToDst);
+                var unpackRegion = new ImageBlit
+                {
+                    SrcSubresource = new ImageSubresourceLayers(
+                        ImageAspectFlags.ColorBit, 0, 0, 1),
+                    SrcOffsets = new ImageBlit.SrcOffsetsBuffer
+                    {
+                        Element0 = new Offset3D(0, 0, 0),
+                        Element1 = new Offset3D((int)source.Width, (int)source.Height, 1),
+                    },
+                    DstSubresource = new ImageSubresourceLayers(
+                        ImageAspectFlags.ColorBit, 0, 0, 1),
+                    DstOffsets = new ImageBlit.DstOffsetsBuffer
+                    {
+                        Element0 = new Offset3D(0, 0, 0),
+                        Element1 = new Offset3D((int)source.Width, (int)source.Height, 1),
+                    },
+                };
+                _vk.CmdBlitImage(
+                    _commandBuffer,
+                    source.Image,
+                    ImageLayout.TransferSrcOptimal,
+                    unpackImage,
+                    ImageLayout.TransferDstOptimal,
+                    1,
+                    &unpackRegion,
+                    Filter.Nearest);
+                var unpackToSrc = new ImageMemoryBarrier
+                {
+                    SType = StructureType.ImageMemoryBarrier,
+                    SrcAccessMask = AccessFlags.TransferWriteBit,
+                    DstAccessMask = AccessFlags.TransferReadBit,
+                    OldLayout = ImageLayout.TransferDstOptimal,
+                    NewLayout = ImageLayout.TransferSrcOptimal,
+                    SrcQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                    DstQueueFamilyIndex = Vk.QueueFamilyIgnored,
+                    Image = unpackImage,
+                    SubresourceRange = ColorSubresourceRange(),
+                };
+                _vk.CmdPipelineBarrier(
+                    _commandBuffer,
+                    PipelineStageFlags.TransferBit,
+                    PipelineStageFlags.TransferBit,
+                    0, 0, null, 0, null, 1, &unpackToSrc);
+                blitSource = unpackImage;
+            }
 
             var sourceX = 0u;
             var sourceY = 0u;
@@ -18578,7 +18744,7 @@ internal static unsafe class VulkanVideoPresenter
                 destinationWidth % sourceWidth == 0 && destinationHeight % sourceHeight == 0;
             _vk.CmdBlitImage(
                 _commandBuffer,
-                source.Image,
+                blitSource,
                 ImageLayout.TransferSrcOptimal,
                 encodeForPresent ? encodeImage : presentationTarget,
                 ImageLayout.TransferDstOptimal,

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
@@ -976,6 +976,61 @@ public static partial class Gen5SpirvTranslator
                         vector);
                     break;
                 }
+                case "VCvtPkU16U32":
+                {
+                    var lo = Ext(38, _uintType, GetRawSource(instruction, 0), UInt(0xFFFFu));
+                    var hi = Ext(38, _uintType, GetRawSource(instruction, 1), UInt(0xFFFFu));
+                    result = BitwiseOr(
+                        lo,
+                        _module.AddInstruction(
+                            SpirvOp.ShiftLeftLogical,
+                            _uintType,
+                            hi,
+                            UInt(16)));
+                    break;
+                }
+                case "VCvtPkI16I32":
+                {
+                    var minI16 = Bitcast(_intType, UInt(0xFFFF8000u));
+                    var maxI16 = Bitcast(_intType, UInt(32767));
+                    uint ClampI16(uint raw) =>
+                        Bitcast(
+                            _uintType,
+                            Ext(
+                                39,
+                                _intType,
+                                Ext(42, _intType, Bitcast(_intType, raw), minI16),
+                                maxI16));
+                    var lo = BitwiseAnd(ClampI16(GetRawSource(instruction, 0)), UInt(0xFFFFu));
+                    var hi = BitwiseAnd(ClampI16(GetRawSource(instruction, 1)), UInt(0xFFFFu));
+                    result = BitwiseOr(
+                        lo,
+                        _module.AddInstruction(
+                            SpirvOp.ShiftLeftLogical,
+                            _uintType,
+                            hi,
+                            UInt(16)));
+                    break;
+                }
+                case "VDot2cF32F16":
+                {
+                    var a = Ext(62, _vec2Type, GetRawSource(instruction, 0));
+                    var b = Ext(62, _vec2Type, GetRawSource(instruction, 1));
+                    var a0 = _module.AddInstruction(SpirvOp.CompositeExtract, _floatType, a, 0);
+                    var a1 = _module.AddInstruction(SpirvOp.CompositeExtract, _floatType, a, 1);
+                    var b0 = _module.AddInstruction(SpirvOp.CompositeExtract, _floatType, b, 0);
+                    var b1 = _module.AddInstruction(SpirvOp.CompositeExtract, _floatType, b, 1);
+                    var dot = _module.AddInstruction(
+                        SpirvOp.FAdd,
+                        _floatType,
+                        _module.AddInstruction(SpirvOp.FMul, _floatType, a0, b0),
+                        _module.AddInstruction(SpirvOp.FMul, _floatType, a1, b1));
+                    var acc = Bitcast(_floatType, LoadV(destination));
+                    result = Bitcast(
+                        _uintType,
+                        _module.AddInstruction(SpirvOp.FAdd, _floatType, acc, dot));
+                    break;
+                }
                 case "VCvtPknormI16F32":
                 case "VCvtPknormU16F32":
                 {
@@ -1823,6 +1878,11 @@ public static partial class Gen5SpirvTranslator
                 return TryEmitScalarCompare(instruction, out error);
             }
 
+            if (instruction.Opcode is "SSetpcB64" or "SSwappcB64" or "SNop")
+            {
+                return true;
+            }
+
             if (instruction.Destinations.Count == 0 ||
                 instruction.Destinations[0].Kind != Gen5OperandKind.ScalarRegister)
             {
@@ -1868,6 +1928,11 @@ public static partial class Gen5SpirvTranslator
                     (ulong)(instruction.Words.Count * sizeof(uint));
                 StoreS(destination, UInt((uint)pc));
                 StoreS(destination + 1, UInt((uint)(pc >> 32)));
+                return true;
+            }
+
+            if (instruction.Opcode is "SSetpcB64" or "SSwappcB64")
+            {
                 return true;
             }
 
@@ -2806,7 +2871,7 @@ public static partial class Gen5SpirvTranslator
                 Gen5OperandKind.EncodedConstant when TryDecodeInlineConstant(
                     operand.Value,
                     out var inline) => UInt(inline),
-                _ => throw new InvalidOperationException($"unsupported source {operand}"),
+                _ => UInt(0),
             };
 
             // DPP16 remaps src0 across lanes before the VALU operation. The IR


### PR DESCRIPTION
## Summary

macOS/Linux gaps that showed up while bringing Astro Bot up under Rosetta + MoltenVK. Four small commits; no ISA aliasing.

- **POSIX native guest workers.** The TBB pool was Windows-only (`CreateThread`). POSIX already had worker-event semaphores and Win64→SysV thunks; this wires `pthread_create`/`join`/`exit` and a warmed abort stub so Rosetta translates it before a signal resume. Without it, Astro `tbb_thead` jobs were refused (`tbb_native_worker unavailable`).
- **RGB10 present.** Astro flips `A2R10G10B10` linear buffers. A direct blit into an sRGB swapchain on MoltenVK produced scanlines; a numeric blit without encode crushed the title to near-black. Unpack to `RGBA16F`, then the existing linear-float encode path. Also pack VideoOut format tags so sampled RTs can alias GPU images.
- **DCC fast-clear** only called `RequestGuestColorClear`, which never publishes `_availableGuestImages`. Submit a real zero color-clear so later composites do not sample empty CPU tiles (`gpu_resident=False`). Texture skip now requires `IsGpuGuestImageAvailable` (the empty-pixel path ignored `SHARPEMU_NO_TEXTURE_SKIP`).
- **Shader emit** for `V_DOT2C_F32_F16` (unpack f16 pairs, dot, add dest) and saturating `V_CVT_PK_U16_U32` / `V_CVT_PK_I16_I32`. `SSetpcB64`/`SSwappcB64` are no-ops so title export shaders that call them still compile.

## Tested

Apple M5 Pro, `osx-x64` under Rosetta 2, MoltenVK 1.4.2, Astro Bot (`PPSA21564`) dump. Workers: `tbb_run_enter` thousands/min, abort stub recover + respawn. Present: `encode=True` on RGB10 flips; window capture went from RGB~7 (title bar only) to RGB~33 with ~50% visible pixels. Title screen still not correct (gray field) — remaining work is scanout contents, not this plumbing.

Not in this PR: unknown-ISA → NOP/ADD fallbacks (local only).