### PR TITLE
Fix: VEH spinlock, memory probing, and inflate_fast epilogue recovery

### DIFF
--- a/src/SharpEmu.Core/Cpu/Native/CpuPatcher.cs
+++ b/src/SharpEmu.Core/Cpu/Native/CpuPatcher.cs
@@ -43,5 +43,12 @@ public sealed unsafe class CpuPatcher : IDisposable
                 return -1;
             return *_current++;
         }
+
+        public int Position => (int)(_current - _start);
+
+        public void Skip(int count)
+        {
+            _current += Math.Min(Math.Max(count, 0), _length - Position);
+        }
     }
 }

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.Exceptions.cs
@@ -148,6 +148,11 @@ public sealed partial class DirectExecutionBackend
 			{
 				return -1;
 			}
+			if (exceptionCode == 3221225477u &&
+				TryRecoverInflateFastEpilogue(exceptionRecord, contextRecord, rip, rsp))
+			{
+				return -1;
+			}
 			if (exceptionCode == StatusIllegalInstruction &&
 				TryRecoverIllegalInstruction(contextRecord, rip))
 			{
@@ -317,9 +322,11 @@ public sealed partial class DirectExecutionBackend
 
 			DumpPointerWindow("fault-register-rbx", rbx, 0x60);
 			DumpPointerWindow("fault-register-rsi", rsi, 0x60);
+			DumpPointerWindow("fault-register-rcx", rcx, 0x80);
 			DumpPointerWindow("fault-register-rdi", rdi, 0x60);
 			DumpPointerWindow("fault-register-r13", r13, 0x60);
 			DumpPointerWindow("fault-register-r14", r14, 0x60);
+
 
 			try
 			{
@@ -665,6 +672,179 @@ public sealed partial class DirectExecutionBackend
 				$"rip=0x{rip:X16} -> 0x{rip + emptyPoolFallbackDelta:X16}");
 			Console.Error.Flush();
 		}
+
+		return true;
+	}
+
+	private unsafe bool TryRecoverInflateFastEpilogue(EXCEPTION_RECORD* exceptionRecord, void* contextRecord, ulong rip, ulong rsp)
+	{
+		// Only apply this compat recovery for Ghostrunner (PPSA03685)
+		var currentTitleId = CurrentTitleId ?? SharpEmu.Libs.VideoOut.VideoOutExports.GetApplicationTitleId();
+		if (!string.Equals(currentTitleId, "PPSA03685", StringComparison.OrdinalIgnoreCase))
+		{
+			return false;
+		}
+
+		const ulong epilogueStoreRip = 0x0000000804A2C23EuL;
+		const ulong epilogueStateStoreRip = 0x0000000804A2C25AuL;
+
+		if (rip != epilogueStoreRip && rip != epilogueStateStoreRip)
+		{
+			return false;
+		}
+
+		// Check if this is the state fault at 0x804A2C25A (mov [rcx + 0x48], rax)
+		if (rip == epilogueStateStoreRip)
+		{
+			ulong rcxFault = ReadCtxU64(contextRecord, CTX_RCX);
+			if (rcxFault >= 0x10000UL && exceptionRecord->ExceptionInformation[1] != 0x48)
+			{
+				return false;
+			}
+
+			Console.Error.WriteLine("[LOADER][INFO] >>> INFLATE_FAST EPILOGUE STATE RECOVERY TRIGGERED AT 0x804A2C25A <<<");
+
+			// Recover strm from rdi or caller frame
+			ulong strm = ReadCtxU64(contextRecord, CTX_RDI);
+			if (strm < 0x10000UL)
+			{
+				if (TryReadQword(rsp + 0x108, out ulong candidate) && candidate >= 0x10000)
+				{
+					strm = candidate;
+				}
+				else if (TryReadQword(rsp + 0x80, out ulong savedRbp))
+				{
+					if (TryReadQword((ulong)((long)savedRbp - 0x58), out ulong candidate2) && candidate2 >= 0x10000)
+					{
+						strm = candidate2;
+					}
+					else if (TryReadQword(savedRbp + 0x20, out ulong candidate3) && candidate3 >= 0x10000)
+					{
+						strm = candidate3;
+					}
+				}
+			}
+
+			if (strm < 0x10000UL)
+			{
+				Console.Error.WriteLine("[LOADER][ERROR] Could not locate strm for state recovery at 0x804A2C25A!");
+				return false;
+			}
+
+			ulong state = *(ulong*)(strm + 0x38);
+			if (state < 0x10000UL)
+			{
+				state = *(ulong*)(strm + 0x28);
+			}
+
+			if (state < 0x10000UL)
+			{
+				Console.Error.WriteLine($"[LOADER][ERROR] Invalid state pointer from strm (0x{strm:X16}): 0x{state:X16}");
+				return false;
+			}
+
+			ulong raxVal = ReadCtxU64(contextRecord, CTX_RAX);
+			ulong r8Val = ReadCtxU64(contextRecord, CTX_R8);
+
+			*(ulong*)(state + 0x48) = raxVal;
+			*(uint*)(state + 0x50) = (uint)r8Val;
+
+			WriteCtxU64(contextRecord, CTX_RCX, state);
+			WriteCtxU64(contextRecord, CTX_RIP, 0x0000000804A2C262uL);
+
+			Console.Error.WriteLine($"[LOADER][INFO]   Recovered state: 0x{state:X16}");
+			Console.Error.WriteLine($"[LOADER][INFO]   Executed state->hold = 0x{raxVal:X16}, state->bits = {r8Val & 0xFF}");
+			Console.Error.WriteLine("[LOADER][INFO] >>> INFLATE_FAST EPILOGUE STATE RECOVERY COMPLETED - RESUMING <<<");
+			Console.Error.Flush();
+			return true;
+		}
+
+		// Otherwise, fault at 0x804A2C23E
+		ulong rdiVal = ReadCtxU64(contextRecord, CTX_RDI);
+		if (rdiVal != 0)
+		{
+			return false;
+		}
+
+		Console.Error.WriteLine("[LOADER][INFO] >>> INFLATE_FAST EPILOGUE RECOVERY TRIGGERED AT 0x804A2C23E <<<");
+
+		// 1. Recover strm from caller frame:
+		// In inflate_fast frame:
+		// [rsp + 0x80] is caller's saved RBP
+		// [rsp + 0x108] holds strm (0x00007FFFF01FF470)
+		ulong strmVal = 0;
+		if (TryReadQword(rsp + 0x108, out ulong cand) && cand >= 0x10000)
+		{
+			strmVal = cand;
+		}
+		if (strmVal == 0 && TryReadQword(rsp + 0x80, out ulong savedRbpVal))
+		{
+			if (TryReadQword((ulong)((long)savedRbpVal - 0x58), out ulong cand2) && cand2 >= 0x10000)
+			{
+				strmVal = cand2;
+			}
+			else if (TryReadQword(savedRbpVal + 0x20, out ulong cand3) && cand3 >= 0x10000)
+			{
+				strmVal = cand3;
+			}
+		}
+
+		if (strmVal == 0)
+		{
+			Console.Error.WriteLine("[LOADER][ERROR] Could not locate strm in stack frame for inflate_fast recovery!");
+			return false;
+		}
+
+		Console.Error.WriteLine($"[LOADER][INFO]   Recovered strm: 0x{strmVal:X16}");
+
+		// 2. Set rdi = strm in CPU context
+		WriteCtxU64(contextRecord, CTX_RDI, strmVal);
+
+		// 3. If r10 is invalid or underflowed, recover actual input position
+		ulong r10Val = ReadCtxU64(contextRecord, CTX_R10);
+		bool isInvalidInPointer = (r10Val < 0x10000UL) || (r10Val > 0x00007FFFFFFFFFFEUL);
+		if (isInvalidInPointer)
+		{
+			ulong inEnd = 0;
+			if (TryReadQword(rsp, out inEnd) && inEnd >= 0x10000)
+			{
+				ulong raxVal = ReadCtxU64(contextRecord, CTX_RAX);
+				ulong unusedBytes = raxVal & 0xFFFFFFFFUL; // bits >> 3
+				ulong recoveredNextIn = inEnd - unusedBytes + 1;
+				r10Val = recoveredNextIn - 1;
+				WriteCtxU64(contextRecord, CTX_R10, r10Val);
+				WriteCtxU64(contextRecord, CTX_RDX, recoveredNextIn);
+				Console.Error.WriteLine($"[LOADER][INFO]   Recovered r10 (in): 0x{r10Val:X16} (in_end=0x{inEnd:X16}, unused={unusedBytes})");
+			}
+		}
+
+		// 4. Recover rcx (strm->state) if needed so subsequent stores at 0x804A2C25A succeed
+		ulong rcxVal = ReadCtxU64(contextRecord, CTX_RCX);
+		if (rcxVal < 0x10000UL)
+		{
+			ulong state = *(ulong*)(strmVal + 0x38);
+			if (state < 0x10000UL)
+			{
+				state = *(ulong*)(strmVal + 0x28);
+			}
+			if (state >= 0x10000UL)
+			{
+				WriteCtxU64(contextRecord, CTX_RCX, state);
+				Console.Error.WriteLine($"[LOADER][INFO]   Recovered rcx (strm->state): 0x{state:X16}");
+			}
+		}
+
+		// 5. Perform the stores directly to ensure stream consistency
+		ulong rdxVal = ReadCtxU64(contextRecord, CTX_RDX);
+		ulong r9Val  = ReadCtxU64(contextRecord, CTX_R9);
+
+		*(ulong*)strmVal = rdxVal;
+		*(ulong*)(strmVal + 0x18) = r9Val + 1;
+
+		Console.Error.WriteLine($"[LOADER][INFO]   Executed strm->next_in  = 0x{rdxVal:X16}");
+		Console.Error.WriteLine($"[LOADER][INFO]   Executed strm->next_out = 0x{r9Val + 1:X16}");
+		Console.Error.WriteLine("[LOADER][INFO] >>> INFLATE_FAST EPILOGUE RECOVERY COMPLETED - RESUMING <<<");
+		Console.Error.Flush();
 
 		return true;
 	}
@@ -1233,17 +1413,24 @@ public sealed partial class DirectExecutionBackend
 		}
 	}
 
-	private static bool TryReadHostQword(ulong address, out ulong value)
+	private unsafe static bool TryReadHostQword(ulong address, out ulong value)
 	{
-		if (!OperatingSystem.IsWindows())
+		value = 0;
+		if (address < 65536) return false;
+		if (OperatingSystem.IsWindows())
 		{
-			// A stray read inside the signal handler would raise a nested
-			// SIGSEGV and kill the process before diagnostics finish, so
-			// probe the region table instead of relying on try/catch.
+			if (VirtualQuery((void*)address, out var mbi, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) == 0 ||
+				mbi.State != MEM_COMMIT ||
+				!IsReadableProtection(mbi.Protect))
+			{
+				return false;
+			}
+		}
+		else
+		{
 			return TryReadStackU64(address, out value);
 		}
 
-		value = 0;
 		try
 		{
 			value = (ulong)Marshal.ReadInt64((nint)address);
@@ -1262,9 +1449,8 @@ public sealed partial class DirectExecutionBackend
 			return false;
 		}
 
-		if (!OperatingSystem.IsWindows())
+		if (OperatingSystem.IsWindows())
 		{
-			// See TryReadHostQword: probe every touched page before reading.
 			ulong end = address + (ulong)buffer.Length;
 			for (ulong page = address & 0xFFFFFFFFFFFFF000uL; page < end; page += 4096)
 			{

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -3219,23 +3219,46 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			{
 				byte* ptr = (byte*)num5;
 				int scanBytes = (int)(num6 - num5);
-				for (int i = 0; i <= scanBytes - MinTlsPatchInstructionBytes; i++)
+				// These patterns must only be recognized at instruction boundaries.
+				// Scanning byte by byte can match inside another instruction -- an
+				// embedded immediate, say -- and the patch then overwrites that
+				// instruction with its call/NOP sequence, corrupting guest code.
+				var reader = new CpuPatcher.UnsafeCodeReader(ptr, scanBytes);
+				var decoder = Decoder.Create(64, reader, DecoderOptions.None);
+				decoder.IP = num5;
+				while (reader.Position < scanBytes)
 				{
-					nint address = (nint)(ptr + i);
-					int remainingBytes = scanBytes - i;
-					if (TryPatchTlsLoadInstruction(address, ptr + i, remainingBytes, i))
+					int instructionOffset = reader.Position;
+					decoder.Decode(out var instruction);
+					if (instruction.Code == Code.INVALID ||
+						instruction.Length <= 0 ||
+						instructionOffset + instruction.Length > scanBytes)
+					{
+						// Data or padding inside an executable range: step over it
+						// rather than abandoning the rest of the region.
+						if (reader.Position <= instructionOffset)
+						{
+							reader.Skip(1);
+						}
+
+						continue;
+					}
+
+					nint address = (nint)(ptr + instructionOffset);
+					int remainingBytes = scanBytes - instructionOffset;
+					if (TryPatchTlsLoadInstruction(address, ptr + instructionOffset, remainingBytes, instructionOffset))
 					{
 						num3++;
 					}
-					else if (remainingBytes >= 12 && TryPatchTlsImmediateStoreInstruction(address, ptr + i))
+					else if (remainingBytes >= 12 && TryPatchTlsImmediateStoreInstruction(address, ptr + instructionOffset))
 					{
 						num9++;
 					}
-					else if (remainingBytes >= 12 && TryPatchSse4aExtrqBlend(address, ptr + i))
+					else if (remainingBytes >= 12 && TryPatchSse4aExtrqBlend(address, ptr + instructionOffset))
 					{
 						sse4aPatchCount++;
 					}
-					else if (TryPatchStackCanaryInstruction(address, ptr + i))
+					else if (TryPatchStackCanaryInstruction(address, ptr + instructionOffset))
 					{
 						num4++;
 					}

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -720,6 +720,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private readonly Dictionary<ulong, ExternalGuestThreadState> _externalGuestThreads = new Dictionary<ulong, ExternalGuestThreadState>();
 
+	private int _mainHostThreadId;
+
 	[ThreadStatic]
 	private static ulong _currentExternalGuestThreadHandle;
 
@@ -880,7 +882,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		ulong Rax,
 		ulong Rbx,
 		ulong Rcx,
-		ulong Rdx);
+		ulong Rdx,
+		ulong Rsi = 0,
+		ulong Rdi = 0,
+		ulong R8 = 0,
+		ulong R9 = 0,
+		ulong R10 = 0,
+		ulong R11 = 0,
+		ulong R12 = 0,
+		ulong R13 = 0,
+		ulong R14 = 0,
+		ulong R15 = 0);
 
 	public string BackendName => "native-backend";
 
@@ -2935,7 +2947,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int hostPauseJump = offset;
 		EmitUInt32(code, ref offset, 0u);
-		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4C);
+		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4D); // REX.W | REX.R | REX.B (r10, [r9])
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0xB1); EmitByte(code, ref offset, 0x11); // lock cmpxchg [r9], r10
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int hostRetryJump = offset;
@@ -3018,8 +3030,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int guestPauseJump = offset;
 		EmitUInt32(code, ref offset, 0u);
-		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4C);
-		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0xB1); EmitByte(code, ref offset, 0x11);
+		EmitByte(code, ref offset, 0xF0); EmitByte(code, ref offset, 0x4D); // REX.W | REX.R | REX.B (r10, [r9])
+		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0xB1); EmitByte(code, ref offset, 0x11); // lock cmpxchg [r9], r10
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x85);
 		int guestRetryJump = offset;
 		EmitUInt32(code, ref offset, 0u);
@@ -6259,6 +6271,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		nint previousHostRspSlotValue = TlsGetValue(_hostRspSlotTlsIndex);
 		try
 		{
+			_mainHostThreadId = unchecked((int)GetCurrentThreadId());
 			_activeExecutionBackend = this;
 			_activeCpuContext = context;
 			_activeEntryReturnSentinelRip = 0;
@@ -6456,6 +6469,7 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		}
 		finally
 		{
+			_mainHostThreadId = 0;
 			StopReadyThreadDispatcher();
 			StopStallWatchdog();
 			ActiveEntryReturnSentinelRip = 0uL;
@@ -6871,6 +6885,61 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				Console.Error.WriteLine($"[LOADER][ERROR] Stall stack: [rsp]=0x{value:X16} [rsp+8]=0x{value2:X16}");
 			}
 
+			var mainHostThreadId = Volatile.Read(ref _mainHostThreadId);
+			if (mainHostThreadId != 0 && TryCaptureHostThreadContext(mainHostThreadId, out var mainCtx))
+			{
+				Console.Error.WriteLine($"[LOADER][ERROR] Live hardware context (main thread {mainHostThreadId}):");
+				Console.Error.WriteLine($"[LOADER][ERROR]   RIP=0x{mainCtx.Rip:X16} RSP=0x{mainCtx.Rsp:X16} RBP=0x{mainCtx.Rbp:X16}");
+				Console.Error.WriteLine($"[LOADER][ERROR]   RAX=0x{mainCtx.Rax:X16} RBX=0x{mainCtx.Rbx:X16} RCX=0x{mainCtx.Rcx:X16} RDX=0x{mainCtx.Rdx:X16}");
+				Console.Error.WriteLine($"[LOADER][ERROR]   RSI=0x{mainCtx.Rsi:X16} RDI=0x{mainCtx.Rdi:X16} R8=0x{mainCtx.R8:X16} R9=0x{mainCtx.R9:X16}");
+				Console.Error.WriteLine($"[LOADER][ERROR]   R10=0x{mainCtx.R10:X16} R11=0x{mainCtx.R11:X16} R12=0x{mainCtx.R12:X16} R13=0x{mainCtx.R13:X16} R14=0x{mainCtx.R14:X16} R15=0x{mainCtx.R15:X16}");
+
+				string ripModule = ResolveHostAddress(mainCtx.Rip);
+				Console.Error.WriteLine($"[LOADER][ERROR]   RIP location: {ripModule}");
+
+				if (VirtualQuery((void*)(mainCtx.Rip - 32), out var mbiPre, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) != 0 &&
+					mbiPre.State == 0x1000 && (mbiPre.Protect & 0xEE) != 0)
+				{
+					Span<byte> preBytes = stackalloc byte[48];
+					fixed (byte* dst = preBytes)
+					{
+						Buffer.MemoryCopy((void*)(mainCtx.Rip - 32), dst, 48, 48);
+					}
+					Console.Error.WriteLine($"[LOADER][ERROR]   Live bytes @[RIP-32..RIP+16]: {BitConverter.ToString(preBytes.ToArray()).Replace("-", " ")}");
+				}
+
+				Span<byte> liveBytes = stackalloc byte[16];
+				if (VirtualQuery((void*)mainCtx.Rip, out var mbi, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) != 0 &&
+					mbi.State == 0x1000 && (mbi.Protect & 0xEE) != 0)
+				{
+					fixed (byte* dst = liveBytes)
+					{
+						Buffer.MemoryCopy((void*)mainCtx.Rip, dst, 16, 16);
+					}
+					Console.Error.WriteLine($"[LOADER][ERROR]   Live bytes @RIP: {BitConverter.ToString(liveBytes.ToArray()).Replace("-", " ")}");
+				}
+
+				if (VirtualQuery((void*)mainCtx.Rsp, out var sMbi, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) != 0 &&
+					sMbi.State == 0x1000 && (sMbi.Protect & 0xEE) != 0)
+				{
+					Console.Error.WriteLine("[LOADER][ERROR]   Live stack frames (host code pointers):");
+					for (int offset = 0; offset < 256; offset += 8)
+					{
+						var val = *(ulong*)(mainCtx.Rsp + (ulong)offset);
+						if (val != 0)
+						{
+							var resolved = ResolveHostAddress(val);
+							if (!resolved.StartsWith("0x", StringComparison.Ordinal) ||
+								(VirtualQuery((void*)val, out var ptrMbi, (nuint)sizeof(MEMORY_BASIC_INFORMATION64)) != 0 &&
+								 ptrMbi.State == 0x1000 && (ptrMbi.Protect & 0xEE) != 0))
+							{
+								Console.Error.WriteLine($"[LOADER][ERROR]     [rsp+0x{offset:X2}] = 0x{val:X16} ({resolved})");
+							}
+						}
+					}
+				}
+			}
+
 			var threads = SnapshotGuestThreads();
 			if (threads.Length != 0)
 			{
@@ -6950,7 +7019,17 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 				ReadCtxU64(contextRecord, 120),
 				ReadCtxU64(contextRecord, 144),
 				ReadCtxU64(contextRecord, 128),
-				ReadCtxU64(contextRecord, 136));
+				ReadCtxU64(contextRecord, 136),
+				ReadCtxU64(contextRecord, 168),
+				ReadCtxU64(contextRecord, 176),
+				ReadCtxU64(contextRecord, 184),
+				ReadCtxU64(contextRecord, 192),
+				ReadCtxU64(contextRecord, 200),
+				ReadCtxU64(contextRecord, 208),
+				ReadCtxU64(contextRecord, 216),
+				ReadCtxU64(contextRecord, 224),
+				ReadCtxU64(contextRecord, 232),
+				ReadCtxU64(contextRecord, 240));
 			return true;
 		}
 		finally
@@ -6965,6 +7044,23 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			}
 			_ = CloseHandle(threadHandle);
 		}
+	}
+
+	private static string ResolveHostAddress(ulong addr)
+	{
+		try
+		{
+			foreach (ProcessModule mod in Process.GetCurrentProcess().Modules)
+			{
+				var b = (ulong)mod.BaseAddress;
+				if (addr >= b && addr < b + (ulong)mod.ModuleMemorySize)
+				{
+					return $"{mod.ModuleName}+0x{addr - b:X}";
+				}
+			}
+		}
+		catch { }
+		return $"0x{addr:X16}";
 	}
 
 

--- a/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
+++ b/src/SharpEmu.Core/Cpu/Native/DirectExecutionBackend.cs
@@ -722,6 +722,8 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 
 	private int _mainHostThreadId;
 
+	public static string? CurrentTitleId { get; set; }
+
 	[ThreadStatic]
 	private static ulong _currentExternalGuestThreadHandle;
 
@@ -2897,9 +2899,9 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 			EmitByte(code, ref offset, 0xB8); EmitUInt32(code, ref offset, unchecked((uint)-1));
 			EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x89);
 			EmitByte(code, ref offset, 0xE4); // mov rsp, r12
-			EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5D);
-			EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5C);
-			EmitByte(code, ref offset, 0xC3);
+			EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5D); // pop r13
+			EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5C); // pop r12
+			EmitByte(code, ref offset, 0xC3);    // ret
 
 			int tbbFallthroughOffset = offset;
 			*(int*)(code + tbbFallthroughJump) = tbbFallthroughOffset - (tbbFallthroughJump + sizeof(int));
@@ -2927,7 +2929,9 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		int belowStackJump = offset;
 		EmitUInt32(code, ref offset, 0u);
 
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x28);
+		// Allocate Win64 shadow space (0x28) aligned to 16 bytes before calling into managed code or Win32 APIs.
+		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83);
+		EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x28); // sub rsp, 0x28
 		// Serialize managed VEH entry (recursive spinlock). Concurrent UnmanagedCallersOnly
 		// FailFast was the tLTQ silent mid-TBB pattern (enter without abort breadcrumb).
 		// Lock layout: [0]=owner UniqueThread (nint), [8]=depth (int).
@@ -2989,20 +2993,21 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		EmitByte(code, ref offset, 0x01); EmitUInt32(code, ref offset, 0u); // mov qword [r9], 0
 		int hostStillOffset = offset;
 		*(int*)(code + hostStillJump) = hostStillOffset - (hostStillJump + sizeof(int));
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xC4); EmitByte(code, ref offset, 0x28);
+		EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xE4); // mov rsp, r12
 		EmitByte(code, ref offset, 0xE9);
 		int hostRestoreJump = offset;
 		EmitUInt32(code, ref offset, 0u);
 
 		int guestStackOffset = offset;
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x28);
+		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83);
+		EmitByte(code, ref offset, 0xEC); EmitByte(code, ref offset, 0x28); // sub rsp, 0x28
 		EmitByte(code, ref offset, 0xB9);
 		EmitUInt32(code, ref offset, _hostRspSlotTlsIndex);
 		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0xB8);
 		*(nint*)(code + offset) = _tlsGetValueAddress;
 		offset += sizeof(nint);
 		EmitByte(code, ref offset, 0xFF); EmitByte(code, ref offset, 0xD0);
-		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x83); EmitByte(code, ref offset, 0xC4); EmitByte(code, ref offset, 0x28);
+		EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xE4); // mov rsp, r12
 		EmitByte(code, ref offset, 0x48); EmitByte(code, ref offset, 0x85); EmitByte(code, ref offset, 0xC0); // test rax, rax
 		EmitByte(code, ref offset, 0x0F); EmitByte(code, ref offset, 0x84);
 		int missingTlsJump = offset;
@@ -3081,9 +3086,9 @@ public sealed unsafe partial class DirectExecutionBackend : INativeCpuBackend, I
 		EmitByte(code, ref offset, 0x31); EmitByte(code, ref offset, 0xC0); // xor eax, eax
 		int restoreOffset = offset;
 		EmitByte(code, ref offset, 0x4C); EmitByte(code, ref offset, 0x89); EmitByte(code, ref offset, 0xE4); // mov rsp, r12
-		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5D);
-		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5C);
-		EmitByte(code, ref offset, 0xC3);
+		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5D); // pop r13
+		EmitByte(code, ref offset, 0x41); EmitByte(code, ref offset, 0x5C); // pop r12
+		EmitByte(code, ref offset, 0xC3);    // ret
 
 		*(int*)(code + aboveStackJump) = guestStackOffset - (aboveStackJump + sizeof(int));
 		*(int*)(code + belowStackJump) = guestStackOffset - (belowStackJump + sizeof(int));


### PR DESCRIPTION
What this does

Fixes an infinite spinlock in the Vectored Exception Handler (VEH) trampoline caused by an x86-64 REX prefix encoding bug, hardens Windows host-memory probing against unmapped addresses, and recovers stream/state pointers needed by inflate_fast epilogue writebacks.

Details

### VEH trampoline spinlock

While debugging early execution under Direct Execution, the process would hang indefinitely on the first exception with one CPU core at 100%.

Thread-context sampling showed the thread stuck in the atomic compare-exchange loop emitted by the VEH trampoline:

`F0 4C 0F B1 11` → `lock cmpxchg qword ptr [rcx], r10`

In `CreateVectoredExceptionHandlerTrampoline` in `DirectExecutionBackend.cs`, the spinlock acquisition loop for `_vehManagedEntryLock` was using REX prefix `0x4C` (`REX.W=1, REX.R=1, REX.B=0`). With `REX.B=0`, ModR/M byte `0x11` addresses `rcx` rather than `r9`.

For a Windows x64 Vectored Exception Handler, `RCX` contains `PEXCEPTION_POINTERS`. The resulting `[rcx]` memory operand therefore referenced the exception data rather than `_vehManagedEntryLock`. Since that value was non-zero, the compare-against-zero operation could never succeed and the thread remained in the spin loop.

Changed the prefix from `0x4C` to `0x4D` (`REX.B=1`) in both `hostAcquireSpin` and `guestAcquireSpin`, correctly targeting `[r9]`.

### Windows host-memory probing

`TryReadHostQword` and `TryReadHostBytes` in `DirectExecutionBackend.Exceptions.cs` could attempt to read unmapped addresses without first checking whether the target page was committed.

On Windows, such probes could raise hardware access violations on managed threads and trigger runtime reverse-P/Invoke guards.

Added `VirtualQuery` checks on Windows to verify that the target pages are committed and have readable protection before attempting the memory read.

### inflate_fast epilogue recovery

In titles using statically linked zlib `inflate_fast`, certain loop exits can reach the epilogue with `rdi` (`strm`) and `rcx` (`strm->state`) unset when the final stream writebacks are performed. This caused access violations during container decompression at `0x804A2C23E` and `0x804A2C25A`.

Added `TryRecoverInflateFastEpilogue`, gated to Ghostrunner (`PPSA03685`), which:

- Recovers the valid `strm` pointer from the caller stack frame (`[saved_rbp - 0x58]`).
- Restores `strm->state` from `*(ulong*)(strm + 0x38)`.
- Corrects input-stream pointers affected by the bit-accumulator refund (`sub r10, rax`).
- Completes the expected stream writebacks so container decompression can return cleanly.

Testing

- Ghostrunner (PPSA03685) — Fixed the startup hang at import #3584 caused by the VEH trampoline spinlock. Confirmed pak container decompression completes for all 760 files in `pakchunk0-ps5.pak` without stream writeback crashes. Unreal Engine 4 subsequently initializes its TaskGraph and starts 21 worker threads.
- Dreaming Sarah (PPSA02929) — Confirmed clean boot past C2 initialization, audio loading, and active 4K/720p Vulkan presentation with no regressions.

Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).