### PR TITLE
fix(shader-compiler): guard VReadfirstlaneB32 against empty active lane mask

### DIFF
--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
@@ -76,7 +76,14 @@ public static partial class Gen5SpirvTranslator
                             _uintType,
                             activeLanes,
                             0);
-                        var firstActiveLane = Ext(73, _uintType, activeLow);
+                        var hasActive = IsNotZero(activeLow);
+                        var firstLsb = Ext(73, _uintType, activeLow);
+                        var firstActiveLane = _module.AddInstruction(
+                            SpirvOp.Select,
+                            _uintType,
+                            hasActive,
+                            firstLsb,
+                            UInt(0));
                         value = _module.AddInstruction(
                             SpirvOp.GroupNonUniformBroadcast,
                             _uintType,


### PR DESCRIPTION
## Summary
When translating `VReadfirstlaneB32`, `FindILsb` is evaluated against `activeLow`. If no lanes are active (`activeLow == 0`), `FindILsb` returns an invalid / out-of-bounds lane index (-1 / 0xFFFFFFFF), causing invalid subgroup broadcast operations in `GroupNonUniformBroadcast`.

This patch introduces a conditional select (`SpirvOp.Select`) using `hasActive`: if `activeLow != 0`, the first active lane index is broadcasted; otherwise lane 0 is selected safely as a neutral fallback.

## Testing
- Verified with `dotnet test tests/SharpEmu.ShaderCompiler.Tests/SharpEmu.ShaderCompiler.Tests.csproj` (95/95 passed).
- Tested on native Vulkan pipeline under Linux (GA107 / RTX 3050).
