### PR TITLE
feat(shader): emit VSadU32, SMulHiI32, and SAbsdiffI32 ALU operations

### DIFF
--- a/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Metal/Gen5MslTranslator.Alu.cs
@@ -251,6 +251,8 @@ public static partial class Gen5MslTranslator
                     $"(((({RawSource(instruction, 0)}) & 0xFFFFu) * (({RawSource(instruction, 1)}) & 0xFFFFu)) + ({RawSource(instruction, 2)}))",
                 "VAdd3U32" =>
                     $"(({RawSource(instruction, 0)}) + ({RawSource(instruction, 1)}) + ({RawSource(instruction, 2)}))",
+                "VSadU32" =>
+                    $"((max({RawSource(instruction, 0)}, {RawSource(instruction, 1)}) - min({RawSource(instruction, 0)}, {RawSource(instruction, 1)})) + ({RawSource(instruction, 2)}))",
                 "VAddLshlU32" =>
                     $"((({RawSource(instruction, 0)}) + ({RawSource(instruction, 1)})) << (({RawSource(instruction, 2)}) & 31u))",
                 "VLshlAddU32" =>
@@ -1141,6 +1143,10 @@ public static partial class Gen5MslTranslator
                     resultExpression = $"mulhi({left}, {right})";
                     sccStatement = string.Empty;
                     break;
+                case "SMulHiI32":
+                    resultExpression = AsUInt($"mulhi(as_type<int>({left}), as_type<int>({right}))");
+                    sccStatement = string.Empty;
+                    break;
                 case "SAndB32":
                     resultExpression = $"({left} & {right})";
                     sccStatement = "NONZERO";
@@ -1227,6 +1233,10 @@ public static partial class Gen5MslTranslator
                 case "SMaxI32":
                     resultExpression = $"(uint)max(as_type<int>({left}), as_type<int>({right}))";
                     sccStatement = $"as_type<int>({left}) > as_type<int>({right})";
+                    break;
+                case "SAbsdiffI32":
+                    resultExpression = AsUInt($"abs(as_type<int>({left}) - as_type<int>({right}))");
+                    sccStatement = "NONZERO";
                     break;
                 case "SLshl1AddU32":
                 case "SLshl2AddU32":

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
@@ -2269,7 +2269,8 @@ public static partial class Gen5SpirvTranslator
                                 _intType,
                                 Bitcast(_intType, left),
                                 Bitcast(_intType, right));
-                            var absDiff = Ext(4, _intType, diff);
+                            // GLSL.std.450 SAbs (5); 4 is FAbs and float-only.
+                            var absDiff = Ext(5, _intType, diff);
                             result = Bitcast(_uintType, absDiff);
                             Store(_scc, IsNotZero(result));
                             break;

--- a/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
+++ b/src/SharpEmu.ShaderCompiler.Vulkan/Gen5SpirvTranslator.Alu.cs
@@ -721,6 +721,17 @@ public static partial class Gen5SpirvTranslator
                             GetRawSource(instruction, 1)),
                         GetRawSource(instruction, 2));
                     break;
+                case "VSadU32":
+                {
+                    var s0 = GetRawSource(instruction, 0);
+                    var s1 = GetRawSource(instruction, 1);
+                    var s2 = GetRawSource(instruction, 2);
+                    var max = Ext(41, _uintType, s0, s1);
+                    var min = Ext(38, _uintType, s0, s1);
+                    var diff = _module.AddInstruction(SpirvOp.ISub, _uintType, max, min);
+                    result = IAdd(diff, s2);
+                    break;
+                }
                 case "VMinU32":
                     result = Ext(
                         38,
@@ -2103,6 +2114,33 @@ public static partial class Gen5SpirvTranslator
                                     _module.Constant64(_ulongType, 32)));
                             break;
                         }
+                        case "SMulHiI32":
+                        {
+                            var wideLeft = _module.AddInstruction(
+                                SpirvOp.SConvert,
+                                _longType,
+                                Bitcast(_intType, left));
+                            var wideRight = _module.AddInstruction(
+                                SpirvOp.SConvert,
+                                _longType,
+                                Bitcast(_intType, right));
+                            var product = _module.AddInstruction(
+                                SpirvOp.IMul,
+                                _longType,
+                                wideLeft,
+                                wideRight);
+                            result = Bitcast(
+                                _uintType,
+                                _module.AddInstruction(
+                                    SpirvOp.SConvert,
+                                    _intType,
+                                    _module.AddInstruction(
+                                        SpirvOp.ShiftRightArithmetic,
+                                        _longType,
+                                        product,
+                                        _module.Constant64(_longType, 32))));
+                            break;
+                        }
                         case "SAndB32":
                             result = BitwiseAnd(left, right);
                             Store(_scc, IsNotZero(result));
@@ -2221,6 +2259,18 @@ public static partial class Gen5SpirvTranslator
                                     left,
                                     offset,
                                     width);
+                            Store(_scc, IsNotZero(result));
+                            break;
+                        }
+                        case "SAbsdiffI32":
+                        {
+                            var diff = _module.AddInstruction(
+                                SpirvOp.ISub,
+                                _intType,
+                                Bitcast(_intType, left),
+                                Bitcast(_intType, right));
+                            var absDiff = Ext(4, _intType, diff);
+                            result = Bitcast(_uintType, absDiff);
                             Store(_scc, IsNotZero(result));
                             break;
                         }

--- a/tests/SharpEmu.ShaderCompiler.Metal.Tests/MslTranslationTests.cs
+++ b/tests/SharpEmu.ShaderCompiler.Metal.Tests/MslTranslationTests.cs
@@ -160,4 +160,34 @@ public sealed class MslTranslationTests
             () => Gen5ComputeFixtures.CompileOrThrow(fixture));
         Assert.Contains("pc=0x", exception.Message, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void SadAndMulHiAndAbsdiffTranslateInMsl()
+    {
+        // s_absdiff_i32 s0, s1, s2
+        const uint sAbsdiff = (0b10u << 30) | (0x2Du << 23) | (0u << 16) | (2u << 8) | 1u;
+        // s_mul_hi_i32 s0, s1, s2
+        const uint sMulHiI32 = (0b10u << 30) | (0x36u << 23) | (0u << 16) | (2u << 8) | 1u;
+        // v_sad_u32 v0, v1, v2, v3
+        const uint vSadWord0 = (0x35u << 26) | (0x15Du << 16) | 0u;
+        const uint vSadWord1 = (256u + 1u) | ((256u + 2u) << 9) | ((256u + 3u) << 18);
+
+        var fixture = new Gen5ComputeFixture(
+            "sad-and-mulhi",
+            [
+                sAbsdiff,
+                sMulHiI32,
+                vSadWord0, vSadWord1,
+                0xBF810000, // s_endpgm
+            ],
+            StoreScalarResourceBase: 0,
+            StoreBackingBytes: 0);
+
+        var shader = Gen5ComputeFixtures.CompileOrThrow(fixture);
+        Assert.Contains("abs(as_type<int>(", shader.Source, StringComparison.Ordinal);
+        Assert.Contains("mulhi(as_type<int>(", shader.Source, StringComparison.Ordinal);
+        Assert.Contains("max(", shader.Source, StringComparison.Ordinal);
+        Assert.Contains("min(", shader.Source, StringComparison.Ordinal);
+    }
 }
+

--- a/tests/SharpEmu.ShaderCompiler.Tests/Gen5MissingAluOpcodeTests.cs
+++ b/tests/SharpEmu.ShaderCompiler.Tests/Gen5MissingAluOpcodeTests.cs
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 SharpEmu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Buffers.Binary;
+using SharpEmu.HLE;
+using SharpEmu.ShaderCompiler;
+using SharpEmu.ShaderCompiler.Vulkan;
+using Xunit;
+
+namespace SharpEmu.ShaderCompiler.Tests;
+
+public sealed class Gen5MissingAluOpcodeTests
+{
+    private const ulong ShaderAddress = 0x1_0000_0000;
+    private const uint SEndpgm = 0xBF810000;
+
+    [Fact]
+    public void SAbsdiffI32_DecodesAndCompiles()
+    {
+        // s_absdiff_i32 s0, s1, s2
+        // SOP2: [31:30]=0b10, [29:23]=0x2D, [22:16]=sdst(0), [15:8]=ssrc1(2), [7:0]=ssrc0(1)
+        const uint sAbsdiff = (0b10u << 30) | (0x2Du << 23) | (0u << 16) | (2u << 8) | 1u;
+        var program = Decode([sAbsdiff, SEndpgm]);
+
+        Assert.Equal(["SAbsdiffI32", "SEndpgm"], program.Instructions.Select(i => i.Opcode));
+
+        var state = new Gen5ShaderState(program, [], null);
+        var scalarRegisters = new uint[256];
+        var evaluation = new Gen5ShaderEvaluation(scalarRegisters, scalarRegisters, [], []);
+
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileComputeShader(
+                state,
+                evaluation,
+                1,
+                1,
+                1,
+                out var shader,
+                out var error),
+            error);
+
+        var opcodes = ReadOpcodes(shader.Spirv);
+        // SAbsdiffI32 should emit signed subtraction (ISub) and SAbs
+        Assert.Contains((ushort)SpirvOp.ISub, opcodes);
+    }
+
+    [Fact]
+    public void SMulHiI32_DecodesAndCompiles()
+    {
+        // s_mul_hi_i32 s0, s1, s2
+        // SOP2: [31:30]=0b10, [29:23]=0x36, [22:16]=sdst(0), [15:8]=ssrc1(2), [7:0]=ssrc0(1)
+        const uint sMulHiI32 = (0b10u << 30) | (0x36u << 23) | (0u << 16) | (2u << 8) | 1u;
+        var program = Decode([sMulHiI32, SEndpgm]);
+
+        Assert.Equal(["SMulHiI32", "SEndpgm"], program.Instructions.Select(i => i.Opcode));
+
+        var state = new Gen5ShaderState(program, [], null);
+        var scalarRegisters = new uint[256];
+        var evaluation = new Gen5ShaderEvaluation(scalarRegisters, scalarRegisters, [], []);
+
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileComputeShader(
+                state,
+                evaluation,
+                1,
+                1,
+                1,
+                out var shader,
+                out var error),
+            error);
+
+        var opcodes = ReadOpcodes(shader.Spirv);
+        // SMulHiI32 should multiply 64-bit signed integers and shift right arithmetic
+        Assert.Contains((ushort)SpirvOp.IMul, opcodes);
+        Assert.Contains((ushort)SpirvOp.ShiftRightArithmetic, opcodes);
+    }
+
+    [Fact]
+    public void VSadU32_DecodesAndCompiles()
+    {
+        // v_sad_u32 v0, v1, v2, v3
+        // VOP3: word0: [31:26]=0x35, [25:16]=0x15D, [7:0]=vdst(0)
+        //       word1: [8:0]=src0(v1=257), [17:9]=src1(v2=258), [26:18]=src2(v3=259)
+        const uint vSadWord0 = (0x35u << 26) | (0x15Du << 16) | 0u;
+        const uint vSadWord1 = (256u + 1u) | ((256u + 2u) << 9) | ((256u + 3u) << 18);
+        var program = Decode([vSadWord0, vSadWord1, SEndpgm]);
+
+        Assert.Equal(["VSadU32", "SEndpgm"], program.Instructions.Select(i => i.Opcode));
+
+        var state = new Gen5ShaderState(program, [], null);
+        var scalarRegisters = new uint[256];
+        var evaluation = new Gen5ShaderEvaluation(scalarRegisters, scalarRegisters, [], []);
+
+        Assert.True(
+            Gen5SpirvTranslator.TryCompileComputeShader(
+                state,
+                evaluation,
+                1,
+                1,
+                1,
+                out var shader,
+                out var error),
+            error);
+
+        var opcodes = ReadOpcodes(shader.Spirv);
+        // VSadU32 calculates abs difference + accumulator
+        Assert.Contains((ushort)SpirvOp.IAdd, opcodes);
+        Assert.Contains((ushort)SpirvOp.ISub, opcodes);
+    }
+
+    private static Gen5ShaderProgram Decode(IReadOnlyList<uint> words)
+    {
+        var memory = new TestCpuMemory(ShaderAddress, words.Count * sizeof(uint));
+        var bytes = new byte[words.Count * sizeof(uint)];
+        for (var index = 0; index < words.Count; index++)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                bytes.AsSpan(index * sizeof(uint)),
+                words[index]);
+        }
+
+        Assert.True(memory.TryWrite(ShaderAddress, bytes));
+
+        var ctx = new CpuContext(memory, Generation.Gen5);
+        Assert.True(
+            Gen5ShaderTranslator.TryDecodeProgram(
+                ctx,
+                ShaderAddress,
+                out var program,
+                out var error),
+            error);
+        return program;
+    }
+
+    private static IReadOnlyList<ushort> ReadOpcodes(byte[] spirv)
+    {
+        var opcodes = new List<ushort>();
+        for (var offset = 5 * sizeof(uint); offset < spirv.Length;)
+        {
+            var word = BinaryPrimitives.ReadUInt32LittleEndian(spirv.AsSpan(offset));
+            var wordCount = (int)(word >> 16);
+            opcodes.Add((ushort)word);
+            offset += wordCount * sizeof(uint);
+        }
+
+        return opcodes;
+    }
+
+    private sealed class TestCpuMemory(ulong baseAddress, int size) : ICpuMemory
+    {
+        private readonly byte[] _storage = new byte[size];
+
+        public bool TryRead(ulong virtualAddress, Span<byte> destination)
+        {
+            var offset = (int)(virtualAddress - baseAddress);
+            if (offset < 0 || offset + destination.Length > _storage.Length)
+            {
+                return false;
+            }
+
+            _storage.AsSpan(offset, destination.Length).CopyTo(destination);
+            return true;
+        }
+
+        public bool TryWrite(ulong virtualAddress, ReadOnlySpan<byte> source)
+        {
+            var offset = (int)(virtualAddress - baseAddress);
+            if (offset < 0 || offset + source.Length > _storage.Length)
+            {
+                return false;
+            }
+
+            source.CopyTo(_storage.AsSpan(offset, source.Length));
+            return true;
+        }
+    }
+}

--- a/tests/SharpEmu.ShaderCompiler.Tests/Gen5MissingAluOpcodeTests.cs
+++ b/tests/SharpEmu.ShaderCompiler.Tests/Gen5MissingAluOpcodeTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System.Buffers.Binary;
+using System.Text;
 using SharpEmu.HLE;
 using SharpEmu.ShaderCompiler;
 using SharpEmu.ShaderCompiler.Vulkan;
@@ -42,6 +43,10 @@ public sealed class Gen5MissingAluOpcodeTests
         var opcodes = ReadOpcodes(shader.Spirv);
         // SAbsdiffI32 should emit signed subtraction (ISub) and SAbs
         Assert.Contains((ushort)SpirvOp.ISub, opcodes);
+        // SAbs is GLSL.std.450 extended opcode 5 (4 would be float-only FAbs)
+        Assert.Contains(
+            (5u, "GLSL.std.450"),
+            ReadExtendedInstructions(shader.Spirv, "GLSL.std.450"));
     }
 
     [Fact]
@@ -130,6 +135,45 @@ public sealed class Gen5MissingAluOpcodeTests
                 out var error),
             error);
         return program;
+    }
+
+    private static IReadOnlyList<(uint Opcode, string Import)> ReadExtendedInstructions(
+        byte[] spirv,
+        string importName)
+    {
+        var words = new uint[spirv.Length / sizeof(uint)];
+        Buffer.BlockCopy(spirv, 0, words, 0, spirv.Length);
+
+        var imports = new Dictionary<uint, string>();
+        var extended = new List<(uint, string)>();
+        for (var offset = 5; offset < words.Length;)
+        {
+            var word = words[offset];
+            var wordCount = (int)(word >> 16);
+            if (wordCount <= 0 || offset + wordCount > words.Length)
+            {
+                break;
+            }
+
+            var opcode = (ushort)word;
+            if (opcode == (ushort)SpirvOp.ExtInstImport)
+            {
+                var nameWords = words.AsSpan(offset + 2, wordCount - 2);
+                var nameBytes = new byte[nameWords.Length * sizeof(uint)];
+                Buffer.BlockCopy(nameWords.ToArray(), 0, nameBytes, 0, nameBytes.Length);
+                var name = Encoding.UTF8.GetString(nameBytes).TrimEnd('\0');
+                imports[words[offset + 1]] = name;
+            }
+            else if (opcode == (ushort)SpirvOp.ExtInst)
+            {
+                var importId = words[offset + 3];
+                extended.Add((words[offset + 4], imports.GetValueOrDefault(importId, string.Empty)));
+            }
+
+            offset += wordCount;
+        }
+
+        return extended.Where(e => e.Item2 == importName).ToList();
     }
 
     private static IReadOnlyList<ushort> ReadOpcodes(byte[] spirv)


### PR DESCRIPTION
## Before submitting

Please read our contribution guidelines before opening a pull request:

➡️ [**CONTRIBUTING.md**](https://github.com/sharpemu/sharpemu/blob/main/CONTRIBUTING.md)

By opening this pull request, you confirm that you have read and agree to follow the contribution guidelines.

## What this does

Implements three ALU operations in the Gen5 shader compilers that previously fell into the `unsupported` paths in both backends. Any shader containing one of them failed to translate, so this unblocks compilation for titles that use them rather than changing runtime behavior.

In the Vulkan SPIR-V backend (`Gen5SpirvTranslator.Alu.cs`):

- `VSadU32` (VOP3 0x15D): sum of absolute differences, emitted as `umax(s0, s1) - umin(s0, s1) + s2` using the GLSL extended instructions, so it stays branch-free and unsigned.
- `SMulHiI32` (SOP2 0x36): signed 32-bit multiply keeping the high half. Both operands are bitcast to signed and sign-extended to 64-bit, multiplied, then shifted right arithmetically by 32 and truncated back. SCC is not written, matching the other non-comparing SOP2 ops.
- `SAbsdiffI32` (SOP2 0x2D): signed absolute difference, emitted as signed subtract followed by `SAbs`, bitcast back to unsigned. SCC is set when the difference is nonzero, consistent with the other result-producing scalar ops.

In the Metal MSL backend (`Gen5MslTranslator.Alu.cs`) the same three ops are lowered to `max()`/`min()`, `mulhi()` over `as_type<int>` casts, and `abs()` over a signed subtract, respectively. `SAbsdiffI32` sets SCC on nonzero there as well.

## Testing

N/A for game runtime behavior, this is contained to the shader translators. Verified with unit tests:

- New `Gen5MissingAluOpcodeTests` in `SharpEmu.ShaderCompiler.Tests`: hand-assembled SOP2/VOP3 encodings for each op are decoded, asserted on the opcode stream, and compiled to SPIR-V, checking the expected SPIR-V instructions (`ISub`, `IMul` + `ShiftRightArithmetic`, etc.) show up.
- New `SadAndMulHiAndAbsdiffTranslateInMsl` in `MslTranslationTests`: same encodings compiled through the MSL path, asserting the expected `abs()`/`mulhi()`/`max()`/`min()` expressions are present in the generated source.

`dotnet test` on both shader test projects passes (98 + 61 tests, 0 failures). No specific game was run against this; I don't have a dump at hand that exercises these opcodes, so the tests above are synthetic fixtures built from the ISA encodings.

## Checklist

By submitting this pull request, you confirm that:

- [x] I have read and followed `CONTRIBUTING.md`.
- [x] I tested my changes or marked the testing section as `N/A`.
- [x] I wrote this pull request description myself and did not paste AI-generated explanations.
- [x] I listed the game(s) I tested (or marked the testing section as `N/A`).
